### PR TITLE
Migrate device controller to messaging layer API

### DIFF
--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -35,6 +35,7 @@ static_library("controller") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
     "${chip_root}/src/platform",
     "${chip_root}/src/transport",
   ]

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -27,11 +27,12 @@
 #pragma once
 
 #include <controller/CHIPDevice.h>
+#include <messaging/ExchangeDelegate.h>
 
 namespace chip {
 namespace Controller {
 
-class DLL_EXPORT ClusterBase
+class DLL_EXPORT ClusterBase : public Messaging::ExchangeDelegate
 {
 public:
     virtual ~ClusterBase() {}
@@ -81,6 +82,9 @@ protected:
     const ClusterId mClusterId;
     Device * mDevice;
     EndpointId mEndpoint;
+    Messaging::ExchangeContext * mExchangeContext;
+    Callback::Callback<> * mResponseHandle;
+    Callback::Callback<> * mReportHandle;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -52,50 +52,6 @@ using namespace chip::Callback;
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    System::PacketBufferHandle resend;
-
-    VerifyOrExit(mSessionManager != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(!buffer.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    // If there is no secure connection to the device, try establishing it
-    if (mState != ConnectionState::SecureConnected)
-    {
-        err = LoadSecureSessionParameters(ResetTransport::kNo);
-        SuccessOrExit(err);
-    }
-    else
-    {
-        // Secure connection already exists
-        // Hold on to the buffer, in case session resumption and resend is needed
-        resend = buffer.Retain();
-    }
-
-    err    = mSessionManager->SendMessage(mDeviceId, std::move(buffer));
-    buffer = nullptr;
-    ChipLogDetail(Controller, "SendMessage returned %d", err);
-
-    // The send could fail due to network timeouts (e.g. broken pipe)
-    // Try sesion resumption if needed
-    if (err != CHIP_NO_ERROR && !resend.IsNull() && mState == ConnectionState::SecureConnected)
-    {
-        mState = ConnectionState::NotConnected;
-
-        err = LoadSecureSessionParameters(ResetTransport::kYes);
-        SuccessOrExit(err);
-
-        err = mSessionManager->SendMessage(mDeviceId, std::move(resend));
-        ChipLogDetail(Controller, "Re-SendMessage returned %d", err);
-        SuccessOrExit(err);
-    }
-
-exit:
-    return err;
-}
-
 CHIP_ERROR Device::Serialize(SerializedDevice & output)
 {
     CHIP_ERROR error       = CHIP_NO_ERROR;
@@ -107,15 +63,8 @@ CHIP_ERROR Device::Serialize(SerializedDevice & output)
 
     CHIP_ZERO_AT(serializable);
 
-    memmove(&serializable.mOpsCreds, &mPairing, sizeof(mPairing));
+    memmove(&serializable.mOpsCreds, &mSecureSessionParameters, sizeof(serializable.mOpsCreds));
     serializable.mDeviceId   = Encoding::LittleEndian::HostSwap64(mDeviceId);
-    serializable.mDevicePort = Encoding::LittleEndian::HostSwap16(mDevicePort);
-    VerifyOrExit(
-        CHIP_NO_ERROR ==
-            Inet::GetInterfaceName(mInterface, Uint8::to_char(serializable.mInterfaceName), sizeof(serializable.mInterfaceName)),
-        error = CHIP_ERROR_INTERNAL);
-    static_assert(sizeof(serializable.mDeviceAddr) <= INET6_ADDRSTRLEN, "Size of device address must fit within INET6_ADDRSTRLEN");
-    mDeviceAddr.ToString(Uint8::to_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr));
 
     serializedLen = chip::Base64Encode(Uint8::to_const_uchar(reinterpret_cast<uint8_t *>(&serializable)),
                                        static_cast<uint16_t>(sizeof(serializable)), Uint8::to_char(output.inner));
@@ -145,120 +94,31 @@ CHIP_ERROR Device::Deserialize(const SerializedDevice & input)
     VerifyOrExit(deserializedLen > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(deserializedLen <= sizeof(serializable), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    // The second parameter to FromString takes the strlen value. We are subtracting 1
-    // from the sizeof(serializable.mDeviceAddr) to account for null termination, since
-    // strlen doesn't include null character in the size.
-    VerifyOrExit(
-        IPAddress::FromString(Uint8::to_const_char(serializable.mDeviceAddr), sizeof(serializable.mDeviceAddr) - 1, mDeviceAddr),
-        error = CHIP_ERROR_INVALID_ADDRESS);
-
-    memmove(&mPairing, &serializable.mOpsCreds, sizeof(mPairing));
+    memmove(&mSecureSessionParameters, &serializable.mOpsCreds, sizeof(mSecureSessionParameters));
     mDeviceId   = Encoding::LittleEndian::HostSwap64(serializable.mDeviceId);
-    mDevicePort = Encoding::LittleEndian::HostSwap16(serializable.mDevicePort);
-
-    // The InterfaceNameToId() API requires initialization of mInterface, and lock/unlock of
-    // LwIP stack.
-    mInterface = INET_NULL_INTERFACEID;
-    if (serializable.mInterfaceName[0] != '\0')
-    {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-        LOCK_TCPIP_CORE();
-#endif
-        INET_ERROR inetErr = Inet::InterfaceNameToId(Uint8::to_const_char(serializable.mInterfaceName), mInterface);
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-        UNLOCK_TCPIP_CORE();
-#endif
-        VerifyOrExit(CHIP_NO_ERROR == inetErr, error = CHIP_ERROR_INTERNAL);
-    }
-
 exit:
     return error;
 }
 
-void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                               const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                               SecureSessionMgr * mgr)
-{
-    if (mState == ConnectionState::SecureConnected)
-    {
-        if (mStatusDelegate != nullptr)
-        {
-            mStatusDelegate->OnMessage(std::move(msgBuf));
-        }
-
-        // TODO: The following callback processing will need further work
-        //       1. The response needs to be parsed as per cluster definition. The response callback
-        //          should carry the parsed response values.
-        //       2. The reports callbacks should also be called with the parsed reports.
-        //       3. The callbacks would be tracked using exchange context. On receiving the
-        //          message, the exchange context in the message should be matched against
-        //          the registered callbacks.
-        // GitHub issue: https://github.com/project-chip/connectedhomeip/issues/3910
-        Cancelable * ca = mResponses.mNext;
-        while (ca != &mResponses)
-        {
-            Callback::Callback<> * cb = Callback::Callback<>::FromCancelable(ca);
-            // Let's advance to the next cancelable, as the current one will get removed
-            // from the list (and once removed, its next will point to itself)
-            ca = ca->mNext;
-            if (cb != nullptr)
-            {
-                ChipLogProgress(Controller, "Dispatching response callback %p", cb);
-                cb->Cancel();
-                cb->mCall(cb->mContext);
-            }
-        }
-
-        ca = mReports.mNext;
-        while (ca != &mReports)
-        {
-            Callback::Callback<> * cb = Callback::Callback<>::FromCancelable(ca);
-            // Let's advance to the next cancelable, as the current one might get removed
-            // from the list in the callback (and if removed, its next will point to itself)
-            ca = ca->mNext;
-            if (cb != nullptr)
-            {
-                ChipLogProgress(Controller, "Dispatching report callback %p", cb);
-                cb->mCall(cb->mContext);
-            }
-        }
-    }
-}
-
-CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
+CHIP_ERROR Device::EstablishCaseSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SecurePairingSession pairingSession;
 
-    if (mSessionManager == nullptr || mState == ConnectionState::SecureConnected)
+    if (mExchangeManager == nullptr || mState == ConnectionState::SecureConnected)
     {
         ExitNow(err = CHIP_ERROR_INCORRECT_STATE);
     }
 
-    err = pairingSession.FromSerializable(mPairing);
-    SuccessOrExit(err);
-
-    if (resetNeeded == ResetTransport::kYes)
     {
-        err = mTransportMgr->ResetTransport(
-            Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv6).SetListenPort(mListenPort)
-#if INET_CONFIG_ENABLE_IPV4
-                ,
-            Transport::UdpListenParameters(mInetLayer).SetAddressType(kIPAddressType_IPv4).SetListenPort(mListenPort)
-#endif
-        );
-        SuccessOrExit(err);
+        Messaging::ChannelBuilder builder;
+        builder.SetPeerNodeId(mDeviceId)
+            //.SetLocalKeyId(mSecureSessionParameters.mLocalKeyId)
+            //.SetPeerKeyId(mSecureSessionParameters.mPeerKeyId)
+        ;
+        mCaseChannel = mExchangeManager->EstablishChannel(builder, this);
     }
 
-    err = mSessionManager->NewPairing(
-        Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)), mDeviceId,
-        &pairingSession);
-    SuccessOrExit(err);
-
-    mState = ConnectionState::SecureConnected;
-
 exit:
-
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "LoadSecureSessionParameters returning error %d\n", err);
@@ -266,35 +126,22 @@ exit:
     return err;
 }
 
-bool Device::GetIpAddress(Inet::IPAddress & addr) const
+void Device::OnEstablished()
 {
-    if (mState == ConnectionState::SecureConnected)
-        addr = mDeviceAddr;
-    return mState == ConnectionState::SecureConnected;
+    // device connected
+    mStatusDelegate->OnStatusChange();
 }
 
-void Device::AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onResponse)
+void Device::OnClosed()
 {
-    CallbackInfo info                 = { endpoint, cluster };
-    Callback::Cancelable * cancelable = onResponse->Cancel();
-
-    static_assert(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
-
-    cancelable->mInfoScalar = 0;
-    memmove(&cancelable->mInfoScalar, &info, sizeof(info));
-    mResponses.Enqueue(cancelable);
+    // device disconnected
+    mStatusDelegate->OnStatusChange();
 }
 
-void Device::AddReportHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onReport)
+void Device::OnFail(CHIP_ERROR err)
 {
-    CallbackInfo info                 = { endpoint, cluster };
-    Callback::Cancelable * cancelable = onReport->Cancel();
-
-    static_assert(sizeof(info) <= sizeof(cancelable->mInfoScalar), "Size of CallbackInfo should be <= size of mInfoScalar");
-
-    cancelable->mInfoScalar = 0;
-    memmove(&cancelable->mInfoScalar, &info, sizeof(info));
-    mReports.Enqueue(cancelable);
+    // device failure
+    mStatusDelegate->OnStatusChange();
 }
 
 } // namespace Controller

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -29,6 +29,9 @@
 #include <app/util/basic-types.h>
 #include <core/CHIPCallback.h>
 #include <core/CHIPCore.h>
+#include <messaging/Channel.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
 #include <support/Base64.h>
 #include <support/DLLUtil.h>
 #include <transport/SecurePairingSession.h>
@@ -51,10 +54,10 @@ using DeviceTransportMgr = TransportMgr<Transport::UDP /* IPv6 */
 #endif
                                         >;
 
-class DLL_EXPORT Device
+class DLL_EXPORT Device : public Messaging::ChannelDelegate
 {
 public:
-    Device() : mInterface(INET_NULL_INTERFACEID), mActive(false), mState(ConnectionState::NotConnected) {}
+    Device() : mActive(false), mState(ConnectionState::NotConnected) {}
     ~Device() {}
 
     /**
@@ -66,17 +69,6 @@ public:
      * @param[in] delegate   The pointer to the delegate object.
      */
     void SetDelegate(DeviceStatusDelegate * delegate) { mStatusDelegate = delegate; }
-
-    // ----- Messaging -----
-    /**
-     * @brief
-     *   Send the provided message to the device
-     *
-     * @param[in] message   The message to be sent.
-     *
-     * @return CHIP_ERROR   CHIP_NO_ERROR on success, or corresponding error
-     */
-    CHIP_ERROR SendMessage(System::PacketBufferHandle message);
 
     /**
      * @brief
@@ -105,12 +97,9 @@ public:
      * @param[in] inetLayer    InetLayer object pointer
      * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
      */
-    void Init(DeviceTransportMgr * transportMgr, SecureSessionMgr * sessionMgr, Inet::InetLayer * inetLayer, uint16_t listenPort)
+    void Init(Messaging::ExchangeManager * exchangeManager)
     {
-        mTransportMgr   = transportMgr;
-        mSessionManager = sessionMgr;
-        mInetLayer      = inetLayer;
-        mListenPort     = listenPort;
+        mExchangeManager = exchangeManager;
     }
 
     /**
@@ -126,19 +115,12 @@ public:
      *
      * @param[in] transportMgr Transport manager object pointer
      * @param[in] sessionMgr   Secure session manager object pointer
-     * @param[in] inetLayer    InetLayer object pointer
-     * @param[in] listenPort   Port on which controller is listening (typically CHIP_PORT)
      * @param[in] deviceId     Node ID of the device
-     * @param[in] devicePort   Port on which device is listening (typically CHIP_PORT)
-     * @param[in] interfaceId  Local Interface ID that should be used to talk to the device
      */
-    void Init(DeviceTransportMgr * transportMgr, SecureSessionMgr * sessionMgr, Inet::InetLayer * inetLayer, uint16_t listenPort,
-              NodeId deviceId, uint16_t devicePort, Inet::InterfaceId interfaceId)
+    void Init(Messaging::ExchangeManager * exchangeManager, NodeId deviceId)
     {
-        Init(transportMgr, sessionMgr, inetLayer, mListenPort);
+        Init(exchangeManager);
         mDeviceId   = deviceId;
-        mDevicePort = devicePort;
-        mInterface  = interfaceId;
         mState      = ConnectionState::Connecting;
     }
 
@@ -158,21 +140,6 @@ public:
 
     /**
      * @brief
-     *   This function is called when a message is received from the corresponding CHIP
-     *   device. The message ownership is transferred to the function, and it is expected
-     *   to release the message buffer before returning.
-     *
-     * @param[in] header        Reference to common packet header of the received message
-     * @param[in] payloadHeader Reference to payload header in the message
-     * @param[in] state         Pointer to the peer connection state on which message is received
-     * @param[in] msgBuf        The message buffer
-     * @param[in] mgr           Pointer to secure session manager which received the message
-     */
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr);
-
-    /**
-     * @brief
      *   Return whether the current device object is actively associated with a paired CHIP
      *   device. An active object can be used to communicate with the corresponding device.
      */
@@ -184,20 +151,23 @@ public:
     {
         SetActive(false);
         mState          = ConnectionState::NotConnected;
-        mSessionManager = nullptr;
         mStatusDelegate = nullptr;
-        mInetLayer      = nullptr;
     }
 
     NodeId GetDeviceId() const { return mDeviceId; }
 
-    void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddr = deviceAddr; }
+    SecurePairingSessionSerializable & GetSecureSessoinParametersForUpdate() { return mSecureSessionParameters; }
 
-    SecurePairingSessionSerializable & GetPairing() { return mPairing; }
+    CHIP_ERROR EstablishPaseSession();
+    CHIP_ERROR EstablishCaseSession();
+    void CloseSession();
 
-    void AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onResponse);
-    void AddReportHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onReport);
+    Messaging::ExchangeContext * NewExchange();
 
+    // Messaging::ChannelDelegate interface
+    void OnEstablished() override;
+    void OnClosed() override;
+    void OnFail(CHIP_ERROR err) override;
 private:
     enum class ConnectionState
     {
@@ -220,35 +190,15 @@ private:
     /* Node ID assigned to the CHIP device */
     NodeId mDeviceId;
 
-    /* IP Address of the CHIP device */
-    Inet::IPAddress mDeviceAddr;
-
-    /* Port on which the CHIP device is receiving messages. Typically it is CHIP_PORT */
-    uint16_t mDevicePort;
-
-    /* Local network interface that should be used to communicate with the device */
-    Inet::InterfaceId mInterface;
-
-    Inet::InetLayer * mInetLayer;
+    SecurePairingSessionSerializable mSecureSessionParameters;
 
     bool mActive;
     ConnectionState mState;
 
-    SecurePairingSessionSerializable mPairing;
-
     DeviceStatusDelegate * mStatusDelegate;
 
-    SecureSessionMgr * mSessionManager;
-
-    DeviceTransportMgr * mTransportMgr;
-
-    /* Track all outstanding response callbacks for this device. The callbacks are
-       registered when a command is sent to the device, to get notified with the results. */
-    Callback::CallbackDeque mResponses;
-
-    /* Track all outstanding callbacks for attribute reports from this device. The callbacks are
-       registered when the user requests attribute reporting for device attributes. */
-    Callback::CallbackDeque mReports;
+    Messaging::ExchangeManager * mExchangeManager;
+    Messaging::ChannelHandle mCaseChannel;
 
     /**
      * @brief
@@ -259,8 +209,6 @@ private:
      * @param[in] resetNeeded   Does the underlying network socket require a reset
      */
     CHIP_ERROR LoadSecureSessionParameters(ResetTransport resetNeeded);
-
-    uint16_t mListenPort;
 };
 
 /**
@@ -273,14 +221,6 @@ class DLL_EXPORT DeviceStatusDelegate
 {
 public:
     virtual ~DeviceStatusDelegate() {}
-
-    /**
-     * @brief
-     *   Called when a message is received from the device.
-     *
-     * @param[in] msg Received message buffer.
-     */
-    virtual void OnMessage(System::PacketBufferHandle msg) = 0;
 
     /**
      * @brief
@@ -300,9 +240,6 @@ typedef struct SerializableDevice
 {
     SecurePairingSessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
-    uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
-    uint16_t mDevicePort; /* This field is serealized in LittelEndian byte order */
-    uint8_t mInterfaceName[kMaxInterfaceName];
 } SerializableDevice;
 
 typedef struct SerializedDevice

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
     err = mSessionManager->Init(localDeviceId, mSystemLayer, mTransportMgr);
     SuccessOrExit(err);
 
-    mSessionManager->SetDelegate(this);
+    //mExchangeManager->Init(...);
 
     mState         = State::Initialized;
     mLocalDeviceId = localDeviceId;
@@ -227,7 +227,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, const SerializedDevice &
         err = device->Deserialize(deviceInfo);
         VerifyOrExit(err == CHIP_NO_ERROR, ReleaseDevice(device));
 
-        device->Init(mTransportMgr, mSessionManager, mInetLayer, mListenPort);
+        device->Init(mExchangeManager);
     }
 
     *out_device = device;
@@ -289,7 +289,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
             err = device->Deserialize(deviceInfo);
             VerifyOrExit(err == CHIP_NO_ERROR, ReleaseDevice(device));
 
-            device->Init(mTransportMgr, mSessionManager, mInetLayer, mListenPort);
+            device->Init(mExchangeManager);
         }
     }
 
@@ -332,33 +332,6 @@ CHIP_ERROR DeviceController::ServiceEventSignal()
 
 exit:
     return err;
-}
-
-void DeviceController::OnNewConnection(const Transport::PeerConnectionState * peerConnection, SecureSessionMgr * mgr) {}
-
-void DeviceController::OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                                         const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                                         SecureSessionMgr * mgr)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint16_t index = 0;
-    NodeId peer;
-
-    VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(header.GetSourceNodeId().HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    peer  = header.GetSourceNodeId().Value();
-    index = FindDeviceIndex(peer);
-    VerifyOrExit(index < kNumMaxActiveDevices, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
-
-    mActiveDevices[index].OnMessageReceived(header, payloadHeader, state, std::move(msgBuf), mgr);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Failed to process received message: err %d", err);
-    }
-    return;
 }
 
 uint16_t DeviceController::GetInactiveDeviceIndex()
@@ -509,13 +482,13 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     err = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId).SetRemoteNodeId(remoteDeviceId), mTransportMgr);
     SuccessOrExit(err);
 
-    device->Init(mTransportMgr, mSessionManager, mInetLayer, mListenPort, remoteDeviceId, remotePort, interfaceId);
+    device->Init(mExchangeManager, remoteDeviceId);
 
     // TODO: BLE rendezvous and IP rendezvous should have same logic in the future after BLE becomes a transport and network
     // provisiong cluster is ready.
     if (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle)
     {
-        device->SetAddress(params.GetPeerAddress().GetIPAddress());
+        //device->SetAddress(params.GetPeerAddress().GetIPAddress());
         mRendezvousSession->OnRendezvousConnectionOpened();
     }
 
@@ -558,11 +531,7 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
     VerifyOrExit(mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_NO_MEMORY);
     device = &mActiveDevices[mDeviceBeingPaired];
 
-    testSecurePairingSecret->ToSerializable(device->GetPairing());
-
-    device->Init(mTransportMgr, mSessionManager, mInetLayer, mListenPort, remoteDeviceId, remotePort, interfaceId);
-
-    device->SetAddress(deviceAddr);
+    device->Init(mExchangeManager, remoteDeviceId);
 
     device->Serialize(serialized);
 
@@ -699,22 +668,19 @@ void DeviceCommissioner::OnRendezvousStatusUpdate(RendezvousSessionDelegate::Sta
     switch (status)
     {
     case RendezvousSessionDelegate::SecurePairingSuccess:
+    {
         ChipLogDetail(Controller, "Remote device completed SPAKE2+ handshake\n");
-        mRendezvousSession->GetPairingSession().ToSerializable(device->GetPairing());
+        mRendezvousSession->GetPairingSession().ToSerializable(device->GetSecureSessoinParametersForUpdate());
 
         if (!mIsIPRendezvous && mPairingDelegate != nullptr)
         {
             mPairingDelegate->OnNetworkCredentialsRequested(mRendezvousSession);
         }
         break;
+    }
 
     case RendezvousSessionDelegate::SecurePairingFailed:
         ChipLogDetail(Controller, "Remote device failed in SPAKE2+ handshake\n");
-        break;
-
-    case RendezvousSessionDelegate::NetworkProvisioningSuccess:
-        ChipLogDetail(Controller, "Remote device was assigned an ip address\n");
-        device->SetAddress(mRendezvousSession->GetIPAddress());
         break;
 
     case RendezvousSessionDelegate::NetworkProvisioningFailed:

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -32,6 +32,7 @@
 #include <controller/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLV.h>
+#include <messaging/ExchangeMgr.h>
 #include <support/DLLUtil.h>
 #include <support/SerializableIntegerSet.h>
 #include <transport/RendezvousSession.h>
@@ -104,7 +105,7 @@ public:
  *   and device pairing information for individual devices). Alternatively, this class can retrieve the
  *   relevant information when the application tries to communicate with the device
  */
-class DLL_EXPORT DeviceController : public SecureSessionMgrDelegate, public PersistentStorageResultDelegate
+class DLL_EXPORT DeviceController : public PersistentStorageResultDelegate
 {
 public:
     DeviceController();
@@ -187,6 +188,7 @@ protected:
     NodeId mLocalDeviceId;
     DeviceTransportMgr * mTransportMgr;
     SecureSessionMgr * mSessionManager;
+    Messaging::ExchangeManager * mExchangeManager;
     PersistentStorageDelegate * mStorageDelegate;
     Inet::InetLayer * mInetLayer;
 
@@ -197,13 +199,6 @@ protected:
     CHIP_ERROR SetPairedDeviceList(const char * pairedDeviceSerializedSet);
 
 private:
-    //////////// SecureSessionMgrDelegate Implementation ///////////////
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader,
-                           const Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf,
-                           SecureSessionMgr * mgr) override;
-
-    void OnNewConnection(const Transport::PeerConnectionState * state, SecureSessionMgr * mgr) override;
-
     //////////// PersistentStorageResultDelegate Implementation ///////////////
     void OnValue(const char * key, const char * value) override;
     void OnStatus(const char * key, Operation op, CHIP_ERROR err) override;

--- a/src/controller/CHIPDeviceController_deprecated.cpp
+++ b/src/controller/CHIPDeviceController_deprecated.cpp
@@ -171,14 +171,6 @@ bool ChipDeviceController::IsConnected() const
     return mState == kState_Initialized;
 }
 
-bool ChipDeviceController::GetIpAddress(Inet::IPAddress & addr) const
-{
-    if (IsConnected() && mDevice != nullptr)
-        return mDevice->GetIpAddress(addr);
-
-    return false;
-}
-
 CHIP_ERROR ChipDeviceController::DisconnectDevice()
 {
     if (mDevice != nullptr)
@@ -189,55 +181,10 @@ CHIP_ERROR ChipDeviceController::DisconnectDevice()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBufferHandle buffer, NodeId peerDevice)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(!buffer.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    mAppReqState = appReqState;
-
-    if (peerDevice != kUndefinedNodeId)
-    {
-        mRemoteDeviceId = peerDevice;
-    }
-    VerifyOrExit(mRemoteDeviceId != kUndefinedNodeId, err = CHIP_ERROR_INCORRECT_STATE);
-
-    if (mDevice == nullptr)
-    {
-        if (mPairingWithoutSecurity)
-        {
-            err = mCommissioner.GetDevice(mRemoteDeviceId, mSerializedTestDevice, &mDevice);
-        }
-        else
-        {
-            err = mCommissioner.GetDevice(mRemoteDeviceId, &mDevice);
-        }
-        SuccessOrExit(err);
-    }
-
-    VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    mDevice->SetDelegate(this);
-
-    err = mDevice->SendMessage(std::move(buffer));
-
-exit:
-
-    return err;
-}
-
 CHIP_ERROR ChipDeviceController::SetDevicePairingDelegate(DevicePairingDelegate * pairingDelegate)
 {
     mCommissioner.SetDevicePairingDelegate(pairingDelegate);
     return CHIP_NO_ERROR;
-}
-
-void ChipDeviceController::OnMessage(System::PacketBufferHandle msgBuf)
-{
-    if (mOnComplete.Response != nullptr)
-    {
-        mOnComplete.Response(this, mAppReqState, std::move(msgBuf));
-    }
 }
 
 } // namespace DeviceController

--- a/src/controller/CHIPDeviceController_deprecated.h
+++ b/src/controller/CHIPDeviceController_deprecated.h
@@ -181,9 +181,6 @@ public:
      */
     CHIP_ERROR SetDevicePairingDelegate(Controller::DevicePairingDelegate * pairingDelegate);
 
-    //////////// DeviceStatusDelegate Implementation ///////////////
-    void OnMessage(System::PacketBufferHandle msg) override;
-
 private:
     enum
     {

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1251,6 +1251,25 @@
 #define CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS                  16
 #endif // CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS
 
+/**
+ *  @def CHIP_CONFIG_MAX_ACTIVE_CHANNELS
+ *
+ *  @brief
+ *    Maximum number of simultaneously active channels
+ */
+#ifndef CHIP_CONFIG_MAX_ACTIVE_CHANNELS
+#define CHIP_CONFIG_MAX_ACTIVE_CHANNELS                    16
+#endif // CHIP_CONFIG_MAX_ACTIVE_CHANNELS
+
+/**
+ *  @def CHIP_CONFIG_MAX_ACTIVE_SESSIONS
+ *
+ *  @brief
+ *    Maximum number of simultaneously active secure sessions
+ */
+#ifndef CHIP_CONFIG_MAX_ACTIVE_SESSIONS
+#define CHIP_CONFIG_MAX_ACTIVE_SESSIONS                    16
+#endif // CHIP_CONFIG_MAX_ACTIVE_SESSIONS
 
 /**
  *  @def CHIP_CONFIG_CONNECT_IP_ADDRS

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -18,6 +18,8 @@ static_library("messaging") {
   output_name = "libMessagingLayer"
 
   sources = [
+    "Channel.cpp",
+    "Channel.h",
     "ErrorCategory.cpp",
     "ErrorCategory.h",
     "ExchangeContext.cpp",

--- a/src/messaging/Channel.cpp
+++ b/src/messaging/Channel.cpp
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <messaging/Channel.h>
+#include <messaging/ChannelContext.h>
+
+namespace chip {
+namespace Messaging {
+
+ChannelState ChannelHandle::GetState() const
+{
+    if (mChannelContext != nullptr)
+        return mChannelContext->GetState();
+    else
+        return ChannelState::kChanneState_None;
+}
+
+void ChannelHandle::Release()
+{
+    mChannelContext->Release();
+}
+
+} // namespace Messaging
+} // namespace chip

--- a/src/messaging/Channel.h
+++ b/src/messaging/Channel.h
@@ -1,0 +1,202 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the API classes for to CHIP Channel.
+ *
+ *      Channel is a object to abstract all low layer dependencies of an
+ *      exchange, including secure session, transport connection and network
+ *      status.
+ *
+ *      Channel is not connection. Channel can abstract both connection
+ *      oriented and connectionless transports, It contains information to send
+ *      and receive messages via exchanges. For example, when using
+ *      connectionless transport, channel will contain peer address and session
+ *      key; when using connection oriented transport, channel will contain
+ *      connection handle and session key.
+ *
+ *      Channel is not session. Session do persistent through cold reboot, but
+ *      channel doesn't. Applications must re-establish channels after a cold
+ *      reboot.
+ *
+ *      Because channel is a local concept, peer device is not able aware of
+ *      channel establishment events. Instead, peer device is able to aware
+ *      session establishment events, connection establishment events for
+ *      connection oriented transport and message received events for
+ *      connectionless transport.
+ */
+
+#pragma once
+
+#include <transport/raw/MessageHeader.h>
+
+namespace chip {
+namespace Messaging {
+
+/**
+ *  @brief
+ *    The ChannelBuilder object provides information to build a Channel.
+ *
+ *    ChannelBuilder can be used by application to provide information to
+ *    request a channel to a peer. When a channel is requested via
+ *    ExchangeManager::EstablishChannel, a ChannelHandle will be return to
+ *    represent the state of the channel
+ *
+ *    The ChannelBuilder object should be short-live and it is only used within
+ *    ExchangeManager::EstablishChannel call, after the call its state will be
+ *    copied into an internal object represented by ChannelHandle, then the
+ *    ChannelBuilder can be safely released.
+ */
+class ChannelBuilder
+{
+public:
+    enum class NetworkPreference
+    {
+        kNetwork_Default,
+        kNetwork_HighBandwidth,
+        kNetwork_LowLatency,
+        kNetwork_LowPowerConsumption,
+    };
+
+    enum class TransportPreference
+    {
+        kTransport_Connectionless,
+        kTransport_PreferConnectionOriented, // will fallback to connectionless TCP is not supported
+        kTransport_ConnectionOriented,       // will fail if TCP is not supported
+
+        kTransport_Default = kTransport_Connectionless,
+    };
+
+    enum class SessionType
+    {
+        kSession_PASE, // Use SPAKE2 key exchange
+        kSession_CASE, // Use SIGMA key exchange
+
+        kSession_Default = kSession_CASE,
+    };
+
+    ChannelBuilder & SetPeerNodeId(NodeId peerNodeId)
+    {
+        mPeerNodeId = peerNodeId;
+        return *this;
+    }
+    NodeId GetPeerNodeId() { return mPeerNodeId; }
+
+    ChannelBuilder & SetNetworkPreference(NetworkPreference preference)
+    {
+        mNetworkPreference = preference;
+        return *this;
+    }
+    NetworkPreference GetNetworkPreference() { return mNetworkPreference; }
+
+    ChannelBuilder & SetTransportPreference(TransportPreference preference)
+    {
+        mTransportPreference = preference;
+        return *this;
+    }
+    TransportPreference GetTransportPreference() { return mTransportPreference; }
+
+    ChannelBuilder & SetSessionType(SessionType preference)
+    {
+        mSessionType = preference;
+        return *this;
+    }
+    SessionType GetSessionType() { return mSessionType; }
+
+private:
+    NodeId mPeerNodeId                       = kUndefinedNodeId;
+    NetworkPreference mNetworkPreference     = NetworkPreference::kNetwork_Default;
+    TransportPreference mTransportPreference = TransportPreference::kTransport_Default;
+    SessionType mSessionType                 = SessionType::kSession_Default;
+};
+
+enum class ChannelState
+{
+    kChanneState_None,
+    kChanneState_Preparing,
+    kChanneState_Ready,
+    kChanneState_Closed,
+    kChanneState_Failed,
+};
+
+class ChannelContext;
+
+/**
+ *  @brief
+ *    ChannelHandle is a reference to a channel. An active ChannelHandle will
+ *    keep the channel available and ready for use, such that a message can be
+ *    sent immediately to the peer.
+ *
+ *    The ChannelHandle controls the lifespan of the channel. The ChannelHandle
+ *    objects are not copyable, so there can be only one instance referring to
+ *    the channel. When the handler is released, the channel will be flagged as
+ *    pending close, and if there is no active exchange which is using the
+ *    channel, the channel will be closed.
+ *
+ *    The ChannelHandle will track channel status, and notify applications
+ *    when the channel state changes via ChannelDelegate.
+ */
+class ChannelHandle
+{
+public:
+    ChannelHandle(ChannelContext * channelContext = nullptr) : mChannelContext(channelContext) {}
+    ~ChannelHandle() { Release(); }
+
+    // non copyable
+    ChannelHandle(const ChannelHandle &) = delete;
+    ChannelHandle & operator=(const ChannelHandle &) = delete;
+
+    // movable
+    ChannelHandle(ChannelHandle && that)
+    {
+        Release();
+        this->mChannelContext = that.mChannelContext;
+        that.mChannelContext  = nullptr;
+    }
+    ChannelHandle & operator=(ChannelHandle && that)
+    {
+        Release();
+        this->mChannelContext = that.mChannelContext;
+        that.mChannelContext  = nullptr;
+        return *this;
+    }
+
+    // public APIs
+    ChannelState GetState() const;
+    void Release();
+
+private:
+    ChannelContext * mChannelContext;
+};
+
+/**
+ *  @brief
+ *    Callback receiver interface of channels
+ */
+class ChannelDelegate
+{
+public:
+    virtual ~ChannelDelegate() {}
+
+    virtual void OnEstablished()        = 0;
+    virtual void OnClosed()             = 0;
+    virtual void OnFail(CHIP_ERROR err) = 0;
+};
+
+} // namespace Messaging
+} // namespace chip

--- a/src/messaging/ChannelContext.h
+++ b/src/messaging/ChannelContext.h
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the API classes for to CHIP Channel.
+ *
+ *      Channel is a object to abstract all low layer dependencies of an
+ *      exchange, including secure session, transport connection and network
+ *      status.
+ *
+ *      Channel is not connection. Channel can abstract both connection
+ *      oriented and connectionless transports, It contains information to send
+ *      and receive messages via exchanges. For example, when using
+ *      connectionless transport, channel will contain peer address and session
+ *      key; when using connection oriented transport, channel will contain
+ *      connection handle and session key.
+ *
+ *      Channel is not session. Session do persistent through cold reboot, but
+ *      channel doesn't. Applications must re-establish channels after a cold
+ *      reboot.
+ *
+ *      Because channel is a local concept, peer device is not able aware of
+ *      channel establishment events. Instead, peer device is able to aware
+ *      session establishment events, connection establishment events for
+ *      connection oriented transport and message received events for
+ *      connectionless transport.
+ */
+
+#pragma once
+
+#include <messaging/Channel.h>
+#include <transport/PeerConnectionState.h>
+
+namespace chip {
+namespace Messaging {
+
+class ChannelContext
+{
+public:
+    ChannelState GetState() const { return mState; }
+    void Release() { /* TODO */ }
+
+    // events of ResolveDelegate
+    //void HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, const MdnsService & address);
+
+    // events of SecureSessionManager
+    void OnNewConnection(const Transport::PeerConnectionState * state);
+    void OnConnectionExpired(const Transport::PeerConnectionState * state);
+private:
+    ChannelState mState = ChannelState::kChanneState_Closed;
+    ChannelDelegate * mDelegate = nullptr;
+
+    enum PrepareState {
+        kPrepareState_AddressResolving,
+        kPrepareState_SessionEstablishing,
+    };
+
+    union {
+        struct {
+            PrepareState mState;
+            NodeId mPeerNodeId;
+        } mPreparing;
+        struct {
+            Transport::PeerConnectionState * mSession;
+        } mReady;
+    };
+};
+
+} // namespace Messaging
+} // namespace chip

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -75,7 +75,6 @@ CHIP_ERROR ExchangeManager::Init(SecureSessionMgr * sessionMgr)
     mContextsInUse = 0;
 
     memset(UMHandlerPool, 0, sizeof(UMHandlerPool));
-    OnExchangeContextChanged = nullptr;
 
     sessionMgr->SetDelegate(this);
 
@@ -91,8 +90,6 @@ CHIP_ERROR ExchangeManager::Shutdown()
         mSessionMgr->SetDelegate(nullptr);
         mSessionMgr = nullptr;
     }
-
-    OnExchangeContextChanged = nullptr;
 
     mState = State::kState_NotInitialized;
 
@@ -134,6 +131,18 @@ CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandler(uint32_t protoco
 CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandler(uint32_t protocolId, uint8_t msgType)
 {
     return UnregisterUMH(protocolId, static_cast<int16_t>(msgType));
+}
+
+ChannelHandle ExchangeManager::EstablishChannel(const ChannelBuilder & builder, ChannelDelegate * delegate)
+{
+    // TODO: not implemented
+    return { nullptr };
+}
+
+ExchangeContext * ExchangeManager::NewExchange(ChannelHandle &)
+{
+    // TODO: not implemented
+    return nullptr;
 }
 
 void ExchangeManager::OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * msgLayer)


### PR DESCRIPTION
 #### Problem
Migrate to messaging layer #4170

 #### Summary of Changes
Change device controller to messaging layer API instead of secure session manager.

**Please ignore first commit, focus on the second commit**. This PR depends on Channel API #4019, first commit is that PR

 There are several issues need to be resolved:

1. The address of the device shouldn't be persistent, it should be always discovered by mDNS. The address doesn't come from network provision. On WiFi network, the address is assigned by home AP, not chip hub, the network provision is not able to assign IP address to a device. And for IPv6, the address is rotated on a regular interval for security reasons.
2. Move device commissioner (PASE procedure) to transport layer, and use Channel API to decouple it from device controller. Here is a diagram showing how to build a PASE session. The orange boxes will be implemented inside device controller; the green boxes are parameters to the `ChannelBuilder`; The blue boxes is the device commissioner, and IMHO, it should be moved into transport layer, because they are not device dependent.

![image](https://user-images.githubusercontent.com/154702/101857981-ac382200-3ba3-11eb-8b35-54b25fed03b9.png)
