### PR TITLE
Add regen all script

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -25,7 +25,8 @@ if sys.version_info[0] < 3:
     exit(1)
 
 # Check if we are in top of CHIP folder
-if not str(os.getcwd()).endswith("connectedhomeip"):
+scripts_path = os.path.join(os.getcwd(), 'scripts/tools/zap_regen_all.py')
+if not os.path.exists(scripts_path):
     print(os.getcwd())
     print('This script must be called from the root of the chip directory')
     exit(1)

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import sys
+import os
+from pathlib import Path
+
+# Check python version
+if sys.version_info[0] < 3:
+    print("Must use Python 3. Current version is " + str(sys.version_info[0]))
+    exit(1)
+
+# Check if we are in top of CHIP folder
+if not str(os.getcwd()).endswith("connectedhomeip"):
+    print(os.getcwd())
+    print('This script must be called from the root of the chip directory')
+    exit(1)
+
+for path in Path('./examples').rglob('*.zap'):
+    os.system("./scripts/tools/zap_generate.sh " + str(path))


### PR DESCRIPTION
 #### Problem
Generating all ZCL files per example is a long and tedious task that will grow with the number of examples. 

 #### Summary of Changes
This script will generate all ZAP templates for each examples automatically. It will search for `*.zap` files in the `examples` directory and then call the `zap_generate.sh` script. Useful when one is modifying the zap templates and want to update all generated files at once.

 Add-on to #3637 