### PR TITLE
Change the 'chip-zcl-zpro-codec-api' encode methods to returns a 'Pac…

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -932,9 +932,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterBarrierControlGoToPercentCommand(buffer->Start(), bufferSize, endPointId, mPercentOpen);
+        return encodeBarrierControlClusterBarrierControlGoToPercentCommand(endPointId, mPercentOpen);
     }
 
     // Global Response: DefaultResponse
@@ -956,9 +956,9 @@ class BarrierControlStop : public ModelCommand
 public:
     BarrierControlStop() : ModelCommand("barrier-control-stop", kBarrierControlClusterId, 0x01) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterBarrierControlStopCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterBarrierControlStopCommand(endPointId);
     }
 
     // Global Response: DefaultResponse
@@ -977,9 +977,9 @@ class DiscoverBarrierControlAttributes : public ModelCommand
 public:
     DiscoverBarrierControlAttributes() : ModelCommand("discover", kBarrierControlClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterDiscoverAttributes(endPointId);
     }
 
     // Global Response: DiscoverAttributesResponse
@@ -1002,9 +1002,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterReadBarrierMovingStateAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterReadBarrierMovingStateAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1027,9 +1027,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1052,9 +1052,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1077,9 +1077,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBarrierControlClusterReadBarrierPositionAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeBarrierControlClusterReadBarrierPositionAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1116,9 +1116,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeBasicClusterResetToFactoryDefaultsCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeBasicClusterResetToFactoryDefaultsCommand(endPointId);
     }
 
     // Global Response: DefaultResponse
@@ -1137,10 +1137,7 @@ class BasicMfgSpecificPing : public ModelCommand
 public:
     BasicMfgSpecificPing() : ModelCommand("ping", kBasicClusterId, 0x00) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterMfgSpecificPingCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeBasicClusterMfgSpecificPingCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -1158,10 +1155,7 @@ class DiscoverBasicAttributes : public ModelCommand
 public:
     DiscoverBasicAttributes() : ModelCommand("discover", kBasicClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeBasicClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -1183,10 +1177,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadZclVersionAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeBasicClusterReadZclVersionAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -1208,10 +1199,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeBasicClusterReadPowerSourceAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeBasicClusterReadPowerSourceAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -1297,10 +1285,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveColorCommand(buffer->Start(), bufferSize, endPointId, mRateX, mRateY, mOptionsMask,
-                                                         mOptionsOverride);
+        return encodeColorControlClusterMoveColorCommand(endPointId, mRateX, mRateY, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1334,11 +1321,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate,
-                                                                    mColorTemperatureMinimum, mColorTemperatureMaximum,
-                                                                    mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveColorTemperatureCommand(endPointId, mMoveMode, mRate, mColorTemperatureMinimum,
+                                                                    mColorTemperatureMaximum, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1372,10 +1358,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveHueCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate, mOptionsMask,
-                                                       mOptionsOverride);
+        return encodeColorControlClusterMoveHueCommand(endPointId, mMoveMode, mRate, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1407,10 +1392,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveSaturationCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate,
-                                                              mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveSaturationCommand(endPointId, mMoveMode, mRate, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1443,10 +1427,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveToColorCommand(buffer->Start(), bufferSize, endPointId, mColorX, mColorY,
-                                                           mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveToColorCommand(endPointId, mColorX, mColorY, mTransitionTime, mOptionsMask,
+                                                           mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1479,10 +1463,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveToColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mColorTemperature,
-                                                                      mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveToColorTemperatureCommand(endPointId, mColorTemperature, mTransitionTime, mOptionsMask,
+                                                                      mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1515,10 +1499,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveToHueCommand(buffer->Start(), bufferSize, endPointId, mHue, mDirection, mTransitionTime,
-                                                         mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveToHueCommand(endPointId, mHue, mDirection, mTransitionTime, mOptionsMask,
+                                                         mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1552,10 +1536,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveToHueAndSaturationCommand(buffer->Start(), bufferSize, endPointId, mHue, mSaturation,
-                                                                      mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveToHueAndSaturationCommand(endPointId, mHue, mSaturation, mTransitionTime, mOptionsMask,
+                                                                      mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1588,10 +1572,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterMoveToSaturationCommand(buffer->Start(), bufferSize, endPointId, mSaturation,
-                                                                mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterMoveToSaturationCommand(endPointId, mSaturation, mTransitionTime, mOptionsMask,
+                                                                mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1624,10 +1608,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterStepColorCommand(buffer->Start(), bufferSize, endPointId, mStepX, mStepY, mTransitionTime,
-                                                         mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterStepColorCommand(endPointId, mStepX, mStepY, mTransitionTime, mOptionsMask,
+                                                         mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1663,11 +1647,11 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterStepColorTemperatureCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize,
-                                                                    mTransitionTime, mColorTemperatureMinimum,
-                                                                    mColorTemperatureMaximum, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterStepColorTemperatureCommand(endPointId, mStepMode, mStepSize, mTransitionTime,
+                                                                    mColorTemperatureMinimum, mColorTemperatureMaximum,
+                                                                    mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1703,10 +1687,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterStepHueCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize,
-                                                       mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterStepHueCommand(endPointId, mStepMode, mStepSize, mTransitionTime, mOptionsMask,
+                                                       mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1740,10 +1724,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterStepSaturationCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize,
-                                                              mTransitionTime, mOptionsMask, mOptionsOverride);
+        return encodeColorControlClusterStepSaturationCommand(endPointId, mStepMode, mStepSize, mTransitionTime, mOptionsMask,
+                                                              mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1774,10 +1758,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterStopMoveStepCommand(buffer->Start(), bufferSize, endPointId, mOptionsMask,
-                                                            mOptionsOverride);
+        return encodeColorControlClusterStopMoveStepCommand(endPointId, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -1800,9 +1783,9 @@ class DiscoverColorControlAttributes : public ModelCommand
 public:
     DiscoverColorControlAttributes() : ModelCommand("discover", kColorControlClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterDiscoverAttributes(endPointId);
     }
 
     // Global Response: DiscoverAttributesResponse
@@ -1825,9 +1808,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadCurrentHueAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadCurrentHueAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1850,10 +1833,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReportCurrentHueAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval,
-                                                                  mMaxInterval, mChange);
+        return encodeColorControlClusterReportCurrentHueAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -1881,9 +1863,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadCurrentSaturationAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadCurrentSaturationAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1906,10 +1888,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReportCurrentSaturationAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval,
-                                                                         mMaxInterval, mChange);
+        return encodeColorControlClusterReportCurrentSaturationAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -1937,9 +1918,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadRemainingTimeAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadRemainingTimeAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1962,9 +1943,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadCurrentXAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadCurrentXAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -1987,10 +1968,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReportCurrentXAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval, mMaxInterval,
-                                                                mChange);
+        return encodeColorControlClusterReportCurrentXAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -2018,9 +1998,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadCurrentYAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadCurrentYAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2043,10 +2023,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReportCurrentYAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval, mMaxInterval,
-                                                                mChange);
+        return encodeColorControlClusterReportCurrentYAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -2074,9 +2053,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorTemperatureAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorTemperatureAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2099,10 +2078,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReportColorTemperatureAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval,
-                                                                        mMaxInterval, mChange);
+        return encodeColorControlClusterReportColorTemperatureAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -2130,9 +2108,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorModeAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorModeAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2155,9 +2133,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadNumberOfPrimariesAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadNumberOfPrimariesAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2180,9 +2158,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary1XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary1XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2205,9 +2183,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary1YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary1YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2230,9 +2208,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary1IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary1IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2255,9 +2233,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary2XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary2XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2280,9 +2258,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary2YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary2YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2305,9 +2283,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary2IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary2IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2330,9 +2308,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary3XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary3XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2355,9 +2333,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary3YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary3YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2380,9 +2358,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary3IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary3IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2405,9 +2383,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary4XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary4XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2430,9 +2408,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary4YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary4YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2455,9 +2433,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary4IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary4IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2480,9 +2458,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary5XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary5XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2505,9 +2483,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary5YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary5YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2530,9 +2508,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary5IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary5IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2555,9 +2533,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary6XAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary6XAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2580,9 +2558,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary6YAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary6YAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2605,9 +2583,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadPrimary6IntensityAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadPrimary6IntensityAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2630,9 +2608,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadEnhancedCurrentHueAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadEnhancedCurrentHueAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2655,9 +2633,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadEnhancedColorModeAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadEnhancedColorModeAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2680,9 +2658,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorLoopActiveAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorLoopActiveAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2705,9 +2683,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorLoopDirectionAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorLoopDirectionAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2730,9 +2708,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorLoopTimeAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorLoopTimeAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2755,9 +2733,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorCapabilitiesAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorCapabilitiesAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2780,9 +2758,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorTempPhysicalMinAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorTempPhysicalMinAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2805,9 +2783,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadColorTempPhysicalMaxAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadColorTempPhysicalMaxAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2830,9 +2808,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -2855,9 +2833,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -3528,10 +3506,7 @@ class DoorLockClearAllPins : public ModelCommand
 public:
     DoorLockClearAllPins() : ModelCommand("clear-all-pins", kDoorLockClusterId, 0x08) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeDoorLockClusterClearAllPinsCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeDoorLockClusterClearAllPinsCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -3556,10 +3531,7 @@ class DoorLockClearAllRfids : public ModelCommand
 public:
     DoorLockClearAllRfids() : ModelCommand("clear-all-rfids", kDoorLockClusterId, 0x19) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeDoorLockClusterClearAllRfidsCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeDoorLockClusterClearAllRfidsCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -3588,9 +3560,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterClearHolidayScheduleCommand(buffer->Start(), bufferSize, endPointId, mHolidayScheduleID);
+        return encodeDoorLockClusterClearHolidayScheduleCommand(endPointId, mHolidayScheduleID);
     }
 
     // Global Response: DefaultResponse
@@ -3623,9 +3595,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterClearPinCommand(buffer->Start(), bufferSize, endPointId, mUserID);
+        return encodeDoorLockClusterClearPinCommand(endPointId, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3658,9 +3630,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterClearRfidCommand(buffer->Start(), bufferSize, endPointId, mUserID);
+        return encodeDoorLockClusterClearRfidCommand(endPointId, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3694,9 +3666,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterClearWeekdayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID);
+        return encodeDoorLockClusterClearWeekdayScheduleCommand(endPointId, mScheduleID, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3731,9 +3703,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterClearYeardayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID);
+        return encodeDoorLockClusterClearYeardayScheduleCommand(endPointId, mScheduleID, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3767,9 +3739,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetHolidayScheduleCommand(buffer->Start(), bufferSize, endPointId, mHolidayScheduleID);
+        return encodeDoorLockClusterGetHolidayScheduleCommand(endPointId, mHolidayScheduleID);
     }
 
     // Global Response: DefaultResponse
@@ -3802,9 +3774,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetPinCommand(buffer->Start(), bufferSize, endPointId, mUserID);
+        return encodeDoorLockClusterGetPinCommand(endPointId, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3837,9 +3809,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetRfidCommand(buffer->Start(), bufferSize, endPointId, mUserID);
+        return encodeDoorLockClusterGetRfidCommand(endPointId, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3872,9 +3844,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetUserTypeCommand(buffer->Start(), bufferSize, endPointId, mUserID);
+        return encodeDoorLockClusterGetUserTypeCommand(endPointId, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3908,9 +3880,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetWeekdayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID);
+        return encodeDoorLockClusterGetWeekdayScheduleCommand(endPointId, mScheduleID, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3945,9 +3917,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterGetYeardayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID);
+        return encodeDoorLockClusterGetYeardayScheduleCommand(endPointId, mScheduleID, mUserID);
     }
 
     // Global Response: DefaultResponse
@@ -3981,9 +3953,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterLockDoorCommand(buffer->Start(), bufferSize, endPointId, mPINOrRFIDCode);
+        return encodeDoorLockClusterLockDoorCommand(endPointId, mPINOrRFIDCode);
     }
 
     // Global Response: DefaultResponse
@@ -4019,10 +3991,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetHolidayScheduleCommand(buffer->Start(), bufferSize, endPointId, mHolidayScheduleID,
-                                                              mLocalStartTime, mLocalEndTime, mOperatingModeDuringHoliday);
+        return encodeDoorLockClusterSetHolidayScheduleCommand(endPointId, mHolidayScheduleID, mLocalStartTime, mLocalEndTime,
+                                                              mOperatingModeDuringHoliday);
     }
 
     // Global Response: DefaultResponse
@@ -4061,9 +4033,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetPinCommand(buffer->Start(), bufferSize, endPointId, mUserID, mUserStatus, mUserType, mPIN);
+        return encodeDoorLockClusterSetPinCommand(endPointId, mUserID, mUserStatus, mUserType, mPIN);
     }
 
     // Global Response: DefaultResponse
@@ -4102,9 +4074,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetRfidCommand(buffer->Start(), bufferSize, endPointId, mUserID, mUserStatus, mUserType, mRFID);
+        return encodeDoorLockClusterSetRfidCommand(endPointId, mUserID, mUserStatus, mUserType, mRFID);
     }
 
     // Global Response: DefaultResponse
@@ -4141,9 +4113,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetUserTypeCommand(buffer->Start(), bufferSize, endPointId, mUserID, mUserType);
+        return encodeDoorLockClusterSetUserTypeCommand(endPointId, mUserID, mUserType);
     }
 
     // Global Response: DefaultResponse
@@ -4183,10 +4155,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetWeekdayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID,
-                                                              mDaysMask, mStartHour, mStartMinute, mEndHour, mEndMinute);
+        return encodeDoorLockClusterSetWeekdayScheduleCommand(endPointId, mScheduleID, mUserID, mDaysMask, mStartHour, mStartMinute,
+                                                              mEndHour, mEndMinute);
     }
 
     // Global Response: DefaultResponse
@@ -4228,10 +4200,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterSetYeardayScheduleCommand(buffer->Start(), bufferSize, endPointId, mScheduleID, mUserID,
-                                                              mLocalStartTime, mLocalEndTime);
+        return encodeDoorLockClusterSetYeardayScheduleCommand(endPointId, mScheduleID, mUserID, mLocalStartTime, mLocalEndTime);
     }
 
     // Global Response: DefaultResponse
@@ -4267,9 +4238,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterUnlockDoorCommand(buffer->Start(), bufferSize, endPointId, mPINOrRFIDCode);
+        return encodeDoorLockClusterUnlockDoorCommand(endPointId, mPINOrRFIDCode);
     }
 
     // Global Response: DefaultResponse
@@ -4303,10 +4274,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterUnlockWithTimeoutCommand(buffer->Start(), bufferSize, endPointId, mTimeoutInSeconds,
-                                                             mPINOrRFIDCode);
+        return encodeDoorLockClusterUnlockWithTimeoutCommand(endPointId, mTimeoutInSeconds, mPINOrRFIDCode);
     }
 
     // Global Response: DefaultResponse
@@ -4336,10 +4306,7 @@ class DiscoverDoorLockAttributes : public ModelCommand
 public:
     DiscoverDoorLockAttributes() : ModelCommand("discover", kDoorLockClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeDoorLockClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeDoorLockClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4361,9 +4328,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterReadLockStateAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeDoorLockClusterReadLockStateAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4385,9 +4352,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterReportLockStateAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval, mMaxInterval);
+        return encodeDoorLockClusterReportLockStateAttribute(endPointId, mMinInterval, mMaxInterval);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -4414,10 +4381,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeDoorLockClusterReadLockTypeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeDoorLockClusterReadLockTypeAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4439,9 +4403,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeDoorLockClusterReadActuatorEnabledAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeDoorLockClusterReadActuatorEnabledAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4606,9 +4570,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterAddGroupCommand(buffer->Start(), bufferSize, endPointId, mGroupId, mGroupName);
+        return encodeGroupsClusterAddGroupCommand(endPointId, mGroupId, mGroupName);
     }
 
     // Global Response: DefaultResponse
@@ -4643,9 +4607,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterAddGroupIfIdentifyingCommand(buffer->Start(), bufferSize, endPointId, mGroupId, mGroupName);
+        return encodeGroupsClusterAddGroupIfIdentifyingCommand(endPointId, mGroupId, mGroupName);
     }
 
     // Global Response: DefaultResponse
@@ -4675,9 +4639,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterGetGroupMembershipCommand(buffer->Start(), bufferSize, endPointId, mGroupCount, mGroupList);
+        return encodeGroupsClusterGetGroupMembershipCommand(endPointId, mGroupCount, mGroupList);
     }
 
     // Global Response: DefaultResponse
@@ -4707,10 +4671,7 @@ class GroupsRemoveAllGroups : public ModelCommand
 public:
     GroupsRemoveAllGroups() : ModelCommand("remove-all-groups", kGroupsClusterId, 0x04) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeGroupsClusterRemoveAllGroupsCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeGroupsClusterRemoveAllGroupsCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4732,9 +4693,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterRemoveGroupCommand(buffer->Start(), bufferSize, endPointId, mGroupId);
+        return encodeGroupsClusterRemoveGroupCommand(endPointId, mGroupId);
     }
 
     // Global Response: DefaultResponse
@@ -4767,9 +4728,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterViewGroupCommand(buffer->Start(), bufferSize, endPointId, mGroupId);
+        return encodeGroupsClusterViewGroupCommand(endPointId, mGroupId);
     }
 
     // Global Response: DefaultResponse
@@ -4798,10 +4759,7 @@ class DiscoverGroupsAttributes : public ModelCommand
 public:
     DiscoverGroupsAttributes() : ModelCommand("discover", kGroupsClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeGroupsClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeGroupsClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4823,9 +4781,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeGroupsClusterReadNameSupportAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeGroupsClusterReadNameSupportAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4860,10 +4818,7 @@ class DiscoverIasZoneAttributes : public ModelCommand
 public:
     DiscoverIasZoneAttributes() : ModelCommand("discover", kIasZoneClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIasZoneClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIasZoneClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4885,10 +4840,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIasZoneClusterReadZoneStateAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIasZoneClusterReadZoneStateAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4910,10 +4862,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIasZoneClusterReadZoneTypeAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIasZoneClusterReadZoneTypeAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -4935,9 +4884,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeIasZoneClusterReadZoneStatusAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeIasZoneClusterReadZoneStatusAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4960,9 +4909,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeIasZoneClusterReadIasCieAddressAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeIasZoneClusterReadIasCieAddressAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -4983,9 +4932,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeIasZoneClusterWriteIasCieAddressAttribute(buffer->Start(), bufferSize, endPointId, mIasCieAddress);
+        return encodeIasZoneClusterWriteIasCieAddressAttribute(endPointId, mIasCieAddress);
     }
 
     // Global Response: WriteAttributesResponse
@@ -5011,10 +4960,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIasZoneClusterReadZoneIdAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIasZoneClusterReadZoneIdAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5072,9 +5018,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeIdentifyClusterIdentifyCommand(buffer->Start(), bufferSize, endPointId, mIdentifyTime);
+        return encodeIdentifyClusterIdentifyCommand(endPointId, mIdentifyTime);
     }
 
     // Global Response: DefaultResponse
@@ -5096,10 +5042,7 @@ class IdentifyIdentifyQuery : public ModelCommand
 public:
     IdentifyIdentifyQuery() : ModelCommand("identify-query", kIdentifyClusterId, 0x01) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIdentifyClusterIdentifyQueryCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIdentifyClusterIdentifyQueryCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5124,10 +5067,7 @@ class DiscoverIdentifyAttributes : public ModelCommand
 public:
     DiscoverIdentifyAttributes() : ModelCommand("discover", kIdentifyClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeIdentifyClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeIdentifyClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5149,9 +5089,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeIdentifyClusterReadIdentifyTimeAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeIdentifyClusterReadIdentifyTimeAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -5197,10 +5137,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterMoveCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate, mOptionsMask,
-                                                    mOptionsOverride);
+        return encodeLevelControlClusterMoveCommand(endPointId, mMoveMode, mRate, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -5232,10 +5171,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterMoveToLevelCommand(buffer->Start(), bufferSize, endPointId, mLevel, mTransitionTime,
-                                                           mOptionsMask, mOptionsOverride);
+        return encodeLevelControlClusterMoveToLevelCommand(endPointId, mLevel, mTransitionTime, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -5265,10 +5203,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterMoveToLevelWithOnOffCommand(buffer->Start(), bufferSize, endPointId, mLevel,
-                                                                    mTransitionTime);
+        return encodeLevelControlClusterMoveToLevelWithOnOffCommand(endPointId, mLevel, mTransitionTime);
     }
 
     // Global Response: DefaultResponse
@@ -5296,9 +5233,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterMoveWithOnOffCommand(buffer->Start(), bufferSize, endPointId, mMoveMode, mRate);
+        return encodeLevelControlClusterMoveWithOnOffCommand(endPointId, mMoveMode, mRate);
     }
 
     // Global Response: DefaultResponse
@@ -5329,10 +5266,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterStepCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize, mTransitionTime,
-                                                    mOptionsMask, mOptionsOverride);
+        return encodeLevelControlClusterStepCommand(endPointId, mStepMode, mStepSize, mTransitionTime, mOptionsMask,
+                                                    mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -5364,10 +5301,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterStepWithOnOffCommand(buffer->Start(), bufferSize, endPointId, mStepMode, mStepSize,
-                                                             mTransitionTime);
+        return encodeLevelControlClusterStepWithOnOffCommand(endPointId, mStepMode, mStepSize, mTransitionTime);
     }
 
     // Global Response: DefaultResponse
@@ -5396,9 +5332,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterStopCommand(buffer->Start(), bufferSize, endPointId, mOptionsMask, mOptionsOverride);
+        return encodeLevelControlClusterStopCommand(endPointId, mOptionsMask, mOptionsOverride);
     }
 
     // Global Response: DefaultResponse
@@ -5421,9 +5357,9 @@ class LevelStopWithOnOff : public ModelCommand
 public:
     LevelStopWithOnOff() : ModelCommand("stop-with-on-off", kLevelClusterId, 0x07) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterStopWithOnOffCommand(buffer->Start(), bufferSize, endPointId);
+        return encodeLevelControlClusterStopWithOnOffCommand(endPointId);
     }
 
     // Global Response: DefaultResponse
@@ -5442,9 +5378,9 @@ class DiscoverLevelAttributes : public ModelCommand
 public:
     DiscoverLevelAttributes() : ModelCommand("discover", kLevelClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+        return encodeLevelControlClusterDiscoverAttributes(endPointId);
     }
 
     // Global Response: DiscoverAttributesResponse
@@ -5467,9 +5403,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterReadCurrentLevelAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeLevelControlClusterReadCurrentLevelAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -5492,10 +5428,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeLevelControlClusterReportCurrentLevelAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval,
-                                                                    mMaxInterval, mChange);
+        return encodeLevelControlClusterReportCurrentLevelAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -5534,10 +5469,7 @@ class OnOffOff : public ModelCommand
 public:
     OnOffOff() : ModelCommand("off", kOnOffClusterId, 0x00) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeOnOffClusterOffCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeOnOffClusterOffCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5555,10 +5487,7 @@ class OnOffOn : public ModelCommand
 public:
     OnOffOn() : ModelCommand("on", kOnOffClusterId, 0x01) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeOnOffClusterOnCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeOnOffClusterOnCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5576,10 +5505,7 @@ class OnOffToggle : public ModelCommand
 public:
     OnOffToggle() : ModelCommand("toggle", kOnOffClusterId, 0x02) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeOnOffClusterToggleCommand(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeOnOffClusterToggleCommand(endPointId); }
 
     // Global Response: DefaultResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5597,10 +5523,7 @@ class DiscoverOnOffAttributes : public ModelCommand
 public:
     DiscoverOnOffAttributes() : ModelCommand("discover", kOnOffClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeOnOffClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeOnOffClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5622,10 +5545,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeOnOffClusterReadOnOffAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeOnOffClusterReadOnOffAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -5646,9 +5566,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeOnOffClusterReportOnOffAttribute(buffer->Start(), bufferSize, endPointId, mMinInterval, mMaxInterval);
+        return encodeOnOffClusterReportOnOffAttribute(endPointId, mMinInterval, mMaxInterval);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -5924,10 +5844,10 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterAddSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID, mTransitionTime,
-                                                  mSceneName, mClusterId, mLength, mValue);
+        return encodeScenesClusterAddSceneCommand(endPointId, mGroupID, mSceneID, mTransitionTime, mSceneName, mClusterId, mLength,
+                                                  mValue);
     }
 
     // Global Response: DefaultResponse
@@ -5966,9 +5886,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterGetSceneMembershipCommand(buffer->Start(), bufferSize, endPointId, mGroupID);
+        return encodeScenesClusterGetSceneMembershipCommand(endPointId, mGroupID);
     }
 
     // Global Response: DefaultResponse
@@ -6003,9 +5923,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterRecallSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID, mTransitionTime);
+        return encodeScenesClusterRecallSceneCommand(endPointId, mGroupID, mSceneID, mTransitionTime);
     }
 
     // Global Response: DefaultResponse
@@ -6033,9 +5953,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterRemoveAllScenesCommand(buffer->Start(), bufferSize, endPointId, mGroupID);
+        return encodeScenesClusterRemoveAllScenesCommand(endPointId, mGroupID);
     }
 
     // Global Response: DefaultResponse
@@ -6069,9 +5989,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterRemoveSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID);
+        return encodeScenesClusterRemoveSceneCommand(endPointId, mGroupID, mSceneID);
     }
 
     // Global Response: DefaultResponse
@@ -6106,9 +6026,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterStoreSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID);
+        return encodeScenesClusterStoreSceneCommand(endPointId, mGroupID, mSceneID);
     }
 
     // Global Response: DefaultResponse
@@ -6143,9 +6063,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterViewSceneCommand(buffer->Start(), bufferSize, endPointId, mGroupID, mSceneID);
+        return encodeScenesClusterViewSceneCommand(endPointId, mGroupID, mSceneID);
     }
 
     // Global Response: DefaultResponse
@@ -6175,10 +6095,7 @@ class DiscoverScenesAttributes : public ModelCommand
 public:
     DiscoverScenesAttributes() : ModelCommand("discover", kScenesClusterId, 0x0c) { ModelCommand::AddArguments(); }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeScenesClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeScenesClusterDiscoverAttributes(endPointId); }
 
     // Global Response: DiscoverAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -6200,10 +6117,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeScenesClusterReadSceneCountAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeScenesClusterReadSceneCountAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -6225,9 +6139,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterReadCurrentSceneAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeScenesClusterReadCurrentSceneAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -6250,9 +6164,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterReadCurrentGroupAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeScenesClusterReadCurrentGroupAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -6275,10 +6189,7 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
-    {
-        return encodeScenesClusterReadSceneValidAttribute(buffer->Start(), bufferSize, endPointId);
-    }
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override { return encodeScenesClusterReadSceneValidAttribute(endPointId); }
 
     // Global Response: ReadAttributesResponse
     bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const override
@@ -6300,9 +6211,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeScenesClusterReadNameSupportAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeScenesClusterReadNameSupportAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -6338,9 +6249,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeTemperatureMeasurementClusterDiscoverAttributes(buffer->Start(), bufferSize, endPointId);
+        return encodeTemperatureMeasurementClusterDiscoverAttributes(endPointId);
     }
 
     // Global Response: DiscoverAttributesResponse
@@ -6363,9 +6274,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -6388,10 +6299,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(buffer->Start(), bufferSize, endPointId,
-                                                                               mMinInterval, mMaxInterval, mChange);
+        return encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(endPointId, mMinInterval, mMaxInterval, mChange);
     }
 
     // Global Response: ConfigureReportingResponse
@@ -6419,9 +6329,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse
@@ -6444,9 +6354,9 @@ public:
         ModelCommand::AddArguments();
     }
 
-    uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) override
+    PacketBufferHandle EncodeCommand(uint8_t endPointId) override
     {
-        return encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(buffer->Start(), bufferSize, endPointId);
+        return encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(endPointId);
     }
 
     // Global Response: ReadAttributesResponse

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -21,8 +21,6 @@
 using namespace ::chip;
 
 namespace {
-// Make sure our buffer is big enough, but this will need a better setup!
-constexpr uint16_t kMaxBufferSize                            = 1024;
 constexpr uint16_t kWaitDurationInSeconds                    = 10;
 constexpr uint8_t kZCLGlobalCmdFrameControlHeader            = 8;
 constexpr uint8_t kZCLClusterCmdFrameControlHeader           = 9;
@@ -85,19 +83,12 @@ exit:
 
 CHIP_ERROR ModelCommand::RunCommandInternal(ChipDevice * device)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    uint16_t payloadLen = 0;
-
-    PacketBufferHandle buffer = PacketBuffer::NewWithAvailableSize(kMaxBufferSize);
-    VerifyOrExit(!buffer.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-
+    CHIP_ERROR err = CHIP_NO_ERROR;
     ChipLogProgress(chipTool, "Endpoint id: '0x%02x', Cluster id: '0x%04x', Command id: '0x%02x'", mEndPointId, mClusterId,
                     mCommandId);
 
-    payloadLen = EncodeCommand(buffer, kMaxBufferSize, mEndPointId);
-    VerifyOrExit(payloadLen != 0, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-
-    buffer->SetDataLength(payloadLen);
+    PacketBufferHandle buffer = EncodeCommand(mEndPointId);
+    VerifyOrExit(!buffer.IsNull(), err = CHIP_ERROR_INTERNAL);
 
 #ifdef DEBUG
     PrintBuffer(buffer);

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -44,7 +44,7 @@ public:
     void OnMessage(PacketBufferHandle buffer) override;
     void OnStatusChange(void) override;
 
-    virtual uint16_t EncodeCommand(const PacketBufferHandle & buffer, uint16_t bufferSize, uint8_t endPointId) = 0;
+    virtual PacketBufferHandle EncodeCommand(uint8_t endPointId) = 0;
     virtual bool HandleGlobalResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const { return false; }
     virtual bool HandleSpecificResponse(uint8_t commandId, uint8_t * message, uint16_t messageLen) const { return false; }
 

--- a/src/app/chip-zcl-zpro-codec-api.h
+++ b/src/app/chip-zcl-zpro-codec-api.h
@@ -21,10 +21,7 @@
 
 #include <app/util/basic-types.h>
 #include <stdint.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <system/SystemPacketBuffer.h>
 
 /*----------------------------------------------------------------------------*\
 | Cluster Name                                                        |   ID   |
@@ -61,57 +58,50 @@ extern "C" {
  * @brief
  *    Encode an BarrierControlGoToPercent command for Barrier Control server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterBarrierControlGoToPercentCommand(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint, uint8_t percentOpen);
+chip::System::PacketBufferHandle encodeBarrierControlClusterBarrierControlGoToPercentCommand(chip::EndpointId destinationEndpoint,
+                                                                                             uint8_t percentOpen);
 
 /**
  * @brief
  *    Encode an BarrierControlStop command for Barrier Control server into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterBarrierControlStopCommand(uint8_t * buffer, uint16_t buf_length,
-                                                              chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterBarrierControlStopCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server discover command into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length,
-                                                       chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server read command for the barrier moving state attribute into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadBarrierMovingStateAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterReadBarrierMovingStateAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server read command for the barrier safety status attribute into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server read command for the barrier capabilities attribute into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server read command for the barrier position attribute into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadBarrierPositionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterReadBarrierPositionAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Barrier Control server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeBarrierControlClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBarrierControlClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Basic                                                       | 0x0000 |
@@ -130,39 +120,37 @@ uint16_t encodeBarrierControlClusterReadClusterRevisionAttribute(uint8_t * buffe
  * @brief
  *    Encode an MfgSpecificPing command for Basic server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterMfgSpecificPingCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterMfgSpecificPingCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an ResetToFactoryDefaults command for Basic server into buffer including the APS frame
  */
-uint16_t encodeBasicClusterResetToFactoryDefaultsCommand(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterResetToFactoryDefaultsCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Basic server discover command into buffer including the APS frame
  */
-uint16_t encodeBasicClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Basic server read command for the ZCL version attribute into buffer including the APS frame
  */
-uint16_t encodeBasicClusterReadZclVersionAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterReadZclVersionAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Basic server read command for the power source attribute into buffer including the APS frame
  */
-uint16_t encodeBasicClusterReadPowerSourceAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterReadPowerSourceAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Basic server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeBasicClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeBasicClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster ColorControl                                                | 0x0300 |
@@ -241,618 +229,564 @@ uint16_t encodeBasicClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16
  * @brief
  *    Encode an MoveColor command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                   int16_t rateX, int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveColorCommand(chip::EndpointId destinationEndpoint, int16_t rateX,
+                                                                           int16_t rateY, uint8_t optionsMask,
+                                                                           uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveColorTemperature command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
-                                                              chip::EndpointId destination_endpoint, uint8_t moveMode,
-                                                              uint16_t rate, uint16_t colorTemperatureMinimum,
-                                                              uint16_t colorTemperatureMaximum, uint8_t optionsMask,
-                                                              uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveColorTemperatureCommand(chip::EndpointId destinationEndpoint,
+                                                                                      uint8_t moveMode, uint16_t rate,
+                                                                                      uint16_t colorTemperatureMinimum,
+                                                                                      uint16_t colorTemperatureMaximum,
+                                                                                      uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveHue command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                 uint8_t moveMode, uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveHueCommand(chip::EndpointId destinationEndpoint, uint8_t moveMode,
+                                                                         uint8_t rate, uint8_t optionsMask,
+                                                                         uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveSaturation command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveSaturationCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t moveMode, uint8_t rate,
-                                                        uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveSaturationCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
+                                                                                uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveToColor command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                     uint16_t colorX, uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
-                                                     uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveToColorCommand(chip::EndpointId destinationEndpoint, uint16_t colorX,
+                                                                             uint16_t colorY, uint16_t transitionTime,
+                                                                             uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveToColorTemperature command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
-                                                                chip::EndpointId destination_endpoint, uint16_t colorTemperature,
-                                                                uint16_t transitionTime, uint8_t optionsMask,
-                                                                uint8_t optionsOverride);
+chip::System::PacketBufferHandle
+encodeColorControlClusterMoveToColorTemperatureCommand(chip::EndpointId destinationEndpoint, uint16_t colorTemperature,
+                                                       uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveToHue command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                   uint8_t hue, uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
-                                                   uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveToHueCommand(chip::EndpointId destinationEndpoint, uint8_t hue,
+                                                                           uint8_t direction, uint16_t transitionTime,
+                                                                           uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveToHueAndSaturation command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToHueAndSaturationCommand(uint8_t * buffer, uint16_t buf_length,
-                                                                chip::EndpointId destination_endpoint, uint8_t hue,
-                                                                uint8_t saturation, uint16_t transitionTime, uint8_t optionsMask,
-                                                                uint8_t optionsOverride);
+chip::System::PacketBufferHandle
+encodeColorControlClusterMoveToHueAndSaturationCommand(chip::EndpointId destinationEndpoint, uint8_t hue, uint8_t saturation,
+                                                       uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an MoveToSaturation command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterMoveToSaturationCommand(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint8_t saturation,
-                                                          uint16_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterMoveToSaturationCommand(chip::EndpointId destinationEndpoint,
+                                                                                  uint8_t saturation, uint16_t transitionTime,
+                                                                                  uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an StepColor command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepColorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                   int16_t stepX, int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
-                                                   uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterStepColorCommand(chip::EndpointId destinationEndpoint, int16_t stepX,
+                                                                           int16_t stepY, uint16_t transitionTime,
+                                                                           uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an StepColorTemperature command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepColorTemperatureCommand(uint8_t * buffer, uint16_t buf_length,
-                                                              chip::EndpointId destination_endpoint, uint8_t stepMode,
-                                                              uint16_t stepSize, uint16_t transitionTime,
-                                                              uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum,
-                                                              uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterStepColorTemperatureCommand(
+    chip::EndpointId destinationEndpoint, uint8_t stepMode, uint16_t stepSize, uint16_t transitionTime,
+    uint16_t colorTemperatureMinimum, uint16_t colorTemperatureMaximum, uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an StepHue command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepHueCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                 uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
-                                                 uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterStepHueCommand(chip::EndpointId destinationEndpoint, uint8_t stepMode,
+                                                                         uint8_t stepSize, uint8_t transitionTime,
+                                                                         uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an StepSaturation command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStepSaturationCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t stepMode, uint8_t stepSize,
-                                                        uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterStepSaturationCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t stepMode, uint8_t stepSize,
+                                                                                uint8_t transitionTime, uint8_t optionsMask,
+                                                                                uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode an StopMoveStep command for Color Control server into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterStopMoveStepCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                      uint8_t optionsMask, uint8_t optionsOverride);
+chip::System::PacketBufferHandle encodeColorControlClusterStopMoveStepCommand(chip::EndpointId destinationEndpoint,
+                                                                              uint8_t optionsMask, uint8_t optionsOverride);
 
 /**
  * @brief
  *    Encode a Color Control server discover command into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the current hue attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadCurrentHueAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server report command for the current hue attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                            uint16_t max_interval, uint8_t change);
+chip::System::PacketBufferHandle encodeColorControlClusterReportCurrentHueAttribute(chip::EndpointId destinationEndpoint,
+                                                                                    uint16_t minInterval, uint16_t maxInterval,
+                                                                                    uint8_t change);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the current saturation attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadCurrentSaturationAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server report command for the current saturation attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentSaturationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                                   uint16_t max_interval, uint8_t change);
+chip::System::PacketBufferHandle encodeColorControlClusterReportCurrentSaturationAttribute(chip::EndpointId destinationEndpoint,
+                                                                                           uint16_t minInterval,
+                                                                                           uint16_t maxInterval, uint8_t change);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the remaining time attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadRemainingTimeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadRemainingTimeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the current x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadCurrentXAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server report command for the current x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                          uint16_t max_interval, uint16_t change);
+chip::System::PacketBufferHandle encodeColorControlClusterReportCurrentXAttribute(chip::EndpointId destinationEndpoint,
+                                                                                  uint16_t minInterval, uint16_t maxInterval,
+                                                                                  uint16_t change);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the current y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCurrentYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadCurrentYAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server report command for the current y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportCurrentYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                          uint16_t max_interval, uint16_t change);
+chip::System::PacketBufferHandle encodeColorControlClusterReportCurrentYAttribute(chip::EndpointId destinationEndpoint,
+                                                                                  uint16_t minInterval, uint16_t maxInterval,
+                                                                                  uint16_t change);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the drift compensation attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadDriftCompensationAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadDriftCompensationAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the compensation text attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadCompensationTextAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadCompensationTextAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color temperature attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorTemperatureAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorTemperatureAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server report command for the color temperature attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReportColorTemperatureAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                                  uint16_t max_interval, uint16_t change);
+chip::System::PacketBufferHandle encodeColorControlClusterReportColorTemperatureAttribute(chip::EndpointId destinationEndpoint,
+                                                                                          uint16_t minInterval,
+                                                                                          uint16_t maxInterval, uint16_t change);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color mode attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorModeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorModeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color control options attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorControlOptionsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                   chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorControlOptionsAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color control options attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorControlOptionsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint,
-                                                                    uint8_t colorControlOptions);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorControlOptionsAttribute(chip::EndpointId destinationEndpoint,
+                                                                                            uint8_t colorControlOptions);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the number of primaries attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadNumberOfPrimariesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadNumberOfPrimariesAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 1 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary1XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary1XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 1 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary1YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary1YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 1 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary1IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary1IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 2 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary2XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary2XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 2 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary2YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary2YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 2 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary2IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary2IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 3 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary3XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary3XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 3 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary3YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary3YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 3 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary3IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary3IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 4 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary4XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary4XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 4 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary4YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary4YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 4 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary4IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary4IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 5 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary5XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary5XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 5 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary5YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary5YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 5 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary5IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary5IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 6 x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary6XAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary6XAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 6 y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary6YAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary6YAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the primary 6 intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadPrimary6IntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadPrimary6IntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the white point x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadWhitePointXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                           chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadWhitePointXAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the white point x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteWhitePointXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint, uint16_t whitePointX);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteWhitePointXAttribute(chip::EndpointId destinationEndpoint,
+                                                                                    uint16_t whitePointX);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the white point y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadWhitePointYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                           chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadWhitePointYAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the white point y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteWhitePointYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint, uint16_t whitePointY);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteWhitePointYAttribute(chip::EndpointId destinationEndpoint,
+                                                                                    uint16_t whitePointY);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point r x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointRXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointRXAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point r x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointRXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointRX);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointRXAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointRX);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point r y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointRYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointRYAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point r y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointRYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointRY);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointRYAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointRY);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point r intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointRIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointRIntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point r intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointRIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint,
-                                                                     uint8_t colorPointRIntensity);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointRIntensityAttribute(chip::EndpointId destinationEndpoint,
+                                                                                             uint8_t colorPointRIntensity);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point g x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointGXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointGXAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point g x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointGXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointGX);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointGXAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointGX);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point g y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointGYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointGYAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point g y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointGYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointGY);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointGYAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointGY);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point g intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointGIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointGIntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point g intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointGIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint,
-                                                                     uint8_t colorPointGIntensity);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointGIntensityAttribute(chip::EndpointId destinationEndpoint,
+                                                                                             uint8_t colorPointGIntensity);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point b x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointBXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointBXAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point b x attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointBXAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointBX);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointBXAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointBX);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point b y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointBYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointBYAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point b y attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointBYAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint, uint16_t colorPointBY);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointBYAttribute(chip::EndpointId destinationEndpoint,
+                                                                                     uint16_t colorPointBY);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color point b intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorPointBIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorPointBIntensityAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the color point b intensity attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterWriteColorPointBIntensityAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                     chip::EndpointId destination_endpoint,
-                                                                     uint8_t colorPointBIntensity);
+chip::System::PacketBufferHandle encodeColorControlClusterWriteColorPointBIntensityAttribute(chip::EndpointId destinationEndpoint,
+                                                                                             uint8_t colorPointBIntensity);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the enhanced current hue attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadEnhancedCurrentHueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadEnhancedCurrentHueAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the enhanced color mode attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadEnhancedColorModeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadEnhancedColorModeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color loop active attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorLoopActiveAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                               chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorLoopActiveAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color loop direction attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorLoopDirectionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                  chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorLoopDirectionAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color loop time attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorLoopTimeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                             chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorLoopTimeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color capabilities attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorCapabilitiesAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                 chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorCapabilitiesAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color temp physical min attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorTempPhysicalMinAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorTempPhysicalMinAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the color temp physical max attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadColorTempPhysicalMaxAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                    chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadColorTempPhysicalMaxAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the couple color temp to level min-mireds attribute into buffer including the
  * APS frame
  */
-uint16_t encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                               chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle
+encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the start up color temperature mireds attribute into buffer including the APS
  * frame
  */
-uint16_t encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                             chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle
+encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Color Control server write command for the start up color temperature mireds attribute into buffer including the APS
  * frame
  */
-uint16_t encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                              chip::EndpointId destination_endpoint,
-                                                                              uint16_t startUpColorTemperatureMireds);
+chip::System::PacketBufferHandle
+encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(chip::EndpointId destinationEndpoint,
+                                                                     uint16_t startUpColorTemperatureMireds);
 
 /**
  * @brief
  *    Encode a Color Control server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeColorControlClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                               chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeColorControlClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster DoorLock                                                    | 0x0101 |
@@ -893,206 +827,195 @@ uint16_t encodeColorControlClusterReadClusterRevisionAttribute(uint8_t * buffer,
  * @brief
  *    Encode an ClearAllPins command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearAllPinsCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearAllPinsCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an ClearAllRfids command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearAllRfidsCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearAllRfidsCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an ClearHolidaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint8_t scheduleId);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearHolidayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                  uint8_t scheduleId);
 
 /**
  * @brief
  *    Encode an ClearPin command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearPinCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearPinCommand(chip::EndpointId destinationEndpoint, uint16_t userId);
 
 /**
  * @brief
  *    Encode an ClearRfid command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearRfidCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                               uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearRfidCommand(chip::EndpointId destinationEndpoint, uint16_t userId);
 
 /**
  * @brief
  *    Encode an ClearWeekdaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint8_t scheduleId,
-                                                          uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearWeekdayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                  uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief
  *    Encode an ClearYeardaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterClearYeardayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint, uint8_t scheduleId,
-                                                          uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterClearYeardayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                  uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief
  *    Encode an GetHolidaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetHolidayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId);
 
 /**
  * @brief
  *    Encode an GetLogRecord command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetLogRecordCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                  uint16_t logIndex);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetLogRecordCommand(chip::EndpointId destinationEndpoint, uint16_t logIndex);
 
 /**
  * @brief
  *    Encode an GetPin command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetPinCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                            uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetPinCommand(chip::EndpointId destinationEndpoint, uint16_t userId);
 
 /**
  * @brief
  *    Encode an GetRfid command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetRfidCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                             uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetRfidCommand(chip::EndpointId destinationEndpoint, uint16_t userId);
 
 /**
  * @brief
  *    Encode an GetUserType command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                 uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetUserTypeCommand(chip::EndpointId destinationEndpoint, uint16_t userId);
 
 /**
  * @brief
  *    Encode an GetWeekdaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId, uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetWeekdayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief
  *    Encode an GetYeardaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterGetYeardayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId, uint16_t userId);
+chip::System::PacketBufferHandle encodeDoorLockClusterGetYeardayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief
  *    Encode an LockDoor command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterLockDoorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              char * pin);
+chip::System::PacketBufferHandle encodeDoorLockClusterLockDoorCommand(chip::EndpointId destinationEndpoint, char * pin);
 
 /**
  * @brief
  *    Encode an SetHolidaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetHolidayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId,
-                                                        uint32_t localStartTime, uint32_t localEndTime,
-                                                        uint8_t operatingModeDuringHoliday);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetHolidayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId, uint32_t localStartTime,
+                                                                                uint32_t localEndTime,
+                                                                                uint8_t operatingModeDuringHoliday);
 
 /**
  * @brief
  *    Encode an SetPin command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetPinCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                            uint16_t userId, uint8_t userStatus, uint8_t userType, char * pin);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetPinCommand(chip::EndpointId destinationEndpoint, uint16_t userId,
+                                                                    uint8_t userStatus, uint8_t userType, char * pin);
 
 /**
  * @brief
  *    Encode an SetRfid command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetRfidCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                             uint16_t userId, uint8_t userStatus, uint8_t userType, char * id);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetRfidCommand(chip::EndpointId destinationEndpoint, uint16_t userId,
+                                                                     uint8_t userStatus, uint8_t userType, char * id);
 
 /**
  * @brief
  *    Encode an SetUserType command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetUserTypeCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                 uint16_t userId, uint8_t userType);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetUserTypeCommand(chip::EndpointId destinationEndpoint, uint16_t userId,
+                                                                         uint8_t userType);
 
 /**
  * @brief
  *    Encode an SetWeekdaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetWeekdayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId, uint16_t userId,
-                                                        uint8_t daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour,
-                                                        uint8_t endMinute);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetWeekdayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId, uint16_t userId,
+                                                                                uint8_t daysMask, uint8_t startHour,
+                                                                                uint8_t startMinute, uint8_t endHour,
+                                                                                uint8_t endMinute);
 
 /**
  * @brief
  *    Encode an SetYeardaySchedule command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterSetYeardayScheduleCommand(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint, uint8_t scheduleId, uint16_t userId,
-                                                        uint32_t localStartTime, uint32_t localEndTime);
+chip::System::PacketBufferHandle encodeDoorLockClusterSetYeardayScheduleCommand(chip::EndpointId destinationEndpoint,
+                                                                                uint8_t scheduleId, uint16_t userId,
+                                                                                uint32_t localStartTime, uint32_t localEndTime);
 
 /**
  * @brief
  *    Encode an UnlockDoor command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterUnlockDoorCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                char * pin);
+chip::System::PacketBufferHandle encodeDoorLockClusterUnlockDoorCommand(chip::EndpointId destinationEndpoint, char * pin);
 
 /**
  * @brief
  *    Encode an UnlockWithTimeout command for Door Lock server into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterUnlockWithTimeoutCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                       uint16_t timeoutInSeconds, char * pin);
+chip::System::PacketBufferHandle encodeDoorLockClusterUnlockWithTimeoutCommand(chip::EndpointId destinationEndpoint,
+                                                                               uint16_t timeoutInSeconds, char * pin);
 
 /**
  * @brief
  *    Encode a Door Lock server discover command into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Door Lock server read command for the lock state attribute into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadLockStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterReadLockStateAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Door Lock server report command for the lock state attribute into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReportLockStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                       uint16_t min_interval, uint16_t max_interval);
+chip::System::PacketBufferHandle encodeDoorLockClusterReportLockStateAttribute(chip::EndpointId destinationEndpoint,
+                                                                               uint16_t minInterval, uint16_t maxInterval);
 
 /**
  * @brief
  *    Encode a Door Lock server read command for the lock type attribute into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadLockTypeAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterReadLockTypeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Door Lock server read command for the actuator enabled attribute into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadActuatorEnabledAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                           chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterReadActuatorEnabledAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Door Lock server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeDoorLockClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                           chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeDoorLockClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Groups                                                      | 0x0004 |
@@ -1114,61 +1037,58 @@ uint16_t encodeDoorLockClusterReadClusterRevisionAttribute(uint8_t * buffer, uin
  * @brief
  *    Encode an AddGroup command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterAddGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                            uint16_t groupId, char * groupName);
+chip::System::PacketBufferHandle encodeGroupsClusterAddGroupCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                    char * groupName);
 
 /**
  * @brief
  *    Encode an AddGroupIfIdentifying command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterAddGroupIfIdentifyingCommand(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint, uint16_t groupId, char * groupName);
+chip::System::PacketBufferHandle encodeGroupsClusterAddGroupIfIdentifyingCommand(chip::EndpointId destinationEndpoint,
+                                                                                 uint16_t groupId, char * groupName);
 
 /**
  * @brief
  *    Encode an GetGroupMembership command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterGetGroupMembershipCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                      uint8_t groupCount, uint16_t groupList);
+chip::System::PacketBufferHandle encodeGroupsClusterGetGroupMembershipCommand(chip::EndpointId destinationEndpoint,
+                                                                              uint8_t groupCount, uint16_t groupList);
 
 /**
  * @brief
  *    Encode an RemoveAllGroups command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterRemoveAllGroupsCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeGroupsClusterRemoveAllGroupsCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an RemoveGroup command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterRemoveGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                               uint16_t groupId);
+chip::System::PacketBufferHandle encodeGroupsClusterRemoveGroupCommand(chip::EndpointId destinationEndpoint, uint16_t groupId);
 
 /**
  * @brief
  *    Encode an ViewGroup command for Groups server into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterViewGroupCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                             uint16_t groupId);
+chip::System::PacketBufferHandle encodeGroupsClusterViewGroupCommand(chip::EndpointId destinationEndpoint, uint16_t groupId);
 
 /**
  * @brief
  *    Encode a Groups server discover command into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeGroupsClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Groups server read command for the name support attribute into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeGroupsClusterReadNameSupportAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Groups server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeGroupsClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeGroupsClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster IasZone                                                     | 0x0500 |
@@ -1188,52 +1108,50 @@ uint16_t encodeGroupsClusterReadClusterRevisionAttribute(uint8_t * buffer, uint1
  * @brief
  *    Encode a IAS Zone server discover command into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the zone state attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadZoneStateAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadZoneStateAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the zone type attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadZoneTypeAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadZoneTypeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the zone status attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadZoneStatusAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadZoneStatusAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the IAS CIE address attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadIasCieAddressAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadIasCieAddressAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server write command for the IAS CIE address attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterWriteIasCieAddressAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint, uint64_t iasCieAddress);
+chip::System::PacketBufferHandle encodeIasZoneClusterWriteIasCieAddressAttribute(chip::EndpointId destinationEndpoint,
+                                                                                 uint64_t iasCieAddress);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the Zone ID attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadZoneIdAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadZoneIdAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a IAS Zone server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeIasZoneClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                          chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIasZoneClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Identify                                                    | 0x0003 |
@@ -1251,41 +1169,38 @@ uint16_t encodeIasZoneClusterReadClusterRevisionAttribute(uint8_t * buffer, uint
  * @brief
  *    Encode an Identify command for Identify server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterIdentifyCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint16_t identifyTime);
+chip::System::PacketBufferHandle encodeIdentifyClusterIdentifyCommand(chip::EndpointId destinationEndpoint, uint16_t identifyTime);
 
 /**
  * @brief
  *    Encode an IdentifyQuery command for Identify server into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterIdentifyQueryCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIdentifyClusterIdentifyQueryCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Identify server discover command into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIdentifyClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Identify server read command for the identify time attribute into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterReadIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIdentifyClusterReadIdentifyTimeAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Identify server write command for the identify time attribute into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterWriteIdentifyTimeAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint, uint16_t identifyTime);
+chip::System::PacketBufferHandle encodeIdentifyClusterWriteIdentifyTimeAttribute(chip::EndpointId destinationEndpoint,
+                                                                                 uint16_t identifyTime);
 
 /**
  * @brief
  *    Encode a Identify server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeIdentifyClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                           chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeIdentifyClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster LevelControl                                                | 0x0008 |
@@ -1309,88 +1224,85 @@ uint16_t encodeIdentifyClusterReadClusterRevisionAttribute(uint8_t * buffer, uin
  * @brief
  *    Encode an Move command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterMoveCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint8_t moveMode, uint8_t rate, uint8_t optionMask, uint8_t optionOverride);
+chip::System::PacketBufferHandle encodeLevelControlClusterMoveCommand(chip::EndpointId destinationEndpoint, uint8_t moveMode,
+                                                                      uint8_t rate, uint8_t optionMask, uint8_t optionOverride);
 
 /**
  * @brief
  *    Encode an MoveToLevel command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterMoveToLevelCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                     uint8_t level, uint16_t transitionTime, uint8_t optionMask,
-                                                     uint8_t optionOverride);
+chip::System::PacketBufferHandle encodeLevelControlClusterMoveToLevelCommand(chip::EndpointId destinationEndpoint, uint8_t level,
+                                                                             uint16_t transitionTime, uint8_t optionMask,
+                                                                             uint8_t optionOverride);
 
 /**
  * @brief
  *    Encode an MoveToLevelWithOnOff command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterMoveToLevelWithOnOffCommand(uint8_t * buffer, uint16_t buf_length,
-                                                              chip::EndpointId destination_endpoint, uint8_t level,
-                                                              uint16_t transitionTime);
+chip::System::PacketBufferHandle encodeLevelControlClusterMoveToLevelWithOnOffCommand(chip::EndpointId destinationEndpoint,
+                                                                                      uint8_t level, uint16_t transitionTime);
 
 /**
  * @brief
  *    Encode an MoveWithOnOff command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterMoveWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                       uint8_t moveMode, uint8_t rate);
+chip::System::PacketBufferHandle encodeLevelControlClusterMoveWithOnOffCommand(chip::EndpointId destinationEndpoint,
+                                                                               uint8_t moveMode, uint8_t rate);
 
 /**
  * @brief
  *    Encode an Step command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterStepCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime, uint8_t optionMask,
-                                              uint8_t optionOverride);
+chip::System::PacketBufferHandle encodeLevelControlClusterStepCommand(chip::EndpointId destinationEndpoint, uint8_t stepMode,
+                                                                      uint8_t stepSize, uint16_t transitionTime, uint8_t optionMask,
+                                                                      uint8_t optionOverride);
 
 /**
  * @brief
  *    Encode an StepWithOnOff command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterStepWithOnOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                       uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime);
+chip::System::PacketBufferHandle encodeLevelControlClusterStepWithOnOffCommand(chip::EndpointId destinationEndpoint,
+                                                                               uint8_t stepMode, uint8_t stepSize,
+                                                                               uint16_t transitionTime);
 
 /**
  * @brief
  *    Encode an Stop command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterStopCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint8_t optionMask, uint8_t optionOverride);
+chip::System::PacketBufferHandle encodeLevelControlClusterStopCommand(chip::EndpointId destinationEndpoint, uint8_t optionMask,
+                                                                      uint8_t optionOverride);
 
 /**
  * @brief
  *    Encode an StopWithOnOff command for Level Control server into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterStopWithOnOffCommand(uint8_t * buffer, uint16_t buf_length,
-                                                       chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeLevelControlClusterStopWithOnOffCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Level Control server discover command into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeLevelControlClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Level Control server read command for the current level attribute into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterReadCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                            chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeLevelControlClusterReadCurrentLevelAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Level Control server report command for the current level attribute into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterReportCurrentLevelAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                              chip::EndpointId destination_endpoint, uint16_t min_interval,
-                                                              uint16_t max_interval, uint8_t change);
+chip::System::PacketBufferHandle encodeLevelControlClusterReportCurrentLevelAttribute(chip::EndpointId destinationEndpoint,
+                                                                                      uint16_t minInterval, uint16_t maxInterval,
+                                                                                      uint8_t change);
 
 /**
  * @brief
  *    Encode a Level Control server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeLevelControlClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                               chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeLevelControlClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster OnOff                                                       | 0x0006 |
@@ -1409,45 +1321,44 @@ uint16_t encodeLevelControlClusterReadClusterRevisionAttribute(uint8_t * buffer,
  * @brief
  *    Encode an Off command for On/off server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterOffCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterOffCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an On command for On/off server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterOnCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterOnCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode an Toggle command for On/off server into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterToggleCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterToggleCommand(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a On/off server discover command into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a On/off server read command for the on/off attribute into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterReadOnOffAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterReadOnOffAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a On/off server report command for the on/off attribute into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterReportOnOffAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                uint16_t min_interval, uint16_t max_interval);
+chip::System::PacketBufferHandle encodeOnOffClusterReportOnOffAttribute(chip::EndpointId destinationEndpoint, uint16_t minInterval,
+                                                                        uint16_t maxInterval);
 
 /**
  * @brief
  *    Encode a On/off server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeOnOffClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                        chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeOnOffClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster Scenes                                                      | 0x0005 |
@@ -1474,94 +1385,92 @@ uint16_t encodeOnOffClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16
  * @brief
  *    Encode an AddScene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterAddSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                            uint16_t groupId, uint8_t sceneId, uint16_t transitionTime, char * sceneName,
-                                            chip::ClusterId clusterId, uint8_t length, uint8_t value);
+chip::System::PacketBufferHandle encodeScenesClusterAddSceneCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                    uint8_t sceneId, uint16_t transitionTime, char * sceneName,
+                                                                    chip::ClusterId clusterId, uint8_t length, uint8_t value);
 
 /**
  * @brief
  *    Encode an GetSceneMembership command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterGetSceneMembershipCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                      uint16_t groupId);
+chip::System::PacketBufferHandle encodeScenesClusterGetSceneMembershipCommand(chip::EndpointId destinationEndpoint,
+                                                                              uint16_t groupId);
 
 /**
  * @brief
  *    Encode an RecallScene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRecallSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                               uint16_t groupId, uint8_t sceneId, uint16_t transitionTime);
+chip::System::PacketBufferHandle encodeScenesClusterRecallSceneCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                       uint8_t sceneId, uint16_t transitionTime);
 
 /**
  * @brief
  *    Encode an RemoveAllScenes command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRemoveAllScenesCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                                   uint16_t groupId);
+chip::System::PacketBufferHandle encodeScenesClusterRemoveAllScenesCommand(chip::EndpointId destinationEndpoint, uint16_t groupId);
 
 /**
  * @brief
  *    Encode an RemoveScene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterRemoveSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                               uint16_t groupId, uint8_t sceneId);
+chip::System::PacketBufferHandle encodeScenesClusterRemoveSceneCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                       uint8_t sceneId);
 
 /**
  * @brief
  *    Encode an StoreScene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterStoreSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                              uint16_t groupId, uint8_t sceneId);
+chip::System::PacketBufferHandle encodeScenesClusterStoreSceneCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                      uint8_t sceneId);
 
 /**
  * @brief
  *    Encode an ViewScene command for Scenes server into buffer including the APS frame
  */
-uint16_t encodeScenesClusterViewSceneCommand(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint,
-                                             uint16_t groupId, uint8_t sceneId);
+chip::System::PacketBufferHandle encodeScenesClusterViewSceneCommand(chip::EndpointId destinationEndpoint, uint16_t groupId,
+                                                                     uint8_t sceneId);
 
 /**
  * @brief
  *    Encode a Scenes server discover command into buffer including the APS frame
  */
-uint16_t encodeScenesClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the scene count attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadSceneCountAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadSceneCountAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the current scene attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadCurrentSceneAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadCurrentSceneAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the current group attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadCurrentGroupAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadCurrentGroupAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the scene valid attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadSceneValidAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadSceneValidAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the name support attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadNameSupportAttribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadNameSupportAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Scenes server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeScenesClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                         chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeScenesClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);
 
 /*----------------------------------------------------------------------------*\
 | Cluster TemperatureMeasurement                                      | 0x0402 |
@@ -1579,46 +1488,40 @@ uint16_t encodeScenesClusterReadClusterRevisionAttribute(uint8_t * buffer, uint1
  * @brief
  *    Encode a Temperature Measurement server discover command into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length,
-                                                               chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encodeTemperatureMeasurementClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Temperature Measurement server read command for the measured value attribute into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                       chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle
+encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Temperature Measurement server report command for the measured value attribute into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         chip::EndpointId destination_endpoint,
-                                                                         uint16_t min_interval, uint16_t max_interval,
-                                                                         int16_t change);
+chip::System::PacketBufferHandle
+encodeTemperatureMeasurementClusterReportMeasuredValueAttribute(chip::EndpointId destinationEndpoint, uint16_t minInterval,
+                                                                uint16_t maxInterval, int16_t change);
 
 /**
  * @brief
  *    Encode a Temperature Measurement server read command for the min measured value attribute into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle
+encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Temperature Measurement server read command for the max measured value attribute into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                          chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle
+encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(chip::EndpointId destinationEndpoint);
 
 /**
  * @brief
  *    Encode a Temperature Measurement server read command for the cluster revision attribute into buffer including the APS frame
  */
-uint16_t encodeTemperatureMeasurementClusterReadClusterRevisionAttribute(uint8_t * buffer, uint16_t buf_length,
-                                                                         chip::EndpointId destination_endpoint);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+chip::System::PacketBufferHandle
+encodeTemperatureMeasurementClusterReadClusterRevisionAttribute(chip::EndpointId destinationEndpoint);

--- a/src/app/zap-templates/chip-zcl-zpro-codec-api.zapt
+++ b/src/app/zap-templates/chip-zcl-zpro-codec-api.zapt
@@ -5,10 +5,7 @@
 
 #include <app/util/basic-types.h>
 #include <stdint.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <system/SystemPacketBuffer.h>
 
 {{> clusters_header}}
 
@@ -20,28 +17,28 @@ extern "C" {
  * @brief
  *    Encode an {{asType name}} command for {{clusterName}} server into buffer including the APS frame
  */
-uint16_t encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asCamelCased label}}{{/chip_server_cluster_command_arguments}});
+chip::System::PacketBufferHandle encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(chip::EndpointId destinationEndpoint{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asCamelCased label}}{{/chip_server_cluster_command_arguments}});
 
 {{/chip_server_cluster_commands}}
 /**
  * @brief
  *    Encode a {{name}} server discover command into buffer including the APS frame
  */
-uint16_t encode{{asCamelCased name false}}ClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encode{{asCamelCased name false}}ClusterDiscoverAttributes(chip::EndpointId destinationEndpoint);
 
 {{#chip_server_cluster_attributes}}
 /**
  * @brief
  *    Encode a {{parent.name}} server read command for the {{name}} attribute into buffer including the APS frame
  */
-uint16_t encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint);
+chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(chip::EndpointId destinationEndpoint);
 
 {{#if (isWritableAttribute)}}
 /**
  * @brief
  *    Encode a {{parent.name}} server write command for the {{name}} attribute into buffer including the APS frame
  */
-uint16_t encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint, {{asUnderlyingZclType type}} {{asCamelCased name}});
+chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(chip::EndpointId destinationEndpoint, {{asUnderlyingZclType type}} {{asCamelCased name}});
 
 {{/if}}
 {{#if (isReportableAttribute)}}
@@ -49,11 +46,8 @@ uint16_t encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name
  * @brief
  *    Encode a {{parent.name}} server report command for the {{name}} attribute into buffer including the APS frame
  */
-uint16_t encode{{asCamelCased parent.name false}}ClusterReport{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, chip::EndpointId destination_endpoint, uint16_t min_interval, uint16_t max_interval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}});
+chip::System::PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterReport{{asCamelCased name false}}Attribute(chip::EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}});
 
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_server_clusters}}
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/src/app/zap-templates/encoder-src.zapt
+++ b/src/app/zap-templates/encoder-src.zapt
@@ -9,150 +9,7 @@
 #include <app/util/basic-types.h>
 
 using namespace chip;
-
-constexpr uint16_t kNullManufacturerCode = 0x0000;
-
-#define CHECK_FRAME_LENGTH(value, name)                                                                                            \
-    if (value == 0)                                                                                                                \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding APS Frame: %s", name);                                                                   \
-        return 0;                                                                                                                  \
-    }
-
-
-#define READ_ATTRIBUTES(name, cluster_id, mfgCode)                                                                                 \
-    uint16_t attr_id_count = sizeof(attr_ids) / sizeof(attr_ids[0]);                                                               \
-    uint16_t result =                                                                                                              \
-        encodeReadAttributesCommand(buffer, buf_length, destination_endpoint, cluster_id, mfgCode, attr_ids, attr_id_count);       \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    return result;
-
-#define WRITE_ATTRIBUTE(name, cluster_id, mfgCode, value)                                                                          \
-    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
-    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, mfgCode, 0x02))                                                \
-    {                                                                                                                              \
-        buf.Put16(attr_id);                                                                                                        \
-        buf.Put(attr_type);                                                                                                        \
-        switch (attr_type)                                                                                                         \
-        {                                                                                                                          \
-        {{#chip_server_writable_attributes_types}}
-        case {{atomicTypeId}}:                                                                                                     \
-          buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>(value));                                               \
-          break;                                                                                                                   \
-        {{/chip_server_writable_attributes_types}}
-        default:                                                                                                                   \
-          ChipLogError(Zcl, "Error encoding %s command", name);                                                                    \
-          return 0;                                                                                                                \
-        }                                                                                                                          \
-    }                                                                                                                              \
-                                                                                                                                   \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    return result;
-
-#define REPORT_ATTRIBUTE(name, cluster_id, mfgCode, isAnalog, value)                                                               \
-    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
-    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, mfgCode, 0x06))                                                \
-    {                                                                                                                              \
-        uint8_t direction = 0x00;                                                                                                  \
-        buf.Put(direction);                                                                                                        \
-        buf.Put16(attr_id);                                                                                                        \
-        buf.Put(attr_type);                                                                                                        \
-        buf.Put16(min_interval);                                                                                                   \
-        buf.Put16(max_interval);                                                                                                   \
-        if (isAnalog)                                                                                                              \
-        {                                                                                                                          \
-            switch (attr_type)                                                                                                     \
-            {                                                                                                                      \
-            {{#chip_server_reportable_attributes_types}}
-            {{#unless (isDiscreteType)}}
-              case {{atomicTypeId}}:                                                                                               \
-                buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>(value));                                         \
-                break;                                                                                                             \
-            {{/unless}}
-            {{/chip_server_reportable_attributes_types}}
-            default:                                                                                                               \
-              ChipLogError(Zcl, "Type is not supported for report attribute: '0x%02x'", attr_type);                                \
-              break;                                                                                                               \
-            }                                                                                                                      \
-        }                                                                                                                          \
-    }                                                                                                                              \
-                                                                                                                                   \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    return result;
-
-#define DISCOVER_ATTRIBUTES(name, cluster_id, mfgCode)                                                                             \
-    BufBound buf = BufBound(buffer, buf_length);                                                                                   \
-    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, mfgCode, 0x0c))                                                \
-    {                                                                                                                              \
-        /* Discover all attributes */                                                                                              \
-        buf.Put16(0x0000);                                                                                                         \
-        buf.Put(0xFF);                                                                                                             \
-    }                                                                                                                              \
-                                                                                                                                   \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    return result;
-
-#define COMMAND_HEADER(name, cluster_id, mfgCode, command_id)                                                                      \
-    BufBound buf    = BufBound(buffer, buf_length);                                                                                \
-    uint16_t result = _encodeClusterSpecificCommand(buf, destination_endpoint, cluster_id, mfgCode, command_id);                   \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }
-
-#define COMMAND_FOOTER(name)                                                                                                       \
-    result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                             \
-    if (result == 0)                                                                                                               \
-    {                                                                                                                              \
-        ChipLogError(Zcl, "Error encoding %s command", name);                                                                      \
-        return 0;                                                                                                                  \
-    }                                                                                                                              \
-    return result;
-
-#define COMMAND_INSERT_STRING(name, str)                                                                                           \
-    {                                                                                                                              \
-        size_t str_length = strlen(str);                                                                                           \
-        if (!CanCastTo<uint8_t>(str_length))                                                                                       \
-        {                                                                                                                          \
-            ChipLogError(Zcl, "Error encoding %s command. String too long: %d", name, str_length);                                 \
-            return 0;                                                                                                              \
-        }                                                                                                                          \
-        buf.Put(static_cast<uint8_t>(str_length));                                                                                 \
-        buf.Put(str);                                                                                                              \
-    }                                                                                                                              \
-
-#define COMMAND(name, cluster_id, mfgCode, command_id)                                                                             \
-    COMMAND_HEADER(name, cluster_id, mfgCode, command_id);                                                                         \
-    COMMAND_FOOTER(name);
-
-using namespace chip;
-extern "C" {
-
-{{> clusters_header}}
-
-{{#chip_server_clusters}}
-#define {{define}}_ID {{asHex code 4}}
-{{/chip_server_clusters}}
+using namespace chip::System;
 
 static uint16_t doEncodeApsFrame(BufBound & buf, ClusterId clusterId, EndpointId sourceEndpoint,
                                  EndpointId destinationEndpoint, EmberApsOption options, GroupId groupId, uint8_t sequence,
@@ -162,25 +19,28 @@ static uint16_t doEncodeApsFrame(BufBound & buf, ClusterId clusterId, EndpointId
     uint8_t control_byte = 0;
     buf.Put(control_byte) // Put in a control byte
         .Put16(clusterId)
-        .Put(sourceEndpoint)
-        .Put(destinationEndpoint)
+        .Put8(sourceEndpoint)
+        .Put8(destinationEndpoint)
         .Put(options, sizeof(EmberApsOption))
         .Put16(groupId)
-        .Put(sequence)
-        .Put(radius);
+        .Put8(sequence)
+        .Put8(radius);
 
-    size_t result = 0;
+    size_t result = buf.Needed();
     if (isMeasuring)
     {
-        result = buf.Needed();
         ChipLogDetail(Zcl, "Measured APS frame size %d", result);
+    }
+    else if (buf.Fit())
+    {
+        ChipLogDetail(Zcl, "Successfully encoded %d bytes", result);
     }
     else
     {
-        result = buf.Fit() ? buf.Needed() : 0;
-        CHECK_FRAME_LENGTH(result, "Buffer too small");
-        ChipLogDetail(Zcl, "Successfully encoded %d bytes", result);
+        ChipLogError(Zcl, "Error encoding APS Frame: Buffer too small");
+        result = 0;
     }
+
     if (!CanCastTo<uint16_t>(result))
     {
         ChipLogError(Zcl, "Can't fit our measured size in uint16_t");
@@ -197,71 +57,67 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
                             apsFrame->options, apsFrame->groupId, apsFrame->sequence, apsFrame->radius, !buffer);
 }
 
-uint16_t _encodeCommand(BufBound & buf, EndpointId destination_endpoint, ClusterId cluster_id, uint16_t mfgCode, CommandId command,
-                        uint8_t frame_control)
-{
-    CHECK_FRAME_LENGTH(buf.Size(), "Buffer is empty");
-
-    uint8_t seq_num            = 1;     // Transaction sequence number.  Just pick something.
-    EndpointId source_endpoint = 1;     // Pick source endpoint as 1 for now.
-
-    if (doEncodeApsFrame(buf, cluster_id, source_endpoint, destination_endpoint, 0, 0, 0, 0, false))
+#define COMMAND_HEADER(name, clusterId)                                                                                            \
+    const char * kName = name;                                                                                                     \
+                                                                                                                                   \
+    PacketBufferHandle payload = PacketBuffer::NewWithAvailableSize(kMaxBufferSize);                                               \
+    if (payload.IsNull())                                                                                                          \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Could not allocate PacketBuffer while trying to encode %s command", kName);                             \
+        return payload;                                                                                                            \
+    }                                                                                                                              \
+                                                                                                                                   \
+    BufBound buf = BufBound(payload->Start(), kMaxBufferSize);                                                                     \
+    if (doEncodeApsFrame(buf, clusterId, kSourceEndpoint, destinationEndpoint, 0, 0, 0, 0, false))                                 \
     {
-        buf.Put(frame_control);
-        if (mfgCode != kNullManufacturerCode)
-        {
-            buf.Put16(mfgCode);
-        }
-        buf.Put(seq_num);
-        buf.Put(command);
-    }
 
-    return buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;
-}
+#define COMMAND_FOOTER()                                                                                                           \
+    }                                                                                                                              \
+    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
+    if (result == 0)                                                                                                               \
+    {                                                                                                                              \
+        ChipLogError(Zcl, "Command %s can't fit in the allocated buffer", kName);                                                  \
+        return PacketBufferHandle();                                                                                               \
+    }                                                                                                                              \
+                                                                                                                                   \
+    payload->SetDataLength(result);                                                                                                \
+    return payload;
 
-uint16_t _encodeClusterSpecificCommand(BufBound & buf, EndpointId destination_endpoint, ClusterId cluster_id, uint16_t mfgCode,
-                                       CommandId command)
-{
-    // This is a cluster-specific command so low two bits are 0b01 and we're sending
-    // client to server, so all the remaining bits are 0.
-    uint8_t frame_control = 0x01;
-    if (mfgCode != kNullManufacturerCode)
-    {
-        frame_control = frame_control | (1u << 2);
-    }
+{{> clusters_header}}
 
-    return _encodeCommand(buf, destination_endpoint, cluster_id, mfgCode, command, frame_control);
-}
+#define EMBER_ZCL_REPORTING_DIRECTION_REPORTED 0x00
 
-uint16_t _encodeGlobalCommand(BufBound & buf, EndpointId destination_endpoint, ClusterId cluster_id, uint16_t mfgCode,
-                              CommandId command)
-{
-    // This is a global command, so the low bits are 0b00 and we're sending client
-    // to server, so all the remaining bits are 0.
-    uint8_t frame_control = 0x00;
-    if (mfgCode != kNullManufacturerCode)
-    {
-        frame_control = frame_control | (1u << 2);
-    }
+{{#zcl_global_commands}}
+#define ZCL_{{asDelimitedMacro label}}_COMMAND_ID ({{asHex code 2}})
+{{/zcl_global_commands}}
 
-    return _encodeCommand(buf, destination_endpoint, cluster_id, mfgCode, command, frame_control);
-}
+{{#chip_server_clusters}}
+#define {{define}}_ID {{asHex code 4}}
+{{#chip_server_cluster_commands}}
+#define ZCL_{{asDelimitedMacro name}}_COMMAND_ID ({{asHex code 2}})
+{{/chip_server_cluster_commands}}
 
-uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, ClusterId cluster_id,
-                                     uint16_t mfgCode, const uint16_t * attr_ids, uint16_t attr_id_count)
-{
-    BufBound buf = BufBound(buffer, buf_length);
-    if (_encodeGlobalCommand(buf, destination_endpoint, cluster_id, mfgCode, 0x00))
-    {
-        for (uint16_t i = 0; i < attr_id_count; ++i)
-        {
-            uint16_t attr_id = attr_ids[i];
-            buf.Put16(attr_id);
-        }
-    }
+{{/chip_server_clusters}}
 
-    return buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;
-}
+// TODO: Find a way to calculate maximum message length for clusters
+//       https://github.com/project-chip/connectedhomeip/issues/965
+constexpr uint16_t kMaxBufferSize = 1024;
+
+// This is a cluster-specific command so low two bits are 0b01.  The command
+// is standard, so does not need a manufacturer code, and we're sending
+// client to server, so all the remaining bits are 0.
+constexpr uint8_t kFrameControlClusterSpecificCommand = 0x01;
+
+// This is a global command, so the low bits are 0b00.  The command is
+// standard, so does not need a manufacturer code, and we're sending client
+// to server, so all the remaining bits are 0.
+constexpr uint8_t kFrameControlGlobalCommand = 0x00;
+
+// Pick source endpoint as 1 for now
+constexpr EndpointId kSourceEndpoint = 1;
+
+// Transaction sequence number. Just pick something for now.
+constexpr uint8_t kSeqNum = 1;
 
 {{#chip_server_clusters}}
 {{> cluster_header}}
@@ -270,56 +126,100 @@ uint16_t encodeReadAttributesCommand(uint8_t * buffer, uint16_t buf_length, Endp
 /*
  * Command {{asCamelCased name false}}
  */
-uint16_t encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asCamelCased label}}{{/chip_server_cluster_command_arguments}})
+PacketBufferHandle encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(EndpointId destinationEndpoint{{#chip_server_cluster_command_arguments}}, {{chipType}} {{asCamelCased label}}{{/chip_server_cluster_command_arguments}})
 {
-    const char * kName = "{{asCamelCased clusterName false}}{{asType name}}";
-    COMMAND_HEADER(kName, {{parent.define}}_ID, {{asHex mfgCode 4}}, {{asHex code 2}});
+    COMMAND_HEADER("{{asType name}}", {{parent.define}}_ID);
     {{#chip_server_cluster_command_arguments}}
     {{#if (isString type)}}
-    COMMAND_INSERT_STRING(kName, {{asCamelCased label}});
-    {{else if (isSignedType)}}
-    buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>({{asCamelCased label}}));
-    {{else}}
-    buf.Put{{chipTypePutLength}}({{asCamelCased label}});
+    size_t {{asCamelCased label}}StrLen = strlen({{asCamelCased label}});
+    if (!CanCastTo<uint8_t>({{asCamelCased label}}StrLen))
+    {
+        ChipLogError(Zcl, "Error encoding %s command. String too long: %d", kName, {{asCamelCased label}}StrLen);
+        return PacketBufferHandle();
+    }
     {{/if}}
     {{/chip_server_cluster_command_arguments}}
-    COMMAND_FOOTER(kName);
+      buf
+    {{#if (isManufacturerSpecificCommand)}}
+        .Put8(kFrameControlClusterSpecificCommand | (1u << 2))
+        .Put16({{asHex mfgCode 4}})
+    {{else}}
+        .Put8(kFrameControlClusterSpecificCommand)
+    {{/if}}
+       .Put8(kSeqNum)
+       .Put8(ZCL_{{asDelimitedMacro name}}_COMMAND_ID)
+    {{#chip_server_cluster_command_arguments}}
+    {{#if (isString type)}}
+       .Put(static_cast<uint8_t>({{asCamelCased label}}StrLen))
+       .Put({{asCamelCased label}})
+    {{else if (isSignedType)}}
+       .Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>({{asCamelCased label}}))
+    {{else}}
+       .Put{{chipTypePutLength}}({{asCamelCased label}})
+    {{/if}}
+    {{/chip_server_cluster_command_arguments}}
+    ;
+    COMMAND_FOOTER();
 }
 
 {{/chip_server_cluster_commands}}
-uint16_t encode{{asCamelCased name false}}ClusterDiscoverAttributes(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
+PacketBufferHandle encode{{asCamelCased name false}}ClusterDiscoverAttributes(EndpointId destinationEndpoint)
 {
-    DISCOVER_ATTRIBUTES("Discover{{asCamelCased name false}}Attributes", {{define}}_ID, {{asHex mfgCode 4}});
+    COMMAND_HEADER("Discover{{asCamelCased name false}}Attributes", {{define}}_ID);
+    buf.Put8(kFrameControlGlobalCommand)
+       .Put8(kSeqNum)
+       .Put8(ZCL_DISCOVER_ATTRIBUTES_COMMAND_ID)
+       .Put16(0x0000)
+       .Put8(0xFF);
+    COMMAND_FOOTER();
 }
 
 {{#chip_server_cluster_attributes}}
 /*
  * Attribute {{asCamelCased name false}}
  */
-uint16_t encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint)
+PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(EndpointId destinationEndpoint)
 {
-    uint16_t attr_ids[] = { {{asHex attributeCode 4}} };
-    READ_ATTRIBUTES("Read{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID, {{asHex mfgCode 4}});
+    COMMAND_HEADER("Read{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID);
+    buf.Put8(kFrameControlGlobalCommand)
+       .Put8(kSeqNum)
+       .Put8(ZCL_READ_ATTRIBUTES_COMMAND_ID)
+       .Put16({{asHex attributeCode 4}});
+    COMMAND_FOOTER();
 }
 
 {{#if (isWritableAttribute)}}
-uint16_t encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, {{asUnderlyingZclType type}} {{asCamelCased name}})
+PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(EndpointId destinationEndpoint, {{asUnderlyingZclType type}} {{asCamelCased name}})
 {
-    uint16_t attr_id = {{asHex attributeCode 4}};
-    uint8_t attr_type = { {{atomicTypeId}} };
-    WRITE_ATTRIBUTE("Write{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID, {{asHex mfgCode 4}}, {{asCamelCased name}});
+    COMMAND_HEADER("Write{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID);
+    buf.Put8(kFrameControlGlobalCommand)
+       .Put8(kSeqNum)
+       .Put8(ZCL_WRITE_ATTRIBUTES_COMMAND_ID)
+       .Put16({{asHex attributeCode 4}})
+       .Put8({{atomicTypeId}})
+       .Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>({{asCamelCased name}}));
+    COMMAND_FOOTER();
 }
 
 {{/if}}
 {{#if (isReportableAttribute)}}
-uint16_t encode{{asCamelCased parent.name false}}ClusterReport{{asCamelCased name false}}Attribute(uint8_t * buffer, uint16_t buf_length, EndpointId destination_endpoint, uint16_t min_interval, uint16_t max_interval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
+PacketBufferHandle encode{{asCamelCased parent.name false}}ClusterReport{{asCamelCased name false}}Attribute(EndpointId destinationEndpoint, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
 {
-    uint16_t attr_id = {{asHex attributeCode 4}};
-    uint8_t attr_type = { {{atomicTypeId}} };
-    REPORT_ATTRIBUTE("Report{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID, {{asHex mfgCode 4}}, {{#unless (isDiscreteType)}}true, change{{else}}false, 0{{/unless}});
+    COMMAND_HEADER("Report{{asCamelCased parent.name false}}{{asCamelCased name false}}", {{parent.define}}_ID);
+    buf.Put8(kFrameControlGlobalCommand)
+       .Put8(kSeqNum)
+       .Put8(ZCL_CONFIGURE_REPORTING_COMMAND_ID)
+       .Put8(EMBER_ZCL_REPORTING_DIRECTION_REPORTED)
+       .Put16({{asHex attributeCode 4}})
+       .Put8({{atomicTypeId}})
+       .Put16(minInterval)
+       .Put16(maxInterval);
+    {{#unless (isDiscreteType)}}
+    buf.Put{{chipTypePutLength}}(static_cast<{{chipTypePutCastType}}>(change));
+    {{/unless}}
+    COMMAND_FOOTER();
 }
 
 {{/if}}
 {{/chip_server_cluster_attributes}}
 {{/chip_server_clusters}}
-} // extern "C"

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -44,26 +44,14 @@ void ClusterBase::Dissociate()
     mDevice = nullptr;
 }
 
-CHIP_ERROR ClusterBase::SendCommand(CommandEncoder commandEncoder, uint16_t maxCmdLen, Callback::Callback<> * responseHandler)
+CHIP_ERROR ClusterBase::SendCommand(chip::System::PacketBufferHandle payload, Callback::Callback<> * responseHandler)
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
-    uint16_t encodedLength = 0;
-    System::PacketBufferHandle message;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(commandEncoder != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(!payload.IsNull(), err = CHIP_ERROR_INTERNAL);
 
-    message = System::PacketBuffer::NewWithAvailableSize(maxCmdLen);
-    VerifyOrExit(!message.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-
-    encodedLength = commandEncoder(message->Start(), message->AvailableDataLength(), mEndpoint);
-    VerifyOrExit(encodedLength != 0, err = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(encodedLength <= maxCmdLen, err = CHIP_ERROR_INTERNAL);
-
-    message->SetDataLength(encodedLength);
-    VerifyOrExit(message->DataLength() >= encodedLength, err = CHIP_ERROR_NO_MEMORY);
-
-    err = mDevice->SendMessage(std::move(message));
+    err = mDevice->SendMessage(std::move(payload));
     SuccessOrExit(err);
 
     if (responseHandler != nullptr)
@@ -80,27 +68,12 @@ exit:
     return err;
 }
 
-CHIP_ERROR ClusterBase::RequestAttributeReporting(RequestEncoder requestEncoder, uint16_t maxCmdLen, uint16_t minInterval,
-                                                  uint16_t maxInterval, Callback::Callback<> * reportHandler)
+CHIP_ERROR ClusterBase::RequestAttributeReporting(chip::System::PacketBufferHandle payload, Callback::Callback<> * responseHandler,
+                                                  Callback::Callback<> * reportHandler)
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
-    uint16_t encodedLength = 0;
-    System::PacketBufferHandle message;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(requestEncoder != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-
-    message = System::PacketBuffer::NewWithAvailableSize(maxCmdLen);
-    VerifyOrExit(!message.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-
-    encodedLength = requestEncoder(message->Start(), message->AvailableDataLength(), mEndpoint, minInterval, maxInterval);
-    VerifyOrExit(encodedLength != 0, err = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(encodedLength <= maxCmdLen, err = CHIP_ERROR_INTERNAL);
-
-    message->SetDataLength(encodedLength);
-    VerifyOrExit(message->DataLength() >= encodedLength, err = CHIP_ERROR_NO_MEMORY);
-
-    err = mDevice->SendMessage(std::move(message));
+    err = SendCommand(std::move(payload), responseHandler);
     SuccessOrExit(err);
 
     if (reportHandler != nullptr)

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -45,38 +45,30 @@ public:
 protected:
     ClusterBase(uint16_t cluster) : mClusterId(cluster) {}
 
-    typedef uint16_t (*CommandEncoder)(uint8_t * command, uint16_t maxLen, EndpointId endpoint);
-
     /**
      * @brief
      *   Send the command, constructed using the given encoder, to the device. Add a callback
      *   handler, that'll be called when the response is received from the device.
      *
-     * @param[in] commandEncoder    The function that encodes the command
-     * @param[in] maxCmdLen         Maximum length expected for the encoded command
+     * @param[in] payload           The payload of the encoded command
      * @param[in] responseHandler   The handler function that's called on receiving command response
      */
-    CHIP_ERROR SendCommand(CommandEncoder commandEncoder, uint16_t maxCmdLen, Callback::Callback<> * responseHandler);
-
-    typedef uint16_t (*RequestEncoder)(uint8_t * request, uint16_t maxLen, EndpointId endpoint, uint16_t minInterval,
-                                       uint16_t maxInterval);
+    CHIP_ERROR SendCommand(chip::System::PacketBufferHandle payload, Callback::Callback<> * responseHandler);
 
     /**
      * @brief
      *   Request attribute reports from the device. The request constructed using the given encoder. Add a callback
      *   handler, that'll be called when the reports are received from the device.
      *
-     * @param[in] requestEncoder    The function that encodes the report request
-     * @param[in] maxCmdLen         Maximum length expected for the encoded command
-     * @param[in] minInterval       The minimum time interval between reports
-     * @param[in] maxInterval       The maximum time interval between reports
+     * @param[in] payload           The payload of the encoded command
+     * @param[in] responseHandler   The handler function that's called on receiving command response
      * @param[in] reportHandler     The handler function that's called on receiving attribute reports
      *                              The reporting handler continues to be called as long as the callback
      *                              is active. The user can stop the reporting by cancelling the callback.
      *                              Reference: chip::Callback::Cancel()
      */
-    CHIP_ERROR RequestAttributeReporting(RequestEncoder requestEncoder, uint16_t maxCmdLen, uint16_t minInterval,
-                                         uint16_t maxInterval, Callback::Callback<> * reportHandler);
+    CHIP_ERROR RequestAttributeReporting(chip::System::PacketBufferHandle payload, Callback::Callback<> * responseHandler,
+                                         Callback::Callback<> * reportHandler);
 
     const ClusterId mClusterId;
     Device * mDevice;

--- a/src/controller/OnOffCluster.cpp
+++ b/src/controller/OnOffCluster.cpp
@@ -22,39 +22,41 @@
 namespace chip {
 namespace Controller {
 
-// TODO: Find a way to calculate maximum message length for clusters
-//       https://github.com/project-chip/connectedhomeip/issues/965
-constexpr uint16_t kMaxOnOffMessageLength = 64;
-
 CHIP_ERROR OnOffCluster::On(Callback::Callback<> * onCompletion)
 {
-    return SendCommand(encodeOnOffClusterOnCommand, kMaxOnOffMessageLength, onCompletion);
+    System::PacketBufferHandle payload = encodeOnOffClusterOnCommand(mEndpoint);
+    return SendCommand(std::move(payload), onCompletion);
 }
 
 CHIP_ERROR OnOffCluster::Off(Callback::Callback<> * onCompletion)
 {
-    return SendCommand(encodeOnOffClusterOffCommand, kMaxOnOffMessageLength, onCompletion);
+    System::PacketBufferHandle payload = encodeOnOffClusterOffCommand(mEndpoint);
+    return SendCommand(std::move(payload), onCompletion);
 }
 
 CHIP_ERROR OnOffCluster::Toggle(Callback::Callback<> * onCompletion)
 {
-    return SendCommand(encodeOnOffClusterToggleCommand, kMaxOnOffMessageLength, onCompletion);
+    System::PacketBufferHandle payload = encodeOnOffClusterToggleCommand(mEndpoint);
+    return SendCommand(std::move(payload), onCompletion);
 }
 
 CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Callback<> * onCompletion)
 {
-    return SendCommand(encodeOnOffClusterReadOnOffAttribute, kMaxOnOffMessageLength, onCompletion);
+    System::PacketBufferHandle payload = encodeOnOffClusterReadOnOffAttribute(mEndpoint);
+    return SendCommand(std::move(payload), onCompletion);
 }
 
-CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Callback<> * onChange, uint16_t minInterval, uint16_t maxInterval)
+CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Callback<> * onCompletion, Callback::Callback<> * onChange,
+                                              uint16_t minInterval, uint16_t maxInterval)
 {
-    return RequestAttributeReporting(encodeOnOffClusterReportOnOffAttribute, kMaxOnOffMessageLength, minInterval, maxInterval,
-                                     onChange);
+    System::PacketBufferHandle payload = encodeOnOffClusterReportOnOffAttribute(mEndpoint, minInterval, maxInterval);
+    return RequestAttributeReporting(std::move(payload), onCompletion, onChange);
 }
 
 CHIP_ERROR OnOffCluster::ReadAttributeClusterRevision(Callback::Callback<> * onCompletion)
 {
-    return CHIP_NO_ERROR;
+    System::PacketBufferHandle payload = encodeOnOffClusterReadClusterRevisionAttribute(mEndpoint);
+    return SendCommand(std::move(payload), onCompletion);
 }
 
 } // namespace Controller

--- a/src/controller/OnOffCluster.h
+++ b/src/controller/OnOffCluster.h
@@ -37,7 +37,8 @@ public:
     CHIP_ERROR Toggle(Callback::Callback<> * onCompletion);
 
     CHIP_ERROR ReadAttributeOnOff(Callback::Callback<> * onCompletion);
-    CHIP_ERROR ReportAttributeOnOff(Callback::Callback<> * onChange, uint16_t minInterval, uint16_t maxInterval);
+    CHIP_ERROR ReportAttributeOnOff(Callback::Callback<> * onCompletion, Callback::Callback<> * onChange, uint16_t minInterval,
+                                    uint16_t maxInterval);
 
     CHIP_ERROR ReadAttributeClusterRevision(Callback::Callback<> * onCompletion);
 };


### PR DESCRIPTION
…ketBufferHandle' directly instead of 'uint16_t'

 #### Problem

The various `encode*` methods of `src/app/chip-zcl-zpro-codec-api.h` returns a `uint16_t` which contains the size of the encoded payload, and takes a `uint8_t * buffer` and a `uint16_t buffer_length` as parameters.

All the calling site are manually creating a `PacketBufferHandle`, passing it to those methods, and then do various checks to make sure everything is fine.

This PR change this behavior so that the `encode*` methods directly returns a `PacketBufferHandle`.

 #### Summary of Changes
  * Rewrite `src/app/zap-templates/encoder-src.zapt` to use `PacketBufferHandle` and to use less macros
  * Update all the calling sites of the various `encode*` methods
  * Update the `encode*` methods signatures