### PR TITLE
Mdns broke running the server examples locally on macOS

### DIFF
--- a/examples/common/chip-app-server/Server.cpp
+++ b/examples/common/chip-app-server/Server.cpp
@@ -159,6 +159,7 @@ void InitServer(AppDelegate * delegate)
         SuccessOrExit(err = gRendezvousServer.Init(params, &gTransports));
     }
 
+#if CHIP_ENABLE_MDNS
     // TODO: advertise this only when really operational once we support both
     // operational and commisioning advertising is supported.
     {
@@ -178,6 +179,7 @@ void InitServer(AppDelegate * delegate)
 
     err = Mdns::ServiceAdvertiser::Instance().Start(&DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
     SuccessOrExit(err);
+#endif
 
     err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing);
     SuccessOrExit(err);


### PR DESCRIPTION
 #### Problem

#4132 is cool. But in the current state it broke my current setup on macOS. It builds fine but the server is not running well as `err = Mdns::ServiceAdvertiser::Instance().Start` returns an error there.

 #### Summary of Changes
 * Add `#if CHIP_ENABLE_MDNS` in `examples/common/chip-app-server/Server.cpp`