### PR TITLE
[shell]:Start CHIP event-loop by default during initialization.

### DIFF
--- a/examples/shell/shell_common/cmd_device.cpp
+++ b/examples/shell/shell_common/cmd_device.cpp
@@ -937,6 +937,10 @@ void cmd_device_init()
 
     streamer_t * sout = streamer_get();
 
+    error = chip::Platform::MemoryInit();
+    VerifyOrExit(error == CHIP_NO_ERROR,
+                 streamer_printf(sout, "Failed to init CHIP platform memory with error: %s\r\n", ErrorStr(error)));
+
     streamer_printf(sout, "Init CHIP Stack\r\n");
     error = PlatformMgr().InitChipStack();
     VerifyOrExit(error == CHIP_NO_ERROR, streamer_printf(sout, "Failed to init CHIP Stack with error: %s\r\n", ErrorStr(error)));

--- a/examples/shell/shell_common/cmd_device.cpp
+++ b/examples/shell/shell_common/cmd_device.cpp
@@ -53,21 +53,6 @@ int cmd_device_help(int argc, char ** argv)
     return 0;
 }
 
-int cmd_device_start(int argc, char ** argv)
-{
-    CHIP_ERROR error  = CHIP_NO_ERROR;
-    streamer_t * sout = streamer_get();
-
-    VerifyOrExit(argc == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    streamer_printf(sout, "Starting Platform Manager Event Loop\r\n");
-    error = PlatformMgr().StartEventLoopTask();
-    SuccessOrExit(error);
-
-exit:
-    return error;
-}
-
 static CHIP_ERROR ConfigGetDone(streamer_t * sout, CHIP_ERROR error)
 {
     if (error)
@@ -925,7 +910,6 @@ static const shell_command_t cmds_device_root = { &cmd_device_dispatch, "device"
 /// Subcommands for root command: `device <subcommand>`
 static const shell_command_t cmds_device[] = {
     { &cmd_device_help, "help", "Usage: device <subcommand>" },
-    { &cmd_device_start, "start", "Start the device layer. Usage: device start" },
     { &cmd_device_get, "get", "Get configuration value. Usage: device get <param_name>" },
     { &cmd_device_config, "config", "Dump entire configuration of device. Usage: device config" },
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
@@ -955,18 +939,19 @@ void cmd_device_init()
 
     streamer_printf(sout, "Init CHIP Stack\r\n");
     error = PlatformMgr().InitChipStack();
-
-    if (error != CHIP_NO_ERROR)
-        streamer_printf(sout, "Failed to init CHIP Stack with error: %s\r\n", ErrorStr(error));
+    VerifyOrExit(error == CHIP_NO_ERROR, streamer_printf(sout, "Failed to init CHIP Stack with error: %s\r\n", ErrorStr(error)));
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     streamer_printf(sout, "Init Thread stack\r\n");
     error = ThreadStackMgr().InitThreadStack();
-    if (error != CHIP_NO_ERROR)
-    {
-        streamer_printf(sout, "ThreadStackMgr().InitThreadStack() failed\r\n");
-    }
+    VerifyOrExit(error == CHIP_NO_ERROR, streamer_printf(sout, "ThreadStackMgr().InitThreadStack() failed\r\n"));
 #endif
 
+    // Starting Platform Manager Event Loop;
+    error = PlatformMgr().StartEventLoopTask();
+    VerifyOrExit(error == CHIP_NO_ERROR, streamer_printf(sout, "Failed to start platform event loop\r\n"));
+
+exit:
+    return;
 #endif // CONFIG_DEVICE_LAYER
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, shell does not start event-loop by default, we need to first issue 'start' command to run device layer event loop before issue other device commands. And 'start' command is always needed.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Start CHIP event-loop by default during initialization.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
