### PR TITLE
Add custom ZCL extensions inside src/app/zap-templates

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-id.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-id.h
@@ -4466,6 +4466,16 @@
 #define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
 #define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
 
+// Attribute ids for cluster: Binding
+
+// Client attributes
+#define ZCL_CLUSTER_REVISION_CLIENT_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_CLIENT_ATTRIBUTE_ID (0xFFFE)
+
+// Server attributes
+#define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
+
 // Attribute ids for cluster: Sample Mfg Specific Cluster
 
 // Client attributes

--- a/examples/all-clusters-app/all-clusters-common/gen/client-command-macro.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/client-command-macro.h
@@ -5662,6 +5662,32 @@
                                   ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID, "uuuub", startIndex, total, startIndex, count,         \
                                   endpointInformationRecordList, endpointInformationRecordListLen);
 
+/** @brief Command description for Bind
+ *
+ * Command: Bind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterBind(nodeId, groupId, endpointId, clusterId)                                               \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_BIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
+/** @brief Command description for Unbind
+ *
+ * Command: Unbind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterUnbind(nodeId, groupId, endpointId, clusterId)                                             \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_UNBIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
 /** @brief Command description for CommandOne
  *
  * Command: CommandOne

--- a/examples/all-clusters-app/all-clusters-common/gen/cluster-id.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/cluster-id.h
@@ -330,6 +330,9 @@
 // Definitions for cluster: ZLL Commissioning
 #define ZCL_ZLL_COMMISSIONING_CLUSTER_ID (0x1000)
 
+// Definitions for cluster: Binding
+#define ZCL_BINDING_CLUSTER_ID (0xF000)
+
 // Definitions for cluster: Sample Mfg Specific Cluster
 #define ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID (0xFC00)
 

--- a/examples/all-clusters-app/all-clusters-common/gen/command-id.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/command-id.h
@@ -683,6 +683,10 @@
 #define ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID (0x42)
 #define ZCL_GET_ENDPOINT_LIST_RESPONSE_COMMAND_ID (0x42)
 
+// Commands for cluster: Binding
+#define ZCL_BIND_COMMAND_ID (0x00)
+#define ZCL_UNBIND_COMMAND_ID (0x01)
+
 // Commands for cluster: Sample Mfg Specific Cluster
 #define ZCL_COMMAND_ONE_COMMAND_ID (0x00)
 

--- a/examples/all-clusters-app/all-clusters-common/gen/print-cluster.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/print-cluster.h
@@ -714,6 +714,12 @@
 #define CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER
 #endif
 
+#if defined(ZCL_USING_BINDING_CLUSTER_SERVER) || defined(ZCL_USING_BINDING_CLUSTER_CLIENT)
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER { ZCL_BINDING_CLUSTER_ID, 61440, "Binding" },
+#else
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER
+#endif
+
 #if defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_SERVER) || defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_CLIENT)
 #define CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER { ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID, 64512, "Sample Mfg Specific Cluster" },
 #else
@@ -850,6 +856,7 @@
     CHIP_PRINTCLUSTER_ELECTRICAL_MEASUREMENT_CLUSTER                                                                               \
     CHIP_PRINTCLUSTER_DIAGNOSTICS_CLUSTER                                                                                          \
     CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER                                                                                    \
+    CHIP_PRINTCLUSTER_BINDING_CLUSTER                                                                                              \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER                                                                                  \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER_2                                                                                \
     CHIP_PRINTCLUSTER_OTA_CONFIGURATION_CLUSTER                                                                                    \

--- a/examples/lighting-app/lighting-common/gen/attribute-id.h
+++ b/examples/lighting-app/lighting-common/gen/attribute-id.h
@@ -4466,6 +4466,16 @@
 #define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
 #define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
 
+// Attribute ids for cluster: Binding
+
+// Client attributes
+#define ZCL_CLUSTER_REVISION_CLIENT_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_CLIENT_ATTRIBUTE_ID (0xFFFE)
+
+// Server attributes
+#define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
+
 // Attribute ids for cluster: Sample Mfg Specific Cluster
 
 // Client attributes

--- a/examples/lighting-app/lighting-common/gen/client-command-macro.h
+++ b/examples/lighting-app/lighting-common/gen/client-command-macro.h
@@ -5662,6 +5662,32 @@
                                   ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID, "uuuub", startIndex, total, startIndex, count,         \
                                   endpointInformationRecordList, endpointInformationRecordListLen);
 
+/** @brief Command description for Bind
+ *
+ * Command: Bind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterBind(nodeId, groupId, endpointId, clusterId)                                               \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_BIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
+/** @brief Command description for Unbind
+ *
+ * Command: Unbind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterUnbind(nodeId, groupId, endpointId, clusterId)                                             \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_UNBIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
 /** @brief Command description for CommandOne
  *
  * Command: CommandOne

--- a/examples/lighting-app/lighting-common/gen/cluster-id.h
+++ b/examples/lighting-app/lighting-common/gen/cluster-id.h
@@ -330,6 +330,9 @@
 // Definitions for cluster: ZLL Commissioning
 #define ZCL_ZLL_COMMISSIONING_CLUSTER_ID (0x1000)
 
+// Definitions for cluster: Binding
+#define ZCL_BINDING_CLUSTER_ID (0xF000)
+
 // Definitions for cluster: Sample Mfg Specific Cluster
 #define ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID (0xFC00)
 

--- a/examples/lighting-app/lighting-common/gen/command-id.h
+++ b/examples/lighting-app/lighting-common/gen/command-id.h
@@ -683,6 +683,10 @@
 #define ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID (0x42)
 #define ZCL_GET_ENDPOINT_LIST_RESPONSE_COMMAND_ID (0x42)
 
+// Commands for cluster: Binding
+#define ZCL_BIND_COMMAND_ID (0x00)
+#define ZCL_UNBIND_COMMAND_ID (0x01)
+
 // Commands for cluster: Sample Mfg Specific Cluster
 #define ZCL_COMMAND_ONE_COMMAND_ID (0x00)
 

--- a/examples/lighting-app/lighting-common/gen/print-cluster.h
+++ b/examples/lighting-app/lighting-common/gen/print-cluster.h
@@ -714,6 +714,12 @@
 #define CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER
 #endif
 
+#if defined(ZCL_USING_BINDING_CLUSTER_SERVER) || defined(ZCL_USING_BINDING_CLUSTER_CLIENT)
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER { ZCL_BINDING_CLUSTER_ID, 61440, "Binding" },
+#else
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER
+#endif
+
 #if defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_SERVER) || defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_CLIENT)
 #define CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER { ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID, 64512, "Sample Mfg Specific Cluster" },
 #else
@@ -850,6 +856,7 @@
     CHIP_PRINTCLUSTER_ELECTRICAL_MEASUREMENT_CLUSTER                                                                               \
     CHIP_PRINTCLUSTER_DIAGNOSTICS_CLUSTER                                                                                          \
     CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER                                                                                    \
+    CHIP_PRINTCLUSTER_BINDING_CLUSTER                                                                                              \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER                                                                                  \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER_2                                                                                \
     CHIP_PRINTCLUSTER_OTA_CONFIGURATION_CLUSTER                                                                                    \

--- a/examples/lock-app/lock-common/gen/attribute-id.h
+++ b/examples/lock-app/lock-common/gen/attribute-id.h
@@ -4466,6 +4466,16 @@
 #define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
 #define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
 
+// Attribute ids for cluster: Binding
+
+// Client attributes
+#define ZCL_CLUSTER_REVISION_CLIENT_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_CLIENT_ATTRIBUTE_ID (0xFFFE)
+
+// Server attributes
+#define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
+
 // Attribute ids for cluster: Sample Mfg Specific Cluster
 
 // Client attributes

--- a/examples/lock-app/lock-common/gen/client-command-macro.h
+++ b/examples/lock-app/lock-common/gen/client-command-macro.h
@@ -5662,6 +5662,32 @@
                                   ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID, "uuuub", startIndex, total, startIndex, count,         \
                                   endpointInformationRecordList, endpointInformationRecordListLen);
 
+/** @brief Command description for Bind
+ *
+ * Command: Bind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterBind(nodeId, groupId, endpointId, clusterId)                                               \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_BIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
+/** @brief Command description for Unbind
+ *
+ * Command: Unbind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterUnbind(nodeId, groupId, endpointId, clusterId)                                             \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_UNBIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
 /** @brief Command description for CommandOne
  *
  * Command: CommandOne

--- a/examples/lock-app/lock-common/gen/cluster-id.h
+++ b/examples/lock-app/lock-common/gen/cluster-id.h
@@ -330,6 +330,9 @@
 // Definitions for cluster: ZLL Commissioning
 #define ZCL_ZLL_COMMISSIONING_CLUSTER_ID (0x1000)
 
+// Definitions for cluster: Binding
+#define ZCL_BINDING_CLUSTER_ID (0xF000)
+
 // Definitions for cluster: Sample Mfg Specific Cluster
 #define ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID (0xFC00)
 

--- a/examples/lock-app/lock-common/gen/command-id.h
+++ b/examples/lock-app/lock-common/gen/command-id.h
@@ -683,6 +683,10 @@
 #define ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID (0x42)
 #define ZCL_GET_ENDPOINT_LIST_RESPONSE_COMMAND_ID (0x42)
 
+// Commands for cluster: Binding
+#define ZCL_BIND_COMMAND_ID (0x00)
+#define ZCL_UNBIND_COMMAND_ID (0x01)
+
 // Commands for cluster: Sample Mfg Specific Cluster
 #define ZCL_COMMAND_ONE_COMMAND_ID (0x00)
 

--- a/examples/lock-app/lock-common/gen/print-cluster.h
+++ b/examples/lock-app/lock-common/gen/print-cluster.h
@@ -714,6 +714,12 @@
 #define CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER
 #endif
 
+#if defined(ZCL_USING_BINDING_CLUSTER_SERVER) || defined(ZCL_USING_BINDING_CLUSTER_CLIENT)
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER { ZCL_BINDING_CLUSTER_ID, 61440, "Binding" },
+#else
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER
+#endif
+
 #if defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_SERVER) || defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_CLIENT)
 #define CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER { ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID, 64512, "Sample Mfg Specific Cluster" },
 #else
@@ -850,6 +856,7 @@
     CHIP_PRINTCLUSTER_ELECTRICAL_MEASUREMENT_CLUSTER                                                                               \
     CHIP_PRINTCLUSTER_DIAGNOSTICS_CLUSTER                                                                                          \
     CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER                                                                                    \
+    CHIP_PRINTCLUSTER_BINDING_CLUSTER                                                                                              \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER                                                                                  \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER_2                                                                                \
     CHIP_PRINTCLUSTER_OTA_CONFIGURATION_CLUSTER                                                                                    \

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-id.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-id.h
@@ -4466,6 +4466,16 @@
 #define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
 #define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
 
+// Attribute ids for cluster: Binding
+
+// Client attributes
+#define ZCL_CLUSTER_REVISION_CLIENT_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_CLIENT_ATTRIBUTE_ID (0xFFFE)
+
+// Server attributes
+#define ZCL_CLUSTER_REVISION_SERVER_ATTRIBUTE_ID (0xFFFD)
+#define ZCL_REPORTING_STATUS_SERVER_ATTRIBUTE_ID (0xFFFE)
+
 // Attribute ids for cluster: Sample Mfg Specific Cluster
 
 // Client attributes

--- a/examples/temperature-measurement-app/esp32/main/gen/client-command-macro.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/client-command-macro.h
@@ -5662,6 +5662,32 @@
                                   ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID, "uuuub", startIndex, total, startIndex, count,         \
                                   endpointInformationRecordList, endpointInformationRecordListLen);
 
+/** @brief Command description for Bind
+ *
+ * Command: Bind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterBind(nodeId, groupId, endpointId, clusterId)                                               \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_BIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
+/** @brief Command description for Unbind
+ *
+ * Command: Unbind
+ * @param nodeId INT64U
+ * @param groupId INT16U
+ * @param endpointId INT8U
+ * @param clusterId CLUSTER_ID
+ */
+#define emberAfFillCommandBindingClusterUnbind(nodeId, groupId, endpointId, clusterId)                                             \
+    emberAfFillExternalBuffer(mask,                                                                                                \
+                                                                                                                                   \
+                              ZCL_UNBIND_COMMAND_ID, "uuuu", nodeId, groupId, endpointId, clusterId);
+
 /** @brief Command description for CommandOne
  *
  * Command: CommandOne

--- a/examples/temperature-measurement-app/esp32/main/gen/cluster-id.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/cluster-id.h
@@ -330,6 +330,9 @@
 // Definitions for cluster: ZLL Commissioning
 #define ZCL_ZLL_COMMISSIONING_CLUSTER_ID (0x1000)
 
+// Definitions for cluster: Binding
+#define ZCL_BINDING_CLUSTER_ID (0xF000)
+
 // Definitions for cluster: Sample Mfg Specific Cluster
 #define ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID (0xFC00)
 

--- a/examples/temperature-measurement-app/esp32/main/gen/command-id.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/command-id.h
@@ -683,6 +683,10 @@
 #define ZCL_GET_ENDPOINT_LIST_REQUEST_COMMAND_ID (0x42)
 #define ZCL_GET_ENDPOINT_LIST_RESPONSE_COMMAND_ID (0x42)
 
+// Commands for cluster: Binding
+#define ZCL_BIND_COMMAND_ID (0x00)
+#define ZCL_UNBIND_COMMAND_ID (0x01)
+
 // Commands for cluster: Sample Mfg Specific Cluster
 #define ZCL_COMMAND_ONE_COMMAND_ID (0x00)
 

--- a/examples/temperature-measurement-app/esp32/main/gen/print-cluster.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/print-cluster.h
@@ -714,6 +714,12 @@
 #define CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER
 #endif
 
+#if defined(ZCL_USING_BINDING_CLUSTER_SERVER) || defined(ZCL_USING_BINDING_CLUSTER_CLIENT)
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER { ZCL_BINDING_CLUSTER_ID, 61440, "Binding" },
+#else
+#define CHIP_PRINTCLUSTER_BINDING_CLUSTER
+#endif
+
 #if defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_SERVER) || defined(ZCL_USING_SAMPLE_MFG_SPECIFIC_CLUSTER_CLIENT)
 #define CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER { ZCL_SAMPLE_MFG_SPECIFIC_CLUSTER_ID, 64512, "Sample Mfg Specific Cluster" },
 #else
@@ -850,6 +856,7 @@
     CHIP_PRINTCLUSTER_ELECTRICAL_MEASUREMENT_CLUSTER                                                                               \
     CHIP_PRINTCLUSTER_DIAGNOSTICS_CLUSTER                                                                                          \
     CHIP_PRINTCLUSTER_ZLL_COMMISSIONING_CLUSTER                                                                                    \
+    CHIP_PRINTCLUSTER_BINDING_CLUSTER                                                                                              \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER                                                                                  \
     CHIP_PRINTCLUSTER_SAMPLE_MFG_SPECIFIC_CLUSTER_2                                                                                \
     CHIP_PRINTCLUSTER_OTA_CONFIGURATION_CLUSTER                                                                                    \

--- a/scripts/tools/zap_configure.sh
+++ b/scripts/tools/zap_configure.sh
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 
+ZAP_TEMPLATES=$PWD/src/app/zap-templates
 cd ./third_party/zap/repo/
 
-node ./src-script/zap-start.js --logToStdout --gen ../../../src/app/zap-templates/app-templates.json
+node ./src-script/zap-start.js --logToStdout -z "$ZAP_TEMPLATES"/zcl/zcl.json --gen "$ZAP_TEMPLATES"/app-templates.json

--- a/scripts/tools/zap_generate.sh
+++ b/scripts/tools/zap_generate.sh
@@ -31,8 +31,9 @@ if [ ! -d "$OUTPUT_DIRECTORY" ]; then
     mkdir -p "$OUTPUT_DIRECTORY"
 fi
 
+ZAP_TEMPLATES=$PWD/src/app/zap-templates
 cd ./third_party/zap/repo/
-node ./src-script/zap-generate.js -z ./zcl-builtin/silabs/zcl.json -g ../../../src/app/zap-templates/app-templates.json -i "$FILE_PATH" -o "$OUTPUT_DIRECTORY"
+node ./src-script/zap-generate.js -z "$ZAP_TEMPLATES"/zcl/zcl.json -g "$ZAP_TEMPLATES"/app-templates.json -i "$FILE_PATH" -o "$OUTPUT_DIRECTORY"
 
 # Check if clang-format is available
 if command -v clang-format &>/dev/null; then

--- a/scripts/tools/zap_generate_chip.sh
+++ b/scripts/tools/zap_generate_chip.sh
@@ -16,5 +16,6 @@
 #    limitations under the License.
 #
 
+ZAP_TEMPLATES=$PWD/src/app/zap-templates
 cd ./third_party/zap/repo/
-node ./src-script/zap-generate.js -z ./zcl-builtin/silabs/zcl.json -g ../../../src/app/zap-templates/chip-templates.json -i ../../../examples/all-clusters-app/all-clusters-common/all-clusters-app.zap -o ../../../
+node ./src-script/zap-generate.js -z "$ZAP_TEMPLATES"/zcl/zcl.json -g "$ZAP_TEMPLATES"/chip-templates.json -i ../../../examples/all-clusters-app/all-clusters-common/all-clusters-app.zap -o ../../../

--- a/src/app/zap-templates/zcl/binding-cluster.xml
+++ b/src/app/zap-templates/zcl/binding-cluster.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="CHIP"/>
+  <cluster>
+    <domain>General</domain>
+    <name>Binding</name>
+    <code>0xF000</code>
+    <define>BINDING_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <description>The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.</description>
+    <command source="client" code="0x00" name="Bind" optional="false">
+      <description>Add a binding</description>
+      <arg name="nodeId" type="INT64U"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="client" code="0x01" name="Unbind" optional="false">
+      <description>Remove a binding</description>
+      <arg name="nodeId" type="INT64U"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/chip-devices.xml
+++ b/src/app/zap-templates/zcl/chip-devices.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>CHIP-All-Clusters-Server</name>
+    <domain>CHIP</domain>
+    <typeName>CHIP all-clusters-app server example</typeName>
+    <profileId editable="false">0x0103</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireCommand>ResetToFactoryDefaults</requireCommand>
+        <requireCommand>MfgSpecificPing</requireCommand>
+      </include>
+      <include cluster="Barrier Control" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>BarrierControlGoToPercent</requireCommand>
+        <requireCommand>BarrierControlStop</requireCommand>
+      </include>
+      <include cluster="Color Control" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_DRIFT_COMPENSATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COMPENSATION_TEXT</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_WHITE_POINT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_WHITE_POINT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_R_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_R_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_R_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_G_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_G_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_G_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_B_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_B_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_POINT_B_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS</requireAttribute>
+        <requireAttribute>START_UP_COLOR_TEMPERATURE_MIREDS</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+      </include>
+      <include cluster="Door Lock" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>LockDoor</requireCommand>
+        <requireCommand>UnlockDoor</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>UnlockWithTimeout</requireCommand>
+        <requireCommand>GetLogRecord</requireCommand>
+        <requireCommand>SetPin</requireCommand>
+        <requireCommand>GetPin</requireCommand>
+        <requireCommand>ClearPin</requireCommand>
+        <requireCommand>ClearAllPins</requireCommand>
+        <requireCommand>SetWeekdaySchedule</requireCommand>
+        <requireCommand>GetWeekdaySchedule</requireCommand>
+        <requireCommand>ClearWeekdaySchedule</requireCommand>
+        <requireCommand>SetYearDaySchedule</requireCommand>
+        <requireCommand>GetYearDaySchedule</requireCommand>
+        <requireCommand>ClearYearDaySchedule</requireCommand>
+        <requireCommand>SetHolidaySchedule</requireCommand>
+        <requireCommand>GetHolidaySchedule</requireCommand>
+        <requireCommand>ClearHolidaySchedule</requireCommand>
+        <requireCommand>SetUserType</requireCommand>
+        <requireCommand>GetUserType</requireCommand>
+        <requireCommand>SetRfid</requireCommand>
+        <requireCommand>GetRfid</requireCommand>
+        <requireCommand>ClearRfid</requireCommand>
+        <requireCommand>ClearAllRfids</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="IAS Zone" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ZoneEnrollResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+      </include>
+      <include cluster="Level Control" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="On/off" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+      </include>
+      <include cluster="Scenes" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>AddSceneResponse</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>ViewSceneResponse</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveSceneResponse</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>RemoveAllScenesResponse</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>StoreSceneResponse</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>GetSceneMembershipResponse</requireCommand>
+      </include>
+      <include cluster="Temperature Measurement" client="false" server="true" clientLocked="true" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/clusters-extensions.xml
+++ b/src/app/zap-templates/zcl/clusters-extensions.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="CHIP"/>
+  <clusterExtension code="0x0000">
+    <command source="client" code="0x00" name="MfgSpecificPing" optional="true" manufacturerCode="0x1002">
+      <description></description>
+    </command>
+  </clusterExtension>
+</configurator>

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -1,0 +1,48 @@
+{
+    "version": "ZCL Test Data",
+    "xmlRoot": [".", "../../../../third_party/zap/repo/zcl-builtin/silabs/"],
+    "xmlFile": [
+        "binding-cluster.xml",
+        "clusters-extensions.xml",
+        "chip-devices.xml",
+        "types.xml",
+        "general.xml",
+        "ha.xml",
+        "ha-devices.xml",
+        "cba.xml",
+        "cba-devices.xml",
+        "ota.xml",
+        "ami.xml",
+        "ami-devices.xml",
+        "zll.xml",
+        "zll-devices.xml",
+        "ta.xml",
+        "ta-devices.xml",
+        "hc.xml",
+        "hc-devices.xml",
+        "green-power.xml",
+        "green-power-devices.xml",
+        "silabs.xml",
+        "lo-devices.xml",
+        "wwah-silabs.xml",
+        "wwah-silabs-devices.xml",
+        "sample-extensions.xml"
+    ],
+
+    "manufacturersXml": "../shared/manufacturers.xml",
+    "options": {
+        "text": {
+            "defaultResponsePolicy": ["Always", "Conditional", "Never"]
+        },
+        "bool": ["commandDiscovery"]
+    },
+    "defaults": {
+        "text": {
+            "manufacturerCodes": "0x1002",
+            "defaultResponsePolicy": "always"
+        },
+        "bool": {
+            "commandDiscovery": true
+        }
+    }
+}


### PR DESCRIPTION
 #### Problem

This PR introduces a folder inside `src/app/zap-templates` to host custom
ZCL extensions such as the `MfgSpecificPing` command introduced in #4127 as
well as the `Binding Cluster` from #4156.

The `Binding Cluster` exposes 2 methods, `Bind` and `Unbind`. The current spec
defines `bindings` has an `RW` attribute but an issue has been opened since it does
not look very convenient (see https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/627)

The `gen/` folders are also updated to reflect the addition of the `Binding Cluster`.

Futhermore, the 2 scripts used to generates the `gen/` folders have also been updated to
points to the `src/app/zap-templates/zcl/zcl.json` instead of `third_party/zap/repo/zcl-builtin/silabs/zcl.json`
since the former is a superset of the later.



