### PR TITLE
AddressSanitizer: global-buffer-overflow in emAfReadOrWriteAttribute

### DIFF
--- a/examples/lighting-app/lighting-common/gen/endpoint_config.h
+++ b/examples/lighting-app/lighting-common/gen/endpoint_config.h
@@ -101,7 +101,7 @@
 #define ATTRIBUTE_SINGLETONS_SIZE (0)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE 3
+#define ATTRIBUTE_MAX_SIZE 6
 
 // Array of endpoints that are supported
 #define FIXED_ENDPOINT_ARRAY                                                                                                       \

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -213,6 +213,9 @@ static void NotifierTest(nlTestSuite * inSuite, void * inContext)
     notifier.Register(&cb);
     notifier.Notify(8);
     NL_TEST_ASSERT(inSuite, n == 1);
+
+    cb.Cancel();
+    cancelcb.Cancel();
 }
 
 /**


### PR DESCRIPTION
 #### Problem

#4418 is trying to enable `ASAN` but there are some issues.

As @bzbarsky-apple suggests in https://github.com/project-chip/connectedhomeip/pull/4118#issuecomment-740932776 the `MAX_ATTRIBUTE_SIZE` from `lighting-common/gen/endpoint_config.h` is wrong. 

But there is also a `stack-use-after-scope` in `src/lib/core/tests/TestCHIPCallback.h`.

 #### Summary of Changes
 * Change `MAX_ATTRIBUTE_SIZE` from `3`to `6` in `examples/lighting-app/lighting-common/gen/endpoint_config.h`
 * Call `CHIPCallback::Cancel` at the end of the test for the callbacks
