### PR TITLE
Use CHIPProjectConfig.h in examples/lighting-app/linux/main.cpp inste…

### DIFF
--- a/config/standalone/CHIPProjectConfig.h
+++ b/config/standalone/CHIPProjectConfig.h
@@ -38,6 +38,10 @@
 // Enable support functions for parsing command-line arguments
 #define CHIP_CONFIG_ENABLE_ARG_PARSER 1
 
+// Use a default pairing code if one hasn't been provisioned in flash.
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
+#define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
+
 // Enable reading DRBG seed data from /dev/(u)random.
 // This is needed for test applications and the CHIP device manager to function
 // properly when CHIP_CONFIG_RNG_IMPLEMENTATION_CHIPDRBG is enabled.

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -44,8 +44,6 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
-constexpr uint32_t kDefaultSetupPinCode = 12345678; // TODO: Should be a macro in CHIPProjectConfig.h like other example apps.
-
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
                                         uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
 {
@@ -113,19 +111,9 @@ CHIP_ERROR PrintQRCodeContent()
     std::string result;
 
     err = ConfigurationMgr().GetSetupPinCode(setUpPINCode);
-    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        setUpPINCode = kDefaultSetupPinCode;
-        err          = ConfigurationMgr().StoreSetupPinCode(setUpPINCode);
-    }
     SuccessOrExit(err);
 
     err = ConfigurationMgr().GetSetupDiscriminator(setUpDiscriminator);
-    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
-    {
-        setUpDiscriminator = GetRandU16() & 0xFFF;
-        err                = ConfigurationMgr().StoreSetupDiscriminator(setUpDiscriminator);
-    }
     SuccessOrExit(err);
 
     err = ConfigurationMgr().GetVendorId(vendorId);


### PR DESCRIPTION
…ad of kDefaultSetupPinCode

 #### Problem

Other examples uses `CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE` and `CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR` instead of an hardcoded value in the source file and a random value.

 #### Summary of Changes
 * Use `CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR` and  `CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR`