### PR TITLE
SystemPacketBuffer.h cleanup

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -122,30 +122,13 @@ CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle payload, Co
     }
 
 exit:
-    if (!payload.IsNull())
-    {
-        System::PacketBuffer * buffer = payload.Release_ForNow();
-        if (buffer != NULL)
-        {
-            System::PacketBuffer::Free(buffer);
-            buffer = nullptr;
-        }
-    }
     return err;
 }
 
 void Command::Shutdown()
 {
     VerifyOrExit(mState != kState_Uninitialized, );
-    if (!mCommandMessageBuf.IsNull())
-    {
-        System::PacketBuffer * buffer = mCommandDataBuf.Release_ForNow();
-        if (buffer != NULL)
-        {
-            System::PacketBuffer::Free(buffer);
-            buffer = nullptr;
-        }
-    }
+    mCommandMessageBuf = nullptr;
 
     if (mpExchangeCtx != nullptr)
     {
@@ -241,14 +224,8 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
     }
     MoveToState(kState_AddCommand);
 
-exit : {
-    System::PacketBuffer * buffer = mCommandDataBuf.Release_ForNow();
-    if (buffer != NULL)
-    {
-        System::PacketBuffer::Free(buffer);
-        buffer = nullptr;
-    }
-}
+exit:
+    mCommandDataBuf = nullptr;
     ChipLogFunctError(err);
     return err;
 }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -109,13 +109,6 @@ void InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext * apEc,
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    System::PacketBuffer * buffer = aPayload.Release_ForNow();
-    if (buffer != NULL)
-    {
-        System::PacketBuffer::Free(buffer);
-        buffer = nullptr;
-    }
-
     ChipLogDetail(DataManagement, "Msg type %d not supported", (int) aMsgType);
 
     // Todo: Add status report

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -697,7 +697,7 @@ void AttributePathTest(nlTestSuite * apSuite, void * apContext)
 
     ParseAttributePath(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void AttributePathListTest(nlTestSuite * apSuite, void * apContext)
@@ -719,7 +719,7 @@ void AttributePathListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributePathList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void EventPathTest(nlTestSuite * apSuite, void * apContext)
@@ -746,7 +746,7 @@ void EventPathTest(nlTestSuite * apSuite, void * apContext)
     eventPathParser.Init(reader);
     ParseEventPath(apSuite, eventPathParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void EventPathListTest(nlTestSuite * apSuite, void * apContext)
@@ -768,7 +768,7 @@ void EventPathListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventPathList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void CommandPathTest(nlTestSuite * apSuite, void * apContext)
@@ -796,7 +796,7 @@ void CommandPathTest(nlTestSuite * apSuite, void * apContext)
 
     ParseCommandPath(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -823,7 +823,7 @@ void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
     eventDataElementParser.Init(reader);
     ParseEventDataElement(apSuite, eventDataElementParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void EventListTest(nlTestSuite * apSuite, void * apContext)
@@ -847,7 +847,7 @@ void EventListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void StatusElementTest(nlTestSuite * apSuite, void * apContext)
@@ -874,7 +874,7 @@ void StatusElementTest(nlTestSuite * apSuite, void * apContext)
     statusElementParser.Init(reader);
     ParseStatusElement(apSuite, statusElementParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
@@ -901,7 +901,7 @@ void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
     attributeStatusElementParser.Init(reader);
     ParseAttributeStatusElement(apSuite, attributeStatusElementParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
@@ -926,7 +926,7 @@ void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeStatusList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -953,7 +953,7 @@ void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
     attributeDataElementParser.Init(reader);
     ParseAttributeDataElement(apSuite, attributeDataElementParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void AttributeDataListTest(nlTestSuite * apSuite, void * apContext)
@@ -977,7 +977,7 @@ void AttributeDataListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeDataList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -1004,7 +1004,7 @@ void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
     commandDataElementParser.Init(reader);
     ParseCommandDataElement(apSuite, commandDataElementParser);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void CommandListTest(nlTestSuite * apSuite, void * apContext)
@@ -1028,7 +1028,7 @@ void CommandListTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseCommandList(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void ReportDataTest(nlTestSuite * apSuite, void * apContext)
@@ -1050,7 +1050,7 @@ void ReportDataTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseReportData(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 void InvokeCommandTest(nlTestSuite * apSuite, void * apContext)
@@ -1072,7 +1072,7 @@ void InvokeCommandTest(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseInvokeCommand(apSuite, reader);
 
-    bufHandle.Adopt(nullptr);
+    bufHandle = nullptr;
 }
 
 /**

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -585,7 +585,7 @@ void BtpEngine::LogState() const
 
     ChipLogError(Ble, "mRxFragmentSize: %d", mRxFragmentSize);
     ChipLogError(Ble, "mRxState: %d", mRxState);
-    ChipLogError(Ble, "mRxBuf: %p", mRxBuf.Get_ForNow());
+    ChipLogError(Ble, "mRxBuf: %d", !mRxBuf.IsNull());
     ChipLogError(Ble, "mRxNextSeqNum: %d", mRxNextSeqNum);
     ChipLogError(Ble, "mRxNewestUnackedSeqNum: %d", mRxNewestUnackedSeqNum);
     ChipLogError(Ble, "mRxOldestUnackedSeqNum: %d", mRxOldestUnackedSeqNum);
@@ -594,7 +594,7 @@ void BtpEngine::LogState() const
 
     ChipLogError(Ble, "mTxFragmentSize: %d", mTxFragmentSize);
     ChipLogError(Ble, "mTxState: %d", mTxState);
-    ChipLogError(Ble, "mTxBuf: %p", mTxBuf.Get_ForNow());
+    ChipLogError(Ble, "mTxBuf: %d", !mTxBuf.IsNull());
     ChipLogError(Ble, "mTxNextSeqNum: %d", mTxNextSeqNum);
     ChipLogError(Ble, "mTxNewestUnackedSeqNum: %d", mTxNewestUnackedSeqNum);
     ChipLogError(Ble, "mTxOldestUnackedSeqNum: %d", mTxOldestUnackedSeqNum);

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -683,7 +683,7 @@ System::Error IPEndPointBasis::PostPacketBufferEvent(chip::System::Layer & aLaye
     if (error != INET_NO_ERROR)
     {
         // If PostEvent() failed, it has not taken ownership of the buffer, so we need to retake it so that it will be freed.
-        aBuffer.Adopt(buf);
+        (void) System::PacketBufferHandle::Adopt(buf);
     }
     return error;
 }

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -1068,7 +1068,7 @@ chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarg
 
     case kInetEvent_TCPDataReceived:
         static_cast<TCPEndPoint &>(aTarget).HandleDataReceived(
-            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+            System::PacketBufferHandle::Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
         break;
 
     case kInetEvent_TCPDataSent:
@@ -1083,14 +1083,14 @@ chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarg
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
     case kInetEvent_RawDataReceived:
         static_cast<RawEndPoint &>(aTarget).HandleDataReceived(
-            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+            System::PacketBufferHandle::Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
         break;
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
 #if INET_CONFIG_ENABLE_UDP_ENDPOINT
     case kInetEvent_UDPDataReceived:
         static_cast<UDPEndPoint &>(aTarget).HandleDataReceived(
-            System::PacketBufferHandle::Create(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
+            System::PacketBufferHandle::Adopt(reinterpret_cast<chip::System::PacketBuffer *>(aArgument)));
         break;
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -957,9 +957,7 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void * arg, struct raw_pcb * pcb, struct
     chip::System::Layer & lSystemLayer = ep->SystemLayer();
     IPPacketInfo * pktInfo             = NULL;
     uint8_t enqueue                    = 1;
-    System::PacketBufferHandle buf;
-
-    buf.Adopt(reinterpret_cast<PacketBuffer *>(static_cast<void *>(p)));
+    System::PacketBufferHandle buf     = System::PacketBufferHandle::Adopt(p);
 
     // Filtering based on the saved ICMP6 types (the only protocol currently supported.)
     if ((ep->IPVer == kIPVersion_6) && (ep->IPProto == kIPProtocol_ICMPv6))

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -869,9 +869,7 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
     UDPEndPoint * ep                   = static_cast<UDPEndPoint *>(arg);
     chip::System::Layer & lSystemLayer = ep->SystemLayer();
     IPPacketInfo * pktInfo             = NULL;
-    System::PacketBufferHandle buf;
-
-    buf.Adopt(reinterpret_cast<PacketBuffer *>(static_cast<void *>(p)));
+    System::PacketBufferHandle buf     = System::PacketBufferHandle::Adopt(p);
 
     pktInfo = GetPacketInfo(buf);
     if (pktInfo != NULL)

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -89,7 +89,7 @@ public:
      *
      *  @param[in]    msgType       The message type of the corresponding protocol.
      *
-     *  @param[in]    msgPayload    A pointer to the PacketBuffer object holding the CHIP message.
+     *  @param[in]    msgPayload    A handle to the PacketBuffer object holding the CHIP message.
      *
      *  @param[in]    sendFlags     Flags set by the application for the CHIP message being sent.
      *

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -51,7 +51,7 @@ public:
      *  @param[in]    packetHeader  A reference to the PacketHeader object.
      *  @param[in]    protocolId    The protocol identifier of the received message.
      *  @param[in]    msgType       The message type of the corresponding protocol.
-     *  @param[in]    payload       A pointer to the PacketBuffer object holding the message payload.
+     *  @param[in]    payload       A handle to the PacketBuffer object holding the message payload.
      */
     virtual void OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
                                    System::PacketBufferHandle payload) = 0;

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -377,7 +377,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kCHIPoBLEWriteReceived: {
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEWriteReceived");
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
     }
     break;
 

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -250,7 +250,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
         break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -243,7 +243,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_RX,
-                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
         break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -216,7 +216,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEWriteReceived:
         HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
-                            PacketBufferHandle::Create(event->CHIPoBLEWriteReceived.Data));
+                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
         break;
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm:

--- a/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.cpp
+++ b/src/platform/Zephyr/GenericBLEManagerImpl_Zephyr.cpp
@@ -481,7 +481,7 @@ CHIP_ERROR GenericBLEManagerImpl_Zephyr<ImplClass>::HandleRXCharWrite(const Chip
                   bt_conn_index(c1WriteEvent->BtConn));
 
     HandleWriteReceived(c1WriteEvent->BtConn, &CHIP_BLE_SVC_ID, &chipUUID_CHIPoBLEChar_RX,
-                        PacketBufferHandle::Create(c1WriteEvent->Data));
+                        PacketBufferHandle::Adopt(c1WriteEvent->Data));
     bt_conn_unref(c1WriteEvent->BtConn);
 
     return CHIP_NO_ERROR;

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -552,7 +552,7 @@ PacketBufferHandle PacketBufferHandle::CloneData()
 
     if (other->AvailableDataLength() < mBuffer->DataLength())
     {
-        other.Free();
+        other = nullptr;
         return other;
     }
 

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -552,7 +552,7 @@ PacketBufferHandle PacketBufferHandle::CloneData()
 
     if (other->AvailableDataLength() < mBuffer->DataLength())
     {
-        other.Adopt(nullptr);
+        other.Free();
         return other;
     }
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -451,7 +451,7 @@ public:
         aOther.mBuffer = nullptr;
     }
 
-    ~PacketBufferHandle() { Free(); }
+    ~PacketBufferHandle() { *this = nullptr; }
 
     /**
      * Take ownership of a PacketBuffer from another PacketBufferHandle, freeing any existing owned buffer.
@@ -472,7 +472,11 @@ public:
      */
     PacketBufferHandle & operator=(decltype(nullptr))
     {
-        Free();
+        if (mBuffer != nullptr)
+        {
+            PacketBuffer::Free(mBuffer);
+        }
+        mBuffer = nullptr;
         return *this;
     }
 
@@ -623,15 +627,6 @@ private:
             buffer->AddRef();
         }
         return PacketBufferHandle(buffer);
-    }
-
-    void Free()
-    {
-        if (mBuffer != nullptr)
-        {
-            PacketBuffer::Free(mBuffer);
-        }
-        mBuffer = nullptr;
     }
 
     PacketBuffer * Get() const { return mBuffer; }

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -659,7 +659,7 @@ void PacketBufferTest::CheckDetachTail(nlTestSuite * inSuite, void * inContext)
             PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
             PacketBuffer * returned = nullptr;
             buffer_1->AddRef(); // The test still holds ownership via buffer_1.
-            PacketBufferHandle buffer_handle = PacketBufferHandle::Create(buffer_1);
+            PacketBufferHandle buffer_handle = PacketBufferHandle::Adopt(buffer_1);
 
             if (theFirstContext != theSecondContext)
             {
@@ -1023,7 +1023,7 @@ void PacketBufferTest::CheckNext(nlTestSuite * inSuite, void * inContext)
             {
                 theFirstContext->buf->next = theSecondContext->buf;
 
-                NL_TEST_ASSERT(inSuite, buffer_1->Next_ForNow() == buffer_2);
+                NL_TEST_ASSERT(inSuite, buffer_1->ChainedBuffer() == buffer_2);
             }
             else
             {

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -99,7 +99,7 @@ protected:
      * This function is the application callback that is invoked when a message is received over a
      * Chip connection.
      *
-     * @param[in]    msgBuf        A pointer to the PacketBuffer object holding the message.
+     * @param[in]    msgBuf        A handle to the PacketBuffer object holding the message.
      *
      * Callback *MUST* free msgBuf as a result of handling.
      */


### PR DESCRIPTION
#### Problem

Code should use `PacketBufferHandle` rather than `PacketBuffer *`.
Some existing methods should be removed or made private so that code
does not have unnecessary access to the raw pointer.

#### Summary of Changes

- convert public use of `PacketBufferHandle::Adopt()`.
- convert internal use of `Adopt()` to private `Free()`.
- renamed `PacketBuffer::Create()` factory to `Adopt()`.
- rename private `PacketBuffer::Next()` to `ChainedBuffer()`.
- explicitly note `PacketBuffer::Next_ForNow()` remaining use in TLV.
- make `PacketBuffer::Free()` private.
- make `PacketBuffer::Consume()` private.
- make `PacketBuffer::AddToEnd_ForNow()` private (still used in tests).
- remove `PacketBuffer::FreeHead_ForNow()`.
- remove `operator*`.

Part of issue #2707 - Figure out a way to express PacketBuffer ownership in the type system
