### PR TITLE
[nrfconnect] Add PWM support to the lighting-app

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -1,9 +1,9 @@
 # CHIP nRF Connect Lighting Example Application
 
 The nRF Connect Lighting Example demonstrates how to remotely control a white
-non-dimmable light bulb. It uses buttons to test changing the lighting and
-device states and LEDs to show the state of these changes. You can use this
-example as a reference for creating your own application.
+dimmable light bulb. It uses buttons to test changing the lighting and device
+states and LEDs to show the state of these changes. You can use this example as
+a reference for creating your own application.
 
 The example is based on [CHIP](https://github.com/project-chip/connectedhomeip)
 and the nRF Connect platform, and supports remote access and control of a

--- a/examples/lighting-app/nrfconnect/dts.overlay
+++ b/examples/lighting-app/nrfconnect/dts.overlay
@@ -15,13 +15,36 @@
  */
 
 / {
+
 	/*
 	* In some default configurations within the nRF Connect SDK,
 	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
 	* This devicetree overlay ensures that default is overridden wherever it
 	* is set, as this application uses the RNG node for entropy exclusively.
 	*/
+
 	chosen {
 		zephyr,entropy = &rng;
 	};
+
+	/*
+	* By default, PWM module is only configured for led0 (LED1 on the board).
+	* The lighting-app, however, uses LED2 to show the state of the lighting,
+	* including its brightness level.
+	*/
+	aliases {
+		pwm-led1 = &pwm_led1;
+	};
+
+	pwmleds {
+		pwm_led1: pwm_led_1 {
+			pwms = < &pwm0 0xe >;
+		};
+	};
+
+};
+
+&pwm0 {
+	ch1-pin = < 0xe >;
+	ch1-inverted;
 };

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -505,13 +505,23 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 
 void AppTask::UpdateClusterState()
 {
-    uint8_t newValue = LightingMgr().IsTurnedOn();
+    uint8_t onoff = LightingMgr().IsTurnedOn();
 
     // write the new on/off value
-    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &newValue,
+    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &onoff,
                                                  ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        LOG_ERR("Updating on/off %x", status);
+        LOG_ERR("Updating on/off cluster failed: %x", status);
+    }
+
+    uint8_t level = LightingMgr().GetLevel();
+
+    status = emberAfWriteAttribute(1, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
+                                   ZCL_DATA8_ATTRIBUTE_TYPE);
+
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        LOG_ERR("Updating level cluster failed: %x", status);
     }
 }

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -100,7 +100,7 @@ int AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::TimerEventHandler, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-    ret = LightingMgr().Init(LIGHTING_GPIO_DEVICE_NAME, LIGHTING_GPIO_PIN);
+    ret = LightingMgr().Init(LIGHTING_PWM_DEVICE, LIGHTING_PWM_CHANNEL);
     if (ret != 0)
         return ret;
 

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -69,7 +69,7 @@ bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint8_t s
         action_initiated = true;
         new_state        = kState_Off;
     }
-    else if (aAction == LEVEL_ACTION)
+    else if (aAction == LEVEL_ACTION && *value != mLevel)
     {
         action_initiated = true;
         if (*value == 0)

--- a/examples/lighting-app/nrfconnect/main/include/AppConfig.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppConfig.h
@@ -30,8 +30,8 @@
 #define BLE_ADVERTISEMENT_START_BUTTON_MASK DK_BTN4_MSK
 
 #define SYSTEM_STATE_LED DK_LED1 // led0 in device tree
-#define LIGHTING_GPIO_DEVICE_NAME DT_GPIO_LABEL(DT_ALIAS(led1), gpios)
-#define LIGHTING_GPIO_PIN DT_GPIO_PIN(DT_ALIAS(led1), gpios)
+#define LIGHTING_PWM_DEVICE DT_PWMS_LABEL(DT_ALIAS(pwm_led1))
+#define LIGHTING_PWM_CHANNEL DT_PWMS_CHANNEL(DT_ALIAS(pwm_led1))
 
 // Time it takes in ms for the simulated actuator to move from one state to another.
 #define ACTUATOR_MOVEMENT_PERIOS_MS 2000

--- a/examples/lighting-app/nrfconnect/main/include/LightingManager.h
+++ b/examples/lighting-app/nrfconnect/main/include/LightingManager.h
@@ -43,22 +43,26 @@ public:
 
     using LightingCallback_fn = void (*)(Action_t, int32_t);
 
-    int Init(const char * gpioDeviceName, gpio_pin_t gpioPin);
+    int Init(const char * pwmDeviceName, uint32_t pwmChannel);
     bool IsTurnedOn() const { return mState == kState_On; }
     bool InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value);
     void SetCallbacks(LightingCallback_fn aActionInitiated_CB, LightingCallback_fn aActionCompleted_CB);
 
 private:
-    friend LightingManager & LightingMgr(void);
+    static constexpr uint8_t kMaxLevel = 255;
+
+    friend LightingManager & LightingMgr();
     State_t mState;
-    gpio_pin_t mGPIOPin;
-    device * mGPIODevice;
+    uint8_t mLevel;
+    const device * mPwmDevice;
+    uint32_t mPwmChannel;
 
     LightingCallback_fn mActionInitiated_CB;
     LightingCallback_fn mActionCompleted_CB;
 
     void Set(bool aOn);
     void SetLevel(uint8_t aLevel);
+    void UpdateLight();
 
     static LightingManager sLight;
 };

--- a/examples/lighting-app/nrfconnect/main/include/LightingManager.h
+++ b/examples/lighting-app/nrfconnect/main/include/LightingManager.h
@@ -45,6 +45,7 @@ public:
 
     int Init(const char * pwmDeviceName, uint32_t pwmChannel);
     bool IsTurnedOn() const { return mState == kState_On; }
+    uint8_t GetLevel() const { return mLevel; }
     bool InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value);
     void SetCallbacks(LightingCallback_fn aActionInitiated_CB, LightingCallback_fn aActionCompleted_CB);
 

--- a/examples/lighting-app/nrfconnect/prj.conf
+++ b/examples/lighting-app/nrfconnect/prj.conf
@@ -20,6 +20,7 @@
 
 # Add support for LEDs and buttons on Nordic development kits
 CONFIG_DK_LIBRARY=y
+CONFIG_PWM=y
 
 # Default OpenThread network settings
 CONFIG_OPENTHREAD_PANID=4660


### PR DESCRIPTION
 #### Problem
#3806 has added Level Control Cluster to the nrfconnect lighting-app, however UI part of the app doesn't make a use of the cluster yet. That is, it doesn't set LED brightness based on the received level. 

 #### Summary of Changes
Use PWM controller on Nordic devices to set brightness of the second LED based on the received Level (0-255).
