### PR TITLE
Add initial IM invoke command integration

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -78,6 +78,8 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     if (chip_build_tools) {
       deps += [
         "${chip_root}/examples/shell/standalone:chip-shell",
+        "${chip_root}/src/app/tests/integration:chip-im-initiator",
+        "${chip_root}/src/app/tests/integration:chip-im-responder",
         "${chip_root}/src/messaging/tests/echo:chip-echo-requester",
         "${chip_root}/src/messaging/tests/echo:chip-echo-responder",
         "${chip_root}/src/qrcodetool",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -28,6 +28,11 @@ static_library("app") {
   output_name = "libCHIPDataModel"
 
   sources = [
+    "Command.cpp",
+    "Command.h",
+    "CommandHandler.cpp",
+    "CommandSender.cpp",
+    "InteractionModelEngine.cpp",
     "MessageDef.cpp",
     "MessageDef.h",
     "decoder.cpp",
@@ -37,6 +42,7 @@ static_library("app") {
   public_deps = [
     ":codec_headers",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
     "${chip_root}/src/system",
     "${nlio_root}:nlio",
   ]

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -1,0 +1,341 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#include "Command.h"
+#include "CommandHandler.h"
+#include "CommandSender.h"
+#include "InteractionModelEngine.h"
+#include <core/CHIPTLVDebug.hpp>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR Command::Init(Messaging::ExchangeManager * apExchangeMgr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // Error if already initialized.
+    if (mpExchangeMgr != nullptr)
+        return CHIP_ERROR_INCORRECT_STATE;
+
+    mpExchangeMgr = apExchangeMgr;
+    mpExchangeCtx = nullptr;
+
+    err = Reset();
+    SuccessOrExit(err);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR Command::Reset()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    ClearExistingExchangeContext();
+
+    if (mCommandMessageBuf.IsNull())
+    {
+        // TODO: Calculate the packet buffer size
+        mCommandMessageBuf = System::PacketBuffer::New();
+        VerifyOrExit(!mCommandMessageBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+    }
+
+    mCommandMessageWriter.Init(mCommandMessageBuf.Get_ForNow());
+    err = mInvokeCommandBuilder.Init(&mCommandMessageWriter);
+    SuccessOrExit(err);
+
+    mInvokeCommandBuilder.CreateCommandListBuilder();
+    MoveToState(kState_Initialized);
+
+exit:
+    ChipLogFunctError(err);
+
+    return err;
+}
+
+CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle payload, CommandRoleId aCommandRoleId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::TLV::TLVReader reader;
+    chip::TLV::TLVReader commandListReader;
+    InvokeCommand::Parser invokeCommandParser;
+    CommandList::Parser commandListParser;
+
+    reader.Init(payload.Get_ForNow());
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = invokeCommandParser.Init(reader);
+    SuccessOrExit(err);
+
+    err = invokeCommandParser.CheckSchemaValidity();
+    SuccessOrExit(err);
+
+    err = invokeCommandParser.GetCommandList(&commandListParser);
+    SuccessOrExit(err);
+
+    commandListParser.GetReader(&commandListReader);
+
+    while (CHIP_NO_ERROR == (err = commandListReader.Next()))
+    {
+        VerifyOrExit(chip::TLV::AnonymousTag == commandListReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrExit(chip::TLV::kTLVType_Structure == commandListReader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
+
+        CommandDataElement::Parser commandElement;
+
+        err = commandElement.Init(commandListReader);
+        SuccessOrExit(err);
+
+        err = commandElement.CheckSchemaValidity();
+        SuccessOrExit(err);
+
+        err = ProcessCommandDataElement(commandElement);
+        SuccessOrExit(err);
+    }
+
+    // if we have exhausted this container
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    if (!payload.IsNull())
+    {
+        System::PacketBuffer * buffer = payload.Release_ForNow();
+        if (buffer != NULL)
+        {
+            System::PacketBuffer::Free(buffer);
+            buffer = nullptr;
+        }
+    }
+    return err;
+}
+
+void Command::Shutdown()
+{
+    VerifyOrExit(mState != kState_Uninitialized, );
+    if (!mCommandMessageBuf.IsNull())
+    {
+        System::PacketBuffer * buffer = mCommandDataBuf.Release_ForNow();
+        if (buffer != NULL)
+        {
+            System::PacketBuffer::Free(buffer);
+            buffer = nullptr;
+        }
+    }
+
+    if (mpExchangeCtx != nullptr)
+    {
+        mpExchangeCtx->Abort();
+        mpExchangeCtx = nullptr;
+    }
+    mpExchangeMgr = nullptr;
+    MoveToState(kState_Uninitialized);
+
+exit:
+    return;
+}
+
+chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
+{
+    mCommandDataBuf = chip::System::PacketBuffer::New();
+    if (mCommandDataBuf.IsNull())
+    {
+        ChipLogDetail(DataManagement, "Unable to allocate PacketBuffer");
+    }
+
+    mCommandDataWriter.Init(mCommandDataBuf.Get_ForNow());
+
+    return mCommandDataWriter;
+}
+
+CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
+                               chip::CommandId aCommandId, uint8_t aFlags)
+{
+    CommandParams commandParams;
+
+    memset(&commandParams, 0, sizeof(CommandParams));
+
+    commandParams.EndpointId = aEndpintId;
+    commandParams.GroupId    = aGroupId;
+    commandParams.ClusterId  = aClusterId;
+    commandParams.CommandId  = aCommandId;
+    commandParams.Flags      = aFlags;
+
+    return AddCommand(commandParams);
+}
+
+CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    const uint8_t * apCommandData;
+    uint32_t apCommandLen;
+
+    apCommandData = mCommandDataBuf->Start();
+    apCommandLen  = mCommandDataBuf->DataLength();
+
+    if (apCommandLen > 0)
+    {
+        VerifyOrExit(apCommandLen > 2, err = CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrExit(apCommandData[0] == chip::TLV::kTLVType_Structure, err = CHIP_ERROR_INVALID_ARGUMENT);
+        // VerifyOrExit(apCommandData[apCommandLen - 1] == chip::TLV::TLVElementType::EndOfContainer, err =
+        // CHIP_ERROR_INVALID_ARGUMENT);
+
+        apCommandData += 1;
+        apCommandLen -= 1;
+    }
+
+    {
+        CommandDataElement::Builder commandDataElement =
+            mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+        CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
+        if (aCommandParams.Flags & kCommandPathFlag_EndpointIdValid)
+        {
+            commandPath.EndpointId(aCommandParams.EndpointId);
+        }
+
+        if (aCommandParams.Flags & kCommandPathFlag_GroupIdValid)
+        {
+            commandPath.GroupId(aCommandParams.GroupId);
+        }
+
+        commandPath.NamespacedClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
+
+        err = commandPath.GetError();
+        SuccessOrExit(err);
+
+        if (apCommandLen > 0)
+        {
+            // Copy the application data into a new TLV structure field contained with the
+            // command structure.  NOTE: The TLV writer will take care of moving the app data
+            // to the correct location within the buffer.
+            err = mInvokeCommandBuilder.GetWriter()->PutPreEncodedContainer(
+                chip::TLV::ContextTag(CommandDataElement::kCsTag_Data), chip::TLV::kTLVType_Structure, apCommandData, apCommandLen);
+            SuccessOrExit(err);
+        }
+        commandDataElement.EndOfCommandDataElement();
+
+        err = commandDataElement.GetError();
+        SuccessOrExit(err);
+    }
+    MoveToState(kState_AddCommand);
+
+exit : {
+    System::PacketBuffer * buffer = mCommandDataBuf.Release_ForNow();
+    if (buffer != NULL)
+    {
+        System::PacketBuffer::Free(buffer);
+        buffer = nullptr;
+    }
+}
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR Command::AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
+                                  const chip::ClusterId aNamespacedClusterId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    StatusElement::Builder statusElementBuilder;
+
+    err = statusElementBuilder.Init(mInvokeCommandBuilder.GetWriter());
+    SuccessOrExit(err);
+
+    statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId, aProtocolCode, aProtocolCode).EndOfStatusElement();
+    err = statusElementBuilder.GetError();
+
+    MoveToState(kState_AddCommand);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR Command::ClearExistingExchangeContext()
+{
+    // Discard any existing exchange context. Effectively we can only have one Echo exchange with
+    // a single node at any one time.
+    if (mpExchangeCtx != nullptr)
+    {
+        mpExchangeCtx->Abort();
+        mpExchangeCtx = nullptr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Command::FinalizeCommandsMessage()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mInvokeCommandBuilder.EndOfInvokeCommand();
+    err = mInvokeCommandBuilder.GetError();
+    SuccessOrExit(err);
+
+    err = mCommandMessageWriter.Finalize();
+    SuccessOrExit(err);
+
+    mCommandMessageBuf->EnsureReservedSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+#if CHIP_DETAIL_LOGGING
+const char * Command::GetStateStr() const
+{
+    switch (mState)
+    {
+    case kState_Uninitialized:
+        return "Uninitialized";
+
+    case kState_Initialized:
+        return "Initialized";
+
+    case kState_AddCommand:
+        return "AddCommand";
+
+    case kState_Sending:
+        return "Sending";
+    }
+    return "N/A";
+}
+#endif // CHIP_DETAIL_LOGGING
+
+void Command::MoveToState(const CommandState aTargetState)
+{
+    mState = aTargetState;
+    ChipLogDetail(DataManagement, "ICR moving to [%10.10s]", GetStateStr());
+}
+
+void Command::ClearState(void)
+{
+    MoveToState(kState_Uninitialized);
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -201,8 +201,6 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
     {
         VerifyOrExit(apCommandLen > 2, err = CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrExit(apCommandData[0] == chip::TLV::kTLVType_Structure, err = CHIP_ERROR_INVALID_ARGUMENT);
-        // VerifyOrExit(apCommandData[apCommandLen - 1] == chip::TLV::TLVElementType::EndOfContainer, err =
-        // CHIP_ERROR_INVALID_ARGUMENT);
 
         apCommandData += 1;
         apCommandLen -= 1;

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Base class for a CHIP IM Command
+ *
+ */
+
+#pragma once
+
+#ifndef _CHIP_INTERACTION_MODEL_COMMAND_H
+#define _CHIP_INTERACTION_MODEL_COMMAND_H
+
+#include <app/MessageDef.h>
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+
+class Command
+{
+public:
+    enum CommandRoleId
+    {
+        kCommandSenderId  = 0,
+        kCommandHandlerId = 1,
+    };
+
+    enum CommandState
+    {
+        kState_Uninitialized = 0, ///< The invoke command message has not been initialized
+        kState_Initialized,       ///< The invoke command message has been initialized and is ready
+        kState_AddCommand,        ///< The invoke command message has added Command
+        kState_Sending,           ///< The invoke command message  has sent out the invoke command
+    };
+
+    /**
+     * Encapsulates arguments to be passed into SendCommand().
+     *
+     */
+    struct CommandParams
+    {
+        chip::EndpointId EndpointId;
+        chip::GroupId GroupId;
+        chip::ClusterId ClusterId;
+        chip::CommandId CommandId;
+        uint8_t Flags;
+    };
+
+    enum CommandPathFlags
+    {
+        kCommandPathFlag_EndpointIdValid = 0x0001, /**< Set when the EndpointId field is valid */
+        kCommandPathFlag_GroupIdValid    = 0x0002, /**< Set when the GroupId field is valid */
+    } CommandPathFlags;
+
+    /**
+     *  Initialize the CommandSender object. Within the lifetime
+     *  of this instance, this method is invoked once after object
+     *  construction until a call to Shutdown is made to terminate the
+     *  instance.
+     *
+     *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
+     *          kState_NotInitialized.
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr);
+
+    /**
+     *  Shutdown the CommandSender. This terminates this instance
+     *  of the object and releases all held resources.
+     *
+     */
+    void Shutdown();
+
+    /**
+     * Send an echo request to a CHIP node.
+     *
+     * @param nodeId        The destination's nodeId
+     * @param payload       A System::PacketBuffer with the payload. This function takes ownership of the System::PacketBuffer
+     *
+     * @return CHIP_ERROR_NO_MEMORY if no ExchangeContext is available.
+     *         Other CHIPF_ERROR codes as returned by the lower layers.
+     *
+     */
+    CHIP_ERROR FinalizeCommandsMessage();
+
+    chip::TLV::TLVWriter & CreateCommandDataElementTLVWriter();
+    CHIP_ERROR AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
+                          chip::CommandId aCommandId, uint8_t Flags);
+    CHIP_ERROR AddCommand(CommandParams & aCommandParams);
+    CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
+                             const chip::ClusterId aNamespacedClusterId);
+    CHIP_ERROR ClearExistingExchangeContext();
+
+    CHIP_ERROR Reset();
+
+    virtual ~Command() = default;
+
+    bool IsFree() { return (nullptr == mpExchangeCtx); };
+    virtual CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) = 0;
+
+protected:
+    void MoveToState(const CommandState aTargetState);
+    CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle payload, CommandRoleId aCommandRoleId);
+    void ClearState();
+    const char * GetStateStr() const;
+
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    chip::System::PacketBufferHandle mCommandMessageBuf;
+
+private:
+    chip::System::PacketBufferHandle mpBufHandle;
+    InvokeCommand::Builder mInvokeCommandBuilder;
+    CommandState mState;
+
+    chip::System::PacketBufferHandle mCommandDataBuf;
+    chip::TLV::TLVWriter mCommandMessageWriter;
+    chip::TLV::TLVWriter mCommandDataWriter;
+};
+} // namespace app
+} // namespace chip
+
+#endif // _CHIP_INTERACTION_MODEL_COMMAND_H

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines object for a CHIP IM Invoke Command Handler
+ *
+ */
+
+#include "CommandHandler.h"
+#include "Command.h"
+#include "CommandSender.h"
+#include "InteractionModelEngine.h"
+
+namespace chip {
+namespace app {
+void CommandHandler::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId,
+                                       uint8_t msgType, System::PacketBufferHandle payload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle response;
+
+    // NOTE: we already know this is an InvokeCommand Request message because we explicitly registered with the
+    // Exchange Manager for unsolicited InvokeCommand Requests.
+
+    mpExchangeCtx = ec;
+
+    err = ProcessCommandMessage(std::move(payload), kCommandHandlerId);
+    SuccessOrExit(err);
+
+    SendCommandResponse(ec->GetPeerNodeId());
+
+exit:
+    ChipLogFunctError(err);
+}
+
+CHIP_ERROR CommandHandler::SendCommandResponse(NodeId aNodeId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = FinalizeCommandsMessage();
+    SuccessOrExit(err);
+
+    VerifyOrExit(mpExchangeCtx != NULL, err = CHIP_ERROR_INCORRECT_STATE);
+    err = mpExchangeCtx->SendMessage(Protocols::kProtocol_InteractionModel, kMsgType_InvokeCommandResponse,
+                                     std::move(mCommandMessageBuf),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+    SuccessOrExit(err);
+
+    MoveToState(kState_Sending);
+
+exit:
+    Shutdown();
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CommandPath::Parser commandPath;
+    chip::TLV::TLVReader commandDataReader;
+    chip::ClusterId clusterId;
+    chip::CommandId commandId;
+
+    err = aCommandElement.GetCommandPath(&commandPath);
+    SuccessOrExit(err);
+
+    err = commandPath.GetNamespacedClusterId(&clusterId);
+    SuccessOrExit(err);
+
+    err = commandPath.GetCommandId(&commandId);
+    SuccessOrExit(err);
+
+    err = aCommandElement.GetData(&commandDataReader);
+    if (CHIP_END_OF_TLV == err)
+    {
+        // Empty Command, Add status code in invoke command response, notify cluster handler to hand it further.
+        err = CHIP_NO_ERROR;
+        ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
+        AddStatusCode(COMMON_STATUS_SUCCESS, chip::Protocols::kProtocol_Protocol_Common, CHIP_ERROR_INVALID_ARGUMENT, clusterId);
+    }
+    else if (CHIP_NO_ERROR == err)
+    {
+        InteractionModelEngine::GetInstance()->ProcessCommand(clusterId, commandId, commandDataReader, this, kCommandHandlerId);
+    }
+
+exit:
+    return err;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
         // Empty Command, Add status code in invoke command response, notify cluster handler to hand it further.
         err = CHIP_NO_ERROR;
         ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-        //Todo: Define ProtocolCode for StatusCode.
+        // Todo: Define ProtocolCode for StatusCode.
         AddStatusCode(COMMON_STATUS_SUCCESS, chip::Protocols::kProtocol_Protocol_Common, 0, clusterId);
     }
     else if (CHIP_NO_ERROR == err)

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -93,7 +93,8 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
         // Empty Command, Add status code in invoke command response, notify cluster handler to hand it further.
         err = CHIP_NO_ERROR;
         ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-        AddStatusCode(COMMON_STATUS_SUCCESS, chip::Protocols::kProtocol_Protocol_Common, CHIP_ERROR_INVALID_ARGUMENT, clusterId);
+        //Todo: Define ProtocolCode for StatusCode.
+        AddStatusCode(COMMON_STATUS_SUCCESS, chip::Protocols::kProtocol_Protocol_Common, 0, clusterId);
     }
     else if (CHIP_NO_ERROR == err)
     {

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -1,0 +1,60 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines object for a CHIP IM Invoke Command Handler
+ *
+ */
+
+#pragma once
+
+#ifndef _CHIP_INTERACTION_MODEL_COMMAND_HANDLER_H
+#define _CHIP_INTERACTION_MODEL_COMMAND_HANDLER_H
+
+#include <app/Command.h>
+#include <app/MessageDef.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <map>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+
+class DLL_EXPORT CommandHandler : public Command
+{
+public:
+    CHIP_ERROR SendCommandResponse(NodeId aNodeId);
+    void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
+                           System::PacketBufferHandle payload);
+
+private:
+    CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
+};
+} // namespace app
+} // namespace chip
+
+#endif // _CHIP_INTERACTION_MODEL_COMMAND_HANDLER_H

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -1,0 +1,151 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines objects for a CHIP IM Invoke Command Sender
+ *
+ */
+
+#include "CommandSender.h"
+#include "Command.h"
+#include "CommandHandler.h"
+#include "InteractionModelEngine.h"
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = FinalizeCommandsMessage();
+    SuccessOrExit(err);
+
+    ClearExistingExchangeContext();
+
+    // Create a new exchange context.
+    mpExchangeCtx = mpExchangeMgr->NewContext(aNodeId, this);
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    mpExchangeCtx->SetResponseTimeout(CHIP_INVOKE_COMMAND_RSP_TIMEOUT);
+
+    err = mpExchangeCtx->SendMessage(Protocols::kProtocol_InteractionModel, kMsgType_InvokeCommandRequest,
+                                     std::move(mCommandMessageBuf),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_ExpectResponse));
+    SuccessOrExit(err);
+    MoveToState(kState_Sending);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ClearExistingExchangeContext();
+    }
+    ChipLogFunctError(err);
+
+    return err;
+}
+
+void CommandSender::OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader, uint32_t aProtocolId,
+                                      uint8_t aMsgType, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // Assert that the exchange context matches the client's current context.
+    // This should never fail because even if SendCommandRequest is called
+    // back-to-back, the second call will call Close() on the first exchange,
+    // which clears the OnMessageReceived callback.
+
+    VerifyOrDie(apEc == mpExchangeCtx);
+
+    // Verify that the message is an Invoke Command Response.
+    // If not, close the exchange and free the payload.
+    if (aProtocolId != Protocols::kProtocol_InteractionModel || aMsgType != kMsgType_InvokeCommandResponse)
+    {
+        apEc->Close();
+        mpExchangeCtx = nullptr;
+        goto exit;
+    }
+
+    // Remove the EC from the app state now. OnMessageReceived can call
+    // SendCommandRequest and install a new one. We abort rather than close
+    // because we no longer care whether the echo request message has been
+    // acknowledged at the transport layer.
+    ClearExistingExchangeContext();
+
+    err = ProcessCommandMessage(std::move(aPayload), kCommandSenderId);
+    SuccessOrExit(err);
+
+exit:
+    Reset();
+    return;
+}
+
+void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apEc)
+{
+    ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Node: %llu", apEc->GetPeerNodeId());
+    Reset();
+}
+
+CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CommandPath::Parser commandPath;
+    chip::TLV::TLVReader commandDataReader;
+    chip::ClusterId clusterId;
+    chip::CommandId commandId;
+    uint16_t generalCode  = 0;
+    uint32_t protocolId   = 0;
+    uint16_t protocolCode = 0;
+    StatusElement::Parser statusElementParser;
+
+    err = aCommandElement.GetStatusElement(&statusElementParser);
+    if (CHIP_NO_ERROR == err)
+    {
+        // Response has status element since either there is error in command response or it is empty response
+        err = statusElementParser.CheckSchemaValidity();
+        SuccessOrExit(err);
+
+        err = statusElementParser.DecodeStatusElement(&generalCode, &protocolId, &protocolCode, &clusterId);
+        SuccessOrExit(err);
+    }
+    else if (CHIP_END_OF_TLV == err)
+    {
+        err = aCommandElement.GetCommandPath(&commandPath);
+        SuccessOrExit(err);
+
+        err = commandPath.GetNamespacedClusterId(&clusterId);
+        SuccessOrExit(err);
+
+        err = commandPath.GetCommandId(&commandId);
+        SuccessOrExit(err);
+
+        err = aCommandElement.GetData(&commandDataReader);
+        if (CHIP_END_OF_TLV == err)
+        {
+            err = CHIP_NO_ERROR;
+            ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
+            AddStatusCode(0, chip::Protocols::kProtocol_Protocol_Common, CHIP_ERROR_INVALID_ARGUMENT, clusterId);
+        }
+        InteractionModelEngine::GetInstance()->ProcessCommand(clusterId, commandId, commandDataReader, this, kCommandSenderId);
+    }
+
+exit:
+    return err;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -138,7 +138,8 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
         {
             err = CHIP_NO_ERROR;
             ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-            AddStatusCode(0, chip::Protocols::kProtocol_Protocol_Common, CHIP_ERROR_INVALID_ARGUMENT, clusterId);
+            //Todo: Define protocol code for StatusCode
+            AddStatusCode(0, chip::Protocols::kProtocol_Protocol_Common, 0, clusterId);
         }
         InteractionModelEngine::GetInstance()->ProcessCommand(clusterId, commandId, commandDataReader, this, kCommandSenderId);
     }

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
         {
             err = CHIP_NO_ERROR;
             ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-            //Todo: Define protocol code for StatusCode
+            // Todo: Define protocol code for StatusCode
             AddStatusCode(0, chip::Protocols::kProtocol_Protocol_Common, 0, clusterId);
         }
         InteractionModelEngine::GetInstance()->ProcessCommand(clusterId, commandId, commandDataReader, this, kCommandSenderId);

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines objects for a CHIP IM Invoke Command Sender
+ *
+ */
+
+#pragma once
+
+#ifndef _CHIP_INTERACTION_MODEL_COMMAND_SENDER_H
+#define _CHIP_INTERACTION_MODEL_COMMAND_SENDER_H
+
+#include <app/MessageDef.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <map>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+#include <app/Command.h>
+
+#define CHIP_INVOKE_COMMAND_RSP_TIMEOUT 5
+#define COMMON_STATUS_SUCCESS 0
+
+namespace chip {
+namespace app {
+
+class DLL_EXPORT DLL_EXPORT CommandSender : public Command, public Messaging::ExchangeDelegate
+{
+public:
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId);
+
+    void OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader, uint32_t aProtocolId,
+                           uint8_t aMsgType, System::PacketBufferHandle aPayload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * apEc) override;
+
+private:
+    CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
+};
+
+} // namespace app
+} // namespace chip
+
+#endif // _CHIP_INTERACTION_MODEL_COMMAND_SENDER_H

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -30,9 +30,16 @@
 
 namespace chip {
 namespace app {
+InteractionModelEngine sInteractionModelEngine;
+
 InteractionModelEngine::InteractionModelEngine() {}
 
-void InteractionModelEngine::SetEventCallback(void * const apAppState, const EventCallback aEventCallback)
+InteractionModelEngine * InteractionModelEngine::GetInstance()
+{
+    return &sInteractionModelEngine;
+}
+
+void InteractionModelEngine::SetEventCallback(void * apAppState, EventCallback aEventCallback)
 {
     mpAppState     = apAppState;
     mEventCallback = aEventCallback;
@@ -140,7 +147,6 @@ void InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext *
         inParam.Clear();
         outParam.Clear();
         outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing = true;
-        outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing = true;
         inParam.mIncomingInvokeCommandRequest.mpPacketHeader             = &aPacketHeader;
 
         mEventCallback(mpAppState, kEvent_OnIncomingInvokeCommandRequest, inParam, outParam);
@@ -216,16 +222,16 @@ CHIP_ERROR InteractionModelEngine::RegisterClusterCommandHandler(chip::ClusterId
     std::pair<HandlersMapType::iterator, bool> insertResult =
         mHandlersMap.insert(HandlersMapType::value_type(HandlerKey(aClusterId, aCommandId, aCommandRoleId), aDispatcher));
 
-    if (insertResult.second == false)
+    if (!insertResult.second)
     {
         err = CHIP_ERROR_INVALID_ARGUMENT;
     }
     else
     {
         ChipLogDetail(DataManagement,
-                      "%s: RegisterClusterCommandHandler registered handler for ClusterId = %d, CommandId = %d, CommandRoleId = "
+                      "RegisterClusterCommandHandler registered handler for ClusterId = %d, CommandId = %d, CommandRoleId = "
                       "%d, Dispatcher = %p",
-                      __FUNCTION__, aClusterId, aCommandId, aCommandRoleId, (void *) aDispatcher);
+                      aClusterId, aCommandId, aCommandRoleId, (void *) aDispatcher);
     }
 
     return err;
@@ -242,9 +248,9 @@ CHIP_ERROR InteractionModelEngine::DeregisterClusterCommandHandler(chip::Cluster
         CommandCbFunct pDispatcher = handlerIt->second;
 
         ChipLogDetail(DataManagement,
-                      "%s: DeregisterClusterCommandHandler unregistered handler for ClusterId = %d, CommandId = %d, CommandRoleId "
+                      "DeregisterClusterCommandHandler unregistered handler for ClusterId = %d, CommandId = %d, CommandRoleId "
                       "= %d, Dispatcher = %p",
-                      __FUNCTION__, aClusterId, aCommandId, aCommandRoleId, (void *) pDispatcher);
+                      aClusterId, aCommandId, aCommandRoleId, (void *) pDispatcher);
         mHandlersMap.erase(handlerIt);
     }
     else
@@ -262,8 +268,8 @@ void InteractionModelEngine::ProcessCommand(chip::ClusterId aClusterId, chip::Co
 
     handlerIt = mHandlersMap.find(HandlerKey(aClusterId, aCommandId, aCommandRoleId));
 
-    ChipLogDetail(DataManagement, "%s for ClusterId = %d, CommandId = %d, CommandRoleId = %d", __FUNCTION__, (int) (aClusterId),
-                  (int) (aCommandId), aCommandRoleId);
+    ChipLogDetail(DataManagement, "ClusterId = %d, CommandId = %d, CommandRoleId = %d", (int) (aClusterId), (int) (aCommandId),
+                  aCommandRoleId);
 
     if (handlerIt != mHandlersMap.end())
     {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1,0 +1,276 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines objects for a CHIP Interaction Data model Engine which handle unsolicitied IM message, and
+ *      manage different kinds of IM client and handlers.
+ *
+ */
+
+#include "InteractionModelEngine.h"
+#include "Command.h"
+#include "CommandHandler.h"
+#include "CommandSender.h"
+
+namespace chip {
+namespace app {
+InteractionModelEngine::InteractionModelEngine() {}
+
+void InteractionModelEngine::SetEventCallback(void * const apAppState, const EventCallback aEventCallback)
+{
+    mpAppState     = apAppState;
+    mEventCallback = aEventCallback;
+}
+
+void InteractionModelEngine::DefaultEventHandler(EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam)
+{
+    IgnoreUnusedVariable(aInParam);
+    IgnoreUnusedVariable(aOutParam);
+
+    ChipLogDetail(DataManagement, "%s event: %d", __func__, aEvent);
+}
+
+CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Error if already initialized.
+    if (mpExchangeMgr != nullptr)
+        return CHIP_ERROR_INCORRECT_STATE;
+
+    mpExchangeMgr = apExchangeMgr;
+
+    err = mpExchangeMgr->RegisterUnsolicitedMessageHandler(Protocols::kProtocol_InteractionModel, this);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+void InteractionModelEngine::Shutdown()
+{
+    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS; ++i)
+    {
+        mCommandHandlerObjs[i].Shutdown();
+    }
+    mHandlersMap.clear();
+}
+
+CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apComandSender)
+{
+    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+    *apComandSender = nullptr;
+
+    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS; ++i)
+    {
+        if (mCommandHandlerObjs[i].IsFree())
+        {
+            *apComandSender = &mCommandSenderObjs[i];
+            err           = mCommandSenderObjs[i].Init(mpExchangeMgr);
+            SuccessOrExit(err);
+            if (CHIP_NO_ERROR != err)
+            {
+                *apComandSender = nullptr;
+                ExitNow();
+            }
+            break;
+        }
+    }
+    
+exit:
+    return err;
+}
+
+void InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+                                              uint32_t aProtocolId, uint8_t aMsgType, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    System::PacketBuffer * buffer = aPayload.Release_ForNow();
+    if (buffer != NULL)
+    {
+        System::PacketBuffer::Free(buffer);
+        buffer = nullptr;
+    }
+
+    ChipLogDetail(DataManagement, "Msg type %d not supported", (int) aMsgType);
+
+    // Todo: Add status report
+    // err = SendStatusReport(ec, kChipProfile_Common, kStatus_UnsupportedMessage);
+    // SuccessOrExit(err);
+
+    apEc->Close();
+    apEc = NULL;
+
+    ChipLogFunctError(err);
+
+    if (NULL != apEc)
+    {
+        apEc->Abort();
+        apEc = NULL;
+    }
+}
+
+void InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+                                                    uint32_t aProtocolId, uint8_t aMsgType, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    CommandHandler * commandServer = nullptr;
+
+    if (nullptr != mEventCallback)
+    {
+        InEventParam inParam;
+        OutEventParam outParam;
+        inParam.Clear();
+        outParam.Clear();
+        outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing = true;
+        outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing = true;
+        inParam.mIncomingInvokeCommandRequest.mpPacketHeader             = &aPacketHeader;
+
+        mEventCallback(mpAppState, kEvent_OnIncomingInvokeCommandRequest, inParam, outParam);
+
+        if (!outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing)
+        {
+            ChipLogDetail(DataManagement, "Command not allowed");
+            ExitNow();
+        }
+    }
+
+    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS; ++i)
+    {
+        if (mCommandHandlerObjs[i].IsFree())
+        {
+            commandServer = &mCommandHandlerObjs[i];
+            err           = commandServer->Init(mpExchangeMgr);
+            SuccessOrExit(err);
+            commandServer->OnMessageReceived(apEc, aPacketHeader, aProtocolId, aMsgType, std::move(aPayload));
+            apEc = nullptr;
+            break;
+        }
+    }
+
+exit:
+    ChipLogFunctError(err);
+
+    if (nullptr != apEc)
+    {
+        apEc->Abort();
+        apEc = NULL;
+    }
+}
+
+void InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+                                               uint32_t aProtocolId, uint8_t aMsgType, System::PacketBufferHandle aPayload)
+{
+    switch (aMsgType)
+    {
+    case kMsgType_InvokeCommandRequest:
+        OnInvokeCommandRequest(apEc, aPacketHeader, aProtocolId, aMsgType, std::move(aPayload));
+        break;
+    default:
+        OnUnknownMsgType(apEc, aPacketHeader, aProtocolId, aMsgType, std::move(aPayload));
+        break;
+    }
+}
+
+void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
+{
+    ChipLogProgress(DataManagement, "Time out! failed to receive echo response from Node: %llu", ec->GetPeerNodeId());
+}
+
+InteractionModelEngine::HandlerKey::HandlerKey(chip::ClusterId aClusterId, chip::CommandId aCommandId,
+                                               Command::CommandRoleId aCommandRoleId) :
+    mClusterId(aClusterId),
+    mCommandId(aCommandId), mCommandRoleId(aCommandRoleId)
+{}
+
+inline bool InteractionModelEngine::HandlerKey::operator<(const HandlerKey & aOtherKey) const
+{
+    return ((mClusterId != aOtherKey.mClusterId)
+                ? (mClusterId < aOtherKey.mClusterId)
+                : ((mCommandId != aOtherKey.mCommandId) ? (mCommandId < aOtherKey.mCommandId)
+                                                        : ((mCommandRoleId < aOtherKey.mCommandRoleId))));
+}
+
+CHIP_ERROR InteractionModelEngine::RegisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
+                                                                 Command::CommandRoleId aCommandRoleId, CommandCbFunct aDispatcher)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    std::pair<HandlersMapType::iterator, bool> insertResult =
+        mHandlersMap.insert(HandlersMapType::value_type(HandlerKey(aClusterId, aCommandId, aCommandRoleId), aDispatcher));
+
+    if (insertResult.second == false)
+    {
+        err = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    else
+    {
+        ChipLogDetail(DataManagement,
+                      "%s: RegisterClusterCommandHandler registered handler for ClusterId = %d, CommandId = %d, CommandRoleId = "
+                      "%d, Dispatcher = %p",
+                      __FUNCTION__, aClusterId, aCommandId, aCommandRoleId, (void *) aDispatcher);
+    }
+
+    return err;
+}
+
+CHIP_ERROR InteractionModelEngine::DeregisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
+                                                                   Command::CommandRoleId aCommandRoleId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    HandlersMapType::iterator handlerIt = mHandlersMap.find(HandlerKey(aClusterId, aCommandId, aCommandRoleId));
+    if (handlerIt != mHandlersMap.end())
+    {
+        CommandCbFunct pDispatcher = handlerIt->second;
+
+        ChipLogDetail(DataManagement,
+                      "%s: DeregisterClusterCommandHandler unregistered handler for ClusterId = %d, CommandId = %d, CommandRoleId "
+                      "= %d, Dispatcher = %p",
+                      __FUNCTION__, aClusterId, aCommandId, aCommandRoleId, (void *) pDispatcher);
+        mHandlersMap.erase(handlerIt);
+    }
+    else
+    {
+        err = CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return err;
+}
+
+void InteractionModelEngine::ProcessCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::TLV::TLVReader & aReader,
+                                            Command * apCommandObj, Command::CommandRoleId aCommandRoleId)
+{
+    HandlersMapType::iterator handlerIt;
+
+    handlerIt = mHandlersMap.find(HandlerKey(aClusterId, aCommandId, aCommandRoleId));
+
+    ChipLogDetail(DataManagement, "%s for ClusterId = %d, CommandId = %d, CommandRoleId = %d", __FUNCTION__, (int) (aClusterId),
+                  (int) (aCommandId), aCommandRoleId);
+
+    if (handlerIt != mHandlersMap.end())
+    {
+        handlerIt->second(aReader, apCommandObj);
+    }
+
+    return;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -74,7 +74,7 @@ void InteractionModelEngine::Shutdown()
 
 CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apComandSender)
 {
-    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+    CHIP_ERROR err  = CHIP_ERROR_NO_MEMORY;
     *apComandSender = nullptr;
 
     for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS; ++i)
@@ -82,7 +82,7 @@ CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apCom
         if (mCommandHandlerObjs[i].IsFree())
         {
             *apComandSender = &mCommandSenderObjs[i];
-            err           = mCommandSenderObjs[i].Init(mpExchangeMgr);
+            err             = mCommandSenderObjs[i].Init(mpExchangeMgr);
             SuccessOrExit(err);
             if (CHIP_NO_ERROR != err)
             {
@@ -92,7 +92,7 @@ CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apCom
             break;
         }
     }
-    
+
 exit:
     return err;
 }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -55,7 +55,8 @@ typedef void (*CommandCbFunct)(chip::TLV::TLVReader & aReader, Command * apComma
 /**
  * @class InteractionModelEngine
  *
- * @brief This is a singleton hosting all CHIP IM unsolicitted message and manage IM related clients and handlers.
+ * @brief This is a singleton hosting all CHIP unsolicited message processing and managing interaction model related clients and
+ * handlers
  *
  */
 class InteractionModelEngine : public Messaging::ExchangeDelegate
@@ -97,20 +98,20 @@ public:
     /**
      * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
      *
-     * @param[in]  aAppState    A pointer to application layer supplied state object
+     * @param[in]  apAppState    A pointer to application layer supplied state object
      * @param[in]  aEvent       A function pointer for event call back
      * @param[in]  aInParam     A const reference to the input parameter for this event
      * @param[out] aOutParam    A reference to the output parameter for this event
      */
-    typedef void (*EventCallback)(void * const aAppState, EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
+    typedef void (*EventCallback)(void * apAppState, EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
 
     /**
      * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
      *
-     * @param[in]  aAppState  		A pointer to application layer supplied state object
+     * @param[in]  apAppState  		A pointer to application layer supplied state object
      * @param[in]  aEventCallback  	A function pointer for event call back
      */
-    void SetEventCallback(void * const aAppState, const EventCallback aEventCallback);
+    void SetEventCallback(void * apAppState, EventCallback aEventCallback);
 
     /**
      * @brief This is the default event handler to be called by application layer for any ignored or unrecognized event

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -144,7 +144,7 @@ public:
                         Command * apCommandObj, Command::CommandRoleId aCommandRoleId);
 
     Messaging::ExchangeManager * GetExchangeManager(void) const { return mpExchangeMgr; };
-    
+
     CHIP_ERROR NewCommandSender(CommandSender ** const apComandSender);
 
 private:

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -1,0 +1,182 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines objects for a CHIP Interaction Data model Engine which handle unsolicitied IM message, and
+ *      manage different kinds of IM client and handlers.
+ *
+ */
+
+#pragma once
+
+#ifndef _CHIP_INTERACTION_MODEL_ENGINE_H
+#define _CHIP_INTERACTION_MODEL_ENGINE_H
+
+#include <app/MessageDef.h>
+#include <core/CHIPCore.h>
+#include <map>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+#include <app/Command.h>
+#include <app/CommandHandler.h>
+#include <app/CommandSender.h>
+
+#define CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS 1
+#define CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS 1
+
+namespace chip {
+namespace app {
+
+typedef void (*CommandCbFunct)(chip::TLV::TLVReader & aReader, Command * apCommandObj);
+
+/**
+ * @class InteractionModelEngine
+ *
+ * @brief This is a singleton hosting all CHIP IM unsolicitted message and manage IM related clients and handlers.
+ *
+ */
+class InteractionModelEngine : public Messaging::ExchangeDelegate
+{
+public:
+    enum EventID
+    {
+        kEvent_OnIncomingInvokeCommandRequest =
+            0, ///< Called when an incoming invoke command request has arrived before applying commands..
+    };
+
+    /**
+     * Incoming parameters sent with events generated directly from this component
+     *
+     */
+    union InEventParam
+    {
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+        struct
+        {
+            const PacketHeader * mpPacketHeader; ///< A pointer to the message information for the request
+        } mIncomingInvokeCommandRequest;
+    };
+
+    /**
+     * Outgoing parameters sent with events generated directly from this component
+     *
+     */
+    union OutEventParam
+    {
+        void Clear(void) { memset(this, 0, sizeof(*this)); }
+
+        struct
+        {
+            bool mShouldContinueProcessing; ///< Set to true if update is allowed.
+        } mIncomingInvokeCommandRequest;
+    };
+
+    /**
+     * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
+     *
+     * @param[in]  aAppState    A pointer to application layer supplied state object
+     * @param[in]  aEvent       A function pointer for event call back
+     * @param[in]  aInParam     A const reference to the input parameter for this event
+     * @param[out] aOutParam    A reference to the output parameter for this event
+     */
+    typedef void (*EventCallback)(void * const aAppState, EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
+
+    /**
+     * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
+     *
+     * @param[in]  aAppState  		A pointer to application layer supplied state object
+     * @param[in]  aEventCallback  	A function pointer for event call back
+     */
+    void SetEventCallback(void * const aAppState, const EventCallback aEventCallback);
+
+    /**
+     * @brief This is the default event handler to be called by application layer for any ignored or unrecognized event
+     *
+     * @param[in]  aEvent       A function pointer for event call back
+     * @param[in]  aInParam     A const reference to the input parameter for this event
+     * @param[out] aOutParam    A reference to the output parameter for this event
+     */
+    static void DefaultEventHandler(EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
+
+    /**
+     * @brief Retrieve the singleton DataManagement Engine. Note this function should be implemented by the
+     *  adoption layer.
+     *
+     *  @return  A pointer to the shared InteractionModel Engine
+     *
+     */
+    static InteractionModelEngine * GetInstance(void);
+
+    InteractionModelEngine(void);
+
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr);
+
+    void Shutdown();
+
+    CHIP_ERROR DeregisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
+                                               Command::CommandRoleId aCommandRoleId);
+    CHIP_ERROR RegisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
+                                             Command::CommandRoleId aCommandRoleId, CommandCbFunct aDispatcher);
+    void ProcessCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::TLV::TLVReader & aReader,
+                        Command * apCommandObj, Command::CommandRoleId aCommandRoleId);
+
+    Messaging::ExchangeManager * GetExchangeManager(void) const { return mpExchangeMgr; };
+    
+    CHIP_ERROR NewCommandSender(CommandSender ** const apComandSender);
+
+private:
+    void OnUnknownMsgType(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader, uint32_t aProtocolId,
+                          uint8_t aMsgType, System::PacketBufferHandle aPayload);
+    void OnInvokeCommandRequest(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader, uint32_t aProtocolId,
+                                uint8_t aMsgType, System::PacketBufferHandle aPayload);
+    void OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader, uint32_t aProtocolId,
+                           uint8_t aMsgType, System::PacketBufferHandle aPayload);
+    void OnResponseTimeout(Messaging::ExchangeContext * ec);
+
+    struct HandlerKey
+    {
+        HandlerKey(chip::ClusterId aClusterId, chip::CommandId aCommandId, Command::CommandRoleId aCommandRoleId);
+
+        chip::ClusterId mClusterId;
+        chip::CommandId mCommandId;
+        Command::CommandRoleId mCommandRoleId;
+        bool operator<(const HandlerKey & aOtherKey) const;
+    };
+
+    typedef std::map<HandlerKey, CommandCbFunct> HandlersMapType;
+
+    HandlersMapType mHandlersMap;
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    void * mpAppState                          = nullptr;
+    EventCallback mEventCallback;
+    CommandHandler mCommandHandlerObjs[CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS];
+    CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS];
+};
+
+} // namespace app
+} // namespace chip
+
+#endif //_CHIP_INTERACTION_MODEL_ENGINE_H

--- a/src/app/MessageDef.cpp
+++ b/src/app/MessageDef.cpp
@@ -2899,15 +2899,19 @@ CHIP_ERROR CommandDataElement::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // check for required fields:
-        const uint16_t RequiredFields = (1 << kCsTag_CommandPath);
-        if ((TagPresenceMask & RequiredFields) == RequiredFields)
+        // check for at most field:
+        const uint16_t CheckDataField          = 1 << kCsTag_Data;
+        const uint16_t CheckStatusElementField = 1 << kCsTag_StatusElement;
+
+        if ((TagPresenceMask & CheckDataField) == CheckDataField &&
+            (TagPresenceMask & CheckStatusElementField) == CheckStatusElementField)
         {
-            err = CHIP_NO_ERROR;
+            // kCsTag_Data and kCsTag_StatusElement both exist
+            err = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
         }
         else
         {
-            err = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
+            err = CHIP_NO_ERROR;
         }
     }
 
@@ -3493,6 +3497,11 @@ CommandList::Builder & InvokeCommand::Builder::CreateCommandListBuilder()
 
 exit:
     // on error, mCommandListBuilder would be un-/partial initialized and cannot be used to write anything
+    return mCommandListBuilder;
+}
+
+CommandList::Builder & InvokeCommand::Builder::GetCommandListBuilder()
+{
     return mCommandListBuilder;
 }
 

--- a/src/app/MessageDef.h
+++ b/src/app/MessageDef.h
@@ -1842,9 +1842,16 @@ public:
     /**
      *  @brief Initialize a CommandList::Builder for writing into the TLV stream
      *
-     *  @return A reference to Path::Builder
+     *  @return A reference to CommandList::Builder
      */
     CommandList::Builder & CreateCommandListBuilder();
+
+    /**
+     *  @brief Get reference to CommandList::Builder
+     *
+     *  @return A reference to CommandList::Builder
+     */
+    CommandList::Builder & GetCommandListBuilder();
 
     /**
      *  @brief Mark the end of this InvokeCommand

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/tools.gni")
+
+assert(chip_build_tools)
+
+executable("chip-im-initiator") {
+  sources = [
+    "chip_im_initiator.cpp",
+    "common.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/protocols",
+    "${chip_root}/src/system",
+  ]
+
+  output_dir = root_out_dir
+}
+
+executable("chip-im-responder") {
+  sources = [
+    "chip_im_responder.cpp",
+    "common.cpp",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app",
+    "${chip_root}/src/app",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/protocols",
+    "${chip_root}/src/system",
+  ]
+
+  output_dir = root_out_dir
+}
+
+group("im") {
+  deps = [
+    ":chip-im-initiator",
+    ":chip-im-responder",
+  ]
+}

--- a/src/app/tests/integration/README.md
+++ b/src/app/tests/integration/README.md
@@ -1,0 +1,44 @@
+# CHIP Example IM Application Tutorial
+
+## Introduction
+
+The CHIP IM example application shows you how to implement a CHIP application
+program using IM protocols.
+
+CHIP Protocols are, essentially, implementations of specific protocols over the
+CHIP transport. Furthermore, when two CHIP nodes are exchanging messages of a
+particular CHIP protocol, they do so over a construct called a CHIP Exchange
+which is a description of a CHIP-based conversation over a CHIP protocol. A CHIP
+Exchange is characterised by the ExchangeContext object, and every CHIP node
+must create an ExchangeContext object before initiating a CHIP conversation.
+
+After constructing a CHIP ExchangeContext, CHIP messages are sent and received
+using the ChipMessageLayer class which sends the CHIP message over a chosen
+transport (TCP, UDP, or CRMP).
+
+## Building
+
+./gn_build.sh
+
+-   After the applications are built, it can be found in the build directory as
+    `out/debug/linux_x64_clang/chip-im-requester and out/debug/linux_x64_clang/chip-im-responder`
+
+## Example Applications Walk Through
+
+As part of this example, we have a ChipImInitiator program that acts as the
+client and sends echo requests to a ChipImResponder program that receives
+InvokeCommandRequests and sends back InvokeCommandResponse messages.
+
+### Test a device over IP
+
+To start the Server in echo mode, run the built executable.
+
+    $ ./chip-im-responder
+
+To start the Client in echo mode, run the built executable and pass it the IP
+address of the server to talk to.
+
+    $ ./chip-im-initiator <Server's IPv4 address>
+
+If valid values are supplied, it will begin to periodically send messages to the
+server address provided for three times.

--- a/src/app/tests/integration/README.md
+++ b/src/app/tests/integration/README.md
@@ -16,13 +16,6 @@ After constructing a CHIP ExchangeContext, CHIP messages are sent and received
 using the ChipMessageLayer class which sends the CHIP message over a chosen
 transport (TCP, UDP, or CRMP).
 
-## Building
-
-./gn_build.sh
-
--   After the applications are built, it can be found in the build directory as
-    `out/debug/linux_x64_clang/chip-im-requester and out/debug/linux_x64_clang/chip-im-responder`
-
 ## Example Applications Walk Through
 
 As part of this example, we have a ChipImInitiator program that acts as the

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -40,16 +40,6 @@
 
 #define IM_CLIENT_PORT (CHIP_PORT + 1)
 
-namespace chip {
-namespace app {
-InteractionModelEngine sInteractionModelEngine;
-InteractionModelEngine * InteractionModelEngine::GetInstance()
-{
-    return &sInteractionModelEngine;
-}
-} // namespace app
-} // namespace chip
-
 namespace {
 
 // Max value for the number of command request sent.

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -1,0 +1,272 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a chip-im-initiator, for the
+ *      CHIP Interaction Data Model Protocol.
+ *
+ *      Currently it provides simple command sender with sample cluster and command
+ *
+ */
+
+#include "common.h"
+
+#include <app/CommandHandler.h>
+#include <app/CommandSender.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <support/ErrorStr.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/SecurePairingSession.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+
+#define IM_CLIENT_PORT (CHIP_PORT + 1)
+
+namespace chip {
+namespace app {
+InteractionModelEngine sInteractionModelEngine;
+InteractionModelEngine * InteractionModelEngine::GetInstance()
+{
+    return &sInteractionModelEngine;
+}
+} // namespace app
+} // namespace chip
+
+namespace {
+
+// Max value for the number of command request sent.
+constexpr size_t kMaxCommandCount = 3;
+
+// The CHIP Command interval time in milliseconds.
+constexpr int32_t gCommandInterval = 1000;
+
+// The CommandSender object.
+chip::app::CommandSender * gpCommandSender = nullptr;
+
+chip::TransportMgr<chip::Transport::UDP> gTransportManager;
+
+chip::SecureSessionMgr gSessionManager;
+
+chip::Inet::IPAddress gDestAddr;
+
+// The last time a CHIP Command was attempted to be sent.
+uint64_t gLastCommandTime = 0;
+
+// True, if the CommandSender is waiting for an CommandResponse
+// after sending an CommandRequest, false otherwise.
+bool gWaitingForCommandResp = false;
+
+// Count of the number of CommandRequests sent.
+uint64_t gCommandCount = 0;
+
+// Count of the number of CommandResponses received.
+uint64_t gCommandRespCount = 0;
+
+bool CommandIntervalExpired(void)
+{
+    uint64_t now = chip::System::Timer::GetCurrentEpoch();
+
+    return (now >= gLastCommandTime + gCommandInterval);
+}
+
+CHIP_ERROR SendCommandRequest(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    gLastCommandTime = chip::System::Timer::GetCurrentEpoch();
+
+    printf("\nSend invoke command request message to Node: %lu\n", chip::kTestDeviceNodeId);
+
+    chip::app::Command::CommandParams CommandParams = { 1,  // Endpoint
+                                                        0,  // GroupId
+                                                        6,  // ClusterId
+                                                        40, // CommandId
+                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+
+    // Add command data here
+
+    uint8_t effectIdentifier = 1; // Dying light
+    uint8_t effectVariant    = 1;
+
+    chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
+
+    chip::TLV::TLVWriter writer = gpCommandSender->CreateCommandDataElementTLVWriter();
+
+    err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+    SuccessOrExit(err);
+
+    err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
+    SuccessOrExit(err);
+
+    err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
+    SuccessOrExit(err);
+
+    err = writer.EndContainer(dummyType);
+    SuccessOrExit(err);
+
+    err = writer.Finalize();
+    SuccessOrExit(err);
+
+    err = gpCommandSender->AddCommand(CommandParams);
+    SuccessOrExit(err);
+
+    err = gpCommandSender->SendCommandRequest(chip::kTestDeviceNodeId);
+    SuccessOrExit(err);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        gWaitingForCommandResp = true;
+        gCommandCount++;
+    }
+    else
+    {
+        printf("Send invoke command request failed, err: %s\n", chip::ErrorStr(err));
+    }
+exit:
+    return err;
+}
+
+CHIP_ERROR EstablishSecureSession()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>(
+        chip::Optional<chip::NodeId>::Value(chip::kTestDeviceNodeId), static_cast<uint16_t>(0), static_cast<uint16_t>(0));
+    VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
+
+    // Attempt to connect to the peer.
+    err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
+                                         chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID)),
+                                     chip::kTestDeviceNodeId, testSecurePairingSecret);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
+        gLastCommandTime = chip::System::Timer::GetCurrentEpoch();
+    }
+    else
+    {
+        printf("Establish secure session succeeded\n");
+    }
+
+    return err;
+}
+
+void HandleCommandResponseReceived(chip::TLV::TLVReader & aReader, chip::app::Command * apCommandObj)
+{
+    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+    uint32_t transitTime = respTime - gLastCommandTime;
+
+    if (aReader.GetLength() != 0)
+    {
+        chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
+    }
+    gWaitingForCommandResp = false;
+    gCommandRespCount++;
+
+    printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gCommandRespCount, gCommandCount,
+           static_cast<double>(gCommandRespCount) * 100 / gCommandCount, static_cast<double>(transitTime) / 1000);
+}
+
+} // namespace
+
+int main(int argc, char * argv[])
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (argc <= 1)
+    {
+        printf("Missing Command Server IP address\n");
+        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    if (!chip::Inet::IPAddress::FromString(argv[1], gDestAddr))
+    {
+        printf("Invalid Command Server IP address: %s\n", argv[1]);
+        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    InitializeChip();
+
+    err = gTransportManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
+                                     .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                                     .SetListenPort(IM_CLIENT_PORT));
+    SuccessOrExit(err);
+
+    err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager);
+    SuccessOrExit(err);
+
+    err = gExchangeManager.Init(&gSessionManager);
+    SuccessOrExit(err);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager);
+    SuccessOrExit(err);
+
+    chip::app::InteractionModelEngine::GetInstance()->RegisterClusterCommandHandler(
+        6, 40, chip::app::Command::CommandRoleId::kCommandSenderId, HandleCommandResponseReceived);
+
+    // Start the CHIP connection to the CHIP im responder.
+    err = EstablishSecureSession();
+    SuccessOrExit(err);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&gpCommandSender);
+    SuccessOrExit(err);
+
+    // Connection has been established. Now send the CommandRequests.
+    for (unsigned int i = 0; i < kMaxCommandCount; i++)
+    {
+        if (SendCommandRequest() != CHIP_NO_ERROR)
+        {
+            printf("Send request failed: %s\n", chip::ErrorStr(err));
+            break;
+        }
+
+        // Wait for response until the Command interval.
+        while (!CommandIntervalExpired())
+        {
+            DriveIO();
+        }
+
+        // Check if expected response was received.
+        if (gWaitingForCommandResp)
+        {
+            printf("No response received\n");
+            gWaitingForCommandResp = false;
+        }
+    }
+
+    chip::app::InteractionModelEngine::GetInstance()->DeregisterClusterCommandHandler(
+        6, 40, chip::app::Command::CommandRoleId::kCommandSenderId);
+
+    gpCommandSender->Shutdown();
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+    ShutdownChip();
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        printf("ChipCommandSender failed: %s\n", chip::ErrorStr(err));
+        exit(EXIT_FAILURE);
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -1,0 +1,153 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a chip-im-responder, for the
+ *      CHIP Interaction Data Model Protocol.
+ *
+ *      Currently it provides simple command handler with sample cluster and command
+ *
+ */
+
+#include "common.h"
+
+#include "app/InteractionModelEngine.h"
+#include <app/CommandHandler.h>
+#include <app/CommandSender.h>
+#include <core/CHIPCore.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include "InteractionModelEngine.h"
+#include <support/ErrorStr.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/SecurePairingSession.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+
+namespace chip {
+namespace app {
+InteractionModelEngine sInteractionModelEngine;
+InteractionModelEngine * InteractionModelEngine::GetInstance()
+{
+    return &sInteractionModelEngine;
+}
+} // namespace app
+} // namespace chip
+
+namespace {
+
+// The CommandHandler object
+chip::TransportMgr<chip::Transport::UDP> gTransportManager;
+chip::SecureSessionMgr gSessionManager;
+chip::SecurePairingUsingTestSecret gTestPairing;
+
+// Callback handler when a CHIP EchoRequest is received.
+void HandleCommandRequestReceived(chip::TLV::TLVReader & aReader, chip::app::Command * apCommandObj)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (aReader.GetLength() != 0)
+    {
+        chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
+    }
+
+    chip::app::Command::CommandParams commandParams = { 1,  // Endpoint
+                                                        0,  // GroupId
+                                                        6,  // ClusterId
+                                                        40, // CommandId
+                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+
+    // Add command data here
+
+    uint8_t effectIdentifier = 1; // Dying light
+    uint8_t effectVariant    = 1;
+
+    chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
+
+    chip::TLV::TLVWriter writer = apCommandObj->CreateCommandDataElementTLVWriter();
+
+    printf("responder constructing response");
+    err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+    SuccessOrExit(err);
+
+    err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
+    SuccessOrExit(err);
+
+    err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
+    SuccessOrExit(err);
+
+    err = writer.EndContainer(dummyType);
+    SuccessOrExit(err);
+
+    err = writer.Finalize();
+    SuccessOrExit(err);
+
+    err = apCommandObj->AddCommand(commandParams);
+    SuccessOrExit(err);
+
+exit:
+    return;
+}
+
+} // namespace
+
+int main(int argc, char * argv[])
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+
+    InitializeChip();
+
+    err = gTransportManager.Init(
+        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
+    SuccessOrExit(err);
+
+    err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager);
+    SuccessOrExit(err);
+
+    err = gExchangeManager.Init(&gSessionManager);
+    SuccessOrExit(err);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager);
+    SuccessOrExit(err);
+
+    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing);
+    SuccessOrExit(err);
+
+    chip::app::InteractionModelEngine::GetInstance()->RegisterClusterCommandHandler(
+        6, 40, chip::app::Command::CommandRoleId::kCommandHandlerId, HandleCommandRequestReceived);
+    printf("Listening for IM requests...\n");
+
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+
+exit:
+    chip::app::InteractionModelEngine::GetInstance()->DeregisterClusterCommandHandler(
+        6, 40, chip::app::Command::CommandRoleId::kCommandHandlerId);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        printf("CommandHandler failed, err:%s\n", chip::ErrorStr(err));
+        exit(EXIT_FAILURE);
+    }
+
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+
+    ShutdownChip();
+
+    return EXIT_SUCCESS;
+}

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -39,16 +39,6 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/UDP.h>
 
-namespace chip {
-namespace app {
-InteractionModelEngine sInteractionModelEngine;
-InteractionModelEngine * InteractionModelEngine::GetInstance()
-{
-    return &sInteractionModelEngine;
-}
-} // namespace app
-} // namespace chip
-
 namespace {
 
 // The CommandHandler object

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements constants, globals and interfaces common
+ *      to and used by CHIP example applications.
+ *
+ */
+
+#include <errno.h>
+
+#include "common.h"
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
+
+// The ExchangeManager global object.
+chip::Messaging::ExchangeManager gExchangeManager;
+
+void InitializeChip(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    printf("Init CHIP Stack\r\n");
+
+    // Initialize System memory and resources
+    err = chip::Platform::MemoryInit();
+    SuccessOrExit(err);
+
+    // Initialize the CHIP stack.
+    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        printf("Failed to init CHIP Stack with err: %s\r\n", chip::ErrorStr(err));
+        exit(EXIT_FAILURE);
+    }
+}
+
+void ShutdownChip(void)
+{
+    gExchangeManager.Shutdown();
+    chip::DeviceLayer::SystemLayer.Shutdown();
+}
+
+void DriveIO(void)
+{
+    struct timeval sleepTime;
+    fd_set readFDs, writeFDs, exceptFDs;
+    int numFDs = 0;
+    int selectRes;
+
+    sleepTime.tv_sec  = 0;
+    sleepTime.tv_usec = NETWORK_SLEEP_TIME_MSECS;
+
+    FD_ZERO(&readFDs);
+    FD_ZERO(&writeFDs);
+    FD_ZERO(&exceptFDs);
+
+    if (chip::DeviceLayer::SystemLayer.State() == chip::System::kLayerState_Initialized)
+        chip::DeviceLayer::SystemLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, sleepTime);
+
+    if (chip::DeviceLayer::InetLayer.State == chip::Inet::InetLayer::kState_Initialized)
+        chip::DeviceLayer::InetLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, sleepTime);
+
+    selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, &sleepTime);
+    if (selectRes < 0)
+    {
+        printf("select failed: %s\n", chip::ErrorStr(chip::System::MapErrorPOSIX(errno)));
+        return;
+    }
+
+    if (chip::DeviceLayer::SystemLayer.State() == chip::System::kLayerState_Initialized)
+    {
+        chip::DeviceLayer::SystemLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+    }
+
+    if (chip::DeviceLayer::InetLayer.State == chip::Inet::InetLayer::kState_Initialized)
+    {
+        chip::DeviceLayer::InetLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+    }
+}
+
+void TLVPrettyPrinter(const char * aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+
+    vprintf(aFormat, args);
+
+    va_end(args);
+}

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -1,0 +1,37 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines some of the common constants, globals and interfaces
+ *      that are common to and used by CHIP example applications.
+ *
+ */
+
+#pragma once
+
+#include <messaging/ExchangeMgr.h>
+
+#define MAX_MESSAGE_SOURCE_STR_LENGTH (100)
+#define NETWORK_SLEEP_TIME_MSECS (100 * 1000)
+
+extern chip::Messaging::ExchangeManager gExchangeManager;
+
+void InitializeChip(void);
+void ShutdownChip(void);
+void DriveIO(void);
+void TLVPrettyPrinter(const char * aFormat, ...);

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -117,7 +117,6 @@ static_library("core") {
 
   public_deps = [
     ":chip_config_header",
-    "${chip_root}/src/app",
     "${chip_root}/src/ble",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/support",
@@ -130,6 +129,5 @@ static_library("core") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/inet",
     "${chip_root}/src/system",
-    "${chip_root}/src/app",
   ]
 }

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -69,6 +69,11 @@ void ExchangeContext::SetResponseExpected(bool inResponseExpected)
     mFlags.Set(ExFlagValues::kFlagResponseExpected, inResponseExpected);
 }
 
+void ExchangeContext::SetResponseTimeout(Timeout timeout)
+{
+    mResponseTimeout = timeout;
+}
+
 CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
                                         const SendFlags & sendFlags, void * msgCtxt)
 {

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -55,6 +55,8 @@ class DLL_EXPORT ExchangeContext : public ReferenceCounted<ExchangeContext, Exch
     friend class ExchangeContextDeletor;
 
 public:
+    typedef uint32_t Timeout; // Type used to express the timeout in this ExchangeContext, in milliseconds
+
     /**
      *  Determine whether the context is the initiator of the exchange.
      *
@@ -146,14 +148,14 @@ public:
     void Free();
     void Reset();
 
+    void SetResponseTimeout(Timeout timeout);
+
 private:
     enum class ExFlagValues : uint16_t
     {
         kFlagInitiator        = 0x0001, // This context is the initiator of the exchange.
         kFlagResponseExpected = 0x0002, // If a response is expected for a message that is being sent.
     };
-
-    typedef uint32_t Timeout; // Type used to express the timeout in this ExchangeContext, in milliseconds
 
     Timeout mResponseTimeout; // Maximum time to wait for response (in milliseconds); 0 disables response timeout.
     ExchangeDelegate * mDelegate   = nullptr;


### PR DESCRIPTION
Problem:
Need to have invoke command per IM spec to unblock CHIP data model

Summary of Changes:
-- Add Command base class to construct Command Message.
-- Add CommandSender and CommandHandle to send and handle command
message.
-- Add InteractionModelEngine to process unsolicted messages and
manage relate client and handler.
-- Add integration test and doc.

Fixes #3636
Test:
./out/debug/linux_x64_clang/chip-im-requester <Server's IPv4 address>
./out/debug/linux_x64_clang/chip-im-responder

Todo:
Add unit tests for Command 
https://github.com/project-chip/connectedhomeip/issues/4243
