### PR TITLE
Fix gn gen with all standalone targets disabled

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -198,27 +198,35 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 
+  standalone_toolchain = "${chip_root}/config/standalone/toolchain:standalone"
+  not_needed([ "standalone_toolchain" ])  # Might not be needed.
+
   if (enable_standalone_chip_tool_build) {
     group("standalone_chip_tool") {
-      deps = [ "${chip_root}/examples/chip-tool(${chip_root}/config/standalone/toolchain:standalone)" ]
+      deps = [ "${chip_root}/examples/chip-tool(${standalone_toolchain})" ]
     }
   }
 
   if (enable_standalone_shell_build) {
     group("standalone_shell") {
-      deps = [ "${chip_root}/examples/shell/standalone(${chip_root}/config/standalone/toolchain:standalone)" ]
+      deps =
+          [ "${chip_root}/examples/shell/standalone(${standalone_toolchain})" ]
     }
   }
 
   if (enable_linux_all_clusters_app_build) {
     group("linux_all_clusters_app") {
-      deps = [ "${chip_root}/examples/all-clusters-app/linux(${chip_root}/config/standalone/toolchain:standalone)" ]
+      deps = [
+        "${chip_root}/examples/all-clusters-app/linux(${standalone_toolchain})",
+      ]
     }
   }
 
   if (enable_linux_lighting_app_build) {
     group("linux_lighting_app") {
-      deps = [ "${chip_root}/examples/lighting-app/linux(${chip_root}/config/standalone/toolchain:standalone)" ]
+      deps = [
+        "${chip_root}/examples/lighting-app/linux(${standalone_toolchain})",
+      ]
     }
   }
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -198,34 +198,27 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 
-  standalone_toolchain = "${chip_root}/config/standalone/toolchain:standalone"
-
   if (enable_standalone_chip_tool_build) {
     group("standalone_chip_tool") {
-      deps = [ "${chip_root}/examples/chip-tool(${standalone_toolchain})" ]
+      deps = [ "${chip_root}/examples/chip-tool(${chip_root}/config/standalone/toolchain:standalone)" ]
     }
   }
 
   if (enable_standalone_shell_build) {
     group("standalone_shell") {
-      deps =
-          [ "${chip_root}/examples/shell/standalone(${standalone_toolchain})" ]
+      deps = [ "${chip_root}/examples/shell/standalone(${chip_root}/config/standalone/toolchain:standalone)" ]
     }
   }
 
   if (enable_linux_all_clusters_app_build) {
     group("linux_all_clusters_app") {
-      deps = [
-        "${chip_root}/examples/all-clusters-app/linux(${standalone_toolchain})",
-      ]
+      deps = [ "${chip_root}/examples/all-clusters-app/linux(${chip_root}/config/standalone/toolchain:standalone)" ]
     }
   }
 
   if (enable_linux_lighting_app_build) {
     group("linux_lighting_app") {
-      deps = [
-        "${chip_root}/examples/lighting-app/linux(${standalone_toolchain})",
-      ]
+      deps = [ "${chip_root}/examples/lighting-app/linux(${chip_root}/config/standalone/toolchain:standalone)" ]
     }
   }
 


### PR DESCRIPTION
e.g. If configuring via

  `gn gen out/nothing --args='target_os="all"  enable_default_builds=false'`

The build fails with:

```
  ERROR at //BUILD.gn:201:26: Assignment had no effect.
    standalone_toolchain = "${chip_root}/config/standalone/toolchain:standalone"
                           ^----------------------------------------------------
  You set the variable "standalone_toolchain" here and it was unused before it went
  out of scope.
```

Inline `${standalone_toolchain}` to fix this. It's a bit unfortunate that
uses in untaken branches trigger this diagnostic.