### PR TITLE
Fix generating qpg6100 without another thread config

### DIFF
--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -44,7 +44,8 @@ static_library("shell_common") {
     "${chip_root}/src/setup_payload",
   ]
 
-  if (current_os == "freertos" || current_os == "zephyr") {
+  if (chip_enable_openthread &&
+      (current_os == "freertos" || current_os == "zephyr")) {
     public_deps += [
       "${openthread_root}:libopenthread-cli-ftd",
       "${openthread_root}:libopenthread-ftd",

--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -19,7 +19,6 @@ import("//build_overrides/qpg6100_sdk.gni")
 arm_platform_config = "${qpg6100_sdk_build_root}/qpg6100_arm.gni"
 
 mbedtls_target = "${qpg6100_sdk_build_root}:qpg6100_sdk"
-openthread_external_mbedtls = mbedtls_target
 
 chip_device_platform = "qpg6100"
 


### PR DESCRIPTION
Generating qpg6100 without also including a thread capable build
triggers the following diagnostic:

```
  ERROR at //src/platform/qpg6100/args.gni:22:31: Build argument has no effect.
  openthread_external_mbedtls = mbedtls_target
                                ^-------------
  The variable "openthread_external_mbedtls" was set as a build argument
  but never appeared in a declare_args() block in any buildfile.
```

Fix it by dropping these unused arguments. This is a temporary issue before
Thread support is brought up, at which time this can be re-added.