### PR TITLE
Call Platform::MemoryInit in the setup code parser library.

### DIFF
--- a/src/android/CHIPTool/.idea/compiler.xml
+++ b/src/android/CHIPTool/.idea/compiler.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
-  </component>
-</project>

--- a/src/android/CHIPTool/.idea/compiler.xml
+++ b/src/android/CHIPTool/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -36,6 +36,7 @@
 #include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
+#include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 #include <support/ScopedBuffer.h>
 
@@ -297,14 +298,14 @@ exit:
 
 CHIP_ERROR QRCodeSetupPayloadParser::populateTLV(SetupPayload & outPayload, const vector<uint8_t> & buf, size_t & index)
 {
-    CHIP_ERROR err        = CHIP_NO_ERROR;
     size_t bitsLeftToRead = (buf.size() * 8) - index;
     size_t tlvBytesLength = (bitsLeftToRead + 7) / 8; // ceil(bitsLeftToRead/8)
     chip::Platform::ScopedMemoryBuffer<uint8_t> tlvArray;
 
-    SuccessOrExit(tlvBytesLength == 0);
+    ReturnErrorCodeIf(tlvBytesLength == 0, CHIP_NO_ERROR);
+
     tlvArray.Alloc(tlvBytesLength);
-    VerifyOrExit(tlvArray, err = CHIP_ERROR_NO_MEMORY);
+    ReturnErrorCodeIf(!tlvArray, CHIP_ERROR_NO_MEMORY);
 
     for (size_t i = 0; i < tlvBytesLength; i++)
     {
@@ -313,11 +314,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::populateTLV(SetupPayload & outPayload, cons
         tlvArray[i] = static_cast<uint8_t>(dest);
     }
 
-    err = parseTLVFields(outPayload, tlvArray.Get(), tlvBytesLength);
-    SuccessOrExit(err);
-
-exit:
-    return err;
+    return parseTLVFields(outPayload, tlvArray.Get(), tlvBytesLength);
 }
 
 static string extractPayload(string inString)

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -1,6 +1,9 @@
 #include "ManualSetupPayloadParser.h"
 #include "QRCodeSetupPayloadParser.h"
 
+#include <support/CHIPMem.h>
+#include <support/logging/CHIPLogging.h>
+
 #include <vector>
 
 #include <jni.h>
@@ -10,6 +13,13 @@ using namespace chip;
 #define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_chip_setuppayload_SetupPayloadParser_##METHOD_NAME
 
 static jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload);
+
+jint JNI_OnLoad(JavaVM * jvm, void * reserved)
+{
+    ChipLogProgress(SetupPayload, "JNI_OnLoad() called");
+    chip::Platform::MemoryInit();
+    return JNI_VERSION_1_6;
+}
 
 JNI_METHOD(jobject, fetchPayloadFromQrCode)(JNIEnv * env, jobject self, jstring qrCodeObj)
 {


### PR DESCRIPTION
 #### Problem
Android APP crashes with SIGABRT when the setup payload parser requires a memory alloocation on the heap (on array parsing).

 #### Summary of Changes
 Crash happens because MemoryInit is never called for the setup payload parser library.
Add a OnLoad method in the JNI code that calls Memory Init.

Also added some logic cleanup in the code for array parsing.
