### PR TITLE
Enable Interaction Model test in Cirque

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -26,6 +26,7 @@ LOG_DIR=${LOG_DIR:-$(mktemp -d)}
 # Append test name here to add more tests for run_all_tests
 CIRQUE_TESTS=(
     "EchoTest"
+    "InteractionModelTest"
     "OnOffClusterTest"
 )
 

--- a/src/app/tests/integration/Dockerfile.initiator
+++ b/src/app/tests/integration/Dockerfile.initiator
@@ -1,0 +1,6 @@
+from chip-cirque-device-base
+
+COPY out/chip-im-initiator /usr/bin/
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh", "initiator"]

--- a/src/app/tests/integration/Dockerfile.responder
+++ b/src/app/tests/integration/Dockerfile.responder
@@ -1,0 +1,6 @@
+from chip-cirque-device-base
+
+COPY out/chip-im-responder /usr/bin/
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh", "responder"]

--- a/src/app/tests/integration/entrypoint.sh
+++ b/src/app/tests/integration/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+service dbus start
+systemctl is-active --quiet dbus && echo dbus is running
+service avahi-daemon start
+/usr/sbin/otbr-agent -I wpan0 spinel+hdlc+uart:///dev/ttyUSB0 &
+sleep 1
+ot-ctl panid 0x1234
+ot-ctl ifconfig up
+ot-ctl thread start
+
+if [ "$1" = "responder" ]; then
+    chip-im-responder
+else
+    sleep infinity
+fi

--- a/src/test_driver/linux-cirque/InteractionModelTest.sh
+++ b/src/test_driver/linux-cirque/InteractionModelTest.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$SOURCE_DIR/../../../"
+
+im_source=$REPO_DIR/src/app/tests/integration
+
+function build_image() {
+    # These files should be successfully compiled elsewhere.
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$im_source"
+    gn gen out >/dev/null
+    run_ninja -C out
+    docker build -t chip_im_initiator -f Dockerfile.initiator . 2>&1
+    docker build -t chip_im_responder -f Dockerfile.responder . 2>&1
+}
+
+function main() {
+    pushd .
+    build_image
+    popd
+    python3 "$SOURCE_DIR/test-interaction-model.py"
+}
+
+source "$SOURCE_DIR"/shell-helpers.sh
+main

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('CHIPInteractionModelTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'CHIP-IM-Initiator',
+        'base_image': 'chip_im_initiator',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    },
+    'device1': {
+        'type': 'CHIP-IM-Responder',
+        'base_image': 'chip_im_responder',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    }
+}
+
+CHIP_PORT = 11097
+
+CIRQUE_URL = "http://localhost:5000"
+
+
+class TestInteractionModel(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+        self.connect_to_thread_network()
+
+    def test_routine(self):
+        self.run_data_model_test()
+
+    def run_data_model_test(self):
+        resp_ips = [device['description']['ipv4_addr'] for device in self.non_ap_devices
+                    if device['type'] == 'CHIP-IM-Responder']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'CHIP-IM-Initiator']
+
+        req_device_id = req_ids[0]
+
+        command = "chip-im-initiator {}"
+
+        for ip in resp_ips:
+            ret = self.execute_device_cmd(
+                req_device_id, command.format(ip))
+            self.assertEqual(
+                ret['return_code'], '0', "{} failure: {}".format("IM", ret['output']))
+
+
+if __name__ == "__main__":
+    sys.exit(TestInteractionModel(DEVICE_CONFIG).run_test())


### PR DESCRIPTION
Problem
We don't have e2e validation for Interaction Model.

Summary of Changes
-- Add e2e validation test for Interaction Mode in cirque

Fixes #4282