### PR TITLE
Fix wrong uint64_t print

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR SendCommandRequest(void)
 
     gLastCommandTime = chip::System::Timer::GetCurrentEpoch();
 
-    printf("\nSend invoke command request message to Node: %lu\n", chip::kTestDeviceNodeId);
+    printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
     chip::app::Command::CommandParams CommandParams = { 1,  // Endpoint
                                                         0,  // GroupId


### PR DESCRIPTION
Problem:
Regression issue
Problem
../../src/app/tests/integration/chip_im_initiator.cpp:86:68: error: format specifies type 'unsigned long' but the argument has type 'chip::NodeId' (aka 'unsigned long long') [-Werror,-Wformat]

Summary of changes

Always use PRIu64 for printing uint64_t, including node ids.

Fixes #4284
