### PR TITLE
[nrfconnect] Replaced default NFC starting with manual trigger

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -67,7 +67,9 @@ commissioner role.
 
 To start the rendezvous, the controller must get the commissioning information
 from the CHIP device. The data payload is encoded within a QR code, printed to
-the UART console, and shared using an NFC tag.
+the UART console, and shared using an NFC tag. For security reasons, you must
+start NFC tag emulation manually after powering up the device by pressing
+**Button 4**.
 
 #### Thread provisioning
 
@@ -143,8 +145,8 @@ opposite one.
 **Button 3** &mdash; Pressing the button once starts the Thread networking in
 the test mode using the default configuration.
 
-**Button 4** &mdash; Pressing the button once starts the Bluetooth LE
-advertising for the predefined period of time.
+**Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
+enables Bluetooth LE advertising for the predefined period of time.
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -121,13 +121,6 @@ int AppTask::Init()
     }
 
     PlatformMgr().AddEventHandler(AppTask::ThreadProvisioningHandler, 0);
-
-    ret = StartNFCTag();
-    if (ret)
-    {
-        LOG_ERR("Starting NFC Tag failed");
-        return ret;
-    }
 #endif
 
     return 0;
@@ -383,6 +376,22 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != BLE_ADVERTISEMENT_START_BUTTON)
         return;
 
+    if (!sNFC.IsTagEmulationStarted())
+    {
+        if (!(GetAppTask().StartNFCTag() < 0))
+        {
+            LOG_INF("Started NFC Tag emulation");
+        }
+        else
+        {
+            LOG_ERR("Starting NFC Tag failed");
+        }
+    }
+    else
+    {
+        LOG_INF("NFC Tag emulation is already started");
+    }
+
     if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
@@ -432,7 +441,7 @@ int AppTask::StartNFCTag()
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());
-    VerifyOrExit(!result, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));
+    VerifyOrExit(result >= 0, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));
 
 exit:
     return result;

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -64,7 +64,9 @@ commissioner role.
 
 To start the rendezvous, the controller must get the commissioning information
 from the CHIP device. The data payload is encoded within a QR code, printed to
-the UART console, and shared using an NFC tag.
+the UART console, and shared using an NFC tag. For security reasons, you must
+start NFC tag emulation manually after powering up the device by pressing
+**Button 4**.
 
 #### Thread provisioning
 
@@ -143,8 +145,8 @@ opposite one.
 **Button 3** &mdash; Pressing the button once starts the Thread networking in
 the test mode using the default configuration.
 
-**Button 4** &mdash; Pressing the button once starts the Bluetooth LE
-advertising for the predefined period of time.
+**Button 4** &mdash; Pressing the button once starts the NFC tag emulation and
+enables Bluetooth LE advertising for the predefined period of time.
 
 **SEGGER J-Link USB port** can be used to get logs from the device or
 communicate with it using the

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -113,13 +113,6 @@ int AppTask::Init()
     }
 
     PlatformMgr().AddEventHandler(AppTask::ThreadProvisioningHandler, 0);
-
-    ret = StartNFCTag();
-    if (ret)
-    {
-        LOG_ERR("Starting NFC Tag failed");
-        return ret;
-    }
 #endif
 
     return 0;
@@ -385,6 +378,22 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != BLE_ADVERTISEMENT_START_BUTTON)
         return;
 
+    if (!sNFC.IsTagEmulationStarted())
+    {
+        if (!(GetAppTask().StartNFCTag() < 0))
+        {
+            LOG_INF("Started NFC Tag emulation");
+        }
+        else
+        {
+            LOG_ERR("Starting NFC Tag failed");
+        }
+    }
+    else
+    {
+        LOG_INF("NFC Tag emulation is already started");
+    }
+
     if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);
@@ -434,7 +443,7 @@ int AppTask::StartNFCTag()
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());
-    VerifyOrExit(!result, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));
+    VerifyOrExit(result >= 0, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));
 
 exit:
     return result;

--- a/examples/platform/nrfconnect/util/NFCWidget.cpp
+++ b/examples/platform/nrfconnect/util/NFCWidget.cpp
@@ -24,6 +24,7 @@
 
 int NFCWidget::Init(chip::DeviceLayer::ConnectivityManager & mgr)
 {
+    mIsTagStarted = false;
     return nfc_t2t_setup(FieldDetectionHandler, &mgr);
 }
 
@@ -42,6 +43,8 @@ int NFCWidget::StartTagEmulation(const char * tagPayload, uint8_t tagPayloadLeng
     result = nfc_t2t_emulation_start();
     VerifyOrExit(result >= 0, ChipLogProgress(AppServer, "nfc_t2t_emulation_start failed: %d", result));
 
+    mIsTagStarted = true;
+
 exit:
     return result;
 }
@@ -50,28 +53,25 @@ int NFCWidget::StopTagEmulation()
 {
     int result = nfc_t2t_emulation_stop();
 
+    VerifyOrExit(result >= 0, ChipLogProgress(AppServer, "nfc_t2t_emulation_stop failed: %d", result));
+
     memset(mNdefBuffer, 0, sizeof(mNdefBuffer));
 
+    mIsTagStarted = false;
+
+exit:
     return result;
+}
+
+bool NFCWidget::IsTagEmulationStarted() const
+{
+    return mIsTagStarted;
 }
 
 void NFCWidget::FieldDetectionHandler(void * context, enum nfc_t2t_event event, const uint8_t * data, size_t data_length)
 {
+    ARG_UNUSED(context);
+    ARG_UNUSED(event);
     ARG_UNUSED(data);
     ARG_UNUSED(data_length);
-
-    switch (event)
-    {
-    case NFC_T2T_EVENT_FIELD_ON: {
-        chip::DeviceLayer::ConnectivityManager * connectivityMgr =
-            reinterpret_cast<chip::DeviceLayer::ConnectivityManager *>(context);
-        if (!connectivityMgr->IsBLEAdvertisingEnabled())
-        {
-            connectivityMgr->SetBLEAdvertisingEnabled(true);
-        }
-    }
-    break;
-    default:
-        break;
-    }
 }

--- a/examples/platform/nrfconnect/util/include/NFCWidget.h
+++ b/examples/platform/nrfconnect/util/include/NFCWidget.h
@@ -27,6 +27,7 @@ public:
     int Init(chip::DeviceLayer::ConnectivityManager & mgr);
     int StartTagEmulation(const char * tagPayload, uint8_t tagPayloadLength);
     int StopTagEmulation();
+    bool IsTagEmulationStarted() const;
 
 private:
     static void FieldDetectionHandler(void * context, enum nfc_t2t_event event, const uint8_t * data, size_t data_length);
@@ -34,4 +35,6 @@ private:
     constexpr static uint8_t mNdefBufferSize = 128;
 
     uint8_t mNdefBuffer[mNdefBufferSize];
+
+    bool mIsTagStarted;
 };


### PR DESCRIPTION
 #### Problem
Spec requirement is that device shall require explicit trigger
of NFC pairing mode via a physical interaction on the device, while
currently NFC tag emulation is started automatically after init.

 #### Summary of Changes
* Moved NFC tag starting method from init to the button handler
* Added GetTagState method to the NFCWidget
* Aligned samples documentation

 Fixes #4286 