### PR TITLE
Some cleanup in secure session manager code

### DIFF
--- a/src/messaging/ReliableMessageManager.cpp
+++ b/src/messaging/ReliableMessageManager.cpp
@@ -409,7 +409,7 @@ CHIP_ERROR ReliableMessageManager::SendFromRetransTable(RetransTableEntry * entr
 
     if (rc)
     {
-        err = mSessionMgr->SendMessage(std::move(entry->retainedBuf), &entry->retainedBuf);
+        err = mSessionMgr->SendEncryptedMessage(std::move(entry->retainedBuf), &entry->retainedBuf);
 
         if (err == CHIP_NO_ERROR)
         {

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -167,15 +167,17 @@ CHIP_ERROR SecureSessionMgr::EncryptMessage(Transport::PeerConnectionState * sta
     VerifyOrExit(CanCastTo<uint16_t>(totalLen + taglen), err = CHIP_ERROR_INTERNAL);
     msgBuf->SetDataLength(static_cast<uint16_t>(totalLen + taglen));
 
-    state->IncrementSendMessageIndex();
-
     ChipLogDetail(Inet, "Secure transport encrypted msg %u", msgId);
 
 exit:
-    if (!msgBuf.IsNull())
+    if (err != CHIP_NO_ERROR)
     {
         const char * errStr = ErrorStr(err);
         ChipLogError(Inet, "Secure transport failed to encrypt msg %u: %s", state->GetSendMessageIndex(), errStr);
+    }
+    else
+    {
+        state->IncrementSendMessageIndex();
     }
 
     return err;
@@ -238,7 +240,8 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHe
         encryptedMsg->SetStart(msgStart);
         encryptedMsg->SetDataLength(msgLen);
 
-        (*bufferRetainSlot) = encryptedMsg.Retain();
+        (*bufferRetainSlot)      = encryptedMsg.Retain();
+        bufferRetainSlot->mMsgId = encryptedMsg.mMsgId;
     }
 
 exit:

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -235,8 +235,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHe
         encryptedMsg->SetStart(msgStart);
         encryptedMsg->SetDataLength(msgLen);
 
-        (*bufferRetainSlot)      = std::move(encryptedMsg);
-        bufferRetainSlot->mMsgId = encryptedMsg.mMsgId;
+        (*bufferRetainSlot) = std::move(encryptedMsg);
     }
 
 exit:

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -92,7 +92,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, NodeId p
 {
     PacketHeader ununsedPacketHeader;
     return SendMessage(payloadHeader, ununsedPacketHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
-                       EncryptionState::kUnencrypted);
+                       EncryptionState::kPayloadIsUnencrypted);
 }
 
 CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle msgBuf,
@@ -111,8 +111,8 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle ms
     msgBuf->SetStart(msgBuf->Start() + headerSize);
 
     PayloadHeader payloadHeader;
-    ReturnErrorOnFailure(
-        SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot, EncryptionState::kEncrypted));
+    ReturnErrorOnFailure(SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
+                                     EncryptionState::kPayloadIsEncrypted));
 
     return CHIP_NO_ERROR;
 }
@@ -206,7 +206,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(PayloadHeader & payloadHeader, PacketHe
     // This marks any connection where we send data to as 'active'
     mPeerConnections.MarkConnectionActive(state);
 
-    if (encryptionState == EncryptionState::kUnencrypted)
+    if (encryptionState == EncryptionState::kPayloadIsUnencrypted)
     {
         err = EncryptPayload(state, payloadHeader, packetHeader, peerNodeId, msgBuf);
         SuccessOrExit(err);

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -219,8 +219,8 @@ private:
 
     enum class EncryptionState
     {
-        kEncrypted,
-        kUnencrypted,
+        kPayloadIsEncrypted,
+        kPayloadIsUnencrypted,
     };
 
     System::Layer * mSystemLayer = nullptr;
@@ -236,7 +236,7 @@ private:
 
     CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, PacketHeader & packetHeader, NodeId peerNodeId,
                            System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,
-                           EncryptionState encrypted);
+                           EncryptionState encryptionState);
 
     /** Schedules a new oneshot timer for checking connection expiry. */
     void ScheduleExpiryTimer();

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -225,8 +225,11 @@ private:
     SecureSessionMgrDelegate * mCB   = nullptr;
     TransportMgrBase * mTransportMgr = nullptr;
 
-    CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, NodeId peerNodeId, System::PacketBufferHandle msgBuf,
-                           EncryptedPacketBufferHandle * bufferRetainSlot, bool isEncrypted);
+    CHIP_ERROR EncryptMessage(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+                              NodeId peerNodeId, System::PacketBufferHandle & msgBuf);
+
+    CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, PacketHeader & packetHeader, NodeId peerNodeId,
+                           System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot, bool isEncrypted);
 
     /** Schedules a new oneshot timer for checking connection expiry. */
     void ScheduleExpiryTimer();

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -157,7 +157,7 @@ public:
     CHIP_ERROR SendMessage(NodeId peerNodeId, System::PacketBufferHandle msgBuf);
     CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, NodeId peerNodeId, System::PacketBufferHandle msgBuf,
                            EncryptedPacketBufferHandle * bufferRetainSlot = nullptr);
-    CHIP_ERROR SendMessage(EncryptedPacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot);
+    CHIP_ERROR SendEncryptedMessage(EncryptedPacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot);
 
     /**
      * @brief
@@ -217,6 +217,12 @@ private:
         kInitialized, /**< State when the object is ready connect to other peers. */
     };
 
+    enum class EncryptionState
+    {
+        kEncrypted,
+        kUnencrypted,
+    };
+
     System::Layer * mSystemLayer = nullptr;
     NodeId mLocalNodeId;                                                                // < Id of the current node
     Transport::PeerConnections<CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE> mPeerConnections; // < Active connections to other peers
@@ -225,11 +231,12 @@ private:
     SecureSessionMgrDelegate * mCB   = nullptr;
     TransportMgrBase * mTransportMgr = nullptr;
 
-    CHIP_ERROR EncryptMessage(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+    CHIP_ERROR EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                               NodeId peerNodeId, System::PacketBufferHandle & msgBuf);
 
     CHIP_ERROR SendMessage(PayloadHeader & payloadHeader, PacketHeader & packetHeader, NodeId peerNodeId,
-                           System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot, bool isEncrypted);
+                           System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,
+                           EncryptionState encrypted);
 
     /** Schedules a new oneshot timer for checking connection expiry. */
     void ScheduleExpiryTimer();

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -242,7 +242,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = secureSessionMgr.SendMessage(payloadHeader, kDestinationNodeId, std::move(buffer), &msgBuf);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = secureSessionMgr.SendMessage(std::move(msgBuf), nullptr);
+    err = secureSessionMgr.SendEncryptedMessage(std::move(msgBuf), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 


### PR DESCRIPTION
 #### Problem
`SecureSessionMgr::SendMessage()` function has grown too big in size, and needs some refactoring.

 #### Summary of Changes

- Moved code to encrypt message to its own function
- Moved code to extract packet header from an pre-encrypted message out of the common function
- Reorganized code to reduce conditional statements and blocks
- Fixed a memory leak (if `mTransportMgr->SendMessage` failed, it could have leaked the retained buffer) 