### PR TITLE
Use standard [[nodiscard]] where available

### DIFF
--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -403,7 +403,10 @@ inline void chipDie(void)
 
 #endif // defined(__cplusplus) && (__cplusplus >= 201103L)
 
-#if defined(__GNUC__) && (__GNUC__ >= 4)
+#if defined(__cplusplus) &&                                                                                                        \
+    ((__cplusplus >= 201703L) || (defined(__GNUC__) && (__GNUC__ >= 7)) || (defined(__clang__)) && (__clang_major__ >= 4))
+#define CHECK_RETURN_VALUE [[nodiscard]]
+#elif defined(__GNUC__) && (__GNUC__ >= 4)
 #define CHECK_RETURN_VALUE __attribute__((warn_unused_result))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1700)
 #define CHECK_RETURN_VALUE _Check_return_


### PR DESCRIPTION
#### Problem

The `CHECK_RETURN_VALUE` macro is conditionally defined to a
non-standard attribute that indicates that a function return value
should not be ignored. C++17 standardizes this as `[[nodiscard]]`
and some compilers also support this attribute in earlier versions.

#### Summary of Changes

Use `[[nodiscard]]` when it is known to be available.
- C++17 or later
- gcc 7 or later, per https://gcc.gnu.org/projects/cxx-status.html
- clang 4 or later, per https://clang.llvm.org/cxx_status.html