### PR TITLE
Revise CHIPTLV to increase PacketBuffer safety

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR Command::Reset()
         VerifyOrExit(!mCommandMessageBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
     }
 
-    mCommandMessageWriter.Init(mCommandMessageBuf.Get_ForNow());
+    mCommandMessageWriter.Init(std::move(mCommandMessageBuf));
     err = mInvokeCommandBuilder.Init(&mCommandMessageWriter);
     SuccessOrExit(err);
 
@@ -78,12 +78,12 @@ exit:
 CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle payload, CommandRoleId aCommandRoleId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVReader reader;
     chip::TLV::TLVReader commandListReader;
     InvokeCommand::Parser invokeCommandParser;
     CommandList::Parser commandListParser;
 
-    reader.Init(payload.Get_ForNow());
+    reader.Init(std::move(payload));
     err = reader.Next();
     SuccessOrExit(err);
 
@@ -128,6 +128,7 @@ exit:
 void Command::Shutdown()
 {
     VerifyOrExit(mState != kState_Uninitialized, );
+    mCommandMessageWriter.Release();
     mCommandMessageBuf = nullptr;
 
     if (mpExchangeCtx != nullptr)
@@ -150,7 +151,7 @@ chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
         ChipLogDetail(DataManagement, "Unable to allocate PacketBuffer");
     }
 
-    mCommandDataWriter.Init(mCommandDataBuf.Get_ForNow());
+    mCommandDataWriter.Init(mCommandDataBuf.Retain());
 
     return mCommandDataWriter;
 }
@@ -273,6 +274,7 @@ CHIP_ERROR Command::FinalizeCommandsMessage()
     err = mCommandMessageWriter.Finalize();
     SuccessOrExit(err);
 
+    mCommandMessageBuf = mCommandMessageWriter.Release();
     mCommandMessageBuf->EnsureReservedSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 
 exit:

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -128,7 +128,7 @@ exit:
 void Command::Shutdown()
 {
     VerifyOrExit(mState != kState_Uninitialized, );
-    mCommandMessageWriter.Release();
+    mCommandMessageWriter.Reset();
     mCommandMessageBuf = nullptr;
 
     if (mpExchangeCtx != nullptr)
@@ -271,10 +271,9 @@ CHIP_ERROR Command::FinalizeCommandsMessage()
     err = mInvokeCommandBuilder.GetError();
     SuccessOrExit(err);
 
-    err = mCommandMessageWriter.Finalize();
+    err = mCommandMessageWriter.Finalize(&mCommandMessageBuf);
     SuccessOrExit(err);
 
-    mCommandMessageBuf = mCommandMessageWriter.Release();
     mCommandMessageBuf->EnsureReservedSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 
 exit:

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -37,6 +37,7 @@
 #include <support/DLLUtil.h>
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 namespace chip {
 namespace app {
@@ -142,8 +143,8 @@ private:
     CommandState mState;
 
     chip::System::PacketBufferHandle mCommandDataBuf;
-    chip::TLV::TLVWriter mCommandMessageWriter;
-    chip::TLV::TLVWriter mCommandDataWriter;
+    chip::System::PacketBufferTLVWriter mCommandMessageWriter;
+    chip::System::PacketBufferTLVWriter mCommandDataWriter;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@
 #include <app/MessageDef.h>
 #include <core/CHIPTLVDebug.hpp>
 #include <support/UnitTestRegistration.h>
-#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 #include <nlunit-test.h>
 
@@ -44,11 +44,11 @@ void TLVPrettyPrinter(const char * aFormat, ...)
     va_end(args);
 }
 
-CHIP_ERROR DebugPrettyPrint(chip::System::PacketBuffer * apMsgBuf)
+CHIP_ERROR DebugPrettyPrint(const chip::System::PacketBufferHandle & aMsgBuf)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVReader reader;
-    reader.Init(apMsgBuf);
+    chip::System::PacketBufferTLVReader reader;
+    reader.Init(aMsgBuf.Retain());
     err = reader.Next();
     chip::TLV::Debug::Dump(reader, TLVPrettyPrinter);
 
@@ -679,19 +679,18 @@ void AttributePathTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     AttributePath::Builder attributePathBuilder;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     attributePathBuilder.Init(&writer);
     BuildAttributePath(apSuite, attributePathBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -703,18 +702,17 @@ void AttributePathTest(nlTestSuite * apSuite, void * apContext)
 void AttributePathListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     BuildAttributePathList(apSuite, writer);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributePathList(apSuite, reader);
@@ -727,19 +725,18 @@ void EventPathTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     EventPath::Parser eventPathParser;
     EventPath::Builder eventPathBuilder;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     eventPathBuilder.Init(&writer);
     BuildEventPath(apSuite, eventPathBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -752,18 +749,17 @@ void EventPathTest(nlTestSuite * apSuite, void * apContext)
 void EventPathListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     BuildEventPathList(apSuite, writer);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventPathList(apSuite, reader);
@@ -774,12 +770,11 @@ void EventPathListTest(nlTestSuite * apSuite, void * apContext)
 void CommandPathTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     CommandPath::Builder commandPathBuilder;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     err = commandPathBuilder.Init(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -788,9 +783,9 @@ void CommandPathTest(nlTestSuite * apSuite, void * apContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -804,19 +799,18 @@ void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     EventDataElement::Builder eventDataElementBuilder;
     EventDataElement::Parser eventDataElementParser;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     eventDataElementBuilder.Init(&writer);
     BuildEventDataElement(apSuite, eventDataElementBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -829,20 +823,19 @@ void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
 void EventListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     EventList::Builder eventListBuilder;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     eventListBuilder.Init(&writer);
     BuildEventList(apSuite, eventListBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventList(apSuite, reader);
@@ -855,19 +848,18 @@ void StatusElementTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Builder statusElementBuilder;
     StatusElement::Parser statusElementParser;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     statusElementBuilder.Init(&writer);
     BuildStatusElement(apSuite, statusElementBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -882,19 +874,18 @@ void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     AttributeStatusElement::Builder attributeStatusElementBuilder;
     AttributeStatusElement::Parser attributeStatusElementParser;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     attributeStatusElementBuilder.Init(&writer);
     BuildAttributeStatusElement(apSuite, attributeStatusElementBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -907,11 +898,10 @@ void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
 void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     AttributeStatusList::Builder attributeStatusListBuilder;
     err = attributeStatusListBuilder.Init(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -919,9 +909,9 @@ void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeStatusList(apSuite, reader);
@@ -934,19 +924,18 @@ void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     AttributeDataElement::Builder attributeDataElementBuilder;
     AttributeDataElement::Parser attributeDataElementParser;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     attributeDataElementBuilder.Init(&writer);
     BuildAttributeDataElement(apSuite, attributeDataElementBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -959,20 +948,19 @@ void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
 void AttributeDataListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     AttributeDataList::Builder attributeDataListBuilder;
     attributeDataListBuilder.Init(&writer);
     BuildAttributeDataList(apSuite, attributeDataListBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeDataList(apSuite, reader);
@@ -985,19 +973,18 @@ void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandDataElement::Builder commandDataElementBuilder;
     CommandDataElement::Parser commandDataElementParser;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     commandDataElementBuilder.Init(&writer);
     BuildCommandDataElement(apSuite, commandDataElementBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -1010,20 +997,19 @@ void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
 void CommandListTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     CommandList::Builder commandListBuilder;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     commandListBuilder.Init(&writer);
     BuildCommandList(apSuite, commandListBuilder);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseCommandList(apSuite, reader);
@@ -1034,18 +1020,17 @@ void CommandListTest(nlTestSuite * apSuite, void * apContext)
 void ReportDataTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     BuildReportData(apSuite, writer);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseReportData(apSuite, reader);
@@ -1056,18 +1041,17 @@ void ReportDataTest(nlTestSuite * apSuite, void * apContext)
 void InvokeCommandTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::TLV::TLVWriter writer;
-    chip::TLV::TLVReader reader;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
     chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buf           = bufHandle.Get_ForNow();
-    writer.Init(buf);
+    writer.Init(bufHandle.Retain());
     BuildInvokeCommand(apSuite, writer);
     err = writer.Finalize();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(buf);
+    DebugPrettyPrint(bufHandle);
 
-    reader.Init(buf);
+    reader.Init(bufHandle.Retain());
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseInvokeCommand(apSuite, reader);

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -681,22 +681,20 @@ void AttributePathTest(nlTestSuite * apSuite, void * apContext)
     AttributePath::Builder attributePathBuilder;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     attributePathBuilder.Init(&writer);
     BuildAttributePath(apSuite, attributePathBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     ParseAttributePath(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void AttributePathListTest(nlTestSuite * apSuite, void * apContext)
@@ -704,20 +702,18 @@ void AttributePathListTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     BuildAttributePathList(apSuite, writer);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributePathList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void EventPathTest(nlTestSuite * apSuite, void * apContext)
@@ -727,23 +723,21 @@ void EventPathTest(nlTestSuite * apSuite, void * apContext)
     EventPath::Builder eventPathBuilder;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     eventPathBuilder.Init(&writer);
     BuildEventPath(apSuite, eventPathBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     eventPathParser.Init(reader);
     ParseEventPath(apSuite, eventPathParser);
-
-    bufHandle = nullptr;
 }
 
 void EventPathListTest(nlTestSuite * apSuite, void * apContext)
@@ -751,20 +745,18 @@ void EventPathListTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     BuildEventPathList(apSuite, writer);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventPathList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void CommandPathTest(nlTestSuite * apSuite, void * apContext)
@@ -773,25 +765,23 @@ void CommandPathTest(nlTestSuite * apSuite, void * apContext)
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
     CommandPath::Builder commandPathBuilder;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     err = commandPathBuilder.Init(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     BuildCommandPath(apSuite, commandPathBuilder);
 
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     ParseCommandPath(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -801,23 +791,21 @@ void EventDataElementTest(nlTestSuite * apSuite, void * apContext)
     EventDataElement::Parser eventDataElementParser;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     eventDataElementBuilder.Init(&writer);
     BuildEventDataElement(apSuite, eventDataElementBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     eventDataElementParser.Init(reader);
     ParseEventDataElement(apSuite, eventDataElementParser);
-
-    bufHandle = nullptr;
 }
 
 void EventListTest(nlTestSuite * apSuite, void * apContext)
@@ -826,21 +814,19 @@ void EventListTest(nlTestSuite * apSuite, void * apContext)
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
     EventList::Builder eventListBuilder;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     eventListBuilder.Init(&writer);
     BuildEventList(apSuite, eventListBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseEventList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void StatusElementTest(nlTestSuite * apSuite, void * apContext)
@@ -850,23 +836,21 @@ void StatusElementTest(nlTestSuite * apSuite, void * apContext)
     StatusElement::Parser statusElementParser;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     statusElementBuilder.Init(&writer);
     BuildStatusElement(apSuite, statusElementBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     statusElementParser.Init(reader);
     ParseStatusElement(apSuite, statusElementParser);
-
-    bufHandle = nullptr;
 }
 
 void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
@@ -876,23 +860,21 @@ void AttributeStatusElementTest(nlTestSuite * apSuite, void * apContext)
     AttributeStatusElement::Parser attributeStatusElementParser;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     attributeStatusElementBuilder.Init(&writer);
     BuildAttributeStatusElement(apSuite, attributeStatusElementBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     attributeStatusElementParser.Init(reader);
     ParseAttributeStatusElement(apSuite, attributeStatusElementParser);
-
-    bufHandle = nullptr;
 }
 
 void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
@@ -900,23 +882,21 @@ void AttributeStatusListTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     AttributeStatusList::Builder attributeStatusListBuilder;
     err = attributeStatusListBuilder.Init(&writer);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     BuildAttributeStatusList(apSuite, attributeStatusListBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeStatusList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -926,23 +906,21 @@ void AttributeDataElementTest(nlTestSuite * apSuite, void * apContext)
     AttributeDataElement::Parser attributeDataElementParser;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     attributeDataElementBuilder.Init(&writer);
     BuildAttributeDataElement(apSuite, attributeDataElementBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     attributeDataElementParser.Init(reader);
     ParseAttributeDataElement(apSuite, attributeDataElementParser);
-
-    bufHandle = nullptr;
 }
 
 void AttributeDataListTest(nlTestSuite * apSuite, void * apContext)
@@ -950,22 +928,20 @@ void AttributeDataListTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     AttributeDataList::Builder attributeDataListBuilder;
     attributeDataListBuilder.Init(&writer);
     BuildAttributeDataList(apSuite, attributeDataListBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseAttributeDataList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
@@ -975,23 +951,21 @@ void CommandDataElementTest(nlTestSuite * apSuite, void * apContext)
     CommandDataElement::Parser commandDataElementParser;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     commandDataElementBuilder.Init(&writer);
     BuildCommandDataElement(apSuite, commandDataElementBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     commandDataElementParser.Init(reader);
     ParseCommandDataElement(apSuite, commandDataElementParser);
-
-    bufHandle = nullptr;
 }
 
 void CommandListTest(nlTestSuite * apSuite, void * apContext)
@@ -1000,21 +974,19 @@ void CommandListTest(nlTestSuite * apSuite, void * apContext)
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
     CommandList::Builder commandListBuilder;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     commandListBuilder.Init(&writer);
     BuildCommandList(apSuite, commandListBuilder);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseCommandList(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void ReportDataTest(nlTestSuite * apSuite, void * apContext)
@@ -1022,20 +994,18 @@ void ReportDataTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     BuildReportData(apSuite, writer);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseReportData(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 void InvokeCommandTest(nlTestSuite * apSuite, void * apContext)
@@ -1043,20 +1013,18 @@ void InvokeCommandTest(nlTestSuite * apSuite, void * apContext)
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVWriter writer;
     chip::System::PacketBufferTLVReader reader;
-    chip::System::PacketBufferHandle bufHandle = chip::System::PacketBuffer::New();
-    writer.Init(bufHandle.Retain());
+    writer.Init(chip::System::PacketBuffer::New());
     BuildInvokeCommand(apSuite, writer);
-    err = writer.Finalize();
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    DebugPrettyPrint(bufHandle);
+    DebugPrettyPrint(buf);
 
-    reader.Init(bufHandle.Retain());
+    reader.Init(std::move(buf));
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     ParseInvokeCommand(apSuite, reader);
-
-    bufHandle = nullptr;
 }
 
 /**

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.h
+++ b/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.h
+++ b/src/include/platform/internal/GenericSoftwareUpdateManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,8 @@
 // #if CHIP_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
 
 #include <platform/SoftwareUpdateManager.h>
+
+#include <system/SystemPacketBuffer.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -82,7 +84,7 @@ private:
     void CheckImageIntegrity();
     void DriveState(SoftwareUpdateManager::State aNextState);
     void GetEventState(int32_t & aEventState);
-    void HandleImageQueryResponse(PacketBuffer * aPayload);
+    void HandleImageQueryResponse(chip::System::PacketBuffer * aPayload);
     void SendQuery();
     void StartImageInstall();
     void PrepareImageStorage();
@@ -107,7 +109,7 @@ private:
     SoftwareUpdateManager::EventCallback mEventHandlerCallback;
     SoftwareUpdateManager::RetryPolicyCallback mRetryPolicyCallback;
 
-    PacketBuffer * mImageQueryPacketBuffer;
+    chip::System::PacketBuffer * mImageQueryPacketBuffer;
 
     bool mScheduledCheckEnabled;
     bool mShouldRetry;

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -122,7 +122,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
     CHIP_ERROR err;
 
     // find the boundaries of an event to throw away
-    reader.Init(this);
+    reader.Init(*this);
     reader.ImplicitProfileId = mImplicitProfileId;
 
     // position the reader on the first element
@@ -142,7 +142,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
     if (mProcessEvictedElement != nullptr)
     {
         // Reinitialize the reader
-        reader.Init(this);
+        reader.Init(*this);
         reader.ImplicitProfileId = mImplicitProfileId;
 
         err = mProcessEvictedElement(*this, mAppData, reader);
@@ -155,6 +155,15 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
 
 exit:
     return err;
+}
+
+/**
+ * @brief
+ *  Implements TLVBackingStore::OnInit(TLVWriter) for circular buffers.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
+{
+    return GetNewBuffer(writer, bufStart, bufLen);
 }
 
 /**
@@ -240,6 +249,15 @@ CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBuffer(TLVWriter & ioWriter, uint8_t *
 
 /**
  * @brief
+ *  Implements TLVBackingStore::OnInit(TVLReader) for circular buffers.
+ */
+CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen)
+{
+    return GetNextBuffer(reader, bufStart, bufLen);
+}
+
+/**
+ * @brief
  *   Get additional space for the TLVReader.
  *
  *  The storage provided by the CHIPCircularTLVBuffer may be
@@ -302,168 +320,6 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNextBuffer(TLVReader & ioReader, const uint
         outBufLen = static_cast<uint32_t>(tail - outBufStart);
     }
     return err;
-}
-
-/**
- * @brief
- *   A trampoline to fetch more space for the TLVWriter.
- *
- * @param[in,out] ioWriter TLVWriter calling this function
- *
- * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
- *
- * @param[out] outBufStart The pointer to the new buffer
- *
- * @param[out] outBufLen   The available length for writing
- *
- * @retval #CHIP_NO_ERROR On success.
- *
- * @retval other           If the function was unable to elide a complete
- *                         top-level TLV element.
- */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNewBufferFunct(TLVWriter & ioWriter, uintptr_t & inBufHandle, uint8_t *& outBufStart,
-                                                    uint32_t & outBufLen)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer * buf;
-
-    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
-
-    err = buf->GetNewBuffer(ioWriter, outBufStart, outBufLen);
-
-exit:
-    return err;
-}
-
-/**
- * @brief
- *   A trampoline to CHIPCircularTLVBuffer::FinalizeBuffer
- *
- * @param[in,out] ioWriter TLVWriter calling this function
- *
- * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
- *
- * @param[in] inBufStart pointer to the start of data (from `TLVWriter`
- *                       perspective)
- *
- * @param[in] inBufLen   length of data in the buffer pointed to by
- *                       `inbufStart`
- *
- * @retval #CHIP_NO_ERROR Unconditionally.
- */
-CHIP_ERROR CHIPCircularTLVBuffer::FinalizeBufferFunct(TLVWriter & ioWriter, uintptr_t inBufHandle, uint8_t * inBufStart,
-                                                      uint32_t inBufLen)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer * buf;
-
-    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
-
-    err = buf->FinalizeBuffer(ioWriter, inBufStart, inBufLen);
-
-exit:
-    return err;
-}
-
-/**
- * @brief
- *   A trampoline to CHIPCircularTLVBuffer::GetNextBuffer
- *
- * @param[in,out] ioReader TLVReader calling this function
- *
- * @param[in,out] inBufHandle A handle to the `CircularTLVWriter` object
- *
- * @param[in,out] outBufStart  The reference to the data buffer.  On
- *                             return, it is set to a value within this
- *                             buffer.
- *
- * @param[out] outBufLen       On return, set to the number of continuous
- *                             bytes that could be read out of the buffer.
- *
- * @retval #CHIP_NO_ERROR      Succeeds unconditionally.
- */
-CHIP_ERROR CHIPCircularTLVBuffer::GetNextBufferFunct(TLVReader & ioReader, uintptr_t & inBufHandle, const uint8_t *& outBufStart,
-                                                     uint32_t & outBufLen)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    CHIPCircularTLVBuffer * buf;
-
-    VerifyOrExit(inBufHandle != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    buf = reinterpret_cast<CHIPCircularTLVBuffer *>(inBufHandle);
-
-    err = buf->GetNextBuffer(ioReader, outBufStart, outBufLen);
-
-exit:
-    return err;
-}
-
-/**
- * @brief
- *   Initializes a TLVWriter object to write from a single CHIPCircularTLVBuffer
- *
- * Writing begins at the last byte of the buffer.  The number of bytes
- * to be written is not constrained by the underlying circular buffer:
- * writing new elements to the buffer will kick out previous elements
- * as long as an individual top-level TLV structure fits within the
- * buffer.  For example, writing a 7-byte top-level boolean TLV into a
- * 7 byte buffer will work indefinitely, but writing an 8-byte TLV
- * structure will result in an error.
- *
- * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
- *
- */
-void CircularTLVWriter::Init(CHIPCircularTLVBuffer * buf)
-{
-    mBufHandle     = reinterpret_cast<uintptr_t>(buf);
-    mLenWritten    = 0;
-    mMaxLen        = UINT32_MAX;
-    mContainerType = kTLVType_NotSpecified;
-    SetContainerOpen(false);
-    SetCloseContainerReserved(false);
-
-    ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer      = CHIPCircularTLVBuffer::GetNewBufferFunct;
-    FinalizeBuffer    = CHIPCircularTLVBuffer::FinalizeBufferFunct;
-
-    GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
-    mWritePoint = mBufStart;
-}
-
-/**
- * @brief
- *   Initializes a TLVReader object to read from a single CHIPCircularTLVBuffer
- *
- * Parsing begins at the start of the buffer (obtained by the
- * buffer->Start() position) and continues until the end of the buffer
- * Parsing may wraparound within the buffer (on any element).  At most
- * buffer->GetQueueSize() bytes are read out.
- *
- * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
- *
- */
-void CircularTLVReader::Init(CHIPCircularTLVBuffer * buf)
-{
-    uint32_t bufLen = 0;
-
-    mBufHandle    = reinterpret_cast<uintptr_t>(buf);
-    GetNextBuffer = CHIPCircularTLVBuffer::GetNextBufferFunct;
-    mLenRead      = 0;
-    mReadPoint    = nullptr;
-    GetNextBuffer(*this, mBufHandle, mReadPoint, bufLen);
-    mBufEnd        = mReadPoint + bufLen;
-    mMaxLen        = buf->DataLength();
-    mControlByte   = kTLVControlByte_NotSpecified;
-    mElemTag       = AnonymousTag;
-    mElemLenOrVal  = 0;
-    mContainerType = kTLVType_NotSpecified;
-    SetContainerOpen(false);
-    ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = nullptr;
 }
 
 } // namespace TLV

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *    All rights reserved.
  *

--- a/src/lib/core/CHIPCircularTLVBuffer.h
+++ b/src/lib/core/CHIPCircularTLVBuffer.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *    All rights reserved.
  *

--- a/src/lib/core/CHIPCircularTLVBuffer.h
+++ b/src/lib/core/CHIPCircularTLVBuffer.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -54,15 +54,11 @@ namespace TLV {
  *    buffer.
  *
  */
-class DLL_EXPORT CHIPCircularTLVBuffer
+class DLL_EXPORT CHIPCircularTLVBuffer : public chip::TLV::TLVBackingStore
 {
 public:
     CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength);
     CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead);
-
-    CHIP_ERROR GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen);
-    CHIP_ERROR FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen);
-    CHIP_ERROR GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen);
 
     inline uint8_t * QueueHead() const { return mQueueHead; }
     inline uint8_t * QueueTail() const { return mQueue + ((static_cast<size_t>(mQueueHead - mQueue) + mQueueLength) % mQueueSize); }
@@ -73,11 +69,12 @@ public:
 
     CHIP_ERROR EvictHead();
 
-    static CHIP_ERROR GetNewBufferFunct(TLVWriter & ioWriter, uintptr_t & inBufHandle, uint8_t *& outBufStart,
-                                        uint32_t & outBufLen);
-    static CHIP_ERROR FinalizeBufferFunct(TLVWriter & ioWriter, uintptr_t inBufHandle, uint8_t * inBufStart, uint32_t inBufLen);
-    static CHIP_ERROR GetNextBufferFunct(TLVReader & ioReader, uintptr_t & inBufHandle, const uint8_t *& outBufStart,
-                                         uint32_t & outBufLen);
+    // chip::TLV::TLVBackingStore overrides:
+    CHIP_ERROR OnInit(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR GetNextBuffer(TLVReader & ioReader, const uint8_t *& outBufStart, uint32_t & outBufLen) override;
+    CHIP_ERROR OnInit(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen) override;
+    CHIP_ERROR FinalizeBuffer(TLVWriter & ioWriter, uint8_t * inBufStart, uint32_t inBufLen) override;
 
     /**
      *  @typedef CHIP_ERROR (*ProcessEvictedElementFunct)(CHIPCircularTLVBuffer &inBuffer, void * inAppData, TLVReader &inReader)
@@ -140,13 +137,40 @@ private:
 class DLL_EXPORT CircularTLVReader : public TLVReader
 {
 public:
-    void Init(CHIPCircularTLVBuffer * buf);
+    /**
+     * @brief
+     *   Initializes a TLVReader object to read from a single CHIPCircularTLVBuffer
+     *
+     * Parsing begins at the start of the buffer (obtained by the
+     * buffer->Start() position) and continues until the end of the buffer
+     * Parsing may wraparound within the buffer (on any element).  At most
+     * buffer->GetQueueSize() bytes are read out.
+     *
+     * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+     *
+     */
+    void Init(CHIPCircularTLVBuffer & buf) { TLVReader::Init(buf, buf.DataLength()); }
 };
 
 class DLL_EXPORT CircularTLVWriter : public TLVWriter
 {
 public:
-    void Init(CHIPCircularTLVBuffer * buf);
+    /**
+     * @brief
+     *   Initializes a TLVWriter object to write from a single CHIPCircularTLVBuffer
+     *
+     * Writing begins at the last byte of the buffer.  The number of bytes
+     * to be written is not constrained by the underlying circular buffer:
+     * writing new elements to the buffer will kick out previous elements
+     * as long as an individual top-level TLV structure fits within the
+     * buffer.  For example, writing a 7-byte top-level boolean TLV into a
+     * 7 byte buffer will work indefinitely, but writing an 8-byte TLV
+     * structure will result in an error.
+     *
+     * @param[in]    buf   A pointer to a fully initialized CHIPCircularTLVBuffer
+     *
+     */
+    void Init(CHIPCircularTLVBuffer & buf) { TLVWriter::Init(buf, UINT32_MAX); }
 };
 
 } // namespace TLV

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -119,9 +119,9 @@ public:
      * Parsing begins at the backing store's start position and continues until the
      * end of the data in the buffer, or maxLen bytes have been parsed.
      *
-     * @param[in]   buf     A pointer to a TLVBackingStore providing the TLV data to be parsed.
-     * @param[in]   maxLen  The maximum of bytes to parse. Defaults to the amount of data
-     *                      in the input buffer.
+     * @param[in]   backingStore    A pointer to a TLVBackingStore providing the TLV data to be parsed.
+     * @param[in]   maxLen          The maximum of bytes to parse. Defaults to the amount of data
+     *                              in the input buffer.
      *
      * @retval #CHIP_NO_ERROR  If the method succeeded.
      * @retval other           Other error codes returned by TLVBackingStore::OnInit().
@@ -747,7 +747,7 @@ public:
     /**
      * Position the destination reader on the next element with the given tag within this reader's current container context
      *
-     * @param[in] tag                      The destination context tag value
+     * @param[in] tagInApiForm             The destination context tag value
      * @param[in] destReader               The destination TLV reader value that was located by given tag
      *
      * @retval #CHIP_NO_ERROR              If the reader was successfully positioned at the given tag
@@ -2300,8 +2300,6 @@ public:
      * or closing a file descriptor.
      *
      * @param[in]       writer          A reference to the TLVWriter object that is being finalized.
-     * @param[in,out]   bufHandle       A uintptr_t context value that was set by previous calls to the
-     *                                  @p GetNewBuffer function.
      * @param[in,out]   bufStart        A pointer to the beginning of the current (and final) output buffer.
      * @param[in,out]   bufLen          The number of bytes contained in the buffer pointed to by @p bufStart.
      *

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -119,8 +119,8 @@ public:
      * Parsing begins at the backing store's start position and continues until the
      * end of the data in the buffer, or maxLen bytes have been parsed.
      *
-     * @param[in]   backingStore    A pointer to a TLVBackingStore providing the TLV data to be parsed.
-     * @param[in]   maxLen          The maximum of bytes to parse. Defaults to the amount of data
+     * @param[in]   backingStore    A reference to a TLVBackingStore providing the TLV data to be parsed.
+     * @param[in]   maxLen          The maximum number of bytes to parse. Defaults to the amount of data
      *                              in the input buffer.
      *
      * @retval #CHIP_NO_ERROR  If the method succeeded.
@@ -837,9 +837,7 @@ public:
     void Init(uint8_t * buf, uint32_t maxLen);
 
     /**
-     * Initializes a TLVWriter object to write into memory provided by a BackingStore.
-     *
-     * @note If a chain of buffers is given, data will only be written to the first buffer.
+     * Initializes a TLVWriter object to write into memory provided by a TLVBackingStore.
      *
      * @note Applications must call Finalize() on the writer before using the contents of the buffer.
      *

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,15 +36,6 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
-// forward declaration of the PacketBuffer class used within the header.
-namespace chip {
-namespace System {
-
-class PacketBuffer;
-
-} // namespace System
-} // namespace chip
-
 /**
  * @namespace chip::TLV
  *
@@ -67,12 +58,12 @@ inline uint8_t operator|(TLVTagControl lhs, TLVElementType rhs)
     return static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs);
 }
 
-using chip::System::PacketBuffer;
-
 enum
 {
     kTLVControlByte_NotSpecified = 0xFFFF
 };
+
+class TLVBackingStore;
 
 /**
  * Provides a memory efficient parser for data encoded in CHIP TLV format.
@@ -95,10 +86,8 @@ enum
  * The reader will continue to return CHIP_END_OF_TLV until it is reinitialized, or the current
  * container is exited (via CloseContainer() / ExitContainer()).
  *
- * A TLVReader object can parse data directly from a fixed input buffer, or from a chain of one
- * or more PacketBuffers.  Additionally, applications can supply a @p GetNextBuffer function to
- * feed data to the reader from an arbitrary source, e.g. a socket or a serial port.
- *
+ * A TLVReader object can parse data directly from a fixed input buffer, or from memory provided
+ * by a TLVBackingStore.
  */
 class DLL_EXPORT TLVReader
 {
@@ -106,66 +95,692 @@ class DLL_EXPORT TLVReader
     friend class TLVUpdater;
 
 public:
-    // *** See CHIPTLVReader.cpp file for API documentation ***
-
+    /**
+     * Initializes a TLVReader object from another TLVReader object.
+     *
+     * @param[in]   aReader  A read-only reference to the TLVReader to initialize
+     *                       this from.
+     *
+     */
     void Init(const TLVReader & aReader);
-    void Init(const uint8_t * data, uint32_t dataLen);
-    void Init(PacketBuffer * buf, uint32_t maxLen = 0xFFFFFFFFUL);
-    void Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguousBuffers);
 
+    /**
+     * Initializes a TLVReader object to read from a single input buffer.
+     *
+     * @param[in]   data    A pointer to a buffer containing the TLV data to be parsed.
+     * @param[in]   dataLen The length of the TLV data to be parsed.
+     *
+     */
+    void Init(const uint8_t * data, uint32_t dataLen);
+
+    /**
+     * Initializes a TLVReader object to read from a TLVBackingStore.
+     *
+     * Parsing begins at the backing store's start position and continues until the
+     * end of the data in the buffer, or maxLen bytes have been parsed.
+     *
+     * @param[in]   buf     A pointer to a TLVBackingStore providing the TLV data to be parsed.
+     * @param[in]   maxLen  The maximum of bytes to parse. Defaults to the amount of data
+     *                      in the input buffer.
+     *
+     * @retval #CHIP_NO_ERROR  If the method succeeded.
+     * @retval other           Other error codes returned by TLVBackingStore::OnInit().
+     */
+    CHIP_ERROR Init(TLVBackingStore & backingStore, uint32_t maxLen = UINT32_MAX);
+
+    /**
+     * Advances the TLVReader object to the next TLV element to be read.
+     *
+     * The Next() method positions the reader object on the next element in a TLV encoding that resides
+     * in the same containment context.  In particular, if the reader is positioned at the outer-most
+     * level of a TLV encoding, calling Next() will advance the reader to the next, top-most element.
+     * If the reader is positioned within a TLV container element (a structure, array or path), calling
+     * Next() will advance the reader to the next member element of the container.
+     *
+     * Since Next() constrains reader motion to the current containment context, calling Next() when
+     * the reader is positioned on a container element will advance @em over the container, skipping
+     * its member elements (and the members of any nested containers) until it reaches the first element
+     * after the container.
+     *
+     * When there are no further elements within a particular containment context the Next() method will
+     * return a #CHIP_END_OF_TLV error and the position of the reader will remain unchanged.
+     *
+     * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
+     * @retval #CHIP_END_OF_TLV            If no further elements are available.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV element
+     *                                      type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval #CHIP_ERROR_UNKNOWN_IMPLICIT_TLV_TAG
+     *                                      If the reader encountered a implicitly-encoded TLV tag for which
+     *                                      the corresponding profile id is unknown.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR Next();
+
+    /**
+     * Advances the TLVReader object to the next TLV element to be read, asserting the type and tag of
+     * the new element.
+     *
+     * The Next(TLVType expectedType, uint64_t expectedTag) method is a convenience method that has the
+     * same behavior as Next(), but also verifies that the type and tag of the new TLV element match
+     * the supplied arguments.
+     *
+     * @param[in] expectedType              The expected data type for the next element.
+     * @param[in] expectedTag               The expected tag for the next element.
+     *
+     * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
+     * @retval #CHIP_END_OF_TLV            If no further elements are available.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the type of the new element does not match the value
+     *                                      of the @p expectedType argument.
+     * @retval #CHIP_ERROR_UNEXPECTED_TLV_ELEMENT
+     *                                      If the tag associated with the new element does not match the
+     *                                      value of the @p expectedTag argument.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV
+     *                                      element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR Next(TLVType expectedType, uint64_t expectedTag);
 
+    /**
+     * Returns the type of the current TLV element.
+     *
+     * @return      A TLVType value describing the data type of the current TLV element.  If the reader
+     *              is not positioned on a TLV element, the return value will be kTLVType_NotSpecified.
+     */
     TLVType GetType() const;
-    uint64_t GetTag() const;
-    uint32_t GetLength() const;
-    uint16_t GetControlByte() const;
 
+    /**
+     * Returns the tag associated with current TLV element.
+     *
+     * The value returned by GetTag() can be used with the tag utility functions (IsProfileTag(),
+     * IsContextTag(), ProfileIdFromTag(), etc.) to determine the type of tag and to extract various tag
+     * field values.
+     *
+     * @note If the reader is not positioned on a TLV element when GetTag() is called, the return value
+     * is undefined. Therefore whenever the position of the reader is uncertain applications should call
+     * GetType() to determine if the reader is position on an element (GetType() != kTLVType_NotSpecified)
+     * before calling GetTag().
+     *
+     * @return      An unsigned integer containing information about the tag associated with the current
+     *              TLV element.
+     */
+    uint64_t GetTag() const { return mElemTag; }
+
+    /**
+     * Returns the length of data associated with current TLV element.
+     *
+     * Data length only applies to elements of type UTF8 string or byte string.  For UTF8 strings, the
+     * value returned is the number of bytes in the string, not the number of characters.
+     *
+     * @return      The length (in bytes) of data associated with the current TLV element, or 0 if the
+     *              current element is not a UTF8 string or byte string, or if the reader is not
+     *              positioned on an element.
+     */
+    uint32_t GetLength() const;
+
+    /**
+     * Returns the control byte associated with current TLV element.
+     *
+     * Ideally, nobody ever needs to know about the control byte and only the
+     * internal implementation of TLV should have access to it. But, nevertheless,
+     * having access to the control byte is helpful for debugging purposes by the
+     * TLV Debug Utilities (that try to decode the tag control byte when pretty
+     * printing the TLV buffer contents).
+     *
+     * @note Unless you really know what you are doing, please refrain from using
+     * this method and the associated control byte information.
+     *
+     * @return      An unsigned integer containing the control byte associated with
+     *              the current TLV element. kTLVControlByte_NotSpecified is
+     *              returned if the reader is not positioned @em on an element.
+     */
+    uint16_t GetControlByte() const { return mControlByte; }
+
+    /**
+     * Get the value of the current element as a bool type.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV boolean type, or the
+     *                                      reader is not positioned on an element.
+     */
     CHIP_ERROR Get(bool & v);
+
+    /**
+     * Get the value of the current element as an 8-bit signed integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(int8_t & v);
+
+    /**
+     * Get the value of the current element as a 16-bit signed integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(int16_t & v);
+
+    /**
+     * Get the value of the current element as a 32-bit signed integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(int32_t & v);
+
+    /**
+     * Get the value of the current element as a 64-bit signed integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(int64_t & v);
+
+    /**
+     * Get the value of the current element as an 8-bit unsigned integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
+     * to unsigned.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(uint8_t & v);
+
+    /**
+     * Get the value of the current element as a 16-bit unsigned integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
+     * to unsigned.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(uint16_t & v);
+
+    /**
+     * Get the value of the current element as a 32-bit unsigned integer.
+     *
+     * If the encoded integer value is larger than the output data type the resultant value will be
+     * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
+     * to unsigned.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(uint32_t & v);
+
+    /**
+     * Get the value of the current element as a 64-bit unsigned integer.
+     *
+     * If the encoded integer value is negative, the value will be converted to unsigned.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
+     *                                      unsigned), or the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(uint64_t & v);
-    CHIP_ERROR Get(float & v);
+
+    /**
+     * Get the value of the current element as a double-precision floating point number.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV floating point type, or
+     *                                      the reader is not positioned on an element.
+     *
+     */
     CHIP_ERROR Get(double & v);
+
+    /**
+     * Get the value of the current element as a single-precision floating point number.
+     *
+     * @param[out]  v                       Receives the value associated with current TLV element.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV floating point type, or
+     *                                      the reader is not positioned on an element.
+     *
+     */
+    CHIP_ERROR Get(float & v);
+
+    /**
+     * Get the value of the current byte or UTF8 string element.
+     *
+     * To determine the required input buffer size, call the GetLength() method before calling GetBytes().
+     *
+     * @note The data output by this method is NOT null-terminated.
+     *
+     * @param[in]  buf                      A pointer to a buffer to receive the string data.
+     * @param[in]  bufSize                  The size in bytes of the buffer pointed to by @p buf.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
+     *                                      the reader is not positioned on an element.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                                      If the supplied buffer is too small to hold the data associated
+     *                                      with the current element.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR GetBytes(uint8_t * buf, uint32_t bufSize);
+
+    /**
+     * Allocates and returns a buffer containing the value of the current byte or UTF8 string.
+     *
+     * This method creates a buffer for and returns a copy of the data associated with the byte
+     * or UTF-8 string element at the current position. Memory for the buffer is obtained with
+     * Platform::MemoryAlloc() and should be freed with Platform::MemoryFree() by the caller when
+     * it is no longer needed.
+     *
+     * @note The data returned by this method is NOT null-terminated.
+     *
+     * @param[out] buf                      A reference to a pointer to which a heap-allocated buffer of
+     *                                      @p dataLen bytes will be assigned on success.
+     * @param[out] dataLen                  A reference to storage for the size, in bytes, of @p buf on
+     *                                      success.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
+     *                                      the reader is not positioned on an element.
+     * @retval #CHIP_ERROR_NO_MEMORY       If memory could not be allocated for the output buffer.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR DupBytes(uint8_t *& buf, uint32_t & dataLen);
+
+    /**
+     * Get the value of the current byte or UTF8 string element as a null terminated string.
+     *
+     * To determine the required input buffer size, call the GetLength() method before calling GetBytes().
+     * The input buffer should be at least one byte bigger than the string length to accommodate the null
+     * character.
+     *
+     * @param[in]  buf                      A pointer to a buffer to receive the byte string data.
+     * @param[in]  bufSize                  The size in bytes of the buffer pointed to by @p buf.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
+     *                                      the reader is not positioned on an element.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                                      If the supplied buffer is too small to hold the data associated
+     *                                      with the current element.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR GetString(char * buf, uint32_t bufSize);
+
+    /**
+     * Allocates and returns a buffer containing the null-terminated value of the current byte or UTF8
+     * string.
+     *
+     * This method creates a buffer for and returns a null-terminated copy of the data associated with
+     * the byte or UTF-8 string element at the current position. Memory for the buffer is obtained with
+     * Platform::MemoryAlloc() and should be freed with chip::Platform::MemoryFree() by the caller when
+     * it is no longer needed.
+     *
+     * @param[out] buf                      A reference to a pointer to which a heap-allocated buffer of
+     *                                      will be assigned on success.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
+     *                                      the reader is not positioned on an element.
+     * @retval #CHIP_ERROR_NO_MEMORY       If memory could not be allocated for the output buffer.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval other                       Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR DupString(char *& buf);
+
+    /**
+     * Get a pointer to the initial encoded byte of a TLV byte or UTF8 string element.
+     *
+     * This method returns a direct pointer the encoded string value within the underlying input buffer.
+     * To succeed, the method requires that the entirety of the string value be present in a single buffer.
+     * Otherwise the method returns #CHIP_ERROR_TLV_UNDERRUN.  This makes the method of limited use when
+     * reading data from multiple discontiguous buffers.
+     *
+     * @param[out] data                     A reference to a const pointer that will receive a pointer to
+     *                                      the underlying string data.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or the
+     *                                      reader is not positioned on an element.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely or the value
+     *                                      of the current string element is not contained within a single
+     *                                      contiguous buffer.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR GetDataPtr(const uint8_t *& data);
 
+    /**
+     * Prepares a TLVReader object for reading the members of TLV container element.
+     *
+     * The EnterContainer() method prepares the current TLVReader object to begin reading the member
+     * elements of a TLV container (a structure, array or path). For every call to EnterContainer()
+     * applications must make a corresponding call to ExitContainer().
+     *
+     * When EnterContainer() is called the TLVReader object must be positioned on the container element
+     * to be read.  The method takes as an argument a reference to a TLVType value which will be used
+     * to save the context of the reader while it is reading the container.
+     *
+     * When the EnterContainer() method returns, the reader is positioned immediately @em before the
+     * first member of the container. Repeatedly calling Next() will advance the reader through the members
+     * of the collection until the end is reached, at which point the reader will return CHIP_END_OF_TLV.
+     *
+     * Once the application has finished reading a container it can continue reading the elements after
+     * the container by calling the ExitContainer() method.
+     *
+     * @param[out] outerContainerType       A reference to a TLVType value that will receive the context
+     *                                      of the reader.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If the current element is not positioned on a container element.
+     *
+     */
     CHIP_ERROR EnterContainer(TLVType & outerContainerType);
+
+    /**
+     * Completes the reading of a TLV container and prepares a TLVReader object to read elements
+     * after the container.
+     *
+     * The ExitContainer() method restores the state of a TLVReader object after a call to
+     * EnterContainer().  For every call to EnterContainer() applications must make a corresponding
+     * call to ExitContainer(), passing the context value returned by the EnterContainer() method.
+     *
+     * When ExitContainer() returns, the reader is positioned immediately before the first element that
+     * follows the container.  From this point an application can use the Next() method to advance
+     * through any remaining elements.
+     *
+     * Once EnterContainer() has been called, applications can call ExitContainer() on a reader at any
+     * point in time, regardless of whether all elements in the underlying container have been read.
+     *
+     * @note Any changes made to the configuration of the reader between the calls to EnterContainer()
+     * and ExitContainer() are NOT undone by the call to ExitContainer().  For example, a change to the
+     * implicit profile id (@p ImplicitProfileId) will not be reversed when a container is exited.  Thus
+     * it is the application's responsibility to adjust the configuration accordingly at the appropriate
+     * times.
+     *
+     * @param[in] outerContainerType        The TLVType value that was returned by the EnterContainer() method.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If OpenContainer() has not been called on the reader, or if
+     *                                      the container reader does not match the one passed to the
+     *                                      OpenContainer() method.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR ExitContainer(TLVType outerContainerType);
+
+    /**
+     * Initializes a new TLVReader object for reading the members of a TLV container element.
+     *
+     * The OpenContainer() method initializes a new TLVReader object for reading the member elements of a
+     * TLV container (a structure, array or path).  When OpenContainer() is called, the current TLVReader
+     * object must be positioned on the container element to be read.  The method takes as its sole argument
+     * a reference to a new reader that will be initialized to read the container.  This reader is known as
+     * the <em>container reader</em> while the reader on which OpenContainer() is called is known as the <em>parent
+     * reader</em>.
+     *
+     * When the OpenContainer() method returns, the container reader is positioned immediately before the
+     * first member of the container. Calling Next() on the container reader will advance through the members
+     * of the collection until the end is reached, at which point the reader will return CHIP_END_OF_TLV.
+     *
+     * While the container reader is open, applications must not make calls on or otherwise alter the state
+     * of the parent reader.  Once an application has finished using the container reader it must close it
+     * by calling CloseContainer() on the parent reader, passing the container reader as an argument.
+     * Applications may close the container reader at any point, with or without reading all elements
+     * contained in the underlying container. After the container reader is closed, applications may
+     * continue their use of the parent reader.
+     *
+     * The container reader inherits various configuration properties from the parent reader.  These are:
+     *
+     * @li The implicit profile id (ImplicitProfileId)
+     * @li The application data pointer (AppData)
+     * @li The GetNextBuffer function pointer
+     *
+     * @note The EnterContainer() method can be used as an alternative to OpenContainer() to read a
+     * container element without initializing a new reader object.
+     *
+     * @param[out] containerReader          A reference to a TLVReader object that will be initialized for
+     *                                      reading the members of the current container element. Any data
+     *                                      associated with the supplied object is overwritten.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If the current element is not positioned on a container element.
+     *
+     */
     CHIP_ERROR OpenContainer(TLVReader & containerReader);
+
+    /**
+     * Completes the reading of a TLV container after a call to OpenContainer().
+     *
+     * The CloseContainer() method restores the state of a parent TLVReader object after a call to
+     * OpenContainer().  For every call to OpenContainer() applications must make a corresponding
+     * call to CloseContainer(), passing a reference to the same container reader to both methods.
+     *
+     * When CloseContainer() returns, the parent reader is positioned immediately before the first
+     * element that follows the container.  From this point an application can use the Next() method
+     * to advance through any remaining elements.
+     *
+     * Applications can call close CloseContainer() on a parent reader at any point in time, regardless
+     * of whether all elements in the underlying container have been read. After CloseContainer() has
+     * been called, the application should consider the container reader 'de-initialized' and must not
+     * use it further without re-initializing it.
+     *
+     * @param[in] containerReader           A reference to the TLVReader object that was supplied to the
+     *                                      OpenContainer() method.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If OpenContainer() has not been called on the reader, or if
+     *                                      the container reader does not match the one passed to the
+     *                                      OpenContainer() method.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV
+     *                                      element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR CloseContainer(TLVReader & containerReader);
-    TLVType GetContainerType() const;
+
+    /**
+     * Returns the type of the container within which the TLVReader is currently reading.
+     *
+     * The GetContainerType() method returns the type of the TLV container within which the TLVReader
+     * is reading.  If the TLVReader is positioned at the outer-most level of a TLV encoding (i.e. before,
+     * on or after the outer-most TLV element), the method will return kTLVType_NotSpecified.
+     *
+     * @return  The TLVType of the current container, or kTLVType_NotSpecified if the TLVReader is not
+     *          positioned within a container.
+     */
+    TLVType GetContainerType() const { return mContainerType; }
+
+    /**
+     * Verifies that the TLVReader object is at the end of a TLV container.
+     *
+     * The VerifyEndOfContainer() method verifies that there are no further TLV elements to be read
+     * within the current TLV container.  This is a convenience method that is equivalent to calling
+     * Next() and checking for a return value of CHIP_END_OF_TLV.
+     *
+     * @note When there are more TLV elements in the collection, this method will change the position
+     * of the reader.
+     *
+     * @retval #CHIP_NO_ERROR              If there are no further TLV elements to be read.
+     * @retval #CHIP_ERROR_UNEXPECTED_TLV_ELEMENT
+     *                                      If another TLV element was found in the collection.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV element
+     *                                      type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR VerifyEndOfContainer();
 
+    /**
+     * Returns the total number of bytes read since the reader was initialized.
+     *
+     * @return Total number of bytes read since the reader was initialized.
+     */
     uint32_t GetLengthRead() const { return mLenRead; }
+
+    /**
+     * Returns the total number of bytes that can be read until the max read length is reached.
+     *
+     * @return Total number of bytes that can be read until the max read length is reached.
+     */
     uint32_t GetRemainingLength() const { return mMaxLen - mLenRead; }
 
+    /**
+     * Gets the point in the underlying input buffer that corresponds to the reader's current position.
+     *
+     * @note Depending on the type of the current element, GetReadPoint() will return a pointer that
+     * is some number of bytes *after* the first byte of the element.  For string types (UTF8 and byte
+     * strings), the pointer will point to the first byte of the string's value.  For container types
+     * (structures, arrays and paths), the pointer will point to the first member element within the
+     * container. For all other types, the pointer will point to the byte immediately after the element's
+     * encoding.
+     *
+     * @return A pointer into underlying input buffer that corresponds to the reader's current position.
+     */
     const uint8_t * GetReadPoint() const { return mReadPoint; }
-    uintptr_t GetBufHandle() const { return mBufHandle; }
 
+    /**
+     * Advances the TLVReader object to immediately after the current TLV element.
+     *
+     * The Skip() method positions the reader object immediately @em after the current TLV element, such
+     * that a subsequent call to Next() will advance the reader to the following element.  Like Next(),
+     * if the reader is positioned on a container element at the time of the call, the members of the
+     * container will be skipped.  If the reader is not positioned on any element, its position remains
+     * unchanged.
+     *
+     * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
+     * @retval #CHIP_END_OF_TLV            If no further elements are available.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the reader encountered an invalid or unsupported TLV
+     *                                      element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
+     * @retval other                        Other CHIP or platform error codes returned by the configured
+     *                                      TLVBackingStore.
+     *
+     */
     CHIP_ERROR Skip();
 
+    /**
+     * Position the destination reader on the next element with the given tag within this reader's current container context
+     *
+     * @param[in] tag                      The destination context tag value
+     * @param[in] destReader               The destination TLV reader value that was located by given tag
+     *
+     * @retval #CHIP_NO_ERROR              If the reader was successfully positioned at the given tag
+     * @retval #CHIP_END_OF_TLV            If the given tag cannot be found
+     * @retval other                       Other CHIP or platform error codes
+     */
     CHIP_ERROR FindElementWithTag(const uint64_t tagInApiForm, TLVReader & destReader) const;
 
+    /**
+     * The profile id to be used for profile tags encoded in implicit form.
+     *
+     * When the reader encounters a profile-specific tag that has been encoded in implicit form, it
+     * uses the value of the @p ImplicitProfileId property as the assumed profile id for the tag.
+     *
+     * By default, the @p ImplicitProfileId property is set to kProfileIdNotSpecified. When decoding
+     * TLV that contains implicitly-encoded tags, applications must set @p ImplicitProfileId prior
+     * to reading any TLV elements having such tags.  The appropriate profile id is usually dependent
+     * on the context of the application or protocol being spoken.
+     *
+     * If an implicitly-encoded tag is encountered while @p ImplicitProfileId is set to
+     * kProfileIdNotSpecified, the reader will return a #CHIP_ERROR_UNKNOWN_IMPLICIT_TLV_TAG error.
+     */
     uint32_t ImplicitProfileId;
-    void * AppData;
 
-    typedef CHIP_ERROR (*GetNextBufferFunct)(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart,
-                                             uint32_t & bufLen);
-    GetNextBufferFunct GetNextBuffer;
+    /**
+     * A pointer field that can be used for application-specific data.
+     */
+    void * AppData;
 
 protected:
     uint64_t mElemTag;
     uint64_t mElemLenOrVal;
-    uintptr_t mBufHandle;
+    TLVBackingStore * mBackingStore;
     const uint8_t * mReadPoint;
     const uint8_t * mBufEnd;
     uint32_t mLenRead;
@@ -190,9 +805,6 @@ protected:
     CHIP_ERROR ReadData(uint8_t * buf, uint32_t len);
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
     TLVElementType ElementType() const;
-
-    static CHIP_ERROR GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart, uint32_t & bufLen);
-    static CHIP_ERROR FailGetNextBuffer(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart, uint32_t & bufLen);
 };
 
 /**
@@ -204,81 +816,990 @@ protected:
  * (structures, arrays or paths) by calling the writer's OpenContainer() or EnterContainer()
  * methods.
  *
- * A TLVWriter object can write data directly to a fixed output buffer, or to a chain of one or
- * more PacketBuffer objects.  Additionally, applications can supply their own @p GetNewBuffer and
- * @p FinalizeBuffer functions to direct output to an arbitrary destination, e.g. a socket or an
- * event queue.
- *
+ * A TLVWriter object can write data directly to a fixed output buffer, or to memory provided by
+ * a TLVBackingStore.
  */
 class DLL_EXPORT TLVWriter
 {
     friend class TLVUpdater;
 
 public:
-    // *** See CHIPTLVWriter.cpp file for API documentation ***
-
+    /**
+     * Initializes a TLVWriter object to write into a single output buffer.
+     *
+     * @note Applications must call Finalize() on the writer before using the contents of the output
+     * buffer.
+     *
+     * @param[in]   buf     A pointer to the buffer into which TLV should be written.
+     * @param[in]   maxLen  The maximum number of bytes that should be written to the output buffer.
+     *
+     */
     void Init(uint8_t * buf, uint32_t maxLen);
-    void Init(PacketBuffer * buf, uint32_t maxLen = 0xFFFFFFFFUL);
-    void Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguousBuffers);
 
+    /**
+     * Initializes a TLVWriter object to write into memory provided by a BackingStore.
+     *
+     * @note If a chain of buffers is given, data will only be written to the first buffer.
+     *
+     * @note Applications must call Finalize() on the writer before using the contents of the buffer.
+     *
+     * @param[in]   backingStore    A TLVBackingStore providing memory, which must outlive the TVLWriter.
+     * @param[in]   maxLen          The maximum number of bytes that should be written to the output buffer.
+     *
+     * @retval #CHIP_NO_ERROR  If the method succeeded.
+     * @retval other           Other error codes returned by TLVBackingStore::OnInit().
+     */
+    CHIP_ERROR Init(TLVBackingStore & backingStore, uint32_t maxLen = UINT32_MAX);
+
+    /**
+     * Finish the writing of a TLV encoding.
+     *
+     * The Finalize() method completes the process of writing a TLV encoding to the underlying output
+     * buffer.  The method must be called by the application before it uses the contents of the buffer.
+     * Finalize() can only be called when there are no container writers open for the current writer.
+     * (See @p OpenContainer()).
+     *
+     * @retval #CHIP_NO_ERROR      If the encoding was finalized successfully.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              FinalizeBuffer() function.
+     */
     CHIP_ERROR Finalize();
 
+    /**
+     * Encodes a TLV signed integer value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR Put(uint64_t tag, int8_t v);
+
+    /**
+     * Encodes a TLV signed integer value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     * @param[in]   preserveSize    True if the value should be encoded in the same number of bytes as
+     *                              at the input type.  False if value should be encoded in the minimum
+     *                              number of bytes necessary to represent the value.  Note: Applications
+     *                              are strongly encouraged to set this parameter to false.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR Put(uint64_t tag, int8_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, int16_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, int16_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, int32_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, int32_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, int64_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, int64_t v, bool preserveSize);
+
+    /**
+     * Encodes a TLV unsigned integer value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag. Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR Put(uint64_t tag, uint8_t v);
+
+    /**
+     * Encodes a TLV unsigned integer value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     * @param[in]   preserveSize    True if the value should be encoded in the same number of bytes as
+     *                              at the input type.  False if value should be encoded in the minimum
+     *                              number of bytes necessary to represent the value.  Note: Applications
+     *                              are strongly encouraged to set this parameter to false.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR Put(uint64_t tag, uint8_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, uint16_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, uint16_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, uint32_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, uint32_t v, bool preserveSize);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
+     */
     CHIP_ERROR Put(uint64_t tag, uint64_t v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
+     */
     CHIP_ERROR Put(uint64_t tag, uint64_t v, bool preserveSize);
-    CHIP_ERROR Put(uint64_t tag, float v);
+
+    /**
+     * Encodes a TLV floating point value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR Put(uint64_t tag, double v);
+
+    /**
+     * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
+     */
+    CHIP_ERROR Put(uint64_t tag, float v);
+
+    /**
+     * Encodes a TLV boolean value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   v               The value to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutBoolean(uint64_t tag, bool v);
+
+    /**
+     * Encodes a TLV byte string value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   buf             A pointer to a buffer containing the bytes string to be encoded.
+     * @param[in]   len             The number of bytes to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutBytes(uint64_t tag, const uint8_t * buf, uint32_t len);
+
+    /**
+     * Encodes a TLV UTF8 string value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   buf             A pointer to the null-terminated UTF-8 string to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutString(uint64_t tag, const char * buf);
+
+    /**
+     * Encodes a TLV UTF8 string value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   buf             A pointer to the UTF-8 string to be encoded.
+     * @param[in]   len             The length (in bytes) of the string to be encoded.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutString(uint64_t tag, const char * buf, uint32_t len);
+
+    /**
+     * @brief
+     *   Encode the string output formatted according to the format in the TLV element.
+     *
+     * PutStringF is an analog of a sprintf where the output is stored in
+     * a TLV element as opposed to a character buffer.  When extended
+     * printf functionality is available, the function is able to output
+     * the result string into a discontinuous underlying storage.  The
+     * implementation supports the following printf enhancements:
+     *
+     * -- The platform supplies a callback-based `vcbprintf` that provides
+     *    the ability to call a custom callback in place of putchar.
+     *
+     * -- The platform supplies a variant of `vsnprintf` called
+     *    `vsnprintf_ex`, that behaves exactly like vsnprintf except it
+     *    has provisions for omitting the first `n` characters of the
+     *    output.
+     *
+     * Note that while the callback-based function may be the simplest and
+     * use the least amount of code, the `vsprintf_ex` variety of
+     * functions will consume less stack.
+     *
+     * If neither of the above is available, the function will allocate a
+     * temporary buffer to hold the output, using Platform::MemoryAlloc().
+     *
+     * @param[in] tag The TLV tag to be encoded with the value, or @p
+     *                AnonymousTag if the value should be encoded without
+     *                a tag.  Tag values should be constructed with one of
+     *                the tag definition functions ProfileTag(),
+     *                ContextTag() or CommonTag().
+     *
+     * @param[in] fmt The format string used to format the argument list.
+     *                Follows the same syntax and rules as the format
+     *                string for `printf` family of functions.
+     *
+     * @param[in] ... A list of arguments to be formatted in the output value
+     *                according to fmt.
+     *
+     * @retval #CHIP_NO_ERROR  If the method succeeded.
+     *
+     * @retval other If underlying calls to TLVWriter methods --
+     *               `WriteElementHead` or `GetNewBuffer` -- failed, their
+     *               error is immediately forwarded up the call stack.
+     */
     CHIP_ERROR PutStringF(uint64_t tag, const char * fmt, ...);
+
+    /**
+     * @brief
+     *   Encode the string output formatted according to the format in the TLV element.
+     *
+     * PutStringF is an analog of a sprintf where the output is stored in
+     * a TLV element as opposed to a character buffer.  When extended
+     * printf functionality is available, the function is able to output
+     * the result string into a discontinuous underlying storage.  The
+     * implementation supports the following printf enhancements:
+     *
+     * -- The platform supplies a callback-based `vcbprintf` that provides
+     *    the ability to call a custom callback in place of putchar.
+     *
+     * -- The platform supplies a variant of `vsnprintf` called
+     *    `vsnprintf_ex`, that behaves exactly like vsnprintf except it
+     *    has provisions for omitting the first `n` characters of the
+     *    output.
+     *
+     * Note that while the callback-based function may be the simplest and
+     * use the least amount of code, the `vsprintf_ex` variety of
+     * functions will consume less stack.
+     *
+     * If neither of the above is available, the function will allocate a
+     * temporary buffer to hold the output, using Platform::MemoryAlloc().
+     *
+     * @param[in] tag The TLV tag to be encoded with the value, or @p
+     *                AnonymousTag if the value should be encoded without
+     *                a tag.  Tag values should be constructed with one of
+     *                the tag definition functions ProfileTag(),
+     *                ContextTag() or CommonTag().
+     *
+     * @param[in] fmt The format string used to format the argument list.
+     *                Follows the same syntax and rules as the format
+     *                string for `printf` family of functions.
+     *
+     * @param[in] ap A list of arguments to be formatted in the output value
+     *                according to fmt.
+     *
+     * @retval #CHIP_NO_ERROR  If the method succeeded.
+     *
+     * @retval other If underlying calls to TLVWriter methods --
+     *               `WriteElementHead` or `GetNewBuffer` -- failed, their
+     *               error is immediately forwarded up the call stack.
+     */
     CHIP_ERROR VPutStringF(uint64_t tag, const char * fmt, va_list ap);
+
+    /**
+     * Encodes a TLV null value.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
+     *                              value should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutNull(uint64_t tag);
+
+    /**
+     * Copies a TLV element from a reader object into the writer.
+     *
+     * The CopyElement() method encodes a new TLV element whose type, tag and value are taken from a TLVReader
+     * object. When the method is called, the supplied reader object is expected to be positioned on the
+     * source TLV element. The newly encoded element will have the same type, tag and contents as the input
+     * container.  If the supplied element is a TLV container (structure, array or path), the entire contents
+     * of the container will be copied.
+     *
+     * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
+     * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
+     * other mode has undefined behavior.
+     *
+     * @param[in]   reader          A reference to a TLVReader object identifying a pre-encoded TLV
+     *                              element that should be copied.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If the supplied reader is not positioned on an element.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN
+     *                              If the underlying TLV encoding associated with the supplied reader ended
+     *                              prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                              If the supplied reader encountered an invalid or unsupported TLV element
+     *                              type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the supplied reader encountered a TLV tag in an invalid context,
+     *                              or if the supplied tag is invalid or inappropriate in the context in
+     *                              which the new container is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
+     *                              function associated with the reader object.
+     *
+     */
     CHIP_ERROR CopyElement(TLVReader & reader);
+
+    /**
+     * Copies a TLV element from a reader object into the writer.
+     *
+     * The CopyElement() method encodes a new TLV element whose type and value are taken from a TLVReader
+     * object. When the method is called, the supplied reader object is expected to be positioned on the
+     * source TLV element. The newly encoded element will have the same type and contents as the input
+     * container, however the tag will be set to the specified argument.  If the supplied element is a
+     * TLV container (structure, array or path), the entire contents of the container will be copied.
+     *
+     * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
+     * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
+     * other mode has undefined behavior.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                              the container should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   reader          A reference to a TLVReader object identifying a pre-encoded TLV
+     *                              element whose type and value should be copied.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If the supplied reader is not positioned on an element.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN
+     *                              If the underlying TLV encoding associated with the supplied reader ended
+     *                              prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                              If the supplied reader encountered an invalid or unsupported TLV element
+     *                              type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the supplied reader encountered a TLV tag in an invalid context,
+     *                              or if the supplied tag is invalid or inappropriate in the context in
+     *                              which the new container is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
+     *                              function associated with the reader object.
+     *
+     */
     CHIP_ERROR CopyElement(uint64_t tag, TLVReader & reader);
 
+    /**
+     * Begins encoding a new TLV container element.
+     *
+     * The StartContainer() method is used to write TLV container elements (structure, arrays or paths)
+     * to an encoding.  The method takes the type and tag (if any) of the new container, and a reference
+     * to a TLVType value which will be used to save the current context of the writer while it is being
+     * used to write the container.
+     *
+     * Once the StartContainer() method returns, the application should use the current TLVWriter object to
+     * write the elements of the container.  When finish, the application must call the EndContainer()
+     * method to finish the encoding of the container.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                              the container should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
+     *                              @p kTLVType_Array or @p kTLVType_Path.
+     * @param[out]  outerContainerType
+     *                              A reference to a TLVType value that will receive the context of the
+     *                              writer.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE
+     *                              If the value specified for containerType is incorrect.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR StartContainer(uint64_t tag, TLVType containerType, TLVType & outerContainerType);
+
+    /**
+     * Completes the encoding of a TLV container element.
+     *
+     * The EndContainer() method completes the encoding of a TLV container element and restores the state
+     * of a TLVWrite object after an earlier call to StartContainer().  For every call to StartContainer()
+     * applications must make a corresponding call to EndContainer(), passing the TLVType value returned
+     * by the StartContainer() call.  When EndContainer() returns, the writer object can be used to write
+     * additional TLV elements that follow the container element.
+     *
+     * @note Any changes made to the configuration of the writer between the calls to StartContainer()
+     * and EndContainer() are NOT undone by the call to EndContainer().  For example, a change to the
+     * implicit profile id (@p ImplicitProfileId) will not be reversed when a container is ended.  Thus
+     * it is the application's responsibility to adjust the configuration accordingly at the appropriate
+     * times.
+     *
+     * @param[in] outerContainerType
+     *                              The TLVType value that was returned by the StartContainer() method.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If a corresponding StartContainer() call was not made.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR EndContainer(TLVType outerContainerType);
+
+    /**
+     * Initializes a new TLVWriter object for writing the members of a TLV container element.
+     *
+     * The OpenContainer() method is used to write TLV container elements (structure, arrays or paths)
+     * to an encoding.  The method takes the type and tag (if any) of the new container, and a reference
+     * to a new writer object (the <em>container writer</em>) that will be initialized for the purpose
+     * of writing the container's elements.  Applications write the members of the new container using
+     * the container writer and then call CloseContainer() to complete the container encoding.
+     *
+     * While the container writer is open, applications must not make calls on or otherwise alter the state
+     * of the parent writer.
+     *
+     * The container writer inherits various configuration properties from the parent writer.  These are:
+     *
+     * @li The implicit profile id (ImplicitProfileId)
+     * @li The application data pointer (AppData)
+     * @li The GetNewBuffer and FinalizeBuffer function pointers
+     *
+     * @note The StartContainer() method can be used as an alternative to OpenContainer() to write a
+     * container element without initializing a new writer object.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                              the container should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
+     *                              @p kTLVType_Array or @p kTLVType_Path.
+     * @param[out]  containerWriter A reference to a TLVWriter object that will be initialized for
+     *                              writing the members of the new container element. Any data
+     *                              associated with the supplied object is overwritten.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE
+     *                              If the value specified for containerType is incorrect.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR OpenContainer(uint64_t tag, TLVType containerType, TLVWriter & containerWriter);
+
+    /**
+     * Completes the writing of a TLV container after a call to OpenContainer().
+     *
+     * The CloseContainer() method restores the state of a parent TLVWriter object after a call to
+     * OpenContainer().  For every call to OpenContainer() applications must make a corresponding
+     * call to CloseContainer(), passing a reference to the same container writer to both methods.
+     *
+     * When CloseContainer() returns, applications may continue to use the parent writer to write
+     * additional TLV elements that appear after the container element.  At this point the supplied
+     * container writer should be considered 'de-initialized' and must not be used without
+     * re-initialization.
+     *
+     * @param[in] containerWriter   A reference to the TLVWriter object that was supplied to the
+     *                              OpenContainer() method.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If the supplied container writer is not in the correct state.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If another container writer has been opened on the supplied
+     *                              container writer and not yet closed.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If completing the encoding of the container would exceed the
+     *                              limit on the maximum number of bytes specified when the writer
+     *                              was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack
+     *                              of memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the
+     *                              configured TLVBackingStore.
+     *
+     */
     CHIP_ERROR CloseContainer(TLVWriter & containerWriter);
+
+    /**
+     * Encodes a TLV container element from a pre-encoded set of member elements
+     *
+     * The PutPreEncodedContainer() method encodes a new TLV container element (a structure, array or path)
+     * containing a set of member elements taken from a pre-encoded buffer.  The input buffer is expected to
+     * contain zero or more full-encoded TLV elements, with tags that conform to the rules associated with
+     * the specified container type (e.g. structure members must have tags, while array members must not).
+     *
+     * The method encodes the entirety of the container element in one call.  When PutPreEncodedContainer()
+     * returns, the writer object can be used to write additional TLV elements following the container element.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                              the container should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
+     *                              @p kTLVType_Array or @p kTLVType_Path.
+     * @param[in]   data            A pointer to a buffer containing zero of more encoded TLV elements that
+     *                              will become the members of the new container.
+     * @param[in]   dataLen         The number of bytes in the @p data buffer.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_WRONG_TLV_TYPE
+     *                              If the value specified for containerType is incorrect.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the specified tag value is invalid or inappropriate in the context
+     *                              in which the value is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR PutPreEncodedContainer(uint64_t tag, TLVType containerType, const uint8_t * data, uint32_t dataLen);
+
+    /**
+     * Copies a TLV container element from TLVReader object
+     *
+     * The CopyContainer() encodes a new TLV container element by copying a pre-encoded container element
+     * located at the current position of a TLVReader object. The method writes the entirety of the new
+     * container element in one call, copying the container's type, tag and elements from the source
+     * encoding. When the method returns, the writer object can be used to write additional TLV elements
+     * following the container element.
+     *
+     * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
+     * input buffer that contains the entirety of the underlying TLV encoding.
+     *
+     * @param[in]   container       A reference to a TLVReader object identifying the pre-encoded TLV
+     *                              container to be copied.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT
+     *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If the supplied reader is not positioned on a container element.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN
+     *                              If the underlying TLV encoding associated with the supplied reader ended
+     *                              prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                              If the supplied reader encountered an invalid or unsupported TLV element
+     *                              type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the supplied reader encountered a TLV tag in an invalid context,
+     *                              or if the tag associated with the source container is invalid or
+     *                              inappropriate in the context in which the new container is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR CopyContainer(TLVReader & container);
+
+    /**
+     * Encodes a TLV container element from a pre-encoded set of member elements
+     *
+     * The CopyContainer() method encodes a new TLV container element (a structure, array or path)
+     * containing a set of member elements taken from a TLVReader object. When the method is called, the
+     * supplied reader object is expected to be positioned on a TLV container element. The newly encoded
+     * container will have the same type and members as the input container.  The tag for the new
+     * container is specified as an input parameter.
+     *
+     * When the method returns, the writer object can be used to write additional TLV elements following
+     * the container element.
+     *
+     * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
+     * input buffer that contains the entirety of the underlying TLV encoding.
+     *
+     * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                              the container should be encoded without a tag.  Tag values should be
+     *                              constructed with one of the tag definition functions ProfileTag(),
+     *                              ContextTag() or CommonTag().
+     * @param[in]   container       A reference to a TLVReader object identifying a pre-encoded TLV
+     *                              container whose type and members should be copied.
+     *
+     * @retval #CHIP_NO_ERROR      If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT
+     *                              If the supplied reader uses a TLVBackingStore rather than a simple buffer.
+     * @retval #CHIP_ERROR_INCORRECT_STATE
+     *                              If the supplied reader is not positioned on a container element.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                              If a container writer has been opened on the current writer and not
+     *                              yet closed.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN
+     *                              If the underlying TLV encoding associated with the supplied reader ended
+     *                              prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                              If the supplied reader encountered an invalid or unsupported TLV element
+     *                              type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                              If the supplied reader encountered a TLV tag in an invalid context,
+     *                              or if the supplied tag is invalid or inappropriate in the context in
+     *                              which the new container is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                              If writing the value would exceed the limit on the maximum number of
+     *                              bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                              If an attempt to allocate an output buffer failed due to lack of
+     *                              memory.
+     * @retval other                Other CHIP or platform-specific errors returned by the configured
+     *                              TLVBackingStore.
+     *
+     */
     CHIP_ERROR CopyContainer(uint64_t tag, TLVReader & container);
+
+    /**
+     * Encodes a TLV container element that contains member elements from a pre-encoded container
+     *
+     * The CopyContainer() method encodes a new TLV container element (a structure, array or path)
+     * containing a set of member elements taken from the contents of a supplied pre-encoded container.
+     * When the method is called, data in the supplied input buffer is parsed as a TLV container element
+     * an a new container is written that has the same type and members as the input container.  The tag
+     * for the new container is specified as an input parameter.
+     *
+     * When the method returns, the writer object can be used to write additional TLV elements following
+     * the container element.
+     *
+     * @param[in] tag                   The TLV tag to be encoded with the container, or @p AnonymousTag if
+     *                                  the container should be encoded without a tag.  Tag values should be
+     *                                  constructed with one of the tag definition functions ProfileTag(),
+     *                                  ContextTag() or CommonTag().
+     * @param[in] encodedContainer      A buffer containing a pre-encoded TLV container whose type and members
+     *                                  should be copied.
+     * @param[in] encodedContainerLen   The length in bytes of the pre-encoded container.
+     *
+     * @retval #CHIP_NO_ERROR          If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
+     *                                  If a container writer has been opened on the current writer and not
+     *                                  yet closed.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN
+     *                                  If the encoded container ended prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                  If the encoded container contained an invalid or unsupported TLV element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG
+     *                                  If the encoded container contained a TLV tag in an invalid context,
+     *                                  or if the supplied tag is invalid or inappropriate in the context in
+     *                                  which the new container is being written.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
+     *                                  If writing the value would exceed the limit on the maximum number of
+     *                                  bytes specified when the writer was initialized.
+     * @retval #CHIP_ERROR_NO_MEMORY
+     *                                  If an attempt to allocate an output buffer failed due to lack of
+     *                                  memory.
+     * @retval other                    Other CHIP or platform-specific errors returned by the configured
+     *                                  TLVBackingStore.
+     *
+     */
     CHIP_ERROR CopyContainer(uint64_t tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen);
-    TLVType GetContainerType() const;
 
-    uint32_t GetLengthWritten();
+    /**
+     * Returns the type of container within which the TLVWriter is currently writing.
+     *
+     * The GetContainerType() method returns the type of the TLV container within which the TLVWriter
+     * is currently writing.  If the TLVWriter is not writing elements within a container (i.e. if writing
+     * at the outer-most level of an encoding) the method returns kTLVType_NotSpecified.
+     *
+     * @return  The TLVType of the current container, or kTLVType_NotSpecified if the TLVWriter is not
+     *          writing elements within a container.
+     */
+    TLVType GetContainerType() const { return mContainerType; }
 
+    /**
+     * Returns the total number of bytes written since the writer was initialized.
+     *
+     * @return Total number of bytes written since the writer was initialized.
+     */
+    uint32_t GetLengthWritten() const { return mLenWritten; }
+
+    /**
+     * The profile id of tags that should be encoded in implicit form.
+     *
+     * When a writer is asked to encode a new element, if the profile id of the tag associated with the
+     * new element matches the value of the @p ImplicitProfileId member, the writer will encode the tag
+     * in implicit form, omitting the profile id in the process.
+     *
+     * By default, the @p ImplicitProfileId property is set to kProfileIdNotSpecified, which instructs
+     * the writer not to emit implicitly encoded tags.  Applications can set @p ImplicitProfileId at any
+     * time to enable encoding tags in implicit form starting at the current point in the encoding.  The
+     * appropriate profile id to set is usually dependent on the context of the application or protocol
+     * being spoken.
+     *
+     * @note The value of the @p ImplicitProfileId member affects the encoding of profile-specific
+     * tags only; the encoding of context-specific tags is unchanged.
+     */
     uint32_t ImplicitProfileId;
+
+    /**
+     * A pointer field that can be used for application-specific data.
+     */
     void * AppData;
 
-    typedef CHIP_ERROR (*GetNewBufferFunct)(TLVWriter & writer, uintptr_t & bufHandle, uint8_t *& bufStart, uint32_t & bufLen);
-    GetNewBufferFunct GetNewBuffer;
-
-    typedef CHIP_ERROR (*FinalizeBufferFunct)(TLVWriter & writer, uintptr_t bufHandle, uint8_t * bufStart, uint32_t bufLen);
-    FinalizeBufferFunct FinalizeBuffer;
-
-    // Implementations of GetNewBufferFunct/FinalizeBufferFunct that support writing into one or more
-    // PacketBuffers.
-    static CHIP_ERROR GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHandle, uint8_t *& bufStart, uint32_t & bufLen);
-    static CHIP_ERROR FinalizePacketBuffer(TLVWriter & writer, uintptr_t bufHandle, uint8_t * bufStart, uint32_t dataLen);
-
 protected:
-    uintptr_t mBufHandle;
+    TLVBackingStore * mBackingStore;
     uint8_t * mBufStart;
     uint8_t * mWritePoint;
     uint32_t mRemainingLen;
@@ -354,26 +1875,259 @@ protected:
  * @note The application is expected to use the TLVUpdater object atomically from the time it calls
  * Init() till it calls Finalize(). The same buffer should NOT be used with other TLVWriter objects.
  *
- * @note The TLVUpdater currently only supports single static buffers. Support for chain of buffers
- * (PacketBuffer) is NOT supported.
+ * @note The TLVUpdater currently only supports single static buffers. TLVBackingStore is NOT supported.
  */
 class DLL_EXPORT TLVUpdater
 {
 public:
+    /**
+     * Initialize a TLVUpdater object to edit a single input buffer.
+     *
+     * On calling this method, the TLV data in the buffer is moved to the end of the
+     * buffer and a private TLVReader object is initialized on this relocated
+     * buffer. A private TLVWriter object is also initialized on the free space that
+     * is now available at the beginning. Applications can use the TLVUpdater object
+     * to parse the TLV data and modify/delete existing elements or add new elements
+     * to the encoding.
+     *
+     * @param[in]   buf     A pointer to a buffer containing the TLV data to be edited.
+     * @param[in]   dataLen The length of the TLV data in the buffer.
+     * @param[in]   maxLen  The total length of the buffer.
+     *
+     * @retval #CHIP_NO_ERROR                  If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT    If the buffer address is invalid.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL    If the buffer is too small.
+     *
+     */
     CHIP_ERROR Init(uint8_t * buf, uint32_t dataLen, uint32_t maxLen);
+
+    /**
+     * Initialize a TLVUpdater object using a TLVReader.
+     *
+     * On calling this method, TLV data in the buffer pointed to by the TLVReader
+     * is moved from the current read point to the end of the buffer. A new
+     * private TLVReader object is initialized to read from this new location, while
+     * a new private TLVWriter object is initialized to write to the freed up buffer
+     * space.
+     *
+     * Note that if the TLVReader is already positioned "on" an element, it is first
+     * backed-off to the start of that element. Also note that this backing off
+     * works well with container elements, i.e., if the TLVReader was already  used
+     * to call EnterContainer(), then there is nothing to back-off. But if the
+     * TLVReader was positioned on the container element and EnterContainer() was
+     * not yet called, then the TLVReader object is backed-off to the start of the
+     * container head.
+     *
+     * The input TLVReader object will be destroyed before returning and the
+     * application must not make use of the same on return.
+     *
+     * @param[in,out]   aReader     Reference to a TLVReader object that will be
+     *                              destroyed before returning.
+     * @param[in]       freeLen     The length of free space (in bytes) available
+     *                              in the pre-encoded data buffer.
+     *
+     * @retval #CHIP_NO_ERROR                  If the method succeeded.
+     * @retval #CHIP_ERROR_INVALID_ARGUMENT    If the buffer address is invalid.
+     * @retval #CHIP_ERROR_NOT_IMPLEMENTED     If reader was initialized on a chain
+     *                                          of buffers.
+     */
     CHIP_ERROR Init(TLVReader & aReader, uint32_t freeLen);
+
     CHIP_ERROR Finalize() { return mUpdaterWriter.Finalize(); }
 
     // Common methods
+
+    /**
+     * Set the Implicit Profile ID for the TLVUpdater object.
+     *
+     * This method sets the implicit profile ID for the TLVUpdater object. When the
+     * updater is asked to encode a new element, if the profile ID of the tag
+     * associated with the new element matches the value of the @p profileId, the
+     * updater will encode the tag in implicit form, thereby omitting the profile ID
+     * in the process.
+     *
+     * @param[in]   profileId   The profile id of tags that should be encoded in
+     *                          implicit form.
+     */
     void SetImplicitProfileId(uint32_t profileId);
     uint32_t GetImplicitProfileId() { return mUpdaterReader.ImplicitProfileId; }
+
+    /**
+     * Copies the current element from input TLV to output TLV.
+     *
+     * The Move() method copies the current element on which the TLVUpdater's reader
+     * is positioned on, to the TLVUpdater's writer. The application should call
+     * Next() and position the TLVUpdater's reader on an element before calling this
+     * method. Just like the TLVReader::Next() method, if the reader is positioned
+     * on a container element at the time of the call, all the members of the
+     * container will be copied. If the reader is not positioned on any element,
+     * nothing changes on calling this method.
+     *
+     * @retval #CHIP_NO_ERROR              If the TLVUpdater reader was
+     *                                      successfully positioned on a new
+     *                                      element.
+     * @retval #CHIP_END_OF_TLV            If the TLVUpdater's reader is pointing
+     *                                      to end of container.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the TLVIpdater's reader is not
+     *                                      positioned on a valid TLV element.
+     * @retval other                        Returns other error codes returned by
+     *                                      TLVReader::Skip() method.
+     *
+     */
     CHIP_ERROR Move();
+
+    /**
+     * Move everything from the TLVUpdater's current read point till end of input
+     * TLV buffer over to output.
+     *
+     * This method supports moving everything from the TLVUpdater's current read
+     * point till the end of the reader buffer over to the TLVUpdater's writer.
+     *
+     * @note This method can be called with the TLVUpdater's reader positioned
+     * anywhere within the input TLV. The reader can also be positioned under
+     * multiple levels of nested containers and this method will still work.
+     *
+     * @note This method also changes the state of the TLVUpdater object to a state
+     * it would be in if the application had painstakingly parsed each element from
+     * the current read point till the end of the input encoding and copied them to
+     * the output TLV.
+     */
     void MoveUntilEnd();
+
+    /**
+     * Prepares a TLVUpdater object for reading elements of a container. It also
+     * encodes a start of container object in the output TLV.
+     *
+     * The EnterContainer() method prepares the current TLVUpdater object to begin
+     * reading the member elements of a TLV container (a structure, array or path).
+     * For every call to EnterContainer() applications must make a corresponding
+     * call to ExitContainer().
+     *
+     * When EnterContainer() is called the TLVUpdater's reader must be positioned on
+     * the container element. The method takes as an argument a reference to a
+     * TLVType value which will be used to save the context of the updater while it
+     * is reading the container.
+     *
+     * When the EnterContainer() method returns, the updater is positioned
+     * immediately @em before the first member of the container. Repeatedly calling
+     * Next() will advance the updater through the members of the collection until
+     * the end is reached, at which point the updater will return CHIP_END_OF_TLV.
+     *
+     * Once the application has finished reading a container it can continue reading
+     * the elements after the container by calling the ExitContainer() method.
+     *
+     * @note This method implicitly encodes a start of container element in the
+     * output TLV buffer.
+     *
+     * @param[out] outerContainerType       A reference to a TLVType value that will
+     *                                      receive the context of the updater.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If the TLVUpdater reader is not
+     *                                      positioned on a container element.
+     * @retval other                        Any other CHIP or platform error code
+     *                                      returned by TLVWriter::StartContainer()
+     *                                      or TLVReader::EnterContainer().
+     *
+     */
     CHIP_ERROR EnterContainer(TLVType & outerContainerType);
+
+    /**
+     * Completes the reading of a TLV container element and encodes an end of TLV
+     * element in the output TLV.
+     *
+     * The ExitContainer() method restores the state of a TLVUpdater object after a
+     * call to EnterContainer(). For every call to EnterContainer() applications
+     * must make a corresponding call to ExitContainer(), passing the context value
+     * returned by the EnterContainer() method.
+     *
+     * When ExitContainer() returns, the TLVUpdater reader is positioned immediately
+     * before the first element that follows the container in the input TLV. From
+     * this point applications can call Next() to advance through any remaining
+     * elements.
+     *
+     * Once EnterContainer() has been called, applications can call ExitContainer()
+     * on the updater at any point in time, regardless of whether all elements in
+     * the underlying container have been read. Also, note that calling
+     * ExitContainer() before reading all the elements in the container, will result
+     * in the updated container getting truncated in the output TLV.
+     *
+     * @note Any changes made to the configuration of the updater between the calls
+     * to EnterContainer() and ExitContainer() are NOT undone by the call to
+     * ExitContainer(). For example, a change to the implicit profile id
+     * (@p ImplicitProfileId) will not be reversed when a container is exited. Thus
+     * it is the application's responsibility to adjust the configuration
+     * accordingly at the appropriate times.
+     *
+     * @param[in] outerContainerType        The TLVType value that was returned by
+     *                                      the EnterContainer() method.
+     *
+     * @retval #CHIP_NO_ERROR              If the method succeeded.
+     * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended
+     *                                      prematurely.
+     * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
+     *                                      If the updater encountered an invalid or
+     *                                      unsupported TLV element type.
+     * @retval #CHIP_ERROR_INVALID_TLV_TAG If the updater encountered a TLV tag in
+     *                                      an invalid context.
+     * @retval other                        Any other CHIP or platform error code
+     *                                      returned by TLVWriter::EndContainer() or
+     *                                      TLVReader::ExitContainer().
+     *
+     */
     CHIP_ERROR ExitContainer(TLVType outerContainerType);
+
     void GetReader(TLVReader & containerReader) { containerReader = mUpdaterReader; }
 
     // Reader methods
+
+    /**
+     * Skip the current element and advance the TLVUpdater object to the next
+     * element in the input TLV.
+     *
+     * The Next() method skips the current element in the input TLV and advances the
+     * TLVUpdater's reader to the next element that resides in the same containment
+     * context. In particular, if the reader is positioned at the outer most level
+     * of a TLV encoding, calling Next() will advance it to the next, top most
+     * element. If the reader is positioned within a TLV container element (a
+     * structure, array or path), calling Next() will advance it to the next member
+     * element of the container.
+     *
+     * Since Next() constrains reader motion to the current containment context,
+     * calling Next() when the reader is positioned on a container element will
+     * advance @em over the container, skipping its member elements (and the members
+     * of any nested containers) until it reaches the first element after the
+     * container.
+     *
+     * When there are no further elements within a particular containment context
+     * the Next() method will return a #CHIP_END_OF_TLV error and the position of
+     * the reader will remain unchanged.
+     *
+     * @note The Next() method implicitly skips the current element. Hence, the
+     * TLVUpdater's private writer state variables will be adjusted to account for
+     * the new freed space (made available by skipping). This means that the
+     * application is expected to call Next() on the TLVUpdater object after a Get()
+     * whose value the application does @em not write back (which from the
+     * TLVUpdater's view is equivalent to skipping that element).
+     *
+     * @note Applications are also expected to call Next() when they are at the end
+     * of a container, and want to add new elements there. This is particularly
+     * important in situations where there is a fixed schema. Applications that have
+     * fixed schemas and know where the container end is cannot just add new
+     * elements at the end, because the TLVUpdater writer's state will not reflect
+     * the correct free space available for the Put() operation. Hence, applications
+     * must call Next() (and possibly also test for CHIP_END_OF_TLV) before adding
+     * elements at the end of a container.
+     *
+     * @retval #CHIP_NO_ERROR              If the TLVUpdater reader was
+     *                                      successfully positioned on a new
+     *                                      element.
+     * @retval other                        Returns the CHIP or platform error
+     *                                      codes returned by the TLVReader::Skip()
+     *                                      and TLVReader::Next() method.
+     *
+     */
     CHIP_ERROR Next();
 
     CHIP_ERROR Get(bool & v) { return mUpdaterReader.Get(v); }
@@ -441,6 +2195,122 @@ private:
     TLVWriter mUpdaterWriter;
     TLVReader mUpdaterReader;
     const uint8_t * mElementStartAddr;
+};
+
+/**
+ * Provides an interface for TLVReader or TLVWriter to use memory other than a simple contiguous buffer.
+ */
+class DLL_EXPORT TLVBackingStore
+{
+public:
+    virtual ~TLVBackingStore() {}
+
+    /**
+     * A function to provide a backing store's initial start position and data length to a reader.
+     *
+     * @param[in]       reader          A reference to the TLVReader object that is requesting input data.
+     * @param[out]      bufStart        A reference to a data pointer. On exit, bufStart is expected to point
+     *                                  to the first byte of TLV data to be parsed.
+     * @param[out]      bufLen          A reference to an unsigned integer that the function must set to
+     *                                  the number of TLV data bytes being returned.  If the end of the
+     *                                  input TLV data has been reached, the function should set this value
+     *                                  to 0.
+     *
+     * @retval #CHIP_NO_ERROR           If the function successfully produced TLV data.
+     * @retval other                    Other CHIP or platform-specific error codes indicating that an error
+     *                                  occurred preventing the function from producing the requested data.
+     */
+    virtual CHIP_ERROR OnInit(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) = 0;
+
+    /**
+     * A function that can be used to retrieve additional TLV data to be parsed.
+     *
+     * When called, the function is expected to produce additional data for the reader to parse or signal
+     * the reader that no more data is available.
+     *
+     * @param[in]       reader          A reference to the TLVReader object that is requesting input data.
+     * @param[in,out]   bufStart        A reference to a data pointer. On entry to the function, @p bufStart
+     *                                  points to one byte beyond the last TLV data byte consumed by the
+     *                                  reader.  On exit, bufStart is expected to point to the first byte
+     *                                  of new TLV data to be parsed.  The new pointer value can be within
+     *                                  the same buffer as the previously consumed data, or it can point
+     *                                  to an entirely new buffer.
+     * @param[out]      bufLen          A reference to an unsigned integer that the function must set to
+     *                                  the number of TLV data bytes being returned.  If the end of the
+     *                                  input TLV data has been reached, the function should set this value
+     *                                  to 0.
+     *
+     * @retval #CHIP_NO_ERROR           If the function successfully produced more TLV data, or the end of
+     *                                  the input data was reached (@p bufLen should be set to 0 in this case).
+     * @retval other                    Other CHIP or platform-specific error codes indicating that an error
+     *                                  occurred preventing the function from producing the requested data.
+     */
+    virtual CHIP_ERROR GetNextBuffer(TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) = 0;
+
+    /**
+     * A function to provide a backing store's initial start position and data length to a writer.
+     *
+     * @param[in]       writer          A reference to the TLVWriter object that is requesting new buffer
+     *                                  space.
+     * @param[out]      bufStart        A reference to a data pointer. On exit, @p bufStart is expected to
+     *                                  point to the beginning of the new output buffer.
+     * @param[out]      bufLen          A reference to an unsigned integer. On exit, @p bufLen is expected
+     *                                  to contain the maximum number of bytes that can be written to the
+     *                                  new output buffer.
+     *
+     * @retval #CHIP_NO_ERROR           If the function was able to supply buffer space for the writer.
+     * @retval other                    Other CHIP or platform-specific error codes indicating that an error
+     *                                  occurred preventing the function from producing buffer space.
+     */
+    virtual CHIP_ERROR OnInit(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) = 0;
+
+    /**
+     * A function that supplies new output buffer space to a TLVWriter.
+     *
+     * The function is expected to return a pointer to a memory location where new data should be written,
+     * along with an associated maximum length. The function can supply write space either by allocating
+     * a new buffer to hold the data or by clearing out previously written data from an existing buffer.
+     *
+     * @param[in]       writer          A reference to the TLVWriter object that is requesting new buffer
+     *                                  space.
+     * @param[in,out]   bufStart        A reference to a data pointer. On entry to the function, @p bufStart
+     *                                  points the beginning of the current output buffer.  On exit, @p bufStart
+     *                                  is expected to point to the beginning of the new output buffer.
+     *                                  The new pointer value can be the same as the previous value (e.g.
+     *                                  if the function copied the existing data elsewhere), or it can point
+     *                                  to an entirely new location.
+     * @param[in,out]   bufLen          A reference to an unsigned integer. On entry to the function,
+     *                                  @p bufLen contains the number of byte of @em unused space in the
+     *                                  current buffer.  On exit, @p bufLen is expected to contain the maximum
+     *                                  number of bytes that can be written to the new output buffer.
+     *
+     * @retval #CHIP_NO_ERROR          If the function was able to supply more buffer space for the writer.
+     * @retval other                    Other CHIP or platform-specific error codes indicating that an error
+     *                                  occurred preventing the function from producing additional buffer
+     *                                  space.
+     */
+    virtual CHIP_ERROR GetNewBuffer(TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) = 0;
+
+    /**
+     * A function used to perform finalization of the output from a TLVWriter object.
+     *
+     * Functions of this type are called when a TLVWriter's Finalize() method is called. The function is
+     * expected to perform any necessary clean-up or finalization related to consuming the output of the
+     * writer object. Examples of this include such things as recording the final length of the encoding,
+     * or closing a file descriptor.
+     *
+     * @param[in]       writer          A reference to the TLVWriter object that is being finalized.
+     * @param[in,out]   bufHandle       A uintptr_t context value that was set by previous calls to the
+     *                                  @p GetNewBuffer function.
+     * @param[in,out]   bufStart        A pointer to the beginning of the current (and final) output buffer.
+     * @param[in,out]   bufLen          The number of bytes contained in the buffer pointed to by @p bufStart.
+     *
+     * @retval #CHIP_NO_ERROR           If finalization was successful.
+     * @retval other                    Other CHIP or platform-specific error codes indicating that an error
+     *                                  occurred during finalization.
+     *
+     */
+    virtual CHIP_ERROR FinalizeBuffer(TLVWriter & writer, uint8_t * bufStart, uint32_t bufLen) = 0;
 };
 
 } // namespace TLV

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,6 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
-#include <system/SystemPacketBuffer.h>
 
 namespace chip {
 namespace TLV {
@@ -39,209 +38,48 @@ using namespace chip::Encoding;
 
 static const uint8_t sTagSizes[] = { 0, 1, 2, 4, 2, 4, 6, 8 };
 
-/**
- * @fn uint32_t TLVReader::GetLengthRead() const
- *
- * Returns the total number of bytes read since the reader was initialized.
- *
- * @return Total number of bytes read since the reader was initialized.
- */
-
-/**
- * @fn uint32_t TLVReader::GetRemainingLength() const
- *
- * Returns the total number of bytes that can be read until the max read length is reached.
- *
- * @return Total number of bytes that can be read until the max read length is reached.
- */
-
-/**
- * @fn const uint8_t *TLVReader::GetReadPoint() const
- *
- * Gets the point in the underlying input buffer that corresponds to the reader's current position.
- *
- * @note Depending on the type of the current element, GetReadPoint() will return a pointer that
- * is some number of bytes *after* the first byte of the element.  For string types (UTF8 and byte
- * strings), the pointer will point to the first byte of the string's value.  For container types
- * (structures, arrays and paths), the pointer will point to the first member element within the
- * container. For all other types, the pointer will point to the byte immediately after the element's
- * encoding.
- *
- * @return A pointer into underlying input buffer that corresponds to the reader's current position.
- */
-
-/**
- *
- * @var uint32_t TLVReader::ImplicitProfileId
- *
- * The profile id to be used for profile tags encoded in implicit form.
- *
- * When the reader encounters a profile-specific tag that has been encoded in implicit form, it
- * uses the value of the @p ImplicitProfileId property as the assumed profile id for the tag.
- *
- * By default, the @p ImplicitProfileId property is set to kProfileIdNotSpecified. When decoding
- * TLV that contains implicitly-encoded tags, applications must set @p ImplicitProfileId prior
- * to reading any TLV elements having such tags.  The appropriate profile id is usually dependent
- * on the context of the application or protocol being spoken.
- *
- * If an implicitly-encoded tag is encountered while @p ImplicitProfileId is set to
- * kProfileIdNotSpecified, the reader will return a #CHIP_ERROR_UNKNOWN_IMPLICIT_TLV_TAG error.
- */
-
-/**
- * @var void *TLVReader::AppData
- *
- * A pointer field that can be used for application-specific data.
- */
-
-/**
- * @typedef CHIP_ERROR (*TLVReader::GetNextBufferFunct)(TLVReader& reader, uintptr_t& bufHandle, const uint8_t *& bufStart,
- * uint32_t& bufLen)
- *
- * A function that can be used to retrieve additional TLV data to be parsed.
- *
- * Functions of this type are used to feed input data to a TLVReader. When called, the function is
- * expected to produce additional data for the reader to parse or signal the reader that no more
- * data is available.
- *
- * @param[in]       reader          A reference to the TLVReader object that is requesting input data.
- * @param[in,out]   bufHandle       A reference to a uintptr_t value that the function can use to store
- *                                  context data between calls.  This value is initialized to 0
- *                                  prior to the first call.
- * @param[in,out]   bufStart        A reference to a data pointer. On entry to the function, @p bufStart
- *                                  points to one byte beyond the last TLV data byte consumed by the
- *                                  reader.  On exit, bufStart is expected to point to the first byte
- *                                  of new TLV data to be parsed.  The new pointer value can be within
- *                                  the same buffer as the previously consumed data, or it can point
- *                                  to an entirely new buffer.
- * @param[out]      bufLen          A reference to an unsigned integer that the function must set to
- *                                  the number of TLV data bytes being returned.  If the end of the
- *                                  input TLV data has been reached, the function should set this value
- *                                  to 0.
- *
- * @retval #CHIP_NO_ERROR          If the function successfully produced more TLV data, or the end of
- *                                  the input data was reached (@p bufLen should be set to 0 in this case).
- * @retval other                    Other CHIP or platform-specific error codes indicating that an error
- *                                  occurred preventing the function from producing the requested data.
- *
- */
-
-/**
- * @var GetNextBufferFunct TLVReader::GetNextBuffer
- *
- * A pointer to a function that will produce input data for the TLVReader object.  If set to NULL (the
- * default value), the reader will assume that no further input data is available.
- *
- * GetNextBuffer can be set by an application at any time, but is typically set when the reader
- * is initialized.
- *
- * See the GetNextBufferFunct type definition for additional information on implementing a
- * GetNextBuffer function.
- */
-
-/**
- * Initializes a TLVReader object to read from a single input buffer.
- *
- * @param[in]   data    A pointer to a buffer containing the TLV data to be parsed.
- * @param[in]   dataLen The length of the TLV data to be parsed.
- *
- */
 void TLVReader::Init(const uint8_t * data, uint32_t dataLen)
 {
-    mBufHandle = 0;
-    mReadPoint = data;
-    mBufEnd    = data + dataLen;
-    mLenRead   = 0;
-    mMaxLen    = dataLen;
+    mBackingStore = nullptr;
+    mReadPoint    = data;
+    mBufEnd       = data + dataLen;
+    mLenRead      = 0;
+    mMaxLen       = dataLen;
     ClearElementState();
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = nullptr;
-    GetNextBuffer     = nullptr;
 }
 
-/**
- * Initializes a TLVReader object to read from a single PacketBuffer.
- *
- * Parsing begins at the buffer's start position (buf->DataStart()) and continues until the
- * end of the data in the buffer (as denoted by buf->Datalen()), or maxLen bytes have been parsed.
- *
- * @param[in]   buf     A pointer to an PacketBuffer containing the TLV data to be parsed.
- * @param[in]   maxLen  The maximum of bytes to parse.  Defaults to the amount of data
- *                      in the input buffer.
- */
-void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen)
+CHIP_ERROR TLVReader::Init(TLVBackingStore & backingStore, uint32_t maxLen)
 {
-    mBufHandle = reinterpret_cast<uintptr_t>(buf);
-    mReadPoint = buf->Start();
-    mBufEnd    = mReadPoint + buf->DataLength();
-    mLenRead   = 0;
-    mMaxLen    = maxLen;
+    mBackingStore   = &backingStore;
+    mReadPoint      = nullptr;
+    uint32_t bufLen = 0;
+    CHIP_ERROR err  = mBackingStore->OnInit(*this, mReadPoint, bufLen);
+    if (err != CHIP_NO_ERROR)
+        return err;
+
+    mBufEnd  = mReadPoint + bufLen;
+    mLenRead = 0;
+    mMaxLen  = maxLen;
     ClearElementState();
     mContainerType = kTLVType_NotSpecified;
     SetContainerOpen(false);
 
     ImplicitProfileId = kProfileIdNotSpecified;
     AppData           = nullptr;
-    GetNextBuffer     = nullptr;
+    return CHIP_NO_ERROR;
 }
 
-/**
- * Initializes a TLVReader object to read from a one or more PacketBuffers.
- *
- * Parsing begins at the initial buffer's start position (buf->DataStart()).  If
- * allowDiscontiguousBuffers is true, the reader will advance through the chain of buffers linked
- * by their Next() pointers. Parsing continues until all data in the buffer chain has been consumed
- * (as denoted by buf->Datalen()), or maxLen bytes have been parsed.
- *
- * @param[in]   buf    A pointer to an PacketBuffer containing the TLV data to be parsed.
- * @param[in]   maxLen  The maximum of bytes to parse.  Defaults to the total amount of data
- *                      in the input buffer chain.
- * @param[in]   allowDiscontiguousBuffers
- *                      If true, advance to the next buffer in the chain once all data in the
- *                      current buffer has been consumed.  If false, stop parsing at the end
- *                      of the initial buffer.
- */
-void TLVReader::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguousBuffers)
-{
-    mBufHandle = reinterpret_cast<uintptr_t>(buf);
-    mReadPoint = buf->Start();
-    mBufEnd    = mReadPoint + buf->DataLength();
-    mLenRead   = 0;
-    mMaxLen    = maxLen;
-    ClearElementState();
-    mContainerType = kTLVType_NotSpecified;
-    SetContainerOpen(false);
-
-    ImplicitProfileId = kProfileIdNotSpecified;
-    AppData           = nullptr;
-
-    if (allowDiscontiguousBuffers)
-    {
-        GetNextBuffer = GetNextPacketBuffer;
-    }
-    else
-    {
-        GetNextBuffer = nullptr;
-    }
-}
-
-/**
- * Initializes a TLVReader object from another TLVReader object.
- *
- * @param[in]   aReader  A read-only reference to the TLVReader to initialize
- *                       this from.
- *
- */
 void TLVReader::Init(const TLVReader & aReader)
 {
     // Initialize private data members
 
     mElemTag       = aReader.mElemTag;
     mElemLenOrVal  = aReader.mElemLenOrVal;
-    mBufHandle     = aReader.mBufHandle;
+    mBackingStore  = aReader.mBackingStore;
     mReadPoint     = aReader.mReadPoint;
     mBufEnd        = aReader.mBufEnd;
     mLenRead       = aReader.mLenRead;
@@ -254,15 +92,8 @@ void TLVReader::Init(const TLVReader & aReader)
 
     ImplicitProfileId = aReader.ImplicitProfileId;
     AppData           = aReader.AppData;
-    GetNextBuffer     = aReader.GetNextBuffer;
 }
 
-/**
- * Returns the type of the current TLV element.
- *
- * @return      A TLVType value describing the data type of the current TLV element.  If the reader
- *              is not positioned on a TLV element, the return value will be kTLVType_NotSpecified.
- */
 TLVType TLVReader::GetType() const
 {
     TLVElementType elemType = ElementType();
@@ -275,57 +106,6 @@ TLVType TLVReader::GetType() const
     return static_cast<TLVType>(static_cast<uint8_t>(elemType) & ~kTLVTypeSizeMask);
 }
 
-/**
- * Returns the control byte associated with current TLV element.
- *
- * Ideally, nobody ever needs to know about the control byte and only the
- * internal implementation of TLV should have access to it. But, nevertheless,
- * having access to the control byte is helpful for debugging purposes by the
- * TLV Debug Utilities (that try to decode the tag control byte when pretty
- * printing the TLV buffer contents).
- *
- * @note Unless you really know what you are doing, please refrain from using
- * this method and the associated control byte information.
- *
- * @return      An unsigned integer containing the control byte associated with
- *              the current TLV element. kTLVControlByte_NotSpecified is
- *              returned if the reader is not positioned @em on an element.
- */
-uint16_t TLVReader::GetControlByte() const
-{
-    return mControlByte;
-}
-
-/**
- * Returns the tag associated with current TLV element.
- *
- * The value returned by GetTag() can be used with the tag utility functions (IsProfileTag(),
- * IsContextTag(), ProfileIdFromTag(), etc.) to determine the type of tag and to extract various tag
- * field values.
- *
- * @note If the reader is not positioned on a TLV element when GetTag() is called, the return value
- * is undefined. Therefore whenever the position of the reader is uncertain applications should call
- * GetType() to determine if the reader is position on an element (GetType() != kTLVType_NotSpecified)
- * before calling GetTag().
- *
- * @return      An unsigned integer containing information about the tag associated with the current
- *              TLV element.
- */
-uint64_t TLVReader::GetTag() const
-{
-    return mElemTag;
-}
-
-/**
- * Returns the length of data associated with current TLV element.
- *
- * Data length only applies to elements of type UTF8 string or byte string.  For UTF8 strings, the
- * value returned is the number of bytes in the string, not the number of characters.
- *
- * @return      The length (in bytes) of data associated with the current TLV element, or 0 if the
- *              current element is not a UTF8 string or byte string, or if the reader is not
- *              positioned on an element.
- */
 uint32_t TLVReader::GetLength() const
 {
     if (TLVTypeHasLength(ElementType()))
@@ -333,16 +113,6 @@ uint32_t TLVReader::GetLength() const
     return 0;
 }
 
-/**
- * Get the value of the current element as a bool type.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV boolean type, or the
- *                                      reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(bool & v)
 {
     TLVElementType elemType = ElementType();
@@ -355,19 +125,6 @@ CHIP_ERROR TLVReader::Get(bool & v)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Get the value of the current element as an 8-bit signed integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(int8_t & v)
 {
     uint64_t v64   = 0;
@@ -376,19 +133,6 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 16-bit signed integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(int16_t & v)
 {
     uint64_t v64   = 0;
@@ -397,19 +141,6 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 32-bit signed integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(int32_t & v)
 {
     uint64_t v64   = 0;
@@ -418,19 +149,6 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 64-bit signed integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(int64_t & v)
 {
     uint64_t v64   = 0;
@@ -439,20 +157,6 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as an 8-bit unsigned integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
- * to unsigned.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(uint8_t & v)
 {
     uint64_t v64   = 0;
@@ -461,20 +165,6 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 16-bit unsigned integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
- * to unsigned.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(uint16_t & v)
 {
     uint64_t v64   = 0;
@@ -483,20 +173,6 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 32-bit unsigned integer.
- *
- * If the encoded integer value is larger than the output data type the resultant value will be
- * truncated.  Similarly, if the encoded integer value is negative, the value will be converted
- * to unsigned.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
-                                        unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(uint32_t & v)
 {
     uint64_t v64   = 0;
@@ -505,18 +181,6 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
     return err;
 }
 
-/**
- * Get the value of the current element as a 64-bit unsigned integer.
- *
- * If the encoded integer value is negative, the value will be converted to unsigned.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV integer type (signed or
- *                                      unsigned), or the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(uint64_t & v)
 {
     switch (ElementType())
@@ -543,16 +207,6 @@ CHIP_ERROR TLVReader::Get(uint64_t & v)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Get the value of the current element as a double-precision floating point number.
- *
- * @param[out]  v                       Receives the value associated with current TLV element.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV floating point type, or
- *                                      the reader is not positioned on an element.
- *
- */
 CHIP_ERROR TLVReader::Get(double & v)
 {
     switch (ElementType())
@@ -583,28 +237,6 @@ CHIP_ERROR TLVReader::Get(double & v)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Get the value of the current byte or UTF8 string element.
- *
- * To determine the required input buffer size, call the GetLength() method before calling GetBytes().
- *
- * @note The data output by this method is NOT null-terminated.
- *
- * @param[in]  buf                      A pointer to a buffer to receive the string data.
- * @param[in]  bufSize                  The size in bytes of the buffer pointed to by @p buf.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
- *                                      the reader is not positioned on an element.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                                      If the supplied buffer is too small to hold the data associated
- *                                      with the current element.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, uint32_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -622,28 +254,6 @@ CHIP_ERROR TLVReader::GetBytes(uint8_t * buf, uint32_t bufSize)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Get the value of the current byte or UTF8 string element as a null terminated string.
- *
- * To determine the required input buffer size, call the GetLength() method before calling GetBytes().
- * The input buffer should be at least one byte bigger than the string length to accommodate the null
- * character.
- *
- * @param[in]  buf                      A pointer to a buffer to receive the byte string data.
- * @param[in]  bufSize                  The size in bytes of the buffer pointed to by @p buf.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
- *                                      the reader is not positioned on an element.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                                      If the supplied buffer is too small to hold the data associated
- *                                      with the current element.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -657,31 +267,6 @@ CHIP_ERROR TLVReader::GetString(char * buf, uint32_t bufSize)
     return GetBytes(reinterpret_cast<uint8_t *>(buf), bufSize - 1);
 }
 
-/**
- * Allocates and returns a buffer containing the value of the current byte or UTF8 string.
- *
- * This method creates a buffer for and returns a copy of the data associated with the byte
- * or UTF-8 string element at the current position. Memory for the buffer is obtained with
- * Platform::MemoryAlloc() and should be freed with Platform::MemoryFree() by the caller when
- * it is no longer needed.
- *
- * @note The data returned by this method is NOT null-terminated.
- *
- * @param[out] buf                      A reference to a pointer to which a heap-allocated buffer of
- *                                      @p dataLen bytes will be assigned on success.
- * @param[out] dataLen                  A reference to storage for the size, in bytes, of @p buf on
- *                                      success.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
- *                                      the reader is not positioned on an element.
- * @retval #CHIP_ERROR_NO_MEMORY       If memory could not be allocated for the output buffer.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer
- *                                      is non-NULL.
- *
- */
 CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -705,28 +290,6 @@ CHIP_ERROR TLVReader::DupBytes(uint8_t *& buf, uint32_t & dataLen)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Allocates and returns a buffer containing the null-terminated value of the current byte or UTF8
- * string.
- *
- * This method creates a buffer for and returns a null-terminated copy of the data associated with
- * the byte or UTF-8 string element at the current position. Memory for the buffer is obtained with
- * Platform::MemoryAlloc() and should be freed with chip::Platform::MemoryFree() by the caller when
- * it is no longer needed.
- *
- * @param[out] buf                      A reference to a pointer to which a heap-allocated buffer of
- *                                      will be assigned on success.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or
- *                                      the reader is not positioned on an element.
- * @retval #CHIP_ERROR_NO_MEMORY       If memory could not be allocated for the output buffer.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer
- *                                      is non-NULL.
- *
- */
 CHIP_ERROR TLVReader::DupString(char *& buf)
 {
     if (!TLVTypeIsString(ElementType()))
@@ -753,28 +316,6 @@ CHIP_ERROR TLVReader::DupString(char *& buf)
     return err;
 }
 
-/**
- * Get a pointer to the initial encoded byte of a TLV byte or UTF8 string element.
- *
- * This method returns a direct pointer the encoded string value within the underlying input buffer.
- * To succeed, the method requires that the entirety of the string value be present in a single buffer.
- * Otherwise the method returns #CHIP_ERROR_TLV_UNDERRUN.  This makes the method of limited use when
- * reading data from multiple discontiguous buffers.
- *
- * @param[out] data                     A reference to a const pointer that will receive a pointer to
- *                                      the underlying string data.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the current element is not a TLV byte or UTF8 string, or the
- *                                      reader is not positioned on an element.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely or the value
- *                                      of the current string element is not contained within a single
- *                                      contiguous buffer.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data)
 {
     CHIP_ERROR err;
@@ -798,100 +339,28 @@ CHIP_ERROR TLVReader::GetDataPtr(const uint8_t *& data)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Initializes a new TLVReader object for reading the members of a TLV container element.
- *
- * The OpenContainer() method initializes a new TLVReader object for reading the member elements of a
- * TLV container (a structure, array or path).  When OpenContainer() is called, the current TLVReader
- * object must be positioned on the container element to be read.  The method takes as its sole argument
- * a reference to a new reader that will be initialized to read the container.  This reader is known as
- * the <em>container reader</em> while the reader on which OpenContainer() is called is known as the <em>parent
- * reader</em>.
- *
- * When the OpenContainer() method returns, the container reader is positioned immediately before the
- * first member of the container. Calling Next() on the container reader will advance through the members
- * of the collection until the end is reached, at which point the reader will return CHIP_END_OF_TLV.
- *
- * While the container reader is open, applications must not make calls on or otherwise alter the state
- * of the parent reader.  Once an application has finished using the container reader it must close it
- * by calling CloseContainer() on the parent reader, passing the container reader as an argument.
- * Applications may close the container reader at any point, with or without reading all elements
- * contained in the underlying container. After the container reader is closed, applications may
- * continue their use of the parent reader.
- *
- * The container reader inherits various configuration properties from the parent reader.  These are:
- *
- * @li The implicit profile id (ImplicitProfileId)
- * @li The application data pointer (AppData)
- * @li The GetNextBuffer function pointer
- *
- * @note The EnterContainer() method can be used as an alternative to OpenContainer() to read a
- * container element without initializing a new reader object.
- *
- * @param[out] containerReader          A reference to a TLVReader object that will be initialized for
- *                                      reading the members of the current container element. Any data
- *                                      associated with the supplied object is overwritten.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE If the current element is not positioned on a container element.
- *
- */
 CHIP_ERROR TLVReader::OpenContainer(TLVReader & containerReader)
 {
     TLVElementType elemType = ElementType();
     if (!TLVTypeIsContainer(elemType))
         return CHIP_ERROR_INCORRECT_STATE;
 
-    containerReader.mBufHandle = mBufHandle;
-    containerReader.mReadPoint = mReadPoint;
-    containerReader.mBufEnd    = mBufEnd;
-    containerReader.mLenRead   = mLenRead;
-    containerReader.mMaxLen    = mMaxLen;
+    containerReader.mBackingStore = mBackingStore;
+    containerReader.mReadPoint    = mReadPoint;
+    containerReader.mBufEnd       = mBufEnd;
+    containerReader.mLenRead      = mLenRead;
+    containerReader.mMaxLen       = mMaxLen;
     containerReader.ClearElementState();
     containerReader.mContainerType = static_cast<TLVType>(elemType);
     containerReader.SetContainerOpen(false);
     containerReader.ImplicitProfileId = ImplicitProfileId;
     containerReader.AppData           = AppData;
-    containerReader.GetNextBuffer     = GetNextBuffer;
 
     SetContainerOpen(true);
 
     return CHIP_NO_ERROR;
 }
 
-/**
- * Completes the reading of a TLV container after a call to OpenContainer().
- *
- * The CloseContainer() method restores the state of a parent TLVReader object after a call to
- * OpenContainer().  For every call to OpenContainer() applications must make a corresponding
- * call to CloseContainer(), passing a reference to the same container reader to both methods.
- *
- * When CloseContainer() returns, the parent reader is positioned immediately before the first
- * element that follows the container.  From this point an application can use the Next() method
- * to advance through any remaining elements.
- *
- * Applications can call close CloseContainer() on a parent reader at any point in time, regardless
- * of whether all elements in the underlying container have been read. After CloseContainer() has
- * been called, the application should consider the container reader 'de-initialized' and must not
- * use it further without re-initializing it.
- *
- * @param[in] containerReader           A reference to the TLVReader object that was supplied to the
- *                                      OpenContainer() method.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE If OpenContainer() has not been called on the reader, or if
- *                                      the container reader does not match the one passed to the
- *                                      OpenContainer() method.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV
- *                                      element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::CloseContainer(TLVReader & containerReader)
 {
     CHIP_ERROR err;
@@ -906,41 +375,16 @@ CHIP_ERROR TLVReader::CloseContainer(TLVReader & containerReader)
     if (err != CHIP_NO_ERROR)
         return err;
 
-    mBufHandle = containerReader.mBufHandle;
-    mReadPoint = containerReader.mReadPoint;
-    mBufEnd    = containerReader.mBufEnd;
-    mLenRead   = containerReader.mLenRead;
-    mMaxLen    = containerReader.mMaxLen;
+    mBackingStore = containerReader.mBackingStore;
+    mReadPoint    = containerReader.mReadPoint;
+    mBufEnd       = containerReader.mBufEnd;
+    mLenRead      = containerReader.mLenRead;
+    mMaxLen       = containerReader.mMaxLen;
     ClearElementState();
 
     return CHIP_NO_ERROR;
 }
 
-/**
- * Prepares a TLVReader object for reading the members of TLV container element.
- *
- * The EnterContainer() method prepares the current TLVReader object to begin reading the member
- * elements of a TLV container (a structure, array or path). For every call to EnterContainer()
- * applications must make a corresponding call to ExitContainer().
- *
- * When EnterContainer() is called the TLVReader object must be positioned on the container element
- * to be read.  The method takes as an argument a reference to a TLVType value which will be used
- * to save the context of the reader while it is reading the container.
- *
- * When the EnterContainer() method returns, the reader is positioned immediately @em before the
- * first member of the container. Repeatedly calling Next() will advance the reader through the members
- * of the collection until the end is reached, at which point the reader will return CHIP_END_OF_TLV.
- *
- * Once the application has finished reading a container it can continue reading the elements after
- * the container by calling the ExitContainer() method.
- *
- * @param[out] outerContainerType       A reference to a TLVType value that will receive the context
- *                                      of the reader.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE If the current element is not positioned on a container element.
- *
- */
 CHIP_ERROR TLVReader::EnterContainer(TLVType & outerContainerType)
 {
     TLVElementType elemType = ElementType();
@@ -956,42 +400,6 @@ CHIP_ERROR TLVReader::EnterContainer(TLVType & outerContainerType)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Completes the reading of a TLV container and prepares a TLVReader object to read elements
- * after the container.
- *
- * The ExitContainer() method restores the state of a TLVReader object after a call to
- * EnterContainer().  For every call to EnterContainer() applications must make a corresponding
- * call to ExitContainer(), passing the context value returned by the EnterContainer() method.
- *
- * When ExitContainer() returns, the reader is positioned immediately before the first element that
- * follows the container.  From this point an application can use the Next() method to advance
- * through any remaining elements.
- *
- * Once EnterContainer() has been called, applications can call ExitContainer() on a reader at any
- * point in time, regardless of whether all elements in the underlying container have been read.
- *
- * @note Any changes made to the configuration of the reader between the calls to EnterContainer()
- * and ExitContainer() are NOT undone by the call to ExitContainer().  For example, a change to the
- * implicit profile id (@p ImplicitProfileId) will not be reversed when a container is exited.  Thus
- * it is the application's responsibility to adjust the configuration accordingly at the appropriate
- * times.
- *
- * @param[in] outerContainerType        The TLVType value that was returned by the EnterContainer() method.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE If OpenContainer() has not been called on the reader, or if
- *                                      the container reader does not match the one passed to the
- *                                      OpenContainer() method.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::ExitContainer(TLVType outerContainerType)
 {
     CHIP_ERROR err;
@@ -1006,29 +414,6 @@ CHIP_ERROR TLVReader::ExitContainer(TLVType outerContainerType)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Verifies that the TVLReader object is at the end of a TLV container.
- *
- * The VerifyEndOfContainer() method verifies that there are no further TLV elements to be read
- * within the current TLV container.  This is a convenience method that is equivalent to calling
- * Next() and checking for a return value of CHIP_END_OF_TLV.
- *
- * @note When there are more TLV elements in the collection, this method will change the position
- * of the reader.
- *
- * @retval #CHIP_NO_ERROR              If there are no further TLV elements to be read.
- * @retval #CHIP_ERROR_UNEXPECTED_TLV_ELEMENT
- *                                      If another TLV element was found in the collection.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV element
- *                                      type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::VerifyEndOfContainer()
 {
     CHIP_ERROR err = Next();
@@ -1039,53 +424,6 @@ CHIP_ERROR TLVReader::VerifyEndOfContainer()
     return err;
 }
 
-/**
- * Returns the type of the container within which the TLVReader is currently reading.
- *
- * The GetContainerType() method returns the type of the TLV container within which the TLVReader
- * is reading.  If the TLVReader is positioned at the outer-most level of a TLV encoding (i.e. before,
- * on or after the outer-most TLV element), the method will return kTLVType_NotSpecified.
- *
- * @return  The TLVType of the current container, or kTLVType_NotSpecified if the TLVReader is not
- *          positioned within a container.
- */
-TLVType TLVReader::GetContainerType() const
-{
-    return mContainerType;
-}
-
-/**
- * Advances the TLVReader object to the next TLV element to be read.
- *
- * The Next() method positions the reader object on the next element in a TLV encoding that resides
- * in the same containment context.  In particular, if the reader is positioned at the outer-most
- * level of a TLV encoding, calling Next() will advance the reader to the next, top-most element.
- * If the reader is positioned within a TLV container element (a structure, array or path), calling
- * Next() will advance the reader to the next member element of the container.
- *
- * Since Next() constrains reader motion to the current containment context, calling Next() when
- * the reader is positioned on a container element will advance @em over the container, skipping
- * its member elements (and the members of any nested containers) until it reaches the first element
- * after the container.
- *
- * When there are no further elements within a particular containment context the Next() method will
- * return a #CHIP_END_OF_TLV error and the position of the reader will remain unchanged.
- *
- * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
- * @retval #CHIP_END_OF_TLV            If no further elements are available.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV element
- *                                      type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval #CHIP_ERROR_UNKNOWN_IMPLICIT_TLV_TAG
- *                                      If the reader encountered a implicitly-encoded TLV tag for which
- *                                      the corresponding profile id is unknown.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::Next()
 {
     CHIP_ERROR err;
@@ -1106,34 +444,6 @@ CHIP_ERROR TLVReader::Next()
     return CHIP_NO_ERROR;
 }
 
-/**
- * Advances the TLVReader object to the next TLV element to be read, asserting the type and tag of
- * the new element.
- *
- * The Next(TLVType expectedType, uint64_t expectedTag) method is a convenience method that has the
- * same behavior as Next(), but also verifies that the type and tag of the new TLV element match
- * the supplied arguments.
- *
- * @param[in] expectedType              The expected data type for the next element.
- * @param[in] expectedTag               The expected tag for the next element.
- *
- * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
- * @retval #CHIP_END_OF_TLV            If no further elements are available.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE  If the type of the new element does not match the value
- *                                      of the @p expectedType argument.
- * @retval #CHIP_ERROR_UNEXPECTED_TLV_ELEMENT
- *                                      If the tag associated with the new element does not match the
- *                                      value of the @p expectedTag argument.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV
- *                                      element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::Next(TLVType expectedType, uint64_t expectedTag)
 {
     CHIP_ERROR err = Next();
@@ -1146,27 +456,6 @@ CHIP_ERROR TLVReader::Next(TLVType expectedType, uint64_t expectedTag)
     return CHIP_NO_ERROR;
 }
 
-/**
- * Advances the TLVReader object to immediately after the current TLV element.
- *
- * The Skip() method positions the reader object immediately @em after the current TLV element, such
- * that a subsequent call to Next() will advance the reader to the following element.  Like Next(),
- * if the reader is positioned on a container element at the time of the call, the members of the
- * container will be skipped.  If the reader is not positioned on any element, its position remains
- * unchanged.
- *
- * @retval #CHIP_NO_ERROR              If the reader was successfully positioned on a new element.
- * @retval #CHIP_END_OF_TLV            If no further elements are available.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the reader encountered an invalid or unsupported TLV
- *                                      element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the reader encountered a TLV tag in an invalid context.
- * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
- *
- */
 CHIP_ERROR TLVReader::Skip()
 {
     CHIP_ERROR err;
@@ -1217,8 +506,7 @@ void TLVReader::ClearElementState()
  * @retval #CHIP_NO_ERROR              If the reader was successfully positioned at the end of the
  *                                      data.
  * @retval other                        Other CHIP or platform error codes returned by the configured
- *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
- *                                      non-NULL.
+ *                                      TLVBackingStore.
  */
 CHIP_ERROR TLVReader::SkipData()
 {
@@ -1483,11 +771,11 @@ CHIP_ERROR TLVReader::EnsureData(CHIP_ERROR noDataErr)
         if (mLenRead == mMaxLen)
             return noDataErr;
 
-        if (GetNextBuffer == nullptr)
+        if (mBackingStore == nullptr)
             return noDataErr;
 
         uint32_t bufLen;
-        err = GetNextBuffer(*this, mBufHandle, mReadPoint, bufLen);
+        err = mBackingStore->GetNextBuffer(*this, mReadPoint, bufLen);
         if (err != CHIP_NO_ERROR)
             return err;
         if (bufLen == 0)
@@ -1553,36 +841,6 @@ TLVElementType TLVReader::ElementType() const
     return static_cast<TLVElementType>(mControlByte & kTLVTypeMask);
 }
 
-CHIP_ERROR TLVReader::GetNextPacketBuffer(TLVReader & reader, uintptr_t & bufHandle, const uint8_t *& bufStart, uint32_t & bufLen)
-{
-    PacketBuffer *& buf = reinterpret_cast<PacketBuffer *&>(bufHandle);
-
-    if (buf != nullptr)
-        buf = buf->Next_ForNow();
-    if (buf != nullptr)
-    {
-        bufStart = buf->Start();
-        bufLen   = buf->DataLength();
-    }
-    else
-    {
-        bufStart = nullptr;
-        bufLen   = 0;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
-/**
- * Position the destination reader on the next element with the given tag within this reader's current container context
- *
- * @param[in] tag                      The destination context tag value
- * @param[in] destReader               The destination TLV reader value that was located by given tag
- *
- * @retval #CHIP_NO_ERROR              If the reader was successfully positioned at the given tag
- * @retval #CHIP_END_OF_TLV            If the given tag cannot be found
- * @retval other                       Other CHIP or platform error codes
- */
 CHIP_ERROR TLVReader::FindElementWithTag(const uint64_t tag, TLVReader & destReader) const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2015-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,25 +33,6 @@ namespace TLV {
 
 using namespace chip::Encoding;
 
-/**
- * Initialize a TLVUpdater object to edit a single input buffer.
- *
- * On calling this method, the TLV data in the buffer is moved to the end of the
- * buffer and a private TLVReader object is initialized on this relocated
- * buffer. A private TLVWriter object is also initialized on the free space that
- * is now available at the beginning. Applications can use the TLVUpdater object
- * to parse the TLV data and modify/delete existing elements or add new elements
- * to the encoding.
- *
- * @param[in]   buf     A pointer to a buffer containing the TLV data to be edited.
- * @param[in]   dataLen The length of the TLV data in the buffer.
- * @param[in]   maxLen  The total length of the buffer.
- *
- * @retval #CHIP_NO_ERROR                  If the method succeeded.
- * @retval #CHIP_ERROR_INVALID_ARGUMENT    If the buffer address is invalid.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL    If the buffer is too small.
- *
- */
 CHIP_ERROR TLVUpdater::Init(uint8_t * buf, uint32_t dataLen, uint32_t maxLen)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -77,36 +58,6 @@ exit:
     return err;
 }
 
-/**
- * Initialize a TLVUpdater object using a TLVReader.
- *
- * On calling this method, TLV data in the buffer pointed to by the TLVReader
- * is moved from the current read point to the end of the buffer. A new
- * private TLVReader object is initialized to read from this new location, while
- * a new private TLVWriter object is initialized to write to the freed up buffer
- * space.
- *
- * Note that if the TLVReader is already positioned "on" an element, it is first
- * backed-off to the start of that element. Also note that this backing off
- * works well with container elements, i.e., if the TLVReader was already  used
- * to call EnterContainer(), then there is nothing to back-off. But if the
- * TLVReader was positioned on the container element and EnterContainer() was
- * not yet called, then the TLVReader object is backed-off to the start of the
- * container head.
- *
- * The input TLVReader object will be destroyed before returning and the
- * application must not make use of the same on return.
- *
- * @param[in,out]   aReader     Reference to a TLVReader object that will be
- *                              destroyed before returning.
- * @param[in]       freeLen     The length of free space (in bytes) available
- *                              in the pre-encoded data buffer.
- *
- * @retval #CHIP_NO_ERROR                  If the method succeeded.
- * @retval #CHIP_ERROR_INVALID_ARGUMENT    If the buffer address is invalid.
- * @retval #CHIP_ERROR_NOT_IMPLEMENTED     If reader was initialized on a chain
- *                                          of buffers.
- */
 CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
@@ -114,8 +65,8 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     uint32_t remainingDataLen = aReader.GetRemainingLength();
     uint32_t readDataLen      = aReader.GetLengthRead();
 
-    // TLVUpdater does not support chain of buffers yet
-    VerifyOrExit(aReader.mBufHandle == 0, err = CHIP_ERROR_NOT_IMPLEMENTED);
+    // TLVUpdater does not support backing stores yet
+    VerifyOrExit(aReader.mBackingStore == 0, err = CHIP_ERROR_NOT_IMPLEMENTED);
 
     // TLVReader should point to a non-NULL buffer
     VerifyOrExit(buf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -137,7 +88,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     memmove(buf + freeLen, buf, remainingDataLen);
 
     // Initialize the internal reader object
-    mUpdaterReader.mBufHandle     = 0;
+    mUpdaterReader.mBackingStore  = 0;
     mUpdaterReader.mReadPoint     = buf + freeLen;
     mUpdaterReader.mBufEnd        = buf + freeLen + remainingDataLen;
     mUpdaterReader.mLenRead       = readDataLen;
@@ -150,10 +101,9 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
 
     mUpdaterReader.ImplicitProfileId = aReader.ImplicitProfileId;
     mUpdaterReader.AppData           = aReader.AppData;
-    mUpdaterReader.GetNextBuffer     = nullptr;
 
     // Initialize the internal writer object
-    mUpdaterWriter.mBufHandle     = 0;
+    mUpdaterWriter.mBackingStore  = 0;
     mUpdaterWriter.mBufStart      = buf - readDataLen;
     mUpdaterWriter.mWritePoint    = buf;
     mUpdaterWriter.mRemainingLen  = freeLen;
@@ -164,8 +114,6 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     mUpdaterWriter.SetCloseContainerReserved(false);
 
     mUpdaterWriter.ImplicitProfileId = aReader.ImplicitProfileId;
-    mUpdaterWriter.GetNewBuffer      = nullptr;
-    mUpdaterWriter.FinalizeBuffer    = nullptr;
 
     // Cache element start address for internal use
     mElementStartAddr = buf + freeLen;
@@ -178,70 +126,12 @@ exit:
     return err;
 }
 
-/**
- * Set the Implicit Profile ID for the TLVUpdater object.
- *
- * This method sets the implicit profile ID for the TLVUpdater object. When the
- * updater is asked to encode a new element, if the profile ID of the tag
- * associated with the new element matches the value of the @p profileId, the
- * updater will encode the tag in implicit form, thereby omitting the profile ID
- * in the process.
- *
- * @param[in]   profileId   The profile id of tags that should be encoded in
- *                          implicit form.
- */
 void TLVUpdater::SetImplicitProfileId(uint32_t profileId)
 {
     mUpdaterReader.ImplicitProfileId = profileId;
     mUpdaterWriter.ImplicitProfileId = profileId;
 }
 
-/**
- * Skip the current element and advance the TLVUpdater object to the next
- * element in the input TLV.
- *
- * The Next() method skips the current element in the input TLV and advances the
- * TLVUpdater's reader to the next element that resides in the same containment
- * context. In particular, if the reader is positioned at the outer most level
- * of a TLV encoding, calling Next() will advance it to the next, top most
- * element. If the reader is positioned within a TLV container element (a
- * structure, array or path), calling Next() will advance it to the next member
- * element of the container.
- *
- * Since Next() constrains reader motion to the current containment context,
- * calling Next() when the reader is positioned on a container element will
- * advance @em over the container, skipping its member elements (and the members
- * of any nested containers) until it reaches the first element after the
- * container.
- *
- * When there are no further elements within a particular containment context
- * the Next() method will return a #CHIP_END_OF_TLV error and the position of
- * the reader will remain unchanged.
- *
- * @note The Next() method implicitly skips the current element. Hence, the
- * TLVUpdater's private writer state variables will be adjusted to account for
- * the new freed space (made available by skipping). This means that the
- * application is expected to call Next() on the TLVUpdater object after a Get()
- * whose value the application does @em not write back (which from the
- * TLVUpdater's view is equivalent to skipping that element).
- *
- * @note Applications are also expected to call Next() when they are at the end
- * of a container, and want to add new elements there. This is particularly
- * important in situations where there is a fixed schema. Applications that have
- * fixed schemas and know where the container end is cannot just add new
- * elements at the end, because the TLVUpdater writer's state will not reflect
- * the correct free space available for the Put() operation. Hence, applications
- * must call Next() (and possibly also test for CHIP_END_OF_TLV) before adding
- * elements at the end of a container.
- *
- * @retval #CHIP_NO_ERROR              If the TLVUpdater reader was
- *                                      successfully positioned on a new
- *                                      element.
- * @retval other                        Returns the CHIP or platform error
- *                                      codes returned by the TLVReader::Skip()
- *                                      and TLVReader::Next() method.
- *
- */
 CHIP_ERROR TLVUpdater::Next()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -260,29 +150,6 @@ exit:
     return err;
 }
 
-/**
- * Copies the current element from input TLV to output TLV.
- *
- * The Move() method copies the current element on which the TLVUpdater's reader
- * is positioned on, to the TLVUpdater's writer. The application should call
- * Next() and position the TLVUpdater's reader on an element before calling this
- * method. Just like the TLVReader::Next() method, if the reader is positioned
- * on a container element at the time of the call, all the members of the
- * container will be copied. If the reader is not positioned on any element,
- * nothing changes on calling this method.
- *
- * @retval #CHIP_NO_ERROR              If the TLVUpdater reader was
- *                                      successfully positioned on a new
- *                                      element.
- * @retval #CHIP_END_OF_TLV            If the TLVUpdater's reader is pointing
- *                                      to end of container.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the TLVIpdater's reader is not
- *                                      positioned on a valid TLV element.
- * @retval other                        Returns other error codes returned by
- *                                      TLVReader::Skip() method.
- *
- */
 CHIP_ERROR TLVUpdater::Move()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -315,22 +182,6 @@ exit:
     return err;
 }
 
-/**
- * Move everything from the TLVUpdater's current read point till end of input
- * TLV buffer over to output.
- *
- * This method supports moving everything from the TLVUpdater's current read
- * point till the end of the reader buffer over to the TLVUpdater's writer.
- *
- * @note This method can be called with the TLVUpdater's reader positioned
- * anywhere within the input TLV. The reader can also be positioned under
- * multiple levels of nested containers and this method will still work.
- *
- * @note This method also changes the state of the TLVUpdater object to a state
- * it would be in if the application had painstakingly parsed each element from
- * the current read point till the end of the input encoding and copied them to
- * the output TLV.
- */
 void TLVUpdater::MoveUntilEnd()
 {
     const uint8_t * buffEnd = mUpdaterReader.GetReadPoint() + mUpdaterReader.GetRemainingLength();
@@ -357,42 +208,6 @@ void TLVUpdater::MoveUntilEnd()
     mUpdaterReader.SetContainerOpen(false);
 }
 
-/**
- * Prepares a TLVUpdater object for reading elements of a container. It also
- * encodes a start of container object in the output TLV.
- *
- * The EnterContainer() method prepares the current TLVUpdater object to begin
- * reading the member elements of a TLV container (a structure, array or path).
- * For every call to EnterContainer() applications must make a corresponding
- * call to ExitContainer().
- *
- * When EnterContainer() is called the TLVUpdater's reader must be positioned on
- * the container element. The method takes as an argument a reference to a
- * TLVType value which will be used to save the context of the updater while it
- * is reading the container.
- *
- * When the EnterContainer() method returns, the updater is positioned
- * immediately @em before the first member of the container. Repeatedly calling
- * Next() will advance the updater through the members of the collection until
- * the end is reached, at which point the updater will return CHIP_END_OF_TLV.
- *
- * Once the application has finished reading a container it can continue reading
- * the elements after the container by calling the ExitContainer() method.
- *
- * @note This method implicitly encodes a start of container element in the
- * output TLV buffer.
- *
- * @param[out] outerContainerType       A reference to a TLVType value that will
- *                                      receive the context of the updater.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE If the TLVUpdater reader is not
- *                                      positioned on a container element.
- * @retval other                        Any other CHIP or platform error code
- *                                      returned by TLVWriter::StartContainer()
- *                                      or TLVReader::EnterContainer().
- *
- */
 CHIP_ERROR TLVUpdater::EnterContainer(TLVType & outerContainerType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -416,49 +231,6 @@ exit:
     return err;
 }
 
-/**
- * Completes the reading of a TLV container element and encodes an end of TLV
- * element in the output TLV.
- *
- * The ExitContainer() method restores the state of a TLVUpdater object after a
- * call to EnterContainer(). For every call to EnterContainer() applications
- * must make a corresponding call to ExitContainer(), passing the context value
- * returned by the EnterContainer() method.
- *
- * When ExitContainer() returns, the TLVUpdater reader is positioned immediately
- * before the first element that follows the container in the input TLV. From
- * this point applications can call Next() to advance through any remaining
- * elements.
- *
- * Once EnterContainer() has been called, applications can call ExitContainer()
- * on the updater at any point in time, regardless of whether all elements in
- * the underlying container have been read. Also, note that calling
- * ExitContainer() before reading all the elements in the container, will result
- * in the updated container getting truncated in the output TLV.
- *
- * @note Any changes made to the configuration of the updater between the calls
- * to EnterContainer() and ExitContainer() are NOT undone by the call to
- * ExitContainer(). For example, a change to the implicit profile id
- * (@p ImplicitProfileId) will not be reversed when a container is exited. Thus
- * it is the application's responsibility to adjust the configuration
- * accordingly at the appropriate times.
- *
- * @param[in] outerContainerType        The TLVType value that was returned by
- *                                      the EnterContainer() method.
- *
- * @retval #CHIP_NO_ERROR              If the method succeeded.
- * @retval #CHIP_ERROR_TLV_UNDERRUN    If the underlying TLV encoding ended
- *                                      prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                      If the updater encountered an invalid or
- *                                      unsupported TLV element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG If the updater encountered a TLV tag in
- *                                      an invalid context.
- * @retval other                        Any other CHIP or platform error code
- *                                      returned by TLVWriter::EndContainer() or
- *                                      TLVReader::ExitContainer().
- *
- */
 CHIP_ERROR TLVUpdater::ExitContainer(TLVType outerContainerType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2015-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,10 +33,10 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
-#include <system/SystemPacketBuffer.h>
 
 #include <stdarg.h>
 #include <stdint.h>
+#include <string.h>
 
 // Doxygen is confused by the __attribute__ annotation
 #ifndef DOXYGEN
@@ -48,130 +48,9 @@ namespace TLV {
 
 using namespace chip::Encoding;
 
-/**
- * @var uint32_t TLVWriter::ImplicitProfileId
- *
- * The profile id of tags that should be encoded in implicit form.
- *
- * When a writer is asked to encode a new element, if the profile id of the tag associated with the
- * new element matches the value of the @p ImplicitProfileId member, the writer will encode the tag
- * in implicit form, omitting the profile id in the process.
- *
- * By default, the @p ImplicitProfileId property is set to kProfileIdNotSpecified, which instructs
- * the writer not to emit implicitly encoded tags.  Applications can set @p ImplicitProfileId at any
- * time to enable encoding tags in implicit form starting at the current point in the encoding.  The
- * appropriate profile id to set is usually dependent on the context of the application or protocol
- * being spoken.
- *
- * @note The value of the @p ImplicitProfileId member affects the encoding of profile-specific
- * tags only; the encoding of context-specific tags is unchanged.
- */
-
-/**
- * @var void *TLVWriter::AppData
- *
- * A pointer field that can be used for application-specific data.
- */
-
-/**
- * @typedef CHIP_ERROR (*TLVWriter::GetNewBufferFunct)(TLVWriter& writer, uintptr_t& bufHandle, uint8_t *& bufStart, uint32_t&
- * bufLen)
- *
- * A function that supplies new output buffer space to a TLVWriter.
- *
- * Functions of this type are used to prepare new buffer space for a TLVWriter to write to. When called,
- * the function is expected to return a pointer to a memory location where new data should be written,
- * along with an associated maximum length. The function can supply write space either by allocating
- * a new buffer to hold the data or by clearing out previously written data from an existing buffer.
- *
- * @param[in]       writer          A reference to the TLVWriter object that is requesting new buffer
- *                                  space.
- * @param[in,out]   bufHandle       A reference to a uintptr_t value that the function can use to store
- *                                  context data between calls.  This value is initialized to 0
- *                                  prior to the first call.
- * @param[in,out]   bufStart        A reference to a data pointer. On entry to the function, @p bufStart
- *                                  points the beginning of the current output buffer.  On exit, @p bufStart
- *                                  is expected to point to the beginning of the new output buffer.
- *                                  The new pointer value can be the same as the previous value (e.g.
- *                                  if the function copied the existing data elsewhere), or it can point
- *                                  to an entirely new location.
- * @param[in,out]   bufLen          A reference to an unsigned integer. On entry to the function,
- *                                  @p bufLen contains the number of byte of @em unused space in the
- *                                  current buffer.  On exit, @p bufLen is expected to contain the maximum
- *                                  number of bytes that can be written to the new output buffer.
- *
- * @retval #CHIP_NO_ERROR          If the function was able to supply more buffer space for the writer.
- * @retval other                    Other CHIP or platform-specific error codes indicating that an error
- *                                  occurred preventing the function from producing additional buffer
- *                                  space.
- *
- */
-
-/**
- * @var GetNewBufferFunct TLVWriter::GetNewBuffer
- *
- * A pointer to a function that will supply new output buffer space to a TLVWriter.
- *
- * A TLVWriter object will call the GetNewBuffer function whenever an attempt is made to write data
- * that exceeds the size of the current output buffer.  If set to NULL (the default value), the
- * writer will return a CHIP_ERROR_NO_MEMORY if the output data overflows the current buffer.
- *
- * GetNewBuffer can be set by an application at any time, but is typically set when the writer
- * is initialized.
- *
- * See the GetNewBufferFunct type definition for additional information on implementing a
- * GetNewBuffer function.
- */
-
-/**
- * @typedef CHIP_ERROR (*TLVWriter::FinalizeBufferFunct)(TLVWriter& writer, uintptr_t bufHandle, uint8_t *bufStart, uint32_t bufLen)
- *
- * A function used to perform finalization of the output from a TLVWriter object.
- *
- * Functions of this type are called when a TLVWriter's Finalize() method is called. The function is
- * expected to perform any necessary clean-up or finalization related to consuming the output of the
- * writer object. Examples of this include such things as recording the final length of the encoding,
- * or closing a file descriptor.
- *
- * @param[in]       writer          A reference to the TLVWriter object that is being finalized.
- * @param[in,out]   bufHandle       A uintptr_t context value that was set by previous calls to the
- *                                  @p GetNewBuffer function.
- * @param[in,out]   bufStart        A pointer to the beginning of the current (and final) output buffer.
- * @param[in,out]   bufLen          The number of bytes contained in the buffer pointed to by @p bufStart.
- *
- * @retval #CHIP_NO_ERROR          If finalization was successful.
- * @retval other                    Other CHIP or platform-specific error codes indicating that an error
- *                                  occurred during finalization.
- *
- */
-
-/**
- * @var FinalizeBufferFunct TLVWriter::FinalizeBuffer
- *
- * A pointer to a function that will be called when the TLVWriter is finalized.
- *
- * A TLVWriter object will call the FinalizeBuffer function whenever its Finalize() method is
- * called. Applications can set the function pointer at any point prior to calling Finalize().
- * By default the pointer is set to NULL, which causes the Finalize() method to forego calling
- * the function.
- *
- * See the FinalizeBufferFunct type definition for additional information on implementing a
- * FinalizeBuffer function.
- */
-
-/**
- * Initializes a TLVWriter object to write into a single output buffer.
- *
- * @note Applications must call Finalize() on the writer before using the contents of the output
- * buffer.
- *
- * @param[in]   buf     A pointer to the buffer into which TLV should be written.
- * @param[in]   maxLen  The maximum number of bytes that should be written to the output buffer.
- *
- */
 NO_INLINE void TLVWriter::Init(uint8_t * buf, uint32_t maxLen)
 {
-    mBufHandle = 0;
+    mBackingStore = nullptr;
     mBufStart = mWritePoint = buf;
     mRemainingLen           = maxLen;
     mLenWritten             = 0;
@@ -181,30 +60,18 @@ NO_INLINE void TLVWriter::Init(uint8_t * buf, uint32_t maxLen)
     SetCloseContainerReserved(true);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer      = nullptr;
-    FinalizeBuffer    = nullptr;
 }
 
-/**
- * Initializes a TLVWriter object to write into a single PacketBuffer.
- *
- * Writing begins immediately after the last byte of existing data in the supplied buffer.
- *
- * @note If a chain of buffers is given, data will only be written to the first buffer.
- *
- * @note Applications must call Finalize() on the writer before using the contents of the buffer.
- *
- * @param[in]   buf     A pointer to an PacketBuffer into which TLV should be written.
- * @param[in]   maxLen  The maximum number of bytes that should be written to the output buffer.
- *
- */
-void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen)
+CHIP_ERROR TLVWriter::Init(TLVBackingStore & backingStore, uint32_t maxLen)
 {
-    mBufHandle = reinterpret_cast<uintptr_t>(buf);
-    mBufStart = mWritePoint = buf->Start() + buf->DataLength();
-    mRemainingLen           = buf->AvailableDataLength();
-    if (mRemainingLen > maxLen)
-        mRemainingLen = maxLen;
+    mBackingStore  = &backingStore;
+    mBufStart      = nullptr;
+    mRemainingLen  = 0;
+    CHIP_ERROR err = mBackingStore->OnInit(*this, mBufStart, mRemainingLen);
+    if (err != CHIP_NO_ERROR)
+        return err;
+
+    mWritePoint    = mBufStart;
     mLenWritten    = 0;
     mMaxLen        = maxLen;
     mContainerType = kTLVType_NotSpecified;
@@ -212,172 +79,29 @@ void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen)
     SetCloseContainerReserved(true);
 
     ImplicitProfileId = kProfileIdNotSpecified;
-    GetNewBuffer      = nullptr;
-    FinalizeBuffer    = FinalizePacketBuffer;
+    return CHIP_NO_ERROR;
 }
 
-/**
- * Initializes a TLVWriter object to write into one or more PacketBuffers
- *
- * Writing begins immediately after the last byte of existing data in the specified buffer. If
- * @p allowDiscontiguousBuffers is true, additional PacketBuffers will be allocated and chained to
- * the supplied buffer as needed to accommodate the amount of data written.  If the specified output
- * buffer is already the head of a chain of buffers, output will be written to the subsequent buffers
- * in the chain before any new buffers are allocated.
- *
- * @note Applications must call Finalize() on the writer before using the contents of the output
- * buffer(s).
- *
- * @param[in]   buf     A pointer to an PacketBuffer into which TLV data should be written.
- * @param[in]   maxLen  The maximum number of bytes that should be written to the output buffer(s).
- * @param[in]   allowDiscontiguousBuffers
- *                      If true, write data to a chain of PacketBuffers, allocating new buffers as
- *                      needed to store the data written.  If false, writing will fail with
- *                      CHIP_ERROR_BUFFER_TOO_SMALL if the written data exceeds the space available
- *                      in the initial output buffer.
- *
- */
-void TLVWriter::Init(PacketBuffer * buf, uint32_t maxLen, bool allowDiscontiguousBuffers)
-{
-    Init(buf, maxLen);
-
-    if (allowDiscontiguousBuffers)
-    {
-        GetNewBuffer = GetNewPacketBuffer;
-    }
-    else
-    {
-        GetNewBuffer = nullptr;
-    }
-}
-
-/**
- * Returns the total number of bytes written since the writer was initialized.
- *
- * @return Total number of bytes written since the writer was initialized.
- */
-uint32_t TLVWriter::GetLengthWritten()
-{
-    return mLenWritten;
-}
-
-/**
- * Finish the writing of a TLV encoding.
- *
- * The Finalize() method completes the process of writing a TLV encoding to the underlying output
- * buffer.  The method must be called by the application before it uses the contents of the buffer.
- * Finalize() can only be called when there are no container writers open for the current writer.
- * (See @p OpenContainer()).
- *
- * @retval #CHIP_NO_ERROR      If the encoding was finalized successfully.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              FinalizeBuffer() function.
- */
 CHIP_ERROR TLVWriter::Finalize()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     if (IsContainerOpen())
         return CHIP_ERROR_TLV_CONTAINER_OPEN;
-    if (FinalizeBuffer != nullptr)
-        err = FinalizeBuffer(*this, mBufHandle, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
+    if (mBackingStore != nullptr)
+        err = mBackingStore->FinalizeBuffer(*this, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
     return err;
 }
 
-/**
- * Encodes a TLV boolean value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutBoolean(uint64_t tag, bool v)
 {
     return WriteElementHead((v) ? TLVElementType::BooleanTrue : TLVElementType::BooleanFalse, tag, 0);
 }
 
-/**
- * Encodes a TLV unsigned integer value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag. Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-/**
- * Encodes a TLV unsigned integer value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- * @param[in]   preserveSize    True if the value should be encoded in the same number of bytes as
- *                              at the input type.  False if value should be encoded in the minimum
- *                              number of bytes necessary to represent the value.  Note: Applications
- *                              are strongly encouraged to set this parameter to false.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -385,17 +109,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -403,17 +121,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint16_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v)
 {
     return Put(tag, static_cast<uint64_t>(v));
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -421,9 +133,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint32_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v)
 {
     TLVElementType elemType;
@@ -438,9 +147,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v)
     return WriteElementHead(elemType, tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, uint8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -448,67 +154,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, uint64_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * Encodes a TLV signed integer value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-/**
- * Encodes a TLV signed integer value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- * @param[in]   preserveSize    True if the value should be encoded in the same number of bytes as
- *                              at the input type.  False if value should be encoded in the minimum
- *                              number of bytes necessary to represent the value.  Note: Applications
- *                              are strongly encouraged to set this parameter to false.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -516,17 +166,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -534,17 +178,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int16_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v)
 {
     return Put(tag, static_cast<int64_t>(v));
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -552,9 +190,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int32_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v)
 {
     TLVElementType elemType;
@@ -569,9 +204,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v)
     return WriteElementHead(elemType, tag, static_cast<uint64_t>(v));
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, int8_t v, bool preserveSize)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v, bool preserveSize)
 {
     if (preserveSize)
@@ -579,9 +211,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, int64_t v, bool preserveSize)
     return Put(tag, v);
 }
 
-/**
- * @overload CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, float v)
 {
     union
@@ -593,32 +222,6 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, float v)
     return WriteElementHead(TLVElementType::FloatingPointNumber32, tag, cvt.u32);
 }
 
-/**
- * Encodes a TLV floating point value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   v               The value to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
 {
     union
@@ -630,64 +233,11 @@ CHIP_ERROR TLVWriter::Put(uint64_t tag, double v)
     return WriteElementHead(TLVElementType::FloatingPointNumber64, tag, cvt.u64);
 }
 
-/**
- * Encodes a TLV byte string value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   buf             A pointer to a buffer containing the bytes string to be encoded.
- * @param[in]   len             The number of bytes to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutBytes(uint64_t tag, const uint8_t * buf, uint32_t len)
 {
     return WriteElementWithData(kTLVType_ByteString, tag, buf, len);
 }
 
-/**
- * Encodes a TLV UTF8 string value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   buf             A pointer to the null-terminated UTF-8 string to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf)
 {
     size_t len = strlen(buf);
@@ -698,82 +248,11 @@ CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf)
     return PutString(tag, buf, static_cast<uint32_t>(len));
 }
 
-/**
- * Encodes a TLV UTF8 string value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   buf             A pointer to the UTF-8 string to be encoded.
- * @param[in]   len             The length (in bytes) of the string to be encoded.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutString(uint64_t tag, const char * buf, uint32_t len)
 {
     return WriteElementWithData(kTLVType_UTF8String, tag, reinterpret_cast<const uint8_t *>(buf), len);
 }
 
-/**
- * @brief
- *   Encode the string output formatted according to the format in the TLV element.
- *
- * PutStringF is an analog of a sprintf where the output is stored in
- * a TLV element as opposed to a character buffer.  When extended
- * printf functionality is available, the function is able to output
- * the result string into a discontinuous underlying storage.  The
- * implementation supports the following printf enhancements:
- *
- * -- The platform supplies a callback-based `vcbprintf` that provides
- *    the ability to call a custom callback in place of putchar.
- *
- * -- The platform supplies a variant of `vsnprintf` called
- *    `vsnprintf_ex`, that behaves exactly like vsnprintf except it
- *    has provisions for omitting the first `n` characters of the
- *    output.
- *
- * Note that while the callback-based function may be the simplest and
- * use the least amount of code, the `vsprintf_ex` variety of
- * functions will consume less stack.
- *
- * If neither of the above is available, the function will allocate a
- * temporary buffer to hold the output, using Platform::MemoryAlloc().
- *
- * @param[in] tag The TLV tag to be encoded with the value, or @p
- *                AnonymousTag if the value should be encoded without
- *                a tag.  Tag values should be constructed with one of
- *                the tag definition functions ProfileTag(),
- *                ContextTag() or CommonTag().
- *
- * @param[in] fmt The format string used to format the argument list.
- *                Follows the same syntax and rules as the format
- *                string for `printf` family of functions.
- *
- * @param[in] ... A list of arguments to be formatted in the output value
- *                according to fmt.
- *
- * @retval #CHIP_NO_ERROR  If the method succeeded.
- *
- * @retval other If underlying calls to TLVWriter methods --
- *               `WriteElementHead` or `GetNewBuffer` -- failed, their
- *               error is immediately forwarded up the call stack.
- */
 CHIP_ERROR TLVWriter::PutStringF(uint64_t tag, const char * fmt, ...)
 {
     CHIP_ERROR err;
@@ -800,50 +279,6 @@ void TLVWriter::CHIPTLVWriterPutcharCB(uint8_t c, void * appState)
 }
 #endif
 
-/**
- * @brief
- *   Encode the string output formatted according to the format in the TLV element.
- *
- * PutStringF is an analog of a sprintf where the output is stored in
- * a TLV element as opposed to a character buffer.  When extended
- * printf functionality is available, the function is able to output
- * the result string into a discontinuous underlying storage.  The
- * implementation supports the following printf enhancements:
- *
- * -- The platform supplies a callback-based `vcbprintf` that provides
- *    the ability to call a custom callback in place of putchar.
- *
- * -- The platform supplies a variant of `vsnprintf` called
- *    `vsnprintf_ex`, that behaves exactly like vsnprintf except it
- *    has provisions for omitting the first `n` characters of the
- *    output.
- *
- * Note that while the callback-based function may be the simplest and
- * use the least amount of code, the `vsprintf_ex` variety of
- * functions will consume less stack.
- *
- * If neither of the above is available, the function will allocate a
- * temporary buffer to hold the output, using Platform::MemoryAlloc().
- *
- * @param[in] tag The TLV tag to be encoded with the value, or @p
- *                AnonymousTag if the value should be encoded without
- *                a tag.  Tag values should be constructed with one of
- *                the tag definition functions ProfileTag(),
- *                ContextTag() or CommonTag().
- *
- * @param[in] fmt The format string used to format the argument list.
- *                Follows the same syntax and rules as the format
- *                string for `printf` family of functions.
- *
- * @param[in] ap A list of arguments to be formatted in the output value
- *                according to fmt.
- *
- * @retval #CHIP_NO_ERROR  If the method succeeded.
- *
- * @retval other If underlying calls to TLVWriter methods --
- *               `WriteElementHead` or `GetNewBuffer` -- failed, their
- *               error is immediately forwarded up the call stack.
- */
 CHIP_ERROR TLVWriter::VPutStringF(uint64_t tag, const char * fmt, va_list ap)
 {
     va_list aq;
@@ -914,15 +349,12 @@ CHIP_ERROR TLVWriter::VPutStringF(uint64_t tag, const char * fmt, va_list ap)
         mLenWritten += writtenBytes;
         if (skipLen < dataLen)
         {
-            VerifyOrExit(GetNewBuffer != NULL, err = CHIP_ERROR_NO_MEMORY);
+            VerifyOrExit(mBackingStore != NULL, err = CHIP_ERROR_NO_MEMORY);
 
-            if (FinalizeBuffer != NULL)
-            {
-                err = FinalizeBuffer(*this, mBufHandle, mBufStart, mWritePoint - mBufStart);
-                SuccessOrExit(err);
-            }
+            err = mBackingStore->FinalizeBuffer(*this, mBufHandle, mBufStart, mWritePoint - mBufStart);
+            SuccessOrExit(err);
 
-            err = GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
+            err = mBackingStore->GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
             SuccessOrExit(err);
 
             mWritePoint = mBufStart;
@@ -959,131 +391,15 @@ exit:
     return err;
 }
 
-/**
- * Encodes a TLV null value.
- *
- * @param[in]   tag             The TLV tag to be encoded with the value, or @p AnonymousTag if the
- *                              value should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutNull(uint64_t tag)
 {
     return WriteElementHead(TLVElementType::Null, tag, 0);
 }
 
-/**
- * Copies a TLV element from a reader object into the writer.
- *
- * The CopyElement() method encodes a new TLV element whose type, tag and value are taken from a TLVReader
- * object. When the method is called, the supplied reader object is expected to be positioned on the
- * source TLV element. The newly encoded element will have the same type, tag and contents as the input
- * container.  If the supplied element is a TLV container (structure, array or path), the entire contents
- * of the container will be copied.
- *
- * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
- * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
- * other mode has undefined behavior.
- *
- * @param[in]   reader          A reference to a TLVReader object identifying a pre-encoded TLV
- *                              element that should be copied.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If the supplied reader is not positioned on an element.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_TLV_UNDERRUN
- *                              If the underlying TLV encoding associated with the supplied reader ended
- *                              prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                              If the supplied reader encountered an invalid or unsupported TLV element
- *                              type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the supplied reader encountered a TLV tag in an invalid context,
- *                              or if the supplied tag is invalid or inappropriate in the context in
- *                              which the new container is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
- *                              function associated with the reader object.
- *
- */
 CHIP_ERROR TLVWriter::CopyElement(TLVReader & reader)
 {
     return CopyElement(reader.GetTag(), reader);
 }
-
-/**
- * Copies a TLV element from a reader object into the writer.
- *
- * The CopyElement() method encodes a new TLV element whose type and value are taken from a TLVReader
- * object. When the method is called, the supplied reader object is expected to be positioned on the
- * source TLV element. The newly encoded element will have the same type and contents as the input
- * container, however the tag will be set to the specified argument.  If the supplied element is a
- * TLV container (structure, array or path), the entire contents of the container will be copied.
- *
- * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
- * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
- * other mode has undefined behavior.
- *
- * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                              the container should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   reader          A reference to a TLVReader object identifying a pre-encoded TLV
- *                              element whose type and value should be copied.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If the supplied reader is not positioned on an element.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_TLV_UNDERRUN
- *                              If the underlying TLV encoding associated with the supplied reader ended
- *                              prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                              If the supplied reader encountered an invalid or unsupported TLV element
- *                              type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the supplied reader encountered a TLV tag in an invalid context,
- *                              or if the supplied tag is invalid or inappropriate in the context in
- *                              which the new container is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
- *                              function associated with the reader object.
- *
- */
 
 const size_t kCHIPTLVCopyChunkSize = 16;
 
@@ -1130,56 +446,6 @@ exit:
     return err;
 }
 
-/**
- * Initializes a new TLVWriter object for writing the members of a TLV container element.
- *
- * The OpenContainer() method is used to write TLV container elements (structure, arrays or paths)
- * to an encoding.  The method takes the type and tag (if any) of the new container, and a reference
- * to a new writer object (the <em>container writer</em>) that will be initialized for the purpose
- * of writing the container's elements.  Applications write the members of the new container using
- * the container writer and then call CloseContainer() to complete the container encoding.
- *
- * While the container writer is open, applications must not make calls on or otherwise alter the state
- * of the parent writer.
- *
- * The container writer inherits various configuration properties from the parent writer.  These are:
- *
- * @li The implicit profile id (ImplicitProfileId)
- * @li The application data pointer (AppData)
- * @li The GetNewBuffer and FinalizeBuffer function pointers
- *
- * @note The StartContainer() method can be used as an alternative to OpenContainer() to write a
- * container element without initializing a new writer object.
- *
- * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                              the container should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
- *                              @p kTLVType_Array or @p kTLVType_Path.
- * @param[out]  containerWriter A reference to a TLVWriter object that will be initialized for
- *                              writing the members of the new container element. Any data
- *                              associated with the supplied object is overwritten.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE
- *                              If the value specified for containerType is incorrect.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWriter & containerWriter)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1202,7 +468,7 @@ CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWrit
         ExitNow();
     }
 
-    containerWriter.mBufHandle     = mBufHandle;
+    containerWriter.mBackingStore  = mBackingStore;
     containerWriter.mBufStart      = mBufStart;
     containerWriter.mWritePoint    = mWritePoint;
     containerWriter.mRemainingLen  = mRemainingLen;
@@ -1212,8 +478,6 @@ CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWrit
     containerWriter.SetContainerOpen(false);
     containerWriter.SetCloseContainerReserved(IsCloseContainerReserved());
     containerWriter.ImplicitProfileId = ImplicitProfileId;
-    containerWriter.GetNewBuffer      = GetNewBuffer;
-    containerWriter.FinalizeBuffer    = FinalizeBuffer;
 
     SetContainerOpen(true);
 
@@ -1221,38 +485,6 @@ exit:
     return err;
 }
 
-/**
- * Completes the writing of a TLV container after a call to OpenContainer().
- *
- * The CloseContainer() method restores the state of a parent TLVWriter object after a call to
- * OpenContainer().  For every call to OpenContainer() applications must make a corresponding
- * call to CloseContainer(), passing a reference to the same container writer to both methods.
- *
- * When CloseContainer() returns, applications may continue to use the parent writer to write
- * additional TLV elements that appear after the container element.  At this point the supplied
- * container writer should be considered 'de-initialized' and must not be used without
- * re-initialization.
- *
- * @param[in] containerWriter   A reference to the TLVWriter object that was supplied to the
- *                              OpenContainer() method.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If the supplied container writer is not in the correct state.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If another container writer has been opened on the supplied
- *                              container writer and not yet closed.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If completing the encoding of the container would exceed the
- *                              limit on the maximum number of bytes specified when the writer
- *                              was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack
- *                              of memory.
- * @retval other                Other CHIP or platform-specific errors returned by the
- *                              configured GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
 {
     if (!TLVTypeIsContainer(containerWriter.mContainerType))
@@ -1261,7 +493,7 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     if (containerWriter.IsContainerOpen())
         return CHIP_ERROR_TLV_CONTAINER_OPEN;
 
-    mBufHandle    = containerWriter.mBufHandle;
+    mBackingStore = containerWriter.mBackingStore;
     mBufStart     = containerWriter.mBufStart;
     mWritePoint   = containerWriter.mWritePoint;
     mRemainingLen = containerWriter.mRemainingLen;
@@ -1278,47 +510,6 @@ CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
     return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
 }
 
-/**
- * Begins encoding a new TLV container element.
- *
- * The StartContainer() method is used to write TLV container elements (structure, arrays or paths)
- * to an encoding.  The method takes the type and tag (if any) of the new container, and a reference
- * to a TLVType value which will be used to save the current context of the writer while it is being
- * used to write the container.
- *
- * Once the StartContainer() method returns, the application should use the current TLVWriter object to
- * write the elements of the container.  When finish, the application must call the EndContainer()
- * method to finish the encoding of the container.
- *
- * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                              the container should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
- *                              @p kTLVType_Array or @p kTLVType_Path.
- * @param[out]  outerContainerType
- *                              A reference to a TLVType value that will receive the context of the
- *                              writer.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE
- *                              If the value specified for containerType is incorrect.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::StartContainer(uint64_t tag, TLVType containerType, TLVType & outerContainerType)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1349,40 +540,6 @@ exit:
     return err;
 }
 
-/**
- * Completes the encoding of a TLV container element.
- *
- * The EndContainer() method completes the encoding of a TLV container element and restores the state
- * of a TLVWrite object after an earlier call to StartContainer().  For every call to StartContainer()
- * applications must make a corresponding call to EndContainer(), passing the TLVType value returned
- * by the StartContainer() call.  When EndContainer() returns, the writer object can be used to write
- * additional TLV elements that follow the container element.
- *
- * @note Any changes made to the configuration of the writer between the calls to StartContainer()
- * and EndContainer() are NOT undone by the call to EndContainer().  For example, a change to the
- * implicit profile id (@p ImplicitProfileId) will not be reversed when a container is ended.  Thus
- * it is the application's responsibility to adjust the configuration accordingly at the appropriate
- * times.
- *
- * @param[in] outerContainerType
- *                              The TLVType value that was returned by the StartContainer() method.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If a corresponding StartContainer() call was not made.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::EndContainer(TLVType outerContainerType)
 {
     if (!TLVTypeIsContainer(mContainerType))
@@ -1396,46 +553,6 @@ CHIP_ERROR TLVWriter::EndContainer(TLVType outerContainerType)
     return WriteElementHead(TLVElementType::EndOfContainer, AnonymousTag, 0);
 }
 
-/**
- * Encodes a TLV container element from a pre-encoded set of member elements
- *
- * The PutPreEncodedContainer() method encodes a new TLV container element (a structure, array or path)
- * containing a set of member elements taken from a pre-encoded buffer.  The input buffer is expected to
- * contain zero or more full-encoded TLV elements, with tags that conform to the rules associated with
- * the specified container type (e.g. structure members must have tags, while array members must not).
- *
- * The method encodes the entirety of the container element in one call.  When PutPreEncodedContainer()
- * returns, the writer object can be used to write additional TLV elements following the container element.
- *
- * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                              the container should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   containerType   The type of container to encode.  Must be one of @p kTLVType_Structure,
- *                              @p kTLVType_Array or @p kTLVType_Path.
- * @param[in]   data            A pointer to a buffer containing zero of more encoded TLV elements that
- *                              will become the members of the new container.
- * @param[in]   dataLen         The number of bytes in the @p data buffer.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_WRONG_TLV_TYPE
- *                              If the value specified for containerType is incorrect.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the specified tag value is invalid or inappropriate in the context
- *                              in which the value is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions.
- *
- */
 CHIP_ERROR TLVWriter::PutPreEncodedContainer(uint64_t tag, TLVType containerType, const uint8_t * data, uint32_t dataLen)
 {
     if (!TLVTypeIsContainer(containerType))
@@ -1448,107 +565,17 @@ CHIP_ERROR TLVWriter::PutPreEncodedContainer(uint64_t tag, TLVType containerType
     return WriteData(data, dataLen);
 }
 
-/**
- * Copies a TLV container element from TLVReader object
- *
- * The CopyContainer() encodes a new TLV container element by copying a pre-encoded container element
- * located at the current position of a TLVReader object. The method writes the entirety of the new
- * container element in one call, copying the container's type, tag and elements from the source
- * encoding. When the method returns, the writer object can be used to write additional TLV elements
- * following the container element.
- *
- * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
- * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
- * other mode has undefined behavior.
- *
- * @param[in]   container       A reference to a TLVReader object identifying the pre-encoded TLV
- *                              container to be copied.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If the supplied reader is not positioned on a container element.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_TLV_UNDERRUN
- *                              If the underlying TLV encoding associated with the supplied reader ended
- *                              prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                              If the supplied reader encountered an invalid or unsupported TLV element
- *                              type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the supplied reader encountered a TLV tag in an invalid context,
- *                              or if the tag associated with the source container is invalid or
- *                              inappropriate in the context in which the new container is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
- *                              function associated with the reader object.
- *
- */
 CHIP_ERROR TLVWriter::CopyContainer(TLVReader & container)
 {
     return CopyContainer(container.GetTag(), container);
 }
 
-/**
- * Encodes a TLV container element from a pre-encoded set of member elements
- *
- * The CopyContainer() method encodes a new TLV container element (a structure, array or path)
- * containing a set of member elements taken from a TLVReader object. When the method is called, the
- * supplied reader object is expected to be positioned on a TLV container element. The newly encoded
- * container will have the same type and members as the input container.  The tag for the new
- * container is specified as an input parameter.
- *
- * When the method returns, the writer object can be used to write additional TLV elements following
- * the container element.
- *
- * @note This method requires the supplied TVLReader object to be reading from a single, contiguous
- * input buffer that contains the entirety of the underlying TLV encoding. Supplying a reader in any
- * other mode has undefined behavior.
- *
- * @param[in]   tag             The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                              the container should be encoded without a tag.  Tag values should be
- *                              constructed with one of the tag definition functions ProfileTag(),
- *                              ContextTag() or CommonTag().
- * @param[in]   container       A reference to a TLVReader object identifying a pre-encoded TLV
- *                              container whose type and members should be copied.
- *
- * @retval #CHIP_NO_ERROR      If the method succeeded.
- * @retval #CHIP_ERROR_INCORRECT_STATE
- *                              If the supplied reader is not positioned on a container element.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                              If a container writer has been opened on the current writer and not
- *                              yet closed.
- * @retval #CHIP_ERROR_TLV_UNDERRUN
- *                              If the underlying TLV encoding associated with the supplied reader ended
- *                              prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                              If the supplied reader encountered an invalid or unsupported TLV element
- *                              type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                              If the supplied reader encountered a TLV tag in an invalid context,
- *                              or if the supplied tag is invalid or inappropriate in the context in
- *                              which the new container is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                              If writing the value would exceed the limit on the maximum number of
- *                              bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                              If an attempt to allocate an output buffer failed due to lack of
- *                              memory.
- * @retval other                Other CHIP or platform-specific errors returned by the configured
- *                              GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
- *                              function associated with the reader object.
- *
- */
 CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, TLVReader & container)
 {
     // NOTE: This function MUST be used with a TVLReader that is reading from a contiguous buffer.
+    if (container.mBackingStore != nullptr)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+
     CHIP_ERROR err;
     TLVType containerType, outerContainerType;
     const uint8_t * containerStart;
@@ -1569,49 +596,6 @@ CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, TLVReader & container)
                                   static_cast<uint32_t>(container.GetReadPoint() - containerStart));
 }
 
-/**
- * Encodes a TLV container element that contains member elements from a pre-encoded container
- *
- * The CopyContainer() method encodes a new TLV container element (a structure, array or path)
- * containing a set of member elements taken from the contents of a supplied pre-encoded container.
- * When the method is called, data in the supplied input buffer is parsed as a TLV container element
- * an a new container is written that has the same type and members as the input container.  The tag
- * for the new container is specified as an input parameter.
- *
- * When the method returns, the writer object can be used to write additional TLV elements following
- * the container element.
- *
- * @param[in] tag                   The TLV tag to be encoded with the container, or @p AnonymousTag if
- *                                  the container should be encoded without a tag.  Tag values should be
- *                                  constructed with one of the tag definition functions ProfileTag(),
- *                                  ContextTag() or CommonTag().
- * @param[in] encodedContainer      A buffer containing a pre-encoded TLV container whose type and members
- *                                  should be copied.
- * @param[in] encodedContainerLen   The length in bytes of the pre-encoded container.
- *
- * @retval #CHIP_NO_ERROR          If the method succeeded.
- * @retval #CHIP_ERROR_TLV_CONTAINER_OPEN
- *                                  If a container writer has been opened on the current writer and not
- *                                  yet closed.
- * @retval #CHIP_ERROR_TLV_UNDERRUN
- *                                  If the encoded container ended prematurely.
- * @retval #CHIP_ERROR_INVALID_TLV_ELEMENT
- *                                  If the encoded container contained an invalid or unsupported TLV element type.
- * @retval #CHIP_ERROR_INVALID_TLV_TAG
- *                                  If the encoded container contained a TLV tag in an invalid context,
- *                                  or if the supplied tag is invalid or inappropriate in the context in
- *                                  which the new container is being written.
- * @retval #CHIP_ERROR_BUFFER_TOO_SMALL
- *                                  If writing the value would exceed the limit on the maximum number of
- *                                  bytes specified when the writer was initialized.
- * @retval #CHIP_ERROR_NO_MEMORY
- *                                  If an attempt to allocate an output buffer failed due to lack of
- *                                  memory.
- * @retval other                    Other CHIP or platform-specific errors returned by the configured
- *                                  GetNewBuffer() or FinalizeBuffer() functions, or by the GetNextBuffer()
- *                                  function associated with the reader object.
- *
- */
 CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen)
 {
     CHIP_ERROR err;
@@ -1627,21 +611,6 @@ CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, const uint8_t * encodedContain
 
 exit:
     return err;
-}
-
-/**
- * Returns the type of container within which the TLVWriter is currently writing.
- *
- * The GetContainerType() method returns the type of the TLV container within which the TLVWriter
- * is currently writing.  If the TLVWriter is not writing elements within a container (i.e. if writing
- * at the outer-most level of an encoding) the method returns kTLVType_NotSpecified.
- *
- * @return  The TLVType of the current container, or kTLVType_NotSpecified if the TLVWriter is not
- *          writing elements within a container.
- */
-TLVType TLVWriter::GetContainerType() const
-{
-    return mContainerType;
 }
 
 CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, uint64_t lenOrVal)
@@ -1797,16 +766,13 @@ CHIP_ERROR TLVWriter::WriteData(const uint8_t * p, uint32_t len)
     {
         if (mRemainingLen == 0)
         {
-            VerifyOrExit(GetNewBuffer != nullptr, err = CHIP_ERROR_NO_MEMORY);
+            VerifyOrExit(mBackingStore != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-            if (FinalizeBuffer != nullptr)
-            {
-                VerifyOrExit(CanCastTo<uint32_t>(mWritePoint - mBufStart), err = CHIP_ERROR_INCORRECT_STATE);
-                err = FinalizeBuffer(*this, mBufHandle, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
-                SuccessOrExit(err);
-            }
+            VerifyOrExit(CanCastTo<uint32_t>(mWritePoint - mBufStart), err = CHIP_ERROR_INCORRECT_STATE);
+            err = mBackingStore->FinalizeBuffer(*this, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
+            SuccessOrExit(err);
 
-            err = GetNewBuffer(*this, mBufHandle, mBufStart, mRemainingLen);
+            err = mBackingStore->GetNewBuffer(*this, mBufStart, mRemainingLen);
             SuccessOrExit(err);
 
             mWritePoint = mBufStart;
@@ -1829,74 +795,6 @@ CHIP_ERROR TLVWriter::WriteData(const uint8_t * p, uint32_t len)
 
 exit:
     return err;
-}
-
-/**
- * An implementation of a TLVWriter GetNewBuffer function for writing to a chain of PacketBuffers.
- *
- * The GetNewPacketBuffer() function supplies new output space to a TLVWriter by allocating a chain
- * of one or more PacketBuffers as needed to store the encoding.  The function is designed to be
- * assigned to the TLVWriter GetNewBuffer function pointer.
- *
- * Note that when using the GetNewPacketBuffer with a TLVWriter, the corresponding FinalizePacketBuffer()
- * function (or an equivalent) should also be used to finalize the buffer chain.
- *
- * See the GetNewBufferFunct type definition for additional information on the API of the
- * GetNewPacketBuffer() function.
- */
-CHIP_ERROR TLVWriter::GetNewPacketBuffer(TLVWriter & writer, uintptr_t & bufHandle, uint8_t *& bufStart, uint32_t & bufLen)
-{
-    PacketBuffer * buf = reinterpret_cast<PacketBuffer *>(bufHandle);
-
-    PacketBuffer * newBuf = buf->Next_ForNow();
-    if (newBuf == nullptr)
-    {
-        System::PacketBufferHandle newBufHandle = PacketBuffer::New(0);
-        if (!newBufHandle.IsNull())
-        {
-            newBuf = newBufHandle.Get_ForNow();
-            buf->AddToEnd(std::move(newBufHandle));
-        }
-    }
-
-    if (newBuf != nullptr)
-    {
-        bufHandle = reinterpret_cast<uintptr_t>(newBuf);
-        bufStart  = newBuf->Start();
-        bufLen    = newBuf->MaxDataLength();
-    }
-    else
-    {
-        bufStart = nullptr;
-        bufLen   = 0;
-    }
-
-    return CHIP_NO_ERROR;
-}
-
-/**
- * An implementation of a TLVWriter FinalizeBuffer function for writing to a chain of PacketBuffers.
- *
- * The FinalizePacketBuffer() function performs the necessary finalization required when using a
- * TLVWriter to write to a chain of PacketBuffers.  The function is designed to be used in conjunction
- * with the GetNewPacketBuffer() function.
- *
- * See the FinalizeBufferFunct type definition for additional information on the API of the
- * FinalizePacketBuffer() function.
- */
-CHIP_ERROR TLVWriter::FinalizePacketBuffer(TLVWriter & writer, uintptr_t bufHandle, uint8_t * bufStart, uint32_t dataLen)
-{
-    PacketBuffer * buf = reinterpret_cast<PacketBuffer *>(bufHandle);
-    uint8_t * endPtr   = bufStart + dataLen;
-
-    intptr_t length = endPtr - buf->Start();
-    if (!CanCastTo<uint16_t>(length))
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-    buf->SetDataLength(static_cast<uint16_t>(length));
-
-    return CHIP_NO_ERROR;
 }
 
 } // namespace TLV

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -38,6 +38,8 @@
 #include <support/RandUtils.h>
 #include <support/ScopedBuffer.h>
 #include <support/UnitTestRegistration.h>
+
+#include <system/TLVPacketBufferBackingStore.h>
 
 #include <string.h>
 
@@ -252,9 +254,11 @@ void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, uint64_t tag, const
     NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen) == 0);
 }
 
-void TestBufferContents(nlTestSuite * inSuite, PacketBuffer * buf, const uint8_t * expectedVal, uint32_t expectedLen)
+void TestBufferContents(nlTestSuite * inSuite, const System::PacketBufferHandle & buffer, const uint8_t * expectedVal,
+                        uint32_t expectedLen)
 {
-    while (buf != nullptr)
+    System::PacketBufferHandle buf = buffer.Retain();
+    while (!buf.IsNull())
     {
         uint16_t len = buf->DataLength();
         NL_TEST_ASSERT(inSuite, len <= expectedLen);
@@ -264,7 +268,7 @@ void TestBufferContents(nlTestSuite * inSuite, PacketBuffer * buf, const uint8_t
         expectedVal += len;
         expectedLen -= len;
 
-        buf = buf->Next_ForNow();
+        buf.Advance();
     }
 
     NL_TEST_ASSERT(inSuite, expectedLen == 0);
@@ -639,7 +643,8 @@ void WriteEncoding3(nlTestSuite * inSuite, TLVWriter & writer)
         TLVWriter writer1;
 
         err = writer.OpenContainer(ProfileTag(TestProfile_1, 1), kTLVType_Structure, writer1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        if (err)
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
         err = writer1.PutBoolean(ProfileTag(TestProfile_2, 2), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -1943,23 +1948,23 @@ void WriteDeleteReadTest(nlTestSuite * inSuite)
  */
 void CheckPacketBuffer(nlTestSuite * inSuite, void * inContext)
 {
-    System::PacketBufferHandle buf = PacketBuffer::New(0);
-    TLVWriter writer;
-    TLVReader reader;
+    System::PacketBufferHandle buf = System::PacketBuffer::New(0);
+    System::PacketBufferTLVWriter writer;
+    System::PacketBufferTLVReader reader;
 
-    writer.Init(buf.Get_ForNow());
+    writer.Init(buf.Retain());
     writer.ImplicitProfileId = TestProfile_2;
 
     WriteEncoding1(inSuite, writer);
 
-    TestBufferContents(inSuite, buf.Get_ForNow(), Encoding1, sizeof(Encoding1));
+    TestBufferContents(inSuite, buf, Encoding1, sizeof(Encoding1));
 
-    reader.Init(buf.Get_ForNow());
+    reader.Init(buf.Retain());
     reader.ImplicitProfileId = TestProfile_2;
 
     ReadEncoding1(inSuite, reader);
 
-    reader.Init(buf.Get_ForNow(), buf->MaxDataLength(), false);
+    reader.Init(buf.Retain(), buf->MaxDataLength());
     reader.ImplicitProfileId = TestProfile_2;
 
     ReadEncoding1(inSuite, reader);
@@ -1995,7 +2000,7 @@ void CheckCircularTLVBufferSimple(nlTestSuite * inSuite, void * inContext)
     CircularTLVReader reader;
     TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     CHIPCircularTLVBuffer buffer(backingStore, 30);
-    writer.Init(&buffer);
+    writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
@@ -2018,7 +2023,7 @@ void CheckCircularTLVBufferSimple(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) == writer.GetLengthWritten());
 
     // At this point the buffer should contain 2 instances of Encoding3.
-    reader.Init(&buffer);
+    reader.Init(buffer);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2045,7 +2050,7 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite * inSuite, void * inContext)
     CircularTLVReader reader;
     TestTLVContext * context = static_cast<TestTLVContext *>(inContext);
     CHIPCircularTLVBuffer buffer(backingStore, 30, &(backingStore[15]));
-    writer.Init(&buffer);
+    writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
@@ -2068,7 +2073,7 @@ void CheckCircularTLVBufferStartMidway(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) == writer.GetLengthWritten());
 
     // At this point the buffer should contain 2 instances of Encoding3.
-    reader.Init(&buffer);
+    reader.Init(buffer);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2096,7 +2101,7 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite * inSuite, void * in
     CircularTLVWriter writer;
     CircularTLVReader reader;
     CHIPCircularTLVBuffer buffer(backingStore, 30);
-    writer.Init(&buffer);
+    writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
@@ -2132,7 +2137,7 @@ void CheckCircularTLVBufferEvictStraddlingEvent(nlTestSuite * inSuite, void * in
     NL_TEST_ASSERT(inSuite, context->mEvictionCount == 7);
 
     // At this point the buffer should contain 2 instances of Encoding3.
-    reader.Init(&buffer);
+    reader.Init(buffer);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2159,7 +2164,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
 
     CHIPCircularTLVBuffer buffer(backingStore, sizeof(backingStore));
     CHIPCircularTLVBuffer buffer1(backingStore1, sizeof(backingStore1));
-    writer.Init(&buffer);
+    writer.Init(buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
@@ -2178,7 +2183,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     // At this point the buffer should contain only the boolean we just wrote
-    reader.Init(&buffer);
+    reader.Init(buffer);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2202,7 +2207,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     int i = 0;
     for (i = 0; i < 2; i++)
     {
-        writer.Init(&buffer1);
+        writer.Init(buffer1);
         writer.ImplicitProfileId = TestProfile_2;
 
         err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -2211,7 +2216,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
         err = writer.Finalize();
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-        reader.Init(&buffer1);
+        reader.Init(buffer1);
         reader.ImplicitProfileId = TestProfile_2;
 
         TestNext<TLVReader>(inSuite, reader);
@@ -2220,12 +2225,12 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
 
         buffer1.EvictHead();
 
-        reader.Init(&buffer1);
+        reader.Init(buffer1);
         reader.ImplicitProfileId = TestProfile_2;
         TestEnd<TLVReader>(inSuite, reader);
     }
 
-    writer.Init(&buffer1);
+    writer.Init(buffer1);
     writer.ImplicitProfileId = TestProfile_2;
 
     context->mEvictionCount = 0;
@@ -2244,7 +2249,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     err = writer.Finalize();
 
     // Verify that we can read out two elements from the buffer
-    reader.Init(&buffer1);
+    reader.Init(buffer1);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2260,7 +2265,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     buffer1.EvictHead();
 
     // At this point the buffer should contain only the second boolean
-    reader.Init(&buffer1);
+    reader.Init(buffer1);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2271,7 +2276,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
 
     // Write another boolean, verify that the buffer is full and contains two booleans
 
-    writer.Init(&buffer1);
+    writer.Init(buffer1);
     writer.ImplicitProfileId = TestProfile_2;
 
     err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -2281,7 +2286,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Verify that we can read out two elements from the buffer
-    reader.Init(&buffer1);
+    reader.Init(buffer1);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
@@ -2298,7 +2303,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     buffer1.EvictHead();
     buffer1.EvictHead();
 
-    reader.Init(&buffer1);
+    reader.Init(buffer1);
     reader.ImplicitProfileId = TestProfile_2;
 
     TestEnd<TLVReader>(inSuite, reader);
@@ -2347,7 +2352,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite * inSuite, void * inContext)
 
     // Initial test: Verify that a straight printf works as expected into continuous buffer.
 
-    writer.Init(&buffer);
+    writer.Init(buffer);
     snprintf(strBuffer, sizeof(strBuffer), "Sample string %zu", num);
 
     err = writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
@@ -2362,7 +2367,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite * inSuite, void * inContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    reader.Init(&buffer);
+    reader.Init(buffer);
 
     // Skip over the initial element
     err = reader.Next();
@@ -2388,7 +2393,7 @@ void CheckCHIPTLVPutStringFCircular(nlTestSuite * inSuite, void * inContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    reader.Init(&buffer);
+    reader.Init(buffer);
     err = reader.Next();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -2409,7 +2414,7 @@ void CheckCHIPTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
     CHIPCircularTLVBuffer buffer(backingStore, bufsize);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    writer.Init(&buffer);
+    writer.Init(buffer);
 
     err = writer.PutString(AnonymousTag, testString);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -2426,7 +2431,7 @@ void CheckCHIPTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
     err = writer.Finalize();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    reader.Init(&buffer);
+    reader.Init(buffer);
 
     err = reader.Next(); // position the reader at the straddling element
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -2440,10 +2445,10 @@ void CheckCHIPTLVSkipCircular(nlTestSuite * inSuite, void * inContext)
  */
 void CheckBufferOverflow(nlTestSuite * inSuite, void * inContext)
 {
-    TLVWriter writer;
-    TLVReader reader;
+    System::PacketBufferTLVWriter writer;
+    System::PacketBufferTLVReader reader;
 
-    System::PacketBufferHandle buf = PacketBuffer::New(0);
+    System::PacketBufferHandle buf = System::PacketBuffer::New(0);
     uint16_t maxDataLen            = buf->MaxDataLength();
     uint16_t reserve = static_cast<uint16_t>((sizeof(Encoding1) < maxDataLen) ? (maxDataLen - sizeof(Encoding1)) + 2 : 0);
 
@@ -2454,20 +2459,19 @@ void CheckBufferOverflow(nlTestSuite * inSuite, void * inContext)
     {
         buf->SetStart(buf->Start() + reserve);
 
-        writer.Init(buf.Get_ForNow());
-        writer.GetNewBuffer      = TLVWriter::GetNewPacketBuffer;
+        writer.Init(buf.Retain(), /* useChainedBuffers = */ true);
         writer.ImplicitProfileId = TestProfile_2;
 
         WriteEncoding1(inSuite, writer);
 
-        TestBufferContents(inSuite, buf.Get_ForNow(), Encoding1, sizeof(Encoding1));
+        TestBufferContents(inSuite, buf, Encoding1, sizeof(Encoding1));
 
-        reader.Init(buf.Get_ForNow(), 0xFFFFFFFFUL, true);
+        reader.Init(buf.Retain(), /* useChainedBuffers = */ true);
         reader.ImplicitProfileId = TestProfile_2;
 
         ReadEncoding1(inSuite, reader);
 
-        buf = PacketBuffer::New(0);
+        buf = System::PacketBuffer::New(0);
     }
 }
 

--- a/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
+++ b/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
@@ -306,12 +306,12 @@ void NetworkProvisioningServerImpl::HandleScanDone()
         }
         err = writer.EndContainer(outerContainerType);
         SuccessOrExit(err);
-        err = writer.Finalize();
+        err = writer.Finalize(&respBuf);
         SuccessOrExit(err);
 
         // Send the scan results to the requestor.  Note that this method takes ownership of the
         // buffer, success or fail.
-        err = SendNetworkScanComplete(encodedResultCount, writerStore.Release());
+        err = SendNetworkScanComplete(encodedResultCount, std::move(respBuf));
         SuccessOrExit(err);
     }
 

--- a/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
+++ b/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
@@ -25,6 +25,7 @@
 #include <core/CHIPTLV.h>
 #include <platform/ESP32/ESP32Utils.h>
 #include <platform/internal/DeviceNetworkInfo.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 #include "esp_event.h"
 #include "esp_wifi.h"
@@ -262,7 +263,7 @@ void NetworkProvisioningServerImpl::HandleScanDone()
     // If the ScanNetworks request is still outstanding...
     if (GetCurrentOp() == kMsgType_ScanNetworks)
     {
-        chip::TLV::TLVWriter writer;
+        System::PacketBufferTLVWriter writer;
         TLVType outerContainerType;
 
         // Sort results by rssi.
@@ -274,7 +275,7 @@ void NetworkProvisioningServerImpl::HandleScanDone()
 
         // Encode the list of scan results into the response buffer.  If the encoded size of all
         // the results exceeds the size of the buffer, encode only what will fit.
-        writer.Init(respBuf.Get_ForNow(), respBuf->AvailableDataLength() - 1);
+        writer.Init(std::move(respBuf));
         err = writer.StartContainer(AnonymousTag, kTLVType_Array, outerContainerType);
         SuccessOrExit(err);
         for (encodedResultCount = 0; encodedResultCount < scanResultCount; encodedResultCount++)
@@ -310,7 +311,7 @@ void NetworkProvisioningServerImpl::HandleScanDone()
 
         // Send the scan results to the requestor.  Note that this method takes ownership of the
         // buffer, success or fail.
-        err = SendNetworkScanComplete(encodedResultCount, std::move(respBuf));
+        err = SendNetworkScanComplete(encodedResultCount, writerStore.Release());
         SuccessOrExit(err);
     }
 

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -1293,10 +1293,10 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     err = writer.CloseContainer(innerWriter);
     SuccessOrExit(err);
 
-    writer.Finalize();
+    err = writer.Finalize(&bufferHandle);
+    SuccessOrExit(err);
 
-    bufferHandle = writer.Release();
-    cValue       = g_variant_new_from_data(G_VARIANT_TYPE("ay"), bufferHandle->Start(), bufferHandle->DataLength(), TRUE, g_free,
+    cValue = g_variant_new_from_data(G_VARIANT_TYPE("ay"), bufferHandle->Start(), bufferHandle->DataLength(), TRUE, g_free,
                                      g_memdup(bufferHandle->Start(), bufferHandle->DataLength()));
     bluez_gatt_characteristic1_set_value(characteristic, cValue);
 

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -65,6 +65,7 @@
 
 #include "CHIPBluezHelper.h"
 #include <support/CodeUtils.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 using namespace ::nl;
 using namespace chip::SetupPayload;
@@ -1276,12 +1277,11 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     // Construct the TLV for the additional data
     GVariant * cValue = nullptr;
     CHIP_ERROR err    = CHIP_NO_ERROR;
-    TLVWriter writer;
+    System::PacketBufferTLVWriter writer;
     TLVWriter innerWriter;
-    chip::System::PacketBufferHandle bufferHandle = chip::System::PacketBuffer::New();
-    chip::System::PacketBuffer * buffer           = bufferHandle.Get_ForNow();
+    chip::System::PacketBufferHandle bufferHandle;
 
-    writer.Init(buffer);
+    writer.Init(chip::System::PacketBuffer::New());
 
     err = writer.OpenContainer(AnonymousTag, kTLVType_Structure, innerWriter);
     SuccessOrExit(err);
@@ -1295,8 +1295,9 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
 
     writer.Finalize();
 
-    cValue = g_variant_new_from_data(G_VARIANT_TYPE("ay"), buffer->Start(), buffer->DataLength(), TRUE, g_free,
-                                     g_memdup(buffer->Start(), buffer->DataLength()));
+    bufferHandle = writer.Release();
+    cValue       = g_variant_new_from_data(G_VARIANT_TYPE("ay"), bufferHandle->Start(), bufferHandle->DataLength(), TRUE, g_free,
+                                     g_memdup(bufferHandle->Start(), bufferHandle->DataLength()));
     bluez_gatt_characteristic1_set_value(characteristic, cValue);
 
     return;

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Project CHIP Authors
+# Copyright (c) 2020-2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,6 +140,8 @@ static_library("system") {
     "SystemTimer.h",
     "SystemWakeEvent.cpp",
     "SystemWakeEvent.h",
+    "TLVPacketBufferBackingStore.cpp",
+    "TLVPacketBufferBackingStore.h",
     "TimeSource.h",
   ]
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -308,9 +308,6 @@ public:
      */
     static PacketBufferHandle New();
 
-    // DO NOT USE. This is present only for existing TLV code that has not yet been converted, and will be removed soon.
-    PacketBuffer * Next_ForNow() const { return ChainedBuffer(); }
-
     // DO NOT USE. Will be made private after #4094 merges.
     void AddRef();
 
@@ -583,7 +580,7 @@ public:
      *
      *  @note This differs from `FreeHead()` in that it does not touch any content in the currently referenced packet buffer;
      *      it only changes which buffer this handle owns. (Note that this could result in the previous buffer being freed,
-     *      if there is no other.) `Advance()` is designed to be used with an addition handle to traverse a buffer chain,
+     *      if there is no other owner.) `Advance()` is designed to be used with an additional handle to traverse a buffer chain,
      *      whereas `FreeHead()` modifies a chain.
      */
     void Advance() { *this = Hold(mBuffer->ChainedBuffer()); }
@@ -598,11 +595,6 @@ public:
      */
     struct pbuf * GetLwIPpbuf() { return static_cast<struct pbuf *>(mBuffer); }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-    // DO NOT USE. This is intended to be used only to call existing TLV::Init() functions that have not yet been converted
-    // to take a PacketBufferHandle, and will be removed soon.
-    // The caller has access but no ownership.
-    PacketBuffer * Get_ForNow() const { return mBuffer; }
 
     /**
      * Creates a copy of the data in this packet.

--- a/src/system/TLVPacketBufferBackingStore.cpp
+++ b/src/system/TLVPacketBufferBackingStore.cpp
@@ -1,0 +1,117 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file contains an implementation of TLVBackingStore using PacketBuffers.
+ */
+
+#include <system/TLVPacketBufferBackingStore.h>
+
+#include <support/SafeInt.h>
+
+namespace chip {
+namespace System {
+
+CHIP_ERROR TLVPacketBufferBackingStore::OnInit(chip::TLV::TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen)
+{
+    bufStart = mHeadBuffer->Start();
+    bufLen   = mHeadBuffer->DataLength();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TLVPacketBufferBackingStore::GetNextBuffer(chip::TLV::TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen)
+{
+    if (mUseChainedBuffers)
+    {
+        mCurrentBuffer.Advance();
+    }
+    else
+    {
+        mCurrentBuffer = nullptr;
+    }
+
+    if (mCurrentBuffer.IsNull())
+    {
+        bufStart = nullptr;
+        bufLen   = 0;
+    }
+    else
+    {
+        bufStart = mCurrentBuffer->Start();
+        bufLen   = mCurrentBuffer->DataLength();
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TLVPacketBufferBackingStore::OnInit(chip::TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
+{
+    bufStart = mHeadBuffer->Start() + mHeadBuffer->DataLength();
+    bufLen   = mHeadBuffer->AvailableDataLength();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TLVPacketBufferBackingStore::FinalizeBuffer(chip::TLV::TLVWriter & writer, uint8_t * bufStart, uint32_t dataLen)
+{
+    uint8_t * endPtr = bufStart + dataLen;
+
+    intptr_t length = endPtr - mCurrentBuffer->Start();
+    if (!CanCastTo<uint16_t>(length))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    mCurrentBuffer->SetDataLength(static_cast<uint16_t>(length));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TLVPacketBufferBackingStore::GetNewBuffer(chip::TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen)
+{
+    if (!mUseChainedBuffers)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    mCurrentBuffer.Advance();
+    if (mCurrentBuffer.IsNull())
+    {
+        mCurrentBuffer = PacketBuffer::New(0);
+        if (mCurrentBuffer.IsNull())
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+        mHeadBuffer->AddToEnd(mCurrentBuffer.Retain());
+    }
+
+    if (mCurrentBuffer.IsNull())
+    {
+        bufStart = nullptr;
+        bufLen   = 0;
+    }
+    else
+    {
+        bufStart = mCurrentBuffer->Start();
+        bufLen   = mCurrentBuffer->MaxDataLength();
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace System
+} // namespace chip

--- a/src/system/TLVPacketBufferBackingStore.h
+++ b/src/system/TLVPacketBufferBackingStore.h
@@ -150,11 +150,7 @@ public:
      *
      * @note No further TLV operations may be performed, unless or until this PacketBufferTLVWriter is re-initialized.
      */
-// TODO: pragmas can be removed after PR #4301
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
     void Reset() { static_cast<void>(mBackingStore.Release()); }
-#pragma GCC diagnostic pop
 
 private:
     CHIP_ERROR Finalize() { return chip::TLV::TLVWriter::Finalize(); }

--- a/src/system/TLVPacketBufferBackingStore.h
+++ b/src/system/TLVPacketBufferBackingStore.h
@@ -1,0 +1,140 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file contains an implementation of TLVBackingStore using PacketBuffers.
+ */
+
+#pragma once
+
+#include <core/CHIPTLV.h>
+#include <system/SystemPacketBuffer.h>
+
+#include <utility>
+
+namespace chip {
+namespace System {
+
+/**
+ * An implementation of TLVBackingStore using PacketBuffers.
+ */
+class TLVPacketBufferBackingStore : public chip::TLV::TLVBackingStore
+{
+public:
+    TLVPacketBufferBackingStore() : mHeadBuffer(nullptr), mCurrentBuffer(nullptr), mUseChainedBuffers(false) {}
+    TLVPacketBufferBackingStore(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    {
+        Init(std::move(buffer), useChainedBuffers);
+    }
+    virtual ~TLVPacketBufferBackingStore() {}
+
+    /**
+     * Take ownership of a backing packet buffer.
+     *
+     * @param[in]    buffer  A handle to PacketBuffer, to be used as backing store for a TLV class.
+     * @param[in]    useChainedBuffers
+     *                       If true, advance to the next buffer in the chain once all data or space
+     *                       in the current buffer has been consumed; a write will allocate new
+     *                       PacketBuffers if necessary.
+     *
+     * @note This must take place before initializing a TLV class with this backing store.
+     */
+    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    {
+        mHeadBuffer        = std::move(buffer);
+        mCurrentBuffer     = mHeadBuffer.Retain();
+        mUseChainedBuffers = useChainedBuffers;
+    }
+    void Adopt(chip::System::PacketBufferHandle buffer) { Init(std::move(buffer), mUseChainedBuffers); }
+
+    /**
+     * Release ownership of the backing packet buffer.
+     *
+     * @note TLV operations must no longer be performed on this store.
+     */
+    chip::System::PacketBufferHandle Release()
+    {
+        mCurrentBuffer = nullptr;
+        return std::move(mHeadBuffer);
+    }
+
+    // TLVBackingStore overrides:
+    CHIP_ERROR OnInit(chip::TLV::TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR GetNextBuffer(chip::TLV::TLVReader & reader, const uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR OnInit(chip::TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR GetNewBuffer(chip::TLV::TLVWriter & writer, uint8_t *& bufStart, uint32_t & bufLen) override;
+    CHIP_ERROR FinalizeBuffer(chip::TLV::TLVWriter & writer, uint8_t * bufStart, uint32_t bufLen) override;
+
+protected:
+    chip::System::PacketBufferHandle mHeadBuffer;
+    chip::System::PacketBufferHandle mCurrentBuffer;
+    bool mUseChainedBuffers;
+};
+
+class DLL_EXPORT PacketBufferTLVReader : public chip::TLV::TLVReader
+{
+public:
+    /**
+     * Initializes a TLVReader object to read from a PacketBuffer.
+     *
+     * @param[in]    buffer  A handle to PacketBuffer, to be used as backing store for a TLV class.
+     * @param[in]    useChainedBuffers
+     *                       If true, advance to the next buffer in the chain once all data
+     *                       in the current buffer has been consumed.
+     */
+    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    {
+        mBackingStore.Init(std::move(buffer), useChainedBuffers);
+        chip::TLV::TLVReader::Init(mBackingStore);
+    }
+
+private:
+    TLVPacketBufferBackingStore mBackingStore;
+};
+
+class DLL_EXPORT PacketBufferTLVWriter : public chip::TLV::TLVWriter
+{
+public:
+    /**
+     * Initializes a TLVWriter object to write to a PacketBuffer.
+     *
+     * @param[in]    buffer  A handle to PacketBuffer, to be used as backing store for a TLV class.
+     * @param[in]    useChainedBuffers
+     *                       If true, advance to the next buffer in the chain once all space
+     *                       in the current buffer has been consumed. Once all existing buffers
+     *                       have been used, new PacketBuffers will be allocated as necessary.
+     */
+    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    {
+        mBackingStore.Init(std::move(buffer), useChainedBuffers);
+        chip::TLV::TLVWriter::Init(mBackingStore);
+    }
+    /**
+     * Return ownership of the underlying PacketBuffer.
+     *
+     * @note No further TLV operations may be performed, unless or until this PacketBufferTLVWriter is re-initialized.
+     */
+    chip::System::PacketBufferHandle Release() { return mBackingStore.Release(); }
+
+private:
+    TLVPacketBufferBackingStore mBackingStore;
+};
+
+} // namespace System
+} // namespace chip


### PR DESCRIPTION
#### Problem

CHIPTLV stores pointers to PacketBuffers (and CHIPCircularTLVBuffers) as integers, and its code also uses some unsafe PacketBuffer methods that are used nowhere else and should be removed.

#### Summary of Changes

- Replace the `int mBufHandle` used to hold pointers in TLV classes, and the associated callbacks, with a `TLVBackingStore` interface.
- Implement the `TLVBackingStore` interface on `CHIPCircularTLVBuffer`.
- Implement the `TLVBackingStore` interface for PacketBuffers, and add PacketBufferTLVReader/Writer modelled on CHIPCircularTLVReader/Writer.
- Moved some trivial accessors into `CHIPTLV.h.`
- Incidentally, move existing interface documentation to `CHIPTLV.h`.
- Removed `PacketBufferHandle` functions `Get_ForNow()` and `Next_ForNow()`, since TLV was the final remaining user.

fixes #4163 Revise CHIPTLV for PacketBuffer safety
