### PR TITLE
Update TestSystemPacketBuffer

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -158,8 +158,11 @@ uint16_t PacketBuffer::ReservedSize() const
     return static_cast<uint16_t>(kDelta - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE);
 }
 
-void PacketBuffer::AddToEnd_ForNow(PacketBuffer * aPacket)
+void PacketBuffer::AddToEnd(PacketBufferHandle aPacketHandle)
 {
+    PacketBuffer * aPacket = aPacketHandle.mBuffer;
+    aPacketHandle.mBuffer  = nullptr;
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     pbuf_cat(this, aPacket);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -177,11 +180,6 @@ void PacketBuffer::AddToEnd_ForNow(PacketBuffer * aPacket)
         lCursor = static_cast<PacketBuffer *>(lCursor->next);
     }
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP
-}
-
-void PacketBuffer::AddToEnd(PacketBufferHandle aPacketHandle)
-{
-    AddToEnd_ForNow(aPacketHandle.Release_ForNow());
 }
 
 void PacketBuffer::CompactHead()

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -254,7 +254,7 @@ public:
     /**
      * Return the last buffer in a buffer chain.
      *
-     *  @return a handle to the next buffer in the buffer chain.
+     *  @return a handle to the last buffer in the buffer chain.
      */
     CHECK_RETURN_VALUE PacketBufferHandle Last();
 
@@ -331,7 +331,6 @@ private:
     PacketBuffer * ChainedBuffer() const { return static_cast<PacketBuffer *>(this->next); }
     PacketBuffer * Consume(uint16_t aConsumeLength);
     void Clear();
-    void AddToEnd_ForNow(PacketBuffer * aPacket);
 
     friend class PacketBufferHandle;
     friend class ::PacketBufferTest;
@@ -583,7 +582,7 @@ public:
      *
      *  @note This differs from `FreeHead()` in that it does not touch any content in the currently referenced packet buffer;
      *      it only changes which buffer this handle owns. (Note that this could result in the previous buffer being freed,
-     *      if there is no other.) `Advance()` is designed to be used with an addition handle to traverse a buffer chain,
+     *      if there is no other owner.) `Advance()` is designed to be used with an additional handle to traverse a buffer chain,
      *      whereas `FreeHead()` modifies a chain.
      */
     void Advance() { *this = Hold(mBuffer->ChainedBuffer()); }
@@ -630,6 +629,8 @@ private:
     }
 
     PacketBuffer * Get() const { return mBuffer; }
+
+    bool operator==(const PacketBufferHandle & aOther) { return mBuffer == aOther.mBuffer; }
 
     PacketBuffer * mBuffer;
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <utility>
+#include <vector>
 
 #include <support/CodeUtils.h>
 #include <support/UnitTestRegistration.h>
@@ -63,9 +65,28 @@ using ::chip::System::pbuf;
 #define TO_LWIP_PBUF(x) (reinterpret_cast<struct pbuf *>(reinterpret_cast<void *>(x)))
 #define OF_LWIP_PBUF(x) (reinterpret_cast<PacketBuffer *>(reinterpret_cast<void *>(x)))
 
+/*
+ * An instance of this class created for the test suite.
+ * It is a friend class of `PacketBuffer` and `PacketBufferHandle` because some tests
+ * use or check private methods or properties.
+ */
 class PacketBufferTest
 {
 public:
+    struct TestContext
+    {
+        const uint16_t * const reserved_sizes;
+        size_t reserved_size_count;
+        const uint16_t * const lengths;
+        size_t length_count;
+        PacketBufferTest * test;
+    };
+
+    static int TestSetup(void * inContext);
+    static int TestTeardown(void * inContext);
+    static int TestInitialize(void * inContext);
+    static int TestTerminate(void * inContext);
+
     static void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext);
     static void CheckStart(nlTestSuite * inSuite, void * inContext);
     static void CheckSetStart(nlTestSuite * inSuite, void * inContext);
@@ -75,243 +96,310 @@ public:
     static void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext);
     static void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext);
     static void CheckReservedSize(nlTestSuite * inSuite, void * inContext);
+    static void CheckHasChainedBuffer(nlTestSuite * inSuite, void * inContext);
     static void CheckAddToEnd(nlTestSuite * inSuite, void * inContext);
-    static void CheckDetachTail(nlTestSuite * inSuite, void * inContext);
+    static void CheckPopHead(nlTestSuite * inSuite, void * inContext);
     static void CheckCompactHead(nlTestSuite * inSuite, void * inContext);
     static void CheckConsumeHead(nlTestSuite * inSuite, void * inContext);
     static void CheckConsume(nlTestSuite * inSuite, void * inContext);
     static void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext);
     static void CheckAlignPayload(nlTestSuite * inSuite, void * inContext);
     static void CheckNext(nlTestSuite * inSuite, void * inContext);
+    static void CheckLast(nlTestSuite * inSuite, void * inContext);
     static void CheckAddRef(nlTestSuite * inSuite, void * inContext);
     static void CheckFree(nlTestSuite * inSuite, void * inContext);
     static void CheckFreeHead(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleConstruct(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleMove(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleFree(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleRetain(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleAdopt(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleHold(nlTestSuite * inSuite, void * inContext);
+    static void CheckHandleAdvance(nlTestSuite * inSuite, void * inContext);
     static void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext);
 
-    static void BufferFree(struct TestContext * theContext);
-};
-
-namespace {
-
-void CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckNewWithAvailableSizeAndFree(inSuite, inContext);
-}
-void CheckStart(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckStart(inSuite, inContext);
-}
-void CheckSetStart(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckSetStart(inSuite, inContext);
-}
-void CheckDataLength(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckDataLength(inSuite, inContext);
-}
-void CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckSetDataLength(inSuite, inContext);
-}
-void CheckTotalLength(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckTotalLength(inSuite, inContext);
-}
-void CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckMaxDataLength(inSuite, inContext);
-}
-void CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckAvailableDataLength(inSuite, inContext);
-}
-void CheckReservedSize(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckReservedSize(inSuite, inContext);
-}
-void CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckAddToEnd(inSuite, inContext);
-}
-void CheckDetachTail(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckDetachTail(inSuite, inContext);
-}
-void CheckCompactHead(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckCompactHead(inSuite, inContext);
-}
-void CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckConsumeHead(inSuite, inContext);
-}
-void CheckConsume(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckConsume(inSuite, inContext);
-}
-void CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckEnsureReservedSize(inSuite, inContext);
-}
-void CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckAlignPayload(inSuite, inContext);
-}
-void CheckNext(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckNext(inSuite, inContext);
-}
-void CheckAddRef(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckAddRef(inSuite, inContext);
-}
-void CheckFree(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckFree(inSuite, inContext);
-}
-void CheckFreeHead(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckFreeHead(inSuite, inContext);
-}
-void CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
-{
-    PacketBufferTest::CheckBuildFreeList(inSuite, inContext);
-}
-
-} // namespace
-
-// Test input vector format.
-
-struct TestContext
-{
-    uint16_t init_len;
-    uint16_t reserved_size;
-    uint8_t * start_buffer;
-    uint8_t * end_buffer;
-    uint8_t * payload_ptr;
-    struct pbuf * buf;
-};
-
-// Test input data.
-
-// clang-format off
-struct TestContext sContext[] =
-{
-      { 0,      0,                               nullptr, nullptr, nullptr, nullptr },
-      { 0,      10,                              nullptr, nullptr, nullptr, nullptr },
-      { 0,      128,                             nullptr, nullptr, nullptr, nullptr },
-      { 0,      1536,                            nullptr, nullptr, nullptr, nullptr },
-      { 0,      CHIP_SYSTEM_PACKETBUFFER_SIZE,   nullptr, nullptr, nullptr, nullptr }
-};
-// clang-format on
-
-const uint16_t sLengths[] = { 0, 1, 10, 128, CHIP_SYSTEM_PACKETBUFFER_SIZE, UINT16_MAX };
-
-// Number of test context examples.
-const size_t kTestElements = sizeof(sContext) / sizeof(struct TestContext);
-const size_t kTestLengths  = sizeof(sLengths) / sizeof(uint16_t);
-
-/**
- *  Free allocated test buffer memory.
- */
-void PacketBufferTest::BufferFree(struct TestContext * theContext)
-{
-    if (theContext->buf != nullptr)
+    static void PrintHandle(const char * tag, const PacketBuffer * buffer)
     {
-        PacketBuffer::Free(OF_LWIP_PBUF(theContext->buf));
-        theContext->buf = nullptr;
+        printf("%s %p ref=%u len=%-4u next=%p\n", tag, buffer, buffer ? buffer->ref : 0, buffer ? buffer->len : 0,
+               buffer ? buffer->next : 0);
+    }
+    static void PrintHandle(const char * tag, const PacketBufferHandle & handle) { PrintHandle(tag, handle.mBuffer); }
+
+private:
+    struct BufferConfiguration
+    {
+        BufferConfiguration(uint16_t aReservedSize = 0) :
+            init_len(0), reserved_size(aReservedSize), start_buffer(nullptr), end_buffer(nullptr), payload_ptr(nullptr),
+            handle(nullptr)
+        {}
+
+        uint16_t init_len;
+        uint16_t reserved_size;
+        uint8_t * start_buffer;
+        uint8_t * end_buffer;
+        uint8_t * payload_ptr;
+        PacketBufferHandle handle;
+    };
+
+    static void PrintHandle(const char * tag, const BufferConfiguration & config) { PrintHandle(tag, config.handle); }
+    static void PrintConfig(const char * tag, const BufferConfiguration & config)
+    {
+        printf("%s pay=%-4zu len=%-4u res=%-4u:", tag, config.payload_ptr - config.start_buffer, config.init_len,
+               config.reserved_size);
+        PrintHandle("", config.handle);
+    }
+
+    PacketBufferTest(TestContext * context);
+    ~PacketBufferTest();
+
+    int InitializeTest(TestContext * context);
+    int TerminateTest(TestContext * context);
+
+    /*
+     * Buffers allocated through PrepareTestBuffer with kRecordHandle set will be recorded in `handles` so that their
+     * reference counts can be verified by ResetHandles(). Initially they have two refs: the recorded one and the returned one.
+     */
+    static constexpr int kRecordHandle     = 0x01;
+    static constexpr int kAllowHandleReuse = 0x02;
+    void PrepareTestBuffer(BufferConfiguration * config, int flags = 0);
+
+    /*
+     * Checks and clears the recorded handles. Returns true if it detects no leaks or double frees.
+     * Called from `TerminateTest()`, but tests may choose to call it more often to verify reference counts.
+     */
+    bool ResetHandles();
+
+    TestContext * mContext;
+    std::vector<BufferConfiguration> configurations;
+    std::vector<PacketBufferHandle> handles;
+};
+
+const uint16_t sTestReservedSizes[] = { 0, 10, 128, 1536, CHIP_SYSTEM_PACKETBUFFER_SIZE };
+const uint16_t sTestLengths[]       = { 0, 1, 10, 128, CHIP_SYSTEM_PACKETBUFFER_SIZE, UINT16_MAX };
+
+PacketBufferTest::TestContext sContext = {
+    sTestReservedSizes,
+    sizeof(sTestReservedSizes) / sizeof(uint16_t),
+    sTestLengths,
+    sizeof(sTestLengths) / sizeof(uint16_t),
+};
+
+PacketBufferTest::PacketBufferTest(TestContext * context) : mContext(context)
+{
+    // Set up the buffer configuration vector for this suite.
+    configurations.resize(0);
+    for (size_t i = 0; i < mContext->reserved_size_count; ++i)
+    {
+        configurations.emplace_back<BufferConfiguration>(mContext->reserved_sizes[i]);
     }
 }
 
-/**
- *  Allocate memory for a test buffer and configure according to test context.
- */
-void BufferAlloc(struct TestContext * theContext)
+int PacketBufferTest::TestSetup(void * inContext)
 {
-    const size_t lInitialSize = CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + theContext->reserved_size;
-    const size_t lAllocSize   = CHIP_SYSTEM_PACKETBUFFER_SIZE;
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    u8_t lType, lFlags;
-#if LWIP_PBUF_FROM_CUSTOM_POOLS
-    u16_t lPool;
-#endif // LWIP_PBUF_FROM_CUSTOM_POOLS
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
-
-    if (theContext->buf == nullptr)
+    TestContext * const theContext = reinterpret_cast<TestContext *>(inContext);
+    theContext->test               = new PacketBufferTest(theContext);
+    if (theContext->test == nullptr)
     {
-        theContext->buf = TO_LWIP_PBUF(PacketBuffer::New(0).Release_ForNow());
+        return FAILURE;
     }
+    return SUCCESS;
+}
 
-    if (theContext->buf == nullptr)
+int PacketBufferTest::TestTeardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+int PacketBufferTest::TestInitialize(void * inContext)
+{
+    TestContext * const theContext = reinterpret_cast<TestContext *>(inContext);
+    if (theContext->test == nullptr)
     {
-        fprintf(stderr, "Failed to allocate %zuB memory: %s\n", lAllocSize, strerror(errno));
+        return FAILURE;
+    }
+    return theContext->test->InitializeTest(theContext);
+}
+
+int PacketBufferTest::InitializeTest(TestContext * context)
+{
+    if (context != mContext)
+    {
+        return FAILURE;
+    }
+    return SUCCESS;
+}
+
+int PacketBufferTest::TestTerminate(void * inContext)
+{
+    TestContext * const theContext = reinterpret_cast<TestContext *>(inContext);
+    if (theContext->test == nullptr)
+    {
+        return FAILURE;
+    }
+    return theContext->test->TerminateTest(theContext);
+}
+
+int PacketBufferTest::TerminateTest(TestContext * context)
+{
+    const bool context_ok = (context == mContext);
+    // Clear the configurations' bufffer handles.
+    for (size_t i = 0; i < configurations.size(); ++i)
+    {
+        configurations[i].handle = nullptr;
+    }
+    const bool handles_ok = ResetHandles();
+    return (context_ok && handles_ok) ? SUCCESS : FAILURE;
+}
+
+/**
+ *  Allocate memory for a test buffer and configure according to test buffer configuration.
+ */
+void PacketBufferTest::PrepareTestBuffer(BufferConfiguration * config, int flags)
+{
+    if (config->handle.IsNull())
+    {
+        config->handle = PacketBuffer::New(0);
+        if (config->handle.IsNull())
+        {
+            printf("NewPacketBuffer: Failed to allocate packet buffer (%zu retained): %s\n", handles.size(), strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+        if (flags & kRecordHandle)
+        {
+            handles.push_back(config->handle.Retain());
+        }
+    }
+    else if ((flags & kAllowHandleReuse) == 0)
+    {
+        printf("Dirty test configuration\n");
         exit(EXIT_FAILURE);
     }
 
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    lType  = PBUF_TYPE(theContext->buf);
-    lFlags = theContext->buf->flags;
-#if LWIP_PBUF_FROM_CUSTOM_POOLS
-    lPool = theContext->buf->pool;
-#endif // LWIP_PBUF_FROM_CUSTOM_POOLS
-    memset(theContext->buf, 0, lAllocSize);
-    PBUF_TYPE(theContext->buf) = lType;
-    theContext->buf->flags     = lFlags;
-#if LWIP_PBUF_FROM_CUSTOM_POOLS
-    theContext->buf->pool = lPool;
-#endif // LWIP_PBUF_FROM_CUSTOM_POOLS
-#else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
-    memset(theContext->buf, 0, lAllocSize);
-#if CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC == 0
-    theContext->buf->alloc_size = lAllocSize;
-#endif // CHIP_SYSTEM_CONFIG_PACKETBUFFER_MAXALLOC == 0
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+    const size_t lInitialSize = CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + config->reserved_size;
+    const size_t lAllocSize   = CHIP_SYSTEM_PACKETBUFFER_SIZE;
 
-    theContext->start_buffer = reinterpret_cast<uint8_t *>(theContext->buf);
-    theContext->end_buffer   = reinterpret_cast<uint8_t *>(theContext->buf) + lAllocSize;
+    uint8_t * const raw = reinterpret_cast<uint8_t *>(config->handle.Get());
+    memset(raw + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE, 0, lAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE);
+
+    config->start_buffer = raw;
+    config->end_buffer   = raw + lAllocSize;
 
     if (lInitialSize > lAllocSize)
     {
-        theContext->payload_ptr = theContext->end_buffer;
+        config->payload_ptr = config->end_buffer;
     }
     else
     {
-        theContext->payload_ptr = theContext->start_buffer + lInitialSize;
+        config->payload_ptr = config->start_buffer + lInitialSize;
     }
+
+    if (config->handle->HasChainedBuffer())
+    {
+        // This should not happen.
+        PacketBuffer::Free(config->handle->ChainedBuffer());
+        config->handle->next = nullptr;
+    }
+    config->handle->payload = config->payload_ptr;
+    config->handle->len     = config->init_len;
+    config->handle->tot_len = config->init_len;
 }
+
+bool PacketBufferTest::ResetHandles()
+{
+    // Check against leaks or double-frees in tests: every handle obtained through
+    // PacketBufferTest::NewPacketBuffer should have a reference count of 1.
+    bool handles_ok = true;
+    for (size_t i = 0; i < handles.size(); ++i)
+    {
+        const PacketBufferHandle & handle = handles[i];
+        if (handle.Get() == nullptr)
+        {
+            printf("TestTerminate: handle %zu null\n", i);
+            handles_ok = false;
+        }
+        else if (handle->ref != 1)
+        {
+            printf("TestTerminate: handle %zu buffer=%p ref=%u\n", i, handle.Get(), handle->ref);
+            handles_ok = false;
+            while (handle->ref > 1)
+            {
+                PacketBuffer::Free(handle.Get());
+            }
+        }
+    }
+    handles.resize(0);
+    return handles_ok;
+}
+
+// Test functions invoked from the suite.
 
 /**
- *  Setup buffer layout as it is used by PacketBuffer class.
+ *  Test PacketBuffer::NewWithAvailableSize() and PacketBuffer::Free() functions.
+ *
+ *  Description: For every buffer-configuration from inContext, create a
+ *               buffer's instance using NewWithAvailableSize() method. Then, verify that
+ *               when the size of the reserved space passed to NewWithAvailableSize() is
+ *               greater than #CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX, the method
+ *               returns NULL. Otherwise, check for correctness of initializing
+ *               the new buffer's internal state. Finally, free the buffer.
  */
-PacketBuffer * PrepareTestBuffer(struct TestContext * theContext)
+void PacketBufferTest::CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
 {
-    BufferAlloc(theContext);
+    TestContext * const theContext = static_cast<TestContext *>(inContext);
+    PacketBufferTest * const test  = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    theContext->buf->next    = nullptr;
-    theContext->buf->payload = theContext->payload_ptr;
-    theContext->buf->ref     = 1;
-    theContext->buf->len     = theContext->init_len;
-    theContext->buf->tot_len = theContext->init_len;
+    for (const auto & config : test->configurations)
+    {
+        const PacketBufferHandle buffer = PacketBuffer::NewWithAvailableSize(config.reserved_size, 0);
 
-    return reinterpret_cast<PacketBuffer *>(theContext->buf);
+        if (config.reserved_size > CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX)
+        {
+            NL_TEST_ASSERT(inSuite, buffer.IsNull());
+            continue;
+        }
+
+        NL_TEST_ASSERT(inSuite, config.reserved_size <= buffer->AllocSize());
+        NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+        if (!buffer.IsNull())
+        {
+            const pbuf * const pb = TO_LWIP_PBUF(buffer.Get());
+
+            NL_TEST_ASSERT(inSuite, pb->len == 0);
+            NL_TEST_ASSERT(inSuite, pb->tot_len == 0);
+            NL_TEST_ASSERT(inSuite, pb->next == nullptr);
+            NL_TEST_ASSERT(inSuite, pb->ref == 1);
+        }
+    }
+
+    // Use the rest of the buffer space
+    std::vector<PacketBufferHandle> allocate_all_the_things;
+    for (;;)
+    {
+        PacketBufferHandle buffer = PacketBuffer::NewWithAvailableSize(0, 0);
+        if (buffer.IsNull())
+        {
+            break;
+        }
+        // Hold on to the buffer, to use up all the buffer space.
+        allocate_all_the_things.push_back(std::move(buffer));
+    }
 }
-// Test functions invoked from the suite.
 
 /**
  *  Test PacketBuffer::Start() function.
  */
 void PacketBufferTest::CheckStart(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
-
-        NL_TEST_ASSERT(inSuite, buffer->Start() == theContext->payload_ptr);
-
-        theContext++;
+        test->PrepareTestBuffer(&config, kRecordHandle);
+        NL_TEST_ASSERT(inSuite, config.handle->Start() == config.payload_ptr);
     }
 }
 
@@ -328,13 +416,16 @@ void PacketBufferTest::CheckStart(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckSetStart(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext          = static_cast<struct TestContext *>(inContext);
-    static const ptrdiff_t sSizePacketBuffer = CHIP_SYSTEM_PACKETBUFFER_SIZE;
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    static constexpr ptrdiff_t sSizePacketBuffer = CHIP_SYSTEM_PACKETBUFFER_SIZE;
+
+    for (auto & config : test->configurations)
     {
         // clang-format off
-        static const ptrdiff_t start_offset[] =
+        static constexpr ptrdiff_t start_offset[] =
         {
             -sSizePacketBuffer,
             -128,
@@ -348,39 +439,38 @@ void PacketBufferTest::CheckSetStart(nlTestSuite * inSuite, void * inContext)
 
         for (ptrdiff_t offset : start_offset)
         {
-            PacketBuffer * buffer  = PrepareTestBuffer(theContext);
-            uint8_t * test_start   = theContext->payload_ptr + offset;
-            uint8_t * verify_start = test_start;
+            test->PrepareTestBuffer(&config, kRecordHandle | kAllowHandleReuse);
+            uint8_t * const test_start = config.payload_ptr + offset;
+            uint8_t * verify_start     = test_start;
 
-            buffer->SetStart(test_start);
+            config.handle->SetStart(test_start);
 
-            if (verify_start < theContext->start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE)
+            if (verify_start < config.start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE)
             {
                 // Set start before valid payload beginning.
-                verify_start = theContext->start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
+                verify_start = config.start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE;
             }
 
-            if (verify_start > theContext->end_buffer)
+            if (verify_start > config.end_buffer)
             {
                 // Set start after valid payload beginning.
-                verify_start = theContext->end_buffer;
+                verify_start = config.end_buffer;
             }
 
-            NL_TEST_ASSERT(inSuite, theContext->buf->payload == verify_start);
+            NL_TEST_ASSERT(inSuite, config.handle->payload == verify_start);
 
-            if ((verify_start - theContext->payload_ptr) > theContext->init_len)
+            if ((verify_start - config.payload_ptr) > config.init_len)
             {
-                // Set start to the beginning of payload, right after buffer's header.
-                NL_TEST_ASSERT(inSuite, theContext->buf->len == 0);
+                // Set start to the beginning of payload, right after handle's header.
+                NL_TEST_ASSERT(inSuite, config.handle->len == 0);
             }
             else
             {
-                // Set start to somewhere between the end of the buffer's
+                // Set start to somewhere between the end of the handle's
                 // header and the end of payload.
-                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->init_len - (verify_start - theContext->payload_ptr)));
+                NL_TEST_ASSERT(inSuite, config.handle->len == (config.init_len - (verify_start - config.payload_ptr)));
             }
         }
-        theContext++;
     }
 }
 
@@ -389,15 +479,15 @@ void PacketBufferTest::CheckSetStart(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckDataLength(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
+        test->PrepareTestBuffer(&config, kRecordHandle);
 
-        NL_TEST_ASSERT(inSuite, buffer->DataLength() == theContext->buf->len);
-
-        theContext++;
+        NL_TEST_ASSERT(inSuite, config.handle->DataLength() == config.handle->len);
     }
 }
 
@@ -416,78 +506,68 @@ void PacketBufferTest::CheckDataLength(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckSetDataLength(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            for (uint16_t length : sLengths)
+            for (size_t i = 0; i < theContext->length_count; ++i)
             {
-                PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
-                PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+                const uint16_t length = theContext->lengths[i];
+                test->PrepareTestBuffer(&config_1, kRecordHandle | kAllowHandleReuse);
+                test->PrepareTestBuffer(&config_2, kRecordHandle | kAllowHandleReuse);
 
-                if (theFirstContext == theSecondContext)
+                if (&config_1 == &config_2)
                 {
                     // headOfChain (the second arg) is NULL
-                    buffer_2->SetDataLength(length, nullptr);
+                    config_2.handle->SetDataLength(length, nullptr);
 
-                    if (length > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    if (length > (config_2.end_buffer - config_2.payload_ptr))
                     {
-                        NL_TEST_ASSERT(
-                            inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite,
-                                       theSecondContext->buf->tot_len ==
-                                           (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->len == (config_2.end_buffer - config_2.payload_ptr));
+                        NL_TEST_ASSERT(inSuite, config_2.handle->tot_len == (config_2.end_buffer - config_2.payload_ptr));
+                        NL_TEST_ASSERT(inSuite, config_2.handle->next == nullptr);
                     }
                     else
                     {
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == length);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == length);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->len == length);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->tot_len == length);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->next == nullptr);
                     }
                 }
                 else
                 {
-                    // headOfChain (the second arg) is buffer_1
-                    buffer_2->SetDataLength(length, buffer_1);
+                    // headOfChain (the second arg) is config_1.handle
+                    config_2.handle->SetDataLength(length, config_1.handle);
 
-                    if (length > (theSecondContext->end_buffer - theSecondContext->payload_ptr))
+                    if (length > (config_2.end_buffer - config_2.payload_ptr))
                     {
-                        NL_TEST_ASSERT(
-                            inSuite, theSecondContext->buf->len == (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite,
-                                       theSecondContext->buf->tot_len ==
-                                           (theSecondContext->end_buffer - theSecondContext->payload_ptr));
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->len == (config_2.end_buffer - config_2.payload_ptr));
+                        NL_TEST_ASSERT(inSuite, config_2.handle->tot_len == (config_2.end_buffer - config_2.payload_ptr));
+                        NL_TEST_ASSERT(inSuite, config_2.handle->next == nullptr);
 
                         NL_TEST_ASSERT(inSuite,
-                                       theFirstContext->buf->tot_len ==
-                                           (theFirstContext->init_len +
-                                            static_cast<int32_t>(theSecondContext->end_buffer - theSecondContext->payload_ptr) -
-                                            static_cast<int32_t>(theSecondContext->init_len)));
+                                       config_1.handle->tot_len ==
+                                           (config_1.init_len + static_cast<int32_t>(config_2.end_buffer - config_2.payload_ptr) -
+                                            static_cast<int32_t>(config_2.init_len)));
                     }
                     else
                     {
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->len == length);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->tot_len == length);
-                        NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->len == length);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->tot_len == length);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->next == nullptr);
 
-                        NL_TEST_ASSERT(inSuite,
-                                       theFirstContext->buf->tot_len ==
-                                           (theFirstContext->init_len + static_cast<int32_t>(length) -
-                                            static_cast<int32_t>(theSecondContext->init_len)));
+                        NL_TEST_ASSERT(
+                            inSuite,
+                            config_1.handle->tot_len ==
+                                (config_1.init_len + static_cast<int32_t>(length) - static_cast<int32_t>(config_2.init_len)));
                     }
                 }
             }
-
-            theSecondContext++;
         }
-
-        theFirstContext++;
     }
 }
 
@@ -496,15 +576,14 @@ void PacketBufferTest::CheckSetDataLength(nlTestSuite * inSuite, void * inContex
  */
 void PacketBufferTest::CheckTotalLength(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
-
-        NL_TEST_ASSERT(inSuite, buffer->TotalLength() == theContext->init_len);
-
-        theContext++;
+        test->PrepareTestBuffer(&config, kRecordHandle);
+        NL_TEST_ASSERT(inSuite, config.handle->TotalLength() == config.init_len);
     }
 }
 
@@ -513,15 +592,15 @@ void PacketBufferTest::CheckTotalLength(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckMaxDataLength(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
+        test->PrepareTestBuffer(&config, kRecordHandle);
 
-        NL_TEST_ASSERT(inSuite, buffer->MaxDataLength() == (theContext->end_buffer - theContext->payload_ptr));
-
-        theContext++;
+        NL_TEST_ASSERT(inSuite, config.handle->MaxDataLength() == (config.end_buffer - config.payload_ptr));
     }
 }
 
@@ -530,16 +609,16 @@ void PacketBufferTest::CheckMaxDataLength(nlTestSuite * inSuite, void * inContex
  */
 void PacketBufferTest::CheckAvailableDataLength(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
+        test->PrepareTestBuffer(&config, kRecordHandle);
 
-        NL_TEST_ASSERT(
-            inSuite, buffer->AvailableDataLength() == ((theContext->end_buffer - theContext->payload_ptr) - theContext->init_len));
-
-        theContext++;
+        NL_TEST_ASSERT(inSuite,
+                       config.handle->AvailableDataLength() == ((config.end_buffer - config.payload_ptr) - config.init_len));
     }
 }
 
@@ -548,23 +627,57 @@ void PacketBufferTest::CheckAvailableDataLength(nlTestSuite * inSuite, void * in
  */
 void PacketBufferTest::CheckReservedSize(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer & lBuffer  = *PrepareTestBuffer(theContext);
-        const size_t kAllocSize = lBuffer.AllocSize();
+        test->PrepareTestBuffer(&config, kRecordHandle);
+        const size_t kAllocSize = config.handle->AllocSize();
 
-        if (theContext->reserved_size > kAllocSize)
+        if (config.reserved_size > kAllocSize)
         {
-            NL_TEST_ASSERT(inSuite, lBuffer.ReservedSize() == kAllocSize);
+            NL_TEST_ASSERT(inSuite, config.handle->ReservedSize() == kAllocSize);
         }
         else
         {
-            NL_TEST_ASSERT(inSuite, lBuffer.ReservedSize() == theContext->reserved_size);
+            NL_TEST_ASSERT(inSuite, config.handle->ReservedSize() == config.reserved_size);
         }
+    }
+}
 
-        theContext++;
+/**
+ *  Test PacketBuffer::HasChainedBuffer() function.
+ */
+void PacketBufferTest::CheckHasChainedBuffer(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
+        {
+            if (&config_1 == &config_2)
+            {
+                continue;
+            }
+
+            test->PrepareTestBuffer(&config_1);
+            test->PrepareTestBuffer(&config_2);
+
+            NL_TEST_ASSERT(inSuite, config_1.handle->HasChainedBuffer() == false);
+            NL_TEST_ASSERT(inSuite, config_2.handle->HasChainedBuffer() == false);
+
+            config_1.handle->AddToEnd(config_2.handle.Retain());
+            NL_TEST_ASSERT(inSuite, config_1.handle->HasChainedBuffer() == true);
+            NL_TEST_ASSERT(inSuite, config_2.handle->HasChainedBuffer() == false);
+
+            config_1.handle = nullptr;
+            config_2.handle = nullptr;
+        }
     }
 }
 
@@ -581,107 +694,111 @@ void PacketBufferTest::CheckReservedSize(nlTestSuite * inSuite, void * inContext
  */
 void PacketBufferTest::CheckAddToEnd(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            struct TestContext * theThirdContext = static_cast<struct TestContext *>(inContext);
-
-            for (size_t kth = 0; kth < kTestElements; kth++)
+            for (auto & config_3 : test->configurations)
             {
-                PacketBuffer * buffer_1 = nullptr;
-                PacketBuffer * buffer_2 = nullptr;
-                PacketBuffer * buffer_3 = nullptr;
-
-                if (theFirstContext == theSecondContext || theFirstContext == theThirdContext ||
-                    theSecondContext == theThirdContext)
+                if (&config_1 == &config_2 || &config_1 == &config_3 || &config_2 == &config_3)
                 {
-                    theThirdContext++;
                     continue;
                 }
 
-                buffer_1 = PrepareTestBuffer(theFirstContext);
-                buffer_2 = PrepareTestBuffer(theSecondContext);
-                buffer_3 = PrepareTestBuffer(theThirdContext);
+                test->PrepareTestBuffer(&config_1);
+                test->PrepareTestBuffer(&config_2);
+                test->PrepareTestBuffer(&config_3);
+                NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1);
+                NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
+                NL_TEST_ASSERT(inSuite, config_3.handle->ref == 1);
 
-                buffer_1->AddToEnd_ForNow(buffer_2);
+                config_1.handle->AddToEnd(config_2.handle.Retain());
+                NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1); // config_1.handle
+                NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
+                NL_TEST_ASSERT(inSuite, config_3.handle->ref == 1); // config_3.handle
 
-                NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == (theFirstContext->init_len + theSecondContext->init_len));
-                NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
-                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == nullptr);
+                NL_TEST_ASSERT(inSuite, config_1.handle->tot_len == (config_1.init_len + config_2.init_len));
+                NL_TEST_ASSERT(inSuite, config_1.handle->next == config_2.handle.Get());
+                NL_TEST_ASSERT(inSuite, config_2.handle->next == nullptr);
+                NL_TEST_ASSERT(inSuite, config_3.handle->next == nullptr);
 
-                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == nullptr);
+                config_1.handle->AddToEnd(config_3.handle.Retain());
+                NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1); // config_1.handle
+                NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
+                NL_TEST_ASSERT(inSuite, config_3.handle->ref == 2); // config_3.handle and config_2.handle->next
 
-                buffer_1->AddToEnd_ForNow(buffer_3);
+                NL_TEST_ASSERT(inSuite, config_1.handle->tot_len == (config_1.init_len + config_2.init_len + config_3.init_len));
+                NL_TEST_ASSERT(inSuite, config_1.handle->next == config_2.handle.Get());
+                NL_TEST_ASSERT(inSuite, config_2.handle->next == config_3.handle.Get());
+                NL_TEST_ASSERT(inSuite, config_3.handle->next == nullptr);
 
-                NL_TEST_ASSERT(inSuite,
-                               theFirstContext->buf->tot_len ==
-                                   (theFirstContext->init_len + theSecondContext->init_len + theThirdContext->init_len));
-                NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
-                NL_TEST_ASSERT(inSuite, theSecondContext->buf->next == theThirdContext->buf);
-                NL_TEST_ASSERT(inSuite, theThirdContext->buf->next == nullptr);
-
-                theThirdContext++;
+                config_1.handle = nullptr;
+                config_2.handle = nullptr;
+                config_3.handle = nullptr;
             }
-
-            theSecondContext++;
         }
-
-        theFirstContext++;
     }
 }
 
 /**
- *  Test PacketBuffer::DetachTail() function.
+ *  Test PacketBuffer::PopHead() function.
  *
  *  Description: Take two initial configurations of PacketBuffer from
  *               inContext and create two PacketBuffer instances based on those
  *               configurations. Next, link those buffers together, with the first
- *               buffer instance pointing to the second one. Then, call DetachTail()
+ *               buffer instance pointing to the second one. Then, call PopHead()
  *               on the first buffer to unlink the second buffer. After the call,
  *               verify correct internal state of the first buffer.
  */
-void PacketBufferTest::CheckDetachTail(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckPopHead(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    // Single buffer test.
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
+        test->PrepareTestBuffer(&config_1, kRecordHandle | kAllowHandleReuse);
+        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
 
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        const PacketBuffer * const buffer_1 = config_1.handle.mBuffer;
+
+        const PacketBufferHandle popped = config_1.handle.PopHead();
+
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, popped.mBuffer == buffer_1);
+        NL_TEST_ASSERT(inSuite, popped->next == nullptr);
+        NL_TEST_ASSERT(inSuite, popped->tot_len == config_1.init_len);
+        NL_TEST_ASSERT(inSuite, popped->ref == 2);
+    }
+    test->ResetHandles();
+
+    // Chained buffers test.
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
         {
-            PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
-            PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
-            PacketBuffer * returned = nullptr;
-            buffer_1->AddRef(); // The test still holds ownership via buffer_1.
-            PacketBufferHandle buffer_handle = PacketBufferHandle::Adopt(buffer_1);
-
-            if (theFirstContext != theSecondContext)
+            if (&config_1 == &config_2)
             {
-                theFirstContext->buf->next    = theSecondContext->buf;
-                theFirstContext->buf->tot_len = static_cast<uint16_t>(theFirstContext->buf->tot_len + theSecondContext->init_len);
+                continue;
             }
 
-            PacketBufferHandle popped = buffer_handle.PopHead();
-            returned                  = buffer_handle.Release_ForNow();
+            test->PrepareTestBuffer(&config_1, kRecordHandle | kAllowHandleReuse);
+            test->PrepareTestBuffer(&config_2, kRecordHandle | kAllowHandleReuse);
 
-            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == nullptr);
-            NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == theFirstContext->init_len);
+            config_1.handle->AddToEnd(config_2.handle.Retain());
 
-            if (theFirstContext != theSecondContext)
-            {
-                NL_TEST_ASSERT(inSuite, returned == buffer_2);
-            }
+            const PacketBufferHandle popped = config_1.handle.PopHead();
 
-            theSecondContext++;
+            NL_TEST_ASSERT(inSuite, config_1.handle == config_2.handle);
+            NL_TEST_ASSERT(inSuite, config_1.handle->next == nullptr);
+            NL_TEST_ASSERT(inSuite, config_1.handle->tot_len == config_1.init_len);
         }
-
-        theFirstContext++;
     }
 }
 
@@ -698,75 +815,107 @@ void PacketBufferTest::CheckDetachTail(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckCompactHead(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    // Single buffer test.
+    for (auto & config : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (size_t i = 0; i < theContext->length_count; ++i)
         {
-            // start with various initial length for the first buffer
-            for (uint16_t firstLength : sLengths)
+            const uint16_t length = theContext->lengths[i];
+
+            test->PrepareTestBuffer(&config, kRecordHandle | kAllowHandleReuse);
+            config.handle->SetDataLength(length, config.handle);
+            const uint16_t data_length = config.handle->DataLength();
+
+            config.handle->CompactHead();
+
+            NL_TEST_ASSERT(inSuite, config.handle->payload == (config.start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE));
+            NL_TEST_ASSERT(inSuite, config.handle->tot_len == data_length);
+        }
+
+        config.handle = nullptr;
+    }
+    NL_TEST_ASSERT(inSuite, test->ResetHandles());
+
+    // Chained buffers test.
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
+        {
+            if (&config_1 == &config_2)
             {
+                continue;
+            }
+
+            // start with various initial length for the first buffer
+            for (size_t i = 0; i < theContext->length_count; ++i)
+            {
+                const uint16_t length_1 = theContext->lengths[i];
+
                 // start with various initial length for the second buffer
-                for (uint16_t secondLength : sLengths)
+                for (size_t j = 0; j < theContext->length_count; ++j)
                 {
-                    PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
-                    PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
-                    uint16_t len1           = 0;
-                    uint16_t len2           = 0;
+                    const uint16_t length_2 = theContext->lengths[j];
 
-                    buffer_1->SetDataLength(firstLength, buffer_1);
-                    len1 = buffer_1->DataLength();
+                    test->PrepareTestBuffer(&config_1, kRecordHandle | kAllowHandleReuse);
+                    NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
 
-                    if (theFirstContext != theSecondContext)
-                    {
-                        theFirstContext->buf->next = theSecondContext->buf;
+                    // CompactHead requires that there be no other references to the chained buffer,
+                    // so we manage it manually.
+                    test->PrepareTestBuffer(&config_2);
+                    NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
+                    PacketBuffer * buffer_2 = config_2.handle.Release_ForNow();
+                    NL_TEST_ASSERT(inSuite, config_2.handle.IsNull());
 
-                        // Add various lengths to the second buffer
-                        buffer_2->SetDataLength(secondLength, buffer_1);
-                        len2 = buffer_2->DataLength();
-                    }
+                    config_1.handle->SetDataLength(length_1, config_1.handle);
+                    const uint16_t data_length_1 = config_1.handle->DataLength();
 
-                    buffer_1->CompactHead();
+                    // This chain will cause buffer_2 to be freed.
+                    config_1.handle->next = buffer_2;
+
+                    // Add various lengths to the second buffer
+                    buffer_2->SetDataLength(length_2, config_1.handle);
+                    const uint16_t data_length_2 = buffer_2->DataLength();
+
+                    config_1.handle->CompactHead();
 
                     NL_TEST_ASSERT(inSuite,
-                                   theFirstContext->buf->payload ==
-                                       (theFirstContext->start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE));
+                                   config_1.handle->payload == (config_1.start_buffer + CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE));
 
-                    /* verify length of the first buffer */
-                    if (theFirstContext == theSecondContext)
+                    if (config_1.handle->tot_len > config_1.handle->MaxDataLength())
                     {
-                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->tot_len == len1);
-                    }
-                    else if (theFirstContext->buf->tot_len > buffer_1->MaxDataLength())
-                    {
-                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->len == buffer_1->MaxDataLength());
-                        NL_TEST_ASSERT(inSuite,
-                                       theSecondContext->buf->len == theFirstContext->buf->tot_len - buffer_1->MaxDataLength());
+                        NL_TEST_ASSERT(inSuite, config_1.handle->len == config_1.handle->MaxDataLength());
+                        NL_TEST_ASSERT(inSuite, buffer_2->len == config_1.handle->tot_len - config_1.handle->MaxDataLength());
+                        NL_TEST_ASSERT(inSuite, config_1.handle->next == buffer_2);
+                        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
+                        NL_TEST_ASSERT(inSuite, buffer_2->ref == 1);
                     }
                     else
                     {
-                        NL_TEST_ASSERT(inSuite, theFirstContext->buf->len == theFirstContext->buf->tot_len);
-                        if (len1 >= buffer_1->MaxDataLength() && len2 == 0)
+                        NL_TEST_ASSERT(inSuite, config_1.handle->len == config_1.handle->tot_len);
+                        if (data_length_1 >= config_1.handle->MaxDataLength() && data_length_2 == 0)
                         {
                             /* make sure the second buffer is not freed */
-                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                            NL_TEST_ASSERT(inSuite, config_1.handle->next == buffer_2);
+                            NL_TEST_ASSERT(inSuite, buffer_2->ref == 1);
                         }
                         else
                         {
                             /* make sure the second buffer is freed */
-                            NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == nullptr);
-                            theSecondContext->buf = nullptr;
+                            NL_TEST_ASSERT(inSuite, config_1.handle->next == nullptr);
+                            buffer_2 = nullptr;
                         }
                     }
+
+                    config_1.handle = nullptr;
                 }
             }
-            theSecondContext++;
+            // Verify and release handles.
+            NL_TEST_ASSERT(inSuite, test->ResetHandles());
         }
-
-        theFirstContext++;
     }
 }
 
@@ -782,36 +931,32 @@ void PacketBufferTest::CheckCompactHead(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        for (uint16_t length : sLengths)
+        for (size_t i = 0; i < theContext->length_count; ++i)
         {
-            PacketBuffer * buffer = PrepareTestBuffer(theContext);
+            const uint16_t length = theContext->lengths[i];
+            test->PrepareTestBuffer(&config, kRecordHandle | kAllowHandleReuse);
 
-            buffer->ConsumeHead(length);
+            config.handle->ConsumeHead(length);
 
-            if (length > theContext->init_len)
+            if (length > config.init_len)
             {
-                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + theContext->init_len));
-                NL_TEST_ASSERT(inSuite, theContext->buf->len == 0);
-                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == 0);
+                NL_TEST_ASSERT(inSuite, config.handle->payload == (config.payload_ptr + config.init_len));
+                NL_TEST_ASSERT(inSuite, config.handle->len == 0);
+                NL_TEST_ASSERT(inSuite, config.handle->tot_len == 0);
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + length));
-                NL_TEST_ASSERT(inSuite, theContext->buf->len == (theContext->buf->len - length));
-                NL_TEST_ASSERT(inSuite, theContext->buf->tot_len == (theContext->buf->tot_len - length));
-            }
-
-            if (theContext->buf->ref == 0)
-            {
-                theContext->buf = nullptr;
+                NL_TEST_ASSERT(inSuite, config.handle->payload == (config.payload_ptr + length));
+                NL_TEST_ASSERT(inSuite, config.handle->len == (config.handle->len - length));
+                NL_TEST_ASSERT(inSuite, config.handle->tot_len == (config.handle->tot_len - length));
             }
         }
-
-        theContext++;
     }
 }
 
@@ -829,79 +974,90 @@ void PacketBufferTest::CheckConsumeHead(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckConsume(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            // consume various amounts of memory
-            for (uint16_t consumeLength : sLengths)
+            if (&config_1 == &config_2)
             {
+                continue;
+            }
+
+            // consume various amounts of memory
+            for (size_t i = 0; i < theContext->length_count; ++i)
+            {
+                const uint16_t consumeLength = theContext->lengths[i];
                 // start with various initial length for the first buffer
-                for (uint16_t firstLength : sLengths)
+                for (size_t j = 0; j < theContext->length_count; ++j)
                 {
+                    const uint16_t len_1 = theContext->lengths[j];
                     // start with various initial length for the second buffer
-                    for (uint16_t secondLength : sLengths)
+                    for (size_t k = 0; k < theContext->length_count; ++k)
                     {
-                        PacketBuffer * buffer_1;
-                        PacketBuffer * buffer_2;
-                        PacketBuffer * returned;
-                        uint16_t buf_1_len = 0;
-                        uint16_t buf_2_len = 0;
+                        const uint16_t len_2 = theContext->lengths[k];
 
-                        if (theFirstContext == theSecondContext)
-                        {
-                            continue;
-                        }
+                        test->PrepareTestBuffer(&config_1);
+                        test->PrepareTestBuffer(&config_2);
+                        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1);
+                        NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
 
-                        buffer_1 = PrepareTestBuffer(theFirstContext);
-                        buffer_2 = PrepareTestBuffer(theSecondContext);
-
-                        theFirstContext->buf->next = theSecondContext->buf;
+                        config_1.handle->AddToEnd(config_2.handle.Retain());
 
                         // Add various lengths to buffers
-                        buffer_1->SetDataLength(firstLength, buffer_1);
-                        buffer_2->SetDataLength(secondLength, buffer_1);
+                        config_1.handle->SetDataLength(len_1, config_1.handle);
+                        config_2.handle->SetDataLength(len_2, config_1.handle);
 
-                        buf_1_len = theFirstContext->buf->len;
-                        buf_2_len = theSecondContext->buf->len;
+                        const uint16_t buf_1_len = config_1.handle->len;
+                        const uint16_t buf_2_len = config_2.handle->len;
 
-                        returned = buffer_1->Consume(consumeLength);
+                        PacketBufferHandle original_handle_1 = config_1.handle.Retain();
+                        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2); // config_1.handle and original_handle_1
+                        NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
+
+                        config_1.handle.Consume(consumeLength);
 
                         if (consumeLength == 0)
                         {
-                            NL_TEST_ASSERT(inSuite, returned == buffer_1);
-                            continue;
+                            NL_TEST_ASSERT(inSuite, config_1.handle == original_handle_1);
+                            NL_TEST_ASSERT(inSuite, config_1.handle->len == buf_1_len);
+                            NL_TEST_ASSERT(inSuite, config_2.handle->len == buf_2_len);
+                            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2); // config_1.handle and original_handle_1
+                            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
                         }
-
-                        if (consumeLength < buf_1_len)
+                        else if (consumeLength < buf_1_len)
                         {
-                            NL_TEST_ASSERT(inSuite, returned == buffer_1);
+                            NL_TEST_ASSERT(inSuite, config_1.handle == original_handle_1);
+                            NL_TEST_ASSERT(inSuite, config_1.handle->len == buf_1_len - consumeLength);
+                            NL_TEST_ASSERT(inSuite, config_2.handle->len == buf_2_len);
+                            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2); // config_1.handle and original_handle_1
+                            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
                         }
-                        else if ((consumeLength >= buf_1_len) &&
-                                 (consumeLength < buf_1_len + buf_2_len ||
+                        else if ((consumeLength < buf_1_len + buf_2_len ||
                                   (consumeLength == buf_1_len + buf_2_len && buf_2_len == 0)))
                         {
-                            NL_TEST_ASSERT(inSuite, returned == buffer_2);
-                            theFirstContext->buf = nullptr;
+                            NL_TEST_ASSERT(inSuite, config_1.handle == config_2.handle);
+                            NL_TEST_ASSERT(inSuite, config_2.handle->len == buf_1_len + buf_2_len - consumeLength);
+                            NL_TEST_ASSERT(inSuite, original_handle_1->ref == 1); // original_handle_1
+                            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2);   // config_1.handle and config_2.handle
                         }
-                        else if (consumeLength >= (buf_1_len + buf_2_len))
+                        else
                         {
-                            NL_TEST_ASSERT(inSuite, returned == nullptr);
-                            theFirstContext->buf  = nullptr;
-                            theSecondContext->buf = nullptr;
+                            NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+                            NL_TEST_ASSERT(inSuite, original_handle_1->ref == 1); // original_handle_1
+                            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);   // config_2.handle
                         }
+
+                        original_handle_1 = nullptr;
+                        config_1.handle   = nullptr;
+                        config_2.handle   = nullptr;
                     }
                 }
             }
-
-            theSecondContext++;
         }
-
-        theFirstContext++;
     }
 }
 
@@ -916,38 +1072,40 @@ void PacketBufferTest::CheckConsume(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckEnsureReservedSize(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        for (uint16_t length : sLengths)
+        for (size_t i = 0; i < theContext->length_count; ++i)
         {
-            PacketBuffer & lBuffer    = *PrepareTestBuffer(theContext);
-            const uint16_t kAllocSize = lBuffer.AllocSize();
-            uint16_t reserved_size    = theContext->reserved_size;
+            const uint16_t length = theContext->lengths[i];
 
-            if (CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + theContext->reserved_size > kAllocSize)
+            test->PrepareTestBuffer(&config, kRecordHandle | kAllowHandleReuse);
+            const uint16_t kAllocSize = config.handle->AllocSize();
+            uint16_t reserved_size    = config.reserved_size;
+
+            if (CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE + config.reserved_size > kAllocSize)
             {
                 reserved_size = static_cast<uint16_t>(kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE);
             }
 
             if (length <= reserved_size)
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == true);
+                NL_TEST_ASSERT(inSuite, config.handle->EnsureReservedSize(length) == true);
                 continue;
             }
 
-            if ((length + theContext->init_len) > (kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE))
+            if ((length + config.init_len) > (kAllocSize - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE))
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == false);
+                NL_TEST_ASSERT(inSuite, config.handle->EnsureReservedSize(length) == false);
                 continue;
             }
 
-            NL_TEST_ASSERT(inSuite, lBuffer.EnsureReservedSize(length) == true);
-            NL_TEST_ASSERT(inSuite, theContext->buf->payload == (theContext->payload_ptr + length - reserved_size));
+            NL_TEST_ASSERT(inSuite, config.handle->EnsureReservedSize(length) == true);
+            NL_TEST_ASSERT(inSuite, config.handle->payload == (config.payload_ptr + length - reserved_size));
         }
-
-        theContext++;
     }
 }
 
@@ -962,44 +1120,45 @@ void PacketBufferTest::CheckEnsureReservedSize(nlTestSuite * inSuite, void * inC
  */
 void PacketBufferTest::CheckAlignPayload(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        for (size_t n = 0; n < kTestLengths - 1; n++)
+        for (size_t n = 0; n < theContext->length_count; ++n)
         {
-            PacketBuffer & lBuffer    = *PrepareTestBuffer(theContext);
-            const uint16_t kAllocSize = lBuffer.AllocSize();
+            test->PrepareTestBuffer(&config, kRecordHandle | kAllowHandleReuse);
+            const uint16_t kAllocSize = config.handle->AllocSize();
 
-            if (sLengths[n] == 0)
+            if (theContext->lengths[n] == 0)
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.AlignPayload(sLengths[n]) == false);
+                NL_TEST_ASSERT(inSuite, config.handle->AlignPayload(theContext->lengths[n]) == false);
                 continue;
             }
 
-            uint16_t reserved_size = theContext->reserved_size;
-            if (theContext->reserved_size > kAllocSize)
+            uint16_t reserved_size = config.reserved_size;
+            if (config.reserved_size > kAllocSize)
             {
                 reserved_size = kAllocSize;
             }
 
-            uint16_t payload_offset = static_cast<uint16_t>(reinterpret_cast<uintptr_t>(lBuffer.Start()) % sLengths[n]);
-            uint16_t payload_shift  = 0;
+            const uint16_t payload_offset =
+                static_cast<uint16_t>(reinterpret_cast<uintptr_t>(config.handle->Start()) % theContext->lengths[n]);
+            uint16_t payload_shift = 0;
             if (payload_offset > 0)
-                payload_shift = static_cast<uint16_t>(sLengths[n] - payload_offset);
+                payload_shift = static_cast<uint16_t>(theContext->lengths[n] - payload_offset);
 
             if (payload_shift <= kAllocSize - reserved_size)
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.AlignPayload(sLengths[n]) == true);
-                NL_TEST_ASSERT(inSuite, ((unsigned long) lBuffer.Start() % sLengths[n]) == 0);
+                NL_TEST_ASSERT(inSuite, config.handle->AlignPayload(theContext->lengths[n]) == true);
+                NL_TEST_ASSERT(inSuite, ((unsigned long) config.handle->Start() % theContext->lengths[n]) == 0);
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, lBuffer.AlignPayload(sLengths[n]) == false);
+                NL_TEST_ASSERT(inSuite, config.handle->AlignPayload(theContext->lengths[n]) == false);
             }
         }
-
-        theContext++;
     }
 }
 
@@ -1008,33 +1167,81 @@ void PacketBufferTest::CheckAlignPayload(nlTestSuite * inSuite, void * inContext
  */
 void PacketBufferTest::CheckNext(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            PacketBuffer * buffer_1 = PrepareTestBuffer(theFirstContext);
-            PacketBuffer * buffer_2 = PrepareTestBuffer(theSecondContext);
+            test->PrepareTestBuffer(&config_1, kRecordHandle | kAllowHandleReuse);
+            test->PrepareTestBuffer(&config_2, kRecordHandle | kAllowHandleReuse);
 
-            if (theFirstContext != theSecondContext)
+            if (&config_1 != &config_2)
             {
-                theFirstContext->buf->next = theSecondContext->buf;
+                NL_TEST_ASSERT(inSuite, config_1.handle->Next().IsNull());
 
-                NL_TEST_ASSERT(inSuite, buffer_1->ChainedBuffer() == buffer_2);
+                config_1.handle->AddToEnd(config_2.handle.Retain());
+
+                NL_TEST_ASSERT(inSuite, config_1.handle->Next() == config_2.handle);
+                NL_TEST_ASSERT(inSuite, config_1.handle->ChainedBuffer() == config_2.handle.Get());
             }
             else
             {
-                NL_TEST_ASSERT(inSuite, !buffer_1->HasChainedBuffer());
+                NL_TEST_ASSERT(inSuite, !config_1.handle->HasChainedBuffer());
             }
 
-            NL_TEST_ASSERT(inSuite, !buffer_2->HasChainedBuffer());
-            theSecondContext++;
+            NL_TEST_ASSERT(inSuite, !config_2.handle->HasChainedBuffer());
         }
+    }
+}
 
-        theFirstContext++;
+/**
+ *  Test PacketBuffer::Last() function.
+ */
+void PacketBufferTest::CheckLast(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
+        {
+            for (auto & config_3 : test->configurations)
+            {
+                if (&config_1 == &config_2 || &config_1 == &config_3 || &config_2 == &config_3)
+                {
+                    continue;
+                }
+
+                test->PrepareTestBuffer(&config_1);
+                test->PrepareTestBuffer(&config_2);
+                test->PrepareTestBuffer(&config_3);
+
+                NL_TEST_ASSERT(inSuite, config_1.handle->Last() == config_1.handle);
+                NL_TEST_ASSERT(inSuite, config_2.handle->Last() == config_2.handle);
+                NL_TEST_ASSERT(inSuite, config_3.handle->Last() == config_3.handle);
+
+                config_1.handle->AddToEnd(config_2.handle.Retain());
+
+                NL_TEST_ASSERT(inSuite, config_1.handle->Last() == config_2.handle);
+                NL_TEST_ASSERT(inSuite, config_2.handle->Last() == config_2.handle);
+                NL_TEST_ASSERT(inSuite, config_3.handle->Last() == config_3.handle);
+
+                config_1.handle->AddToEnd(config_3.handle.Retain());
+
+                NL_TEST_ASSERT(inSuite, config_1.handle->Last() == config_3.handle);
+                NL_TEST_ASSERT(inSuite, config_2.handle->Last() == config_3.handle);
+                NL_TEST_ASSERT(inSuite, config_3.handle->Last() == config_3.handle);
+
+                config_1.handle = nullptr;
+                config_2.handle = nullptr;
+                config_3.handle = nullptr;
+            }
+        }
     }
 }
 
@@ -1043,77 +1250,17 @@ void PacketBufferTest::CheckNext(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckAddRef(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config : test->configurations)
     {
-        PacketBuffer * buffer = PrepareTestBuffer(theContext);
-        buffer->AddRef();
-
-        NL_TEST_ASSERT(inSuite, theContext->buf->ref == 2);
-
-        theContext++;
-    }
-}
-
-/**
- *  Test PacketBuffer::NewWithAvailableSize() and PacketBuffer::Free() functions.
- *
- *  Description: For every buffer-configuration from inContext, create a
- *               buffer's instance using NewWithAvailableSize() method. Then, verify that
- *               when the size of the reserved space passed to NewWithAvailableSize() is
- *               greater than #CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX, the method
- *               returns NULL. Otherwise, check for correctness of initializing
- *               the new buffer's internal state. Finally, free the buffer.
- */
-void PacketBufferTest::CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, void * inContext)
-{
-    struct TestContext * theContext = static_cast<struct TestContext *>(inContext);
-    PacketBufferHandle buffer;
-
-    for (size_t ith = 0; ith < kTestElements; ith++)
-    {
-        struct pbuf * pb = nullptr;
-
-        buffer = PacketBuffer::NewWithAvailableSize(theContext->reserved_size, 0);
-
-        if (theContext->reserved_size > CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX)
-        {
-            NL_TEST_ASSERT(inSuite, buffer.IsNull());
-            theContext++;
-            continue;
-        }
-
-        NL_TEST_ASSERT(inSuite, theContext->reserved_size <= buffer->AllocSize());
-        NL_TEST_ASSERT(inSuite, !buffer.IsNull());
-
-        if (!buffer.IsNull())
-        {
-            pb = TO_LWIP_PBUF(buffer.Get());
-
-            NL_TEST_ASSERT(inSuite, pb->len == 0);
-            NL_TEST_ASSERT(inSuite, pb->tot_len == 0);
-            NL_TEST_ASSERT(inSuite, pb->next == nullptr);
-            NL_TEST_ASSERT(inSuite, pb->ref == 1);
-        }
-
-        theContext++;
-    }
-
-    // Use the rest of the buffer space
-    for (;;)
-    {
-        buffer = PacketBuffer::NewWithAvailableSize(0, 0);
-        if (buffer.IsNull())
-        {
-            break;
-        }
-        // Leak the buffer on purpose, to use up all the buffer space.
-        // (Compilers other than GCC recognize the `(void)` idiom, which is mandated in C++20.)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-        (void) buffer.Release_ForNow();
-#pragma GCC diagnostic pop
+        test->PrepareTestBuffer(&config, kRecordHandle);
+        const auto refs = config.handle->ref;
+        config.handle->AddRef();
+        NL_TEST_ASSERT(inSuite, config.handle->ref == refs + 1);
+        config.handle->ref = refs; // Don't leak buffers.
     }
 }
 
@@ -1130,69 +1277,88 @@ void PacketBufferTest::CheckNewWithAvailableSizeAndFree(nlTestSuite * inSuite, v
  */
 void PacketBufferTest::CheckFree(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    const decltype(PacketBuffer::ref) init_ref_count[] = { 1, 2, 3 };
+    constexpr size_t kRefs                             = sizeof(init_ref_count) / sizeof(init_ref_count[0]);
+
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            const uint8_t init_ref_count[] = { 1, 2, 3 };
-            const int refs                 = sizeof(init_ref_count) / sizeof(uint16_t);
+            if (&config_1 == &config_2)
+            {
+                continue;
+            }
 
             // start with various buffer ref counts
-            for (size_t r = 0; r < refs; r++)
+            for (size_t r = 0; r < kRefs; r++)
             {
-                PacketBuffer * buffer_1;
+                config_1.handle = PacketBuffer::New(0);
+                config_2.handle = PacketBuffer::New(0);
+                NL_TEST_ASSERT(inSuite, !config_1.handle.IsNull());
+                NL_TEST_ASSERT(inSuite, !config_2.handle.IsNull());
 
-                if (theFirstContext == theSecondContext)
+                test->PrepareTestBuffer(&config_1, kAllowHandleReuse);
+                test->PrepareTestBuffer(&config_2, kAllowHandleReuse);
+                NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1);
+                NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
+
+                // Chain buffers.
+                config_1.handle->next = config_2.handle.Get();
+
+                // Add various buffer ref counts.
+                const auto initial_refs_1 = config_1.handle->ref = init_ref_count[r];
+                const auto initial_refs_2 = config_2.handle->ref = init_ref_count[(r + 1) % kRefs];
+
+                // Free head.
+                PacketBuffer::Free(config_1.handle.mBuffer);
+                if (initial_refs_1 == 1)
                 {
-                    continue;
+                    config_1.handle.mBuffer = nullptr;
                 }
 
-                buffer_1 = PrepareTestBuffer(theFirstContext);
-                (void) PrepareTestBuffer(theSecondContext);
-
-                theFirstContext->buf->next = theSecondContext->buf;
-
-                // Add various buffer ref counts
-                theFirstContext->buf->ref  = init_ref_count[r];
-                theSecondContext->buf->ref = init_ref_count[(r + 1) % refs];
-
-                PacketBuffer::Free(buffer_1);
-
-                NL_TEST_ASSERT(inSuite, theFirstContext->buf->ref == (init_ref_count[r] - 1));
-
-                if (init_ref_count[r] == 1)
+                // Verification.
+                if (initial_refs_1 > 1)
                 {
-                    NL_TEST_ASSERT(inSuite, theSecondContext->buf->ref == (init_ref_count[(r + 1) % refs] - 1));
+                    // Verify that head ref count is decremented.
+                    NL_TEST_ASSERT(inSuite, config_1.handle->ref == initial_refs_1 - 1);
+                    // Verify that chain is maintained.
+                    NL_TEST_ASSERT(inSuite, config_1.handle->next == config_2.handle.Get());
+                    // Verify that chained buffer ref count has not changed.
+                    NL_TEST_ASSERT(inSuite, config_2.handle->ref == initial_refs_2);
                 }
                 else
                 {
-                    NL_TEST_ASSERT(inSuite, theSecondContext->buf->ref == (init_ref_count[(r + 1) % refs]));
+                    if (initial_refs_2 > 1)
+                    {
+                        // Verify that chained buffer ref count is decremented.
+                        NL_TEST_ASSERT(inSuite, config_2.handle->ref == initial_refs_2 - 1);
+                    }
+                    else
+                    {
+                        // Since the test used fake ref counts, config_2.handle now points
+                        // to a freed buffer; clear the handle's internal pointer.
+                        config_2.handle.mBuffer = nullptr;
+                    }
                 }
 
-                if (init_ref_count[r] > 1)
+                // Clean up.
+                if (!config_1.handle.IsNull())
                 {
-                    NL_TEST_ASSERT(inSuite, theFirstContext->buf->next == theSecondContext->buf);
+                    config_1.handle->next = nullptr;
+                    config_1.handle->ref  = 1;
+                    config_1.handle       = nullptr;
                 }
-
-                if (theFirstContext->buf->ref == 0)
+                if (!config_2.handle.IsNull())
                 {
-                    theFirstContext->buf = nullptr;
-                }
-
-                if (theSecondContext->buf->ref == 0)
-                {
-                    theSecondContext->buf = nullptr;
+                    config_2.handle->ref = 1;
+                    config_2.handle      = nullptr;
                 }
             }
-
-            theSecondContext++;
         }
-
-        theFirstContext++;
     }
 }
 
@@ -1207,48 +1373,269 @@ void PacketBufferTest::CheckFree(nlTestSuite * inSuite, void * inContext)
  */
 void PacketBufferTest::CheckFreeHead(nlTestSuite * inSuite, void * inContext)
 {
-    struct TestContext * theFirstContext = static_cast<struct TestContext *>(inContext);
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
-    for (size_t ith = 0; ith < kTestElements; ith++)
+    for (auto & config_1 : test->configurations)
     {
-        struct TestContext * theSecondContext = static_cast<struct TestContext *>(inContext);
-
-        for (size_t jth = 0; jth < kTestElements; jth++)
+        for (auto & config_2 : test->configurations)
         {
-            PacketBuffer * buffer_1;
-            PacketBuffer * buffer_2;
-            PacketBuffer * returned = nullptr;
-
-            if (theFirstContext == theSecondContext)
+            if (&config_1 == &config_2)
             {
                 continue;
             }
 
-            buffer_1 = PrepareTestBuffer(theFirstContext);
-            buffer_2 = PrepareTestBuffer(theSecondContext);
+            // Test PacketBuffer::FreeHead
 
-            theFirstContext->buf->next = theSecondContext->buf;
+            test->PrepareTestBuffer(&config_1, kAllowHandleReuse);
+            test->PrepareTestBuffer(&config_2, kAllowHandleReuse);
+            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
 
-            returned = PacketBuffer::FreeHead(buffer_1);
+            PacketBufferHandle handle_1 = config_1.handle.Retain();
+            config_1.handle->AddToEnd(config_2.handle.Retain());
+            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
 
-            NL_TEST_ASSERT(inSuite, returned == buffer_2);
+            PacketBuffer * const returned = PacketBuffer::FreeHead(config_1.handle.Release_ForNow());
 
-            theFirstContext->buf = nullptr;
-            theSecondContext++;
+            NL_TEST_ASSERT(inSuite, handle_1->ref == 1);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and returned
+            NL_TEST_ASSERT(inSuite, returned == config_2.handle.Get());
+
+            config_1.handle = nullptr;
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2);
+            config_2.handle = nullptr;
+            NL_TEST_ASSERT(inSuite, returned->ref == 1);
+            PacketBuffer::Free(returned);
+
+            // Test PacketBufferHandle::FreeHead
+
+            test->PrepareTestBuffer(&config_1, kAllowHandleReuse);
+            test->PrepareTestBuffer(&config_2, kAllowHandleReuse);
+            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 1);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 1);
+
+            handle_1 = config_1.handle.Retain();
+            config_1.handle->AddToEnd(config_2.handle.Retain());
+            NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle->next
+
+            PacketBuffer * const buffer_1 = config_1.handle.Get();
+
+            config_1.handle.FreeHead();
+
+            NL_TEST_ASSERT(inSuite, buffer_1->ref == 1);
+            NL_TEST_ASSERT(inSuite, config_1.handle == config_2.handle);
+            NL_TEST_ASSERT(inSuite, config_2.handle->ref == 2); // config_2.handle and config_1.handle
+
+            config_1.handle = nullptr;
+            config_2.handle = nullptr;
         }
-
-        theFirstContext++;
     }
 }
 
-/**
- *  Test PacketBuffer::BuildFreeList() function.
- */
-void PacketBufferTest::CheckBuildFreeList(nlTestSuite * inSuite, void * inContext)
+void PacketBufferTest::CheckHandleConstruct(nlTestSuite * inSuite, void * inContext)
 {
-    // BuildFreeList() is a private method called automatically.
-    (void) inSuite;
-    (void) inContext;
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    PacketBufferHandle handle_1;
+    NL_TEST_ASSERT(inSuite, handle_1.IsNull());
+
+    PacketBufferHandle handle_2(nullptr);
+    NL_TEST_ASSERT(inSuite, handle_2.IsNull());
+
+    PacketBufferHandle handle_3(PacketBuffer::New());
+    NL_TEST_ASSERT(inSuite, !handle_3.IsNull());
+
+    // Private constructor.
+    PacketBuffer * const buffer_3 = handle_3.Release_ForNow();
+    PacketBufferHandle handle_4(buffer_3);
+    NL_TEST_ASSERT(inSuite, handle_4.Get() == buffer_3);
+}
+
+void PacketBufferTest::CheckHandleMove(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
+        {
+            if (&config_1 == &config_2)
+            {
+                continue;
+            }
+
+            test->PrepareTestBuffer(&config_1, kRecordHandle);
+            test->PrepareTestBuffer(&config_2, kRecordHandle);
+
+            const PacketBuffer * const buffer_1 = config_1.handle.Get();
+            const PacketBuffer * const buffer_2 = config_2.handle.Get();
+            NL_TEST_ASSERT(inSuite, buffer_1 != buffer_2);
+            NL_TEST_ASSERT(inSuite, buffer_1->ref == 2); // test.handles and config_1.handle
+            NL_TEST_ASSERT(inSuite, buffer_2->ref == 2); // test.handles and config_2.handle
+
+            config_1.handle = std::move(config_2.handle);
+            NL_TEST_ASSERT(inSuite, config_1.handle.Get() == buffer_2);
+            NL_TEST_ASSERT(inSuite, config_2.handle.Get() == nullptr);
+            NL_TEST_ASSERT(inSuite, buffer_1->ref == 1); // test.handles
+            NL_TEST_ASSERT(inSuite, buffer_2->ref == 2); // test.handles and config_1.handle
+
+            config_1.handle = nullptr;
+        }
+    }
+}
+
+void PacketBufferTest::CheckHandleFree(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        test->PrepareTestBuffer(&config_1, kRecordHandle);
+
+        const PacketBuffer * const buffer_1 = config_1.handle.Get();
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 2); // test.handles and config_1.handle
+
+        config_1.handle = nullptr;
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, config_1.handle.Get() == nullptr);
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 1); // test.handles only
+    }
+}
+
+void PacketBufferTest::CheckHandleRetain(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        test->PrepareTestBuffer(&config_1, kRecordHandle);
+
+        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2); // test.handles and config_1.handle
+
+        PacketBufferHandle handle_1 = config_1.handle.Retain();
+
+        NL_TEST_ASSERT(inSuite, config_1.handle == handle_1);
+        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 3); // test.handles and config_1.handle and handle_1
+    }
+}
+
+void PacketBufferTest::CheckHandleAdopt(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        test->PrepareTestBuffer(&config_1, kRecordHandle);
+        PacketBuffer * buffer_1 = config_1.handle.Release_ForNow();
+
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 2); // test.handles and buffer_1
+
+        config_1.handle = PacketBufferHandle::Adopt(buffer_1);
+        NL_TEST_ASSERT(inSuite, config_1.handle.Get() == buffer_1);
+        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2); // test.handles and config_1.handle
+
+        config_1.handle = nullptr;
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 1); // test.handles only
+    }
+}
+
+void PacketBufferTest::CheckHandleHold(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        test->PrepareTestBuffer(&config_1, kRecordHandle);
+        PacketBuffer * buffer_1 = config_1.handle.Release_ForNow();
+
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 2); // test.handles and buffer_1
+
+        config_1.handle = PacketBufferHandle::Hold(buffer_1);
+        NL_TEST_ASSERT(inSuite, config_1.handle.Get() == buffer_1);
+        NL_TEST_ASSERT(inSuite, config_1.handle->ref == 3); // test.handles and config_1.handle and buffer_1
+
+        config_1.handle = nullptr;
+        NL_TEST_ASSERT(inSuite, config_1.handle.IsNull());
+        NL_TEST_ASSERT(inSuite, buffer_1->ref == 2); // test.handles only and buffer_1
+
+        PacketBuffer::Free(buffer_1);
+    }
+}
+
+void PacketBufferTest::CheckHandleAdvance(nlTestSuite * inSuite, void * inContext)
+{
+    struct TestContext * const theContext = static_cast<struct TestContext *>(inContext);
+    PacketBufferTest * const test         = theContext->test;
+    NL_TEST_ASSERT(inSuite, test->mContext == theContext);
+
+    for (auto & config_1 : test->configurations)
+    {
+        for (auto & config_2 : test->configurations)
+        {
+            for (auto & config_3 : test->configurations)
+            {
+                if (&config_1 == &config_2 || &config_1 == &config_3 || &config_2 == &config_3)
+                {
+                    continue;
+                }
+
+                test->PrepareTestBuffer(&config_1);
+                test->PrepareTestBuffer(&config_2);
+                test->PrepareTestBuffer(&config_3);
+
+                PacketBufferHandle handle_1 = config_1.handle.Retain();
+                PacketBufferHandle handle_2 = config_2.handle.Retain();
+                PacketBufferHandle handle_3 = config_3.handle.Retain();
+
+                config_1.handle->AddToEnd(config_2.handle.Retain());
+                config_1.handle->AddToEnd(config_3.handle.Retain());
+
+                NL_TEST_ASSERT(inSuite, config_1.handle->ChainedBuffer() == config_2.handle.Get());
+                NL_TEST_ASSERT(inSuite, config_2.handle->ChainedBuffer() == config_3.handle.Get());
+                NL_TEST_ASSERT(inSuite, config_3.handle->HasChainedBuffer() == false);
+                NL_TEST_ASSERT(inSuite, handle_1->ref == 2); // handle_1 and config_1.handle
+                NL_TEST_ASSERT(inSuite, handle_2->ref == 3); // handle_2 and config_2.handle and config_1.handle->next
+                NL_TEST_ASSERT(inSuite, handle_3->ref == 3); // handle_3 and config_3.handle and config_2.handle->next
+
+                config_1.handle.Advance();
+
+                NL_TEST_ASSERT(inSuite, config_1.handle == handle_2);
+                NL_TEST_ASSERT(inSuite, handle_1->ref == 1); // handle_1 only
+                NL_TEST_ASSERT(inSuite, handle_2->ref == 4); // handle_2, config_[12].handle, handle_1->next
+                NL_TEST_ASSERT(inSuite, handle_3->ref == 3); // handle_3, config_3.handle, config_2.handle->next
+
+                config_1.handle.Advance();
+
+                NL_TEST_ASSERT(inSuite, config_1.handle == handle_3);
+                NL_TEST_ASSERT(inSuite, handle_1->ref == 1); // handle_1 only
+                NL_TEST_ASSERT(inSuite, handle_2->ref == 3); // handle_2, config_2.handle, handle_1->next
+                NL_TEST_ASSERT(inSuite, handle_3->ref == 4); // handle_3, config_[13].handle, handle_2->next
+
+                config_1.handle = nullptr;
+                config_2.handle = nullptr;
+                config_3.handle = nullptr;
+            }
+        }
+    }
 }
 
 /**
@@ -1257,83 +1644,50 @@ void PacketBufferTest::CheckBuildFreeList(nlTestSuite * inSuite, void * inContex
 // clang-format off
 const nlTest sTests[] =
 {
-    NL_TEST_DEF("PacketBuffer::NewWithAvailableSize&PacketBuffer::Free", CheckNewWithAvailableSizeAndFree),
-    NL_TEST_DEF("PacketBuffer::Start",                          CheckStart),
-    NL_TEST_DEF("PacketBuffer::SetStart",                       CheckSetStart),
-    NL_TEST_DEF("PacketBuffer::DataLength",                     CheckDataLength),
-    NL_TEST_DEF("PacketBuffer::SetDataLength",                  CheckSetDataLength),
-    NL_TEST_DEF("PacketBuffer::TotalLength",                    CheckTotalLength),
-    NL_TEST_DEF("PacketBuffer::MaxDataLength",                  CheckMaxDataLength),
-    NL_TEST_DEF("PacketBuffer::AvailableDataLength",            CheckAvailableDataLength),
-    NL_TEST_DEF("PacketBuffer::ReservedSize",                   CheckReservedSize),
-    NL_TEST_DEF("PacketBuffer::AddToEnd",                       CheckAddToEnd),
-    NL_TEST_DEF("PacketBuffer::DetachTail",                     CheckDetachTail),
-    NL_TEST_DEF("PacketBuffer::CompactHead",                    CheckCompactHead),
-    NL_TEST_DEF("PacketBuffer::ConsumeHead",                    CheckConsumeHead),
-    NL_TEST_DEF("PacketBuffer::Consume",                        CheckConsume),
-    NL_TEST_DEF("PacketBuffer::EnsureReservedSize",             CheckEnsureReservedSize),
-    NL_TEST_DEF("PacketBuffer::AlignPayload",                   CheckAlignPayload),
-    NL_TEST_DEF("PacketBuffer::Next",                           CheckNext),
-    NL_TEST_DEF("PacketBuffer::AddRef",                         CheckAddRef),
-    NL_TEST_DEF("PacketBuffer::Free",                           CheckFree),
-    NL_TEST_DEF("PacketBuffer::FreeHead",                       CheckFreeHead),
-    NL_TEST_DEF("PacketBuffer::BuildFreeList",                  CheckBuildFreeList),
+    NL_TEST_DEF("PacketBuffer::NewWithAvailableSize&PacketBuffer::Free", PacketBufferTest::CheckNewWithAvailableSizeAndFree),
+    NL_TEST_DEF("PacketBuffer::Start",                                   PacketBufferTest::CheckStart),
+    NL_TEST_DEF("PacketBuffer::SetStart",                                PacketBufferTest::CheckSetStart),
+    NL_TEST_DEF("PacketBuffer::DataLength",                              PacketBufferTest::CheckDataLength),
+    NL_TEST_DEF("PacketBuffer::SetDataLength",                           PacketBufferTest::CheckSetDataLength),
+    NL_TEST_DEF("PacketBuffer::TotalLength",                             PacketBufferTest::CheckTotalLength),
+    NL_TEST_DEF("PacketBuffer::MaxDataLength",                           PacketBufferTest::CheckMaxDataLength),
+    NL_TEST_DEF("PacketBuffer::AvailableDataLength",                     PacketBufferTest::CheckAvailableDataLength),
+    NL_TEST_DEF("PacketBuffer::HasChainedBuffer",                        PacketBufferTest::CheckHasChainedBuffer),
+    NL_TEST_DEF("PacketBuffer::ReservedSize",                            PacketBufferTest::CheckReservedSize),
+    NL_TEST_DEF("PacketBuffer::AddToEnd",                                PacketBufferTest::CheckAddToEnd),
+    NL_TEST_DEF("PacketBuffer::PopHead",                                 PacketBufferTest::CheckPopHead),
+    NL_TEST_DEF("PacketBuffer::CompactHead",                             PacketBufferTest::CheckCompactHead),
+    NL_TEST_DEF("PacketBuffer::ConsumeHead",                             PacketBufferTest::CheckConsumeHead),
+    NL_TEST_DEF("PacketBuffer::Consume",                                 PacketBufferTest::CheckConsume),
+    NL_TEST_DEF("PacketBuffer::EnsureReservedSize",                      PacketBufferTest::CheckEnsureReservedSize),
+    NL_TEST_DEF("PacketBuffer::AlignPayload",                            PacketBufferTest::CheckAlignPayload),
+    NL_TEST_DEF("PacketBuffer::Next",                                    PacketBufferTest::CheckNext),
+    NL_TEST_DEF("PacketBuffer::Last",                                    PacketBufferTest::CheckLast),
+    NL_TEST_DEF("PacketBuffer::AddRef",                                  PacketBufferTest::CheckAddRef),
+    NL_TEST_DEF("PacketBuffer::Free",                                    PacketBufferTest::CheckFree),
+    NL_TEST_DEF("PacketBuffer::FreeHead",                                PacketBufferTest::CheckFreeHead),
+    NL_TEST_DEF("PacketBuffer::HandleConstruct",                         PacketBufferTest::CheckHandleConstruct),
+    NL_TEST_DEF("PacketBuffer::HandleMove",                              PacketBufferTest::CheckHandleMove),
+    NL_TEST_DEF("PacketBuffer::HandleFree",                              PacketBufferTest::CheckHandleFree),
+    NL_TEST_DEF("PacketBuffer::HandleRetain",                            PacketBufferTest::CheckHandleRetain),
+    NL_TEST_DEF("PacketBuffer::HandleAdopt",                             PacketBufferTest::CheckHandleAdopt),
+    NL_TEST_DEF("PacketBuffer::HandleHold",                              PacketBufferTest::CheckHandleHold),
+    NL_TEST_DEF("PacketBuffer::HandleAdvance",                           PacketBufferTest::CheckHandleAdvance),
 
     NL_TEST_SENTINEL()
 };
 // clang-format on
 
-/**
- * Set up the test suite.
- *
- *  This is a work-around to initiate PacketBuffer protected class instance's data and set it to a known state, before an instance
- *  is created.
- */
-int TestSetup(void * inContext)
-{
-    struct TestContext * theContext = reinterpret_cast<TestContext *>(inContext);
-
-    for (size_t ith = 0; ith < kTestElements; ith++)
-    {
-        BufferAlloc(theContext);
-        theContext++;
-    }
-
-    return (SUCCESS);
-}
-
-/**
- * Tear down the test suite.
- *
- *  Free memory reserved at TestSetup.
- */
-int TestTeardown(void * inContext)
-{
-    struct TestContext * theContext = reinterpret_cast<TestContext *>(inContext);
-
-    for (size_t ith = 0; ith < kTestElements; ith++)
-    {
-        PacketBufferTest::BufferFree(theContext);
-        theContext++;
-    }
-
-    return (SUCCESS);
-}
-
 int TestSystemPacketBuffer(void)
-{ /*
- #if CHIP_SYSTEM_CONFIG_USE_LWIP
-     tcpip_init(NULL, NULL);
- #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
- */
-
+{
     // clang-format off
-    nlTestSuite theSuite =
-	{
-        "chip-system-packetbuffer",
-        &sTests[0],
-        TestSetup,
-        TestTeardown
+    nlTestSuite theSuite = {
+        .name ="chip-system-packetbuffer",
+        .tests = &sTests[0],
+        .setup = PacketBufferTest::TestSetup,
+        .tear_down = PacketBufferTest::TestTeardown,
+        // .initialize = PacketBufferTest::TestInitialize,
+        .terminate = PacketBufferTest::TestTerminate
     };
     // clang-format on
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -910,11 +910,13 @@ void PacketBufferTest::CheckCompactHead(nlTestSuite * inSuite, void * inContext)
                         }
                     }
 
+                    NL_TEST_ASSERT(inSuite, config_1.handle->ref == 2);
                     config_1.handle = nullptr;
+
+                    // Verify and release handles.
+                    NL_TEST_ASSERT(inSuite, test->ResetHandles());
                 }
             }
-            // Verify and release handles.
-            NL_TEST_ASSERT(inSuite, test->ResetHandles());
         }
     }
 }
@@ -1489,6 +1491,8 @@ void PacketBufferTest::CheckHandleMove(nlTestSuite * inSuite, void * inContext)
 
             config_1.handle = nullptr;
         }
+        // Verify and release handles.
+        NL_TEST_ASSERT(inSuite, test->ResetHandles());
     }
 }
 


### PR DESCRIPTION
#### Problem

Uses of `PacketBuffer` have largely been replaced by `PacketBufferHandle`. The unit test had not kept up.

#### Summary of Changes

- Added tests for PacketBufferHandle specifically.
- Added many checks of reference counts to verify the ownership model.
- Some more refactoring into `PacketBufferTest`, friend class of `PacketBuffer` and `PacketBufferHandle`, to use private fields and track buffer allocations.

part of #2707 - Figure out a way to express PacketBuffer ownership in the type system
