### PR TITLE
Add more unit tests for sending pre-encrypted messages

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -123,10 +123,8 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle ms
     msgBuf->SetStart(msgBuf->Start() + headerSize);
 
     PayloadHeader payloadHeader;
-    ReturnErrorOnFailure(SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
-                                     EncryptionState::kPayloadIsEncrypted));
-
-    return CHIP_NO_ERROR;
+    return SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
+                                     EncryptionState::kPayloadIsEncrypted);
 }
 
 CHIP_ERROR SecureSessionMgr::EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader,

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(EncryptedPacketBufferHandle ms
 
     PayloadHeader payloadHeader;
     return SendMessage(payloadHeader, packetHeader, peerNodeId, std::move(msgBuf), bufferRetainSlot,
-                                     EncryptionState::kPayloadIsEncrypted);
+                       EncryptionState::kPayloadIsEncrypted);
 }
 
 CHIP_ERROR SecureSessionMgr::EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader,

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -75,10 +75,7 @@ public:
      *
      * @returns empty handle on allocation failure.
      */
-    EncryptedPacketBufferHandle CloneData()
-    {
-        return EncryptedPacketBufferHandle(PacketBufferHandle::CloneData());
-    }
+    EncryptedPacketBufferHandle CloneData() { return EncryptedPacketBufferHandle(PacketBufferHandle::CloneData()); }
 
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -68,6 +68,18 @@ public:
 
     uint32_t GetMsgId() const { return mMsgId; }
 
+    /**
+     * Creates a copy of the data in this packet.
+     *
+     * Does NOT support chained buffers.
+     *
+     * @returns empty handle on allocation failure.
+     */
+    EncryptedPacketBufferHandle CloneData()
+    {
+        return EncryptedPacketBufferHandle(PacketBufferHandle::CloneData());
+    }
+
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle
     friend class SecureSessionMgr;

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -322,7 +322,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Destination Node ID
     EncryptedPacketBufferHandle badDestNodeIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badDestNodeIdMsg->Start(), badDestNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   packetHeader.Decode(badDestNodeIdMsg->Start(), badDestNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, packetHeader.GetDestinationNodeId().Value() == kDestinationNodeId);
     packetHeader.SetDestinationNodeId(kSourceNodeId);
@@ -337,7 +338,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Source Node ID
     EncryptedPacketBufferHandle badSrcNodeIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   packetHeader.Decode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
 
     packetHeader.SetSourceNodeId(kDestinationNodeId);
     packetHeader.Encode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize);
@@ -351,7 +353,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Message ID
     EncryptedPacketBufferHandle badMessageIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badMessageIdMsg->Start(), badMessageIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite,
+                   packetHeader.Decode(badMessageIdMsg->Start(), badMessageIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
 
     uint32_t msgID = packetHeader.GetMessageId();
     packetHeader.SetMessageId(msgID + 1);
@@ -385,7 +388,6 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
-
 }
 
 // Test Suite

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -371,8 +371,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     EncryptedPacketBufferHandle badKeyIdMsg = msgBuf.CloneData();
     NL_TEST_ASSERT(inSuite, packetHeader.Decode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
 
-    uint16_t keyID = packetHeader.GetEncryptionKeyID();
-    packetHeader.SetEncryptionKeyID(keyID + 1);
+    // the secure channel is setup to use key ID 1, and 2. So let's use 3 here. 
+    packetHeader.SetEncryptionKeyID(3);
     packetHeader.Encode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize);
 
     err = secureSessionMgr.SendEncryptedMessage(std::move(badKeyIdMsg), nullptr);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -73,7 +73,8 @@ public:
 
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        const uint16_t headerSize = header.EncodeSizeBytes();
+        const uint16_t headerSize           = header.EncodeSizeBytes();
+        System::PacketBufferHandle recvdMsg = msgBuf.CloneData();
 
         VerifyOrReturnError(msgBuf->EnsureReservedSize(headerSize), CHIP_ERROR_NO_MEMORY);
 
@@ -82,6 +83,7 @@ public:
         uint16_t actualEncodedHeaderSize;
         ReturnErrorOnFailure(header.Encode(msgBuf->Start(), msgBuf->DataLength(), &actualEncodedHeaderSize));
 
+        HandleMessageReceived(header, address, std::move(recvdMsg));
         return CHIP_NO_ERROR;
     }
 
@@ -242,8 +244,148 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     err = secureSessionMgr.SendMessage(payloadHeader, kDestinationNodeId, std::move(buffer), &msgBuf);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
     err = secureSessionMgr.SendEncryptedMessage(std::move(msgBuf), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+}
+
+void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    uint16_t payload_len = sizeof(PAYLOAD);
+
+    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+
+    chip::System::PacketBufferHandle buffer = chip::System::PacketBuffer::NewWithAvailableSize(payload_len);
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    memmove(buffer->Start(), PAYLOAD, payload_len);
+    buffer->SetDataLength(payload_len);
+
+    IPAddress addr;
+    IPAddress::FromString("127.0.0.1", addr);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    TransportMgr<OutgoingTransport> transportMgr;
+    SecureSessionMgr secureSessionMgr;
+
+    err = transportMgr.Init("LOOPBACK");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.mSuite = inSuite;
+
+    secureSessionMgr.SetDelegate(&callback);
+
+    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing2);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Should be able to send a message to itself by just calling send.
+    callback.ReceiveHandlerCallCount = 0;
+
+    PayloadHeader payloadHeader;
+    EncryptedPacketBufferHandle msgBuf;
+
+    // Set the exchange ID for this header.
+    payloadHeader.SetExchangeID(0);
+
+    // Set the protocol ID for this header.
+    payloadHeader.SetProtocolID(chip::Protocols::kProtocol_Echo);
+
+    // Set the message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::kEchoMessageType_EchoRequest);
+
+    payloadHeader.SetInitiator(true);
+
+    err = secureSessionMgr.SendMessage(payloadHeader, kDestinationNodeId, std::move(buffer), &msgBuf);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    uint16_t headerSize = 0;
+    PacketHeader packetHeader;
+
+    // Change Destination Node ID
+    EncryptedPacketBufferHandle badDestNodeIdMsg = msgBuf.CloneData();
+    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badDestNodeIdMsg->Start(), badDestNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, packetHeader.GetDestinationNodeId().Value() == kDestinationNodeId);
+    packetHeader.SetDestinationNodeId(kSourceNodeId);
+    packetHeader.Encode(badDestNodeIdMsg->Start(), badDestNodeIdMsg->DataLength(), &headerSize);
+
+    err = secureSessionMgr.SendEncryptedMessage(std::move(badDestNodeIdMsg), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Change Source Node ID
+    EncryptedPacketBufferHandle badSrcNodeIdMsg = msgBuf.CloneData();
+    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+
+    packetHeader.SetSourceNodeId(kDestinationNodeId);
+    packetHeader.Encode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize);
+
+    err = secureSessionMgr.SendEncryptedMessage(std::move(badSrcNodeIdMsg), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Change Message ID
+    EncryptedPacketBufferHandle badMessageIdMsg = msgBuf.CloneData();
+    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badMessageIdMsg->Start(), badMessageIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+
+    uint32_t msgID = packetHeader.GetMessageId();
+    packetHeader.SetMessageId(msgID + 1);
+    packetHeader.Encode(badMessageIdMsg->Start(), badMessageIdMsg->DataLength(), &headerSize);
+
+    err = secureSessionMgr.SendEncryptedMessage(std::move(badMessageIdMsg), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Change Key ID
+    EncryptedPacketBufferHandle badKeyIdMsg = msgBuf.CloneData();
+    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+
+    uint16_t keyID = packetHeader.GetEncryptionKeyID();
+    packetHeader.SetEncryptionKeyID(keyID + 1);
+    packetHeader.Encode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize);
+
+    err = secureSessionMgr.SendEncryptedMessage(std::move(badKeyIdMsg), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Send the correct encrypted msg
+    err = secureSessionMgr.SendEncryptedMessage(std::move(msgBuf), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 1; });
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
 }
 
 // Test Suite
@@ -254,9 +396,10 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 const nlTest sTests[] =
 {
-    NL_TEST_DEF("Simple Init Test",              CheckSimpleInitTest),
-    NL_TEST_DEF("Message Self Test",             CheckMessageTest),
-    NL_TEST_DEF("Send Encrypted Packet Test",    SendEncryptedPacketTest),
+    NL_TEST_DEF("Simple Init Test",               CheckSimpleInitTest),
+    NL_TEST_DEF("Message Self Test",              CheckMessageTest),
+    NL_TEST_DEF("Send Encrypted Packet Test",     SendEncryptedPacketTest),
+    NL_TEST_DEF("Send Bad Encrypted Packet Test", SendBadEncryptedPacketTest),
 
     NL_TEST_SENTINEL()
 };

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -371,7 +371,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     EncryptedPacketBufferHandle badKeyIdMsg = msgBuf.CloneData();
     NL_TEST_ASSERT(inSuite, packetHeader.Decode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
 
-    // the secure channel is setup to use key ID 1, and 2. So let's use 3 here. 
+    // the secure channel is setup to use key ID 1, and 2. So let's use 3 here.
     packetHeader.SetEncryptionKeyID(3);
     packetHeader.Encode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize);
 


### PR DESCRIPTION
 #### Problem
An API to send pre-encrypted packets was recently added to `SecureSessionMgr` class. A part of the encrypted packet header is not actually encrypted, but it's used in message integrity check. So, if any field in this unencrypted header is modified, the message integrity check will fail, and the packet would be discarded.

More unit tests are needed to cover these conditions.  

 #### Summary of Changes
Added the missing unit tests.
