### PR TITLE
Remove prefix from enum class SendMessageFlag and ExFlagValues definations.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -58,8 +58,7 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
 
     VerifyOrExit(mpExchangeCtx != NULL, err = CHIP_ERROR_INCORRECT_STATE);
     err = mpExchangeCtx->SendMessage(Protocols::kProtocol_InteractionModel, kMsgType_InvokeCommandResponse,
-                                     std::move(mCommandMessageBuf),
-                                     Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+                                     std::move(mCommandMessageBuf), Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
     SuccessOrExit(err);
 
     MoveToState(kState_Sending);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId)
 
     err = mpExchangeCtx->SendMessage(Protocols::kProtocol_InteractionModel, kMsgType_InvokeCommandRequest,
                                      std::move(mCommandMessageBuf),
-                                     Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_ExpectResponse));
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
     SuccessOrExit(err);
     MoveToState(kState_Sending);
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(mSecureSession);
     VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);
     if ((state->GetPeerAddress().GetTransportType() == Transport::Type::kUdp) && mReliableMessageContext.AutoRequestAck() &&
-        !sendFlags.Has(SendMessageFlags::kSendFlag_NoAutoRequestAck))
+        !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck))
     {
         payloadHeader.SetNeedsAck(true);
     }
@@ -126,7 +126,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     }
 
     // If a response message is expected...
-    if (sendFlags.Has(SendMessageFlags::kSendFlag_ExpectResponse))
+    if (sendFlags.Has(SendMessageFlags::kExpectResponse))
     {
         // Only one 'response expected' message can be outstanding at a time.
         VerifyOrExit(!IsResponseExpected(), err = CHIP_ERROR_INCORRECT_STATE);
@@ -389,7 +389,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, con
 
         // An acknowledgment needs to be sent back to the peer for this message on this exchange,
         // Set the flag in message header indicating an ack requested by peer;
-        msgFlags.Set(MessageFlagValues::kMessageFlag_PeerRequestedAck);
+        msgFlags.Set(MessageFlagValues::kPeerRequestedAck);
 
         // Also set the flag in the exchange context indicating an ack requested;
         mReliableMessageContext.SetPeerRequestedAck(true);

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -38,44 +38,44 @@ namespace Messaging {
 enum class MessageFlagValues : uint32_t
 {
     /**< Indicates that the existing source node identifier must be reused. */
-    kMessageFlag_ReuseSourceId = 0x00000020,
+    kReuseSourceId = 0x00000020,
     /**< Indicates that the CHIP message is already encoded. */
-    kMessageFlag_MessageEncoded = 0x00001000,
+    kMessageEncoded = 0x00001000,
     /**< Indicates that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
-    kMessageFlag_DefaultMulticastSourceAddress = 0x00002000,
+    kDefaultMulticastSourceAddress = 0x00002000,
     /**< Indicates that the sender of the  message requested an acknowledgment. */
-    kMessageFlag_PeerRequestedAck = 0x00004000,
+    kPeerRequestedAck = 0x00004000,
     /**< Indicates that the message is a duplicate of a previously received message. */
-    kMessageFlag_DuplicateMessage = 0x00008000,
+    kDuplicateMessage = 0x00008000,
     /**< Indicates that the peer's group key message counter is not synchronized. */
-    kMessageFlag_PeerGroupMsgIdNotSynchronized = 0x00010000,
+    kPeerGroupMsgIdNotSynchronized = 0x00010000,
     /**< Indicates that the source of the message is the initiator of the CHIP exchange. */
-    kMessageFlag_FromInitiator = 0x00020000,
+    kFromInitiator = 0x00020000,
     /**< Indicates that message is being sent/received via the local ephemeral UDP port. */
-    kMessageFlag_ViaEphemeralUDPPort = 0x00040000,
+    kViaEphemeralUDPPort = 0x00040000,
 };
 
 using MessageFlags = BitFlags<uint32_t, MessageFlagValues>;
 
 enum class SendMessageFlags : uint16_t
 {
-    kSendFlag_None = 0x0000,
+    kNone = 0x0000,
     /**< Used to indicate that automatic retransmission is enabled. */
-    kSendFlag_AutoRetrans = 0x0001,
+    kAutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */
-    kSendFlag_ExpectResponse = 0x0002,
+    kExpectResponse = 0x0002,
     /**< Used to indicate that the source node ID in the message header can be reused. */
-    kSendFlag_ReuseSourceId = 0x0020,
+    kReuseSourceId = 0x0020,
     /**< Used to indicate that the message is already encoded. */
-    kSendFlag_AlreadyEncoded = 0x0080,
+    kAlreadyEncoded = 0x0080,
     /**< Used to indicate that default IPv6 source address selection should be used when sending IPv6 multicast messages. */
-    kSendFlag_DefaultMulticastSourceAddress = 0x0100,
+    kDefaultMulticastSourceAddress = 0x0100,
     /**< Used to indicate that the current message is the initiator of the exchange. */
-    kSendFlag_FromInitiator = 0x0200,
+    kFromInitiator = 0x0200,
     /**< Used to send a ReliableMessageProtocol message requesting an acknowledgment. */
-    kSendFlag_RequestAck = 0x0400,
+    kRequestAck = 0x0400,
     /**< Suppress the auto-request acknowledgment feature when sending a message. */
-    kSendFlag_NoAutoRequestAck = 0x0800,
+    kNoAutoRequestAck = 0x0800,
 };
 
 using SendFlags = BitFlags<uint16_t, SendMessageFlags>;

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -273,7 +273,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<u
     mManager->ExpireTicks();
 
     // If the message IS a duplicate.
-    if (MsgFlags.Has(MessageFlagValues::kMessageFlag_DuplicateMessage))
+    if (MsgFlags.Has(MessageFlagValues::kDuplicateMessage))
     {
 #if !defined(NDEBUG)
         ChipLogProgress(ExchangeManager, "Forcing tx of solitary ack for duplicate MsgId:%08" PRIX32, MessageId);
@@ -352,7 +352,7 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     {
         err = mExchange->SendMessage(Protocols::kProtocol_SecureChannel,
                                      static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck), std::move(msgBuf),
-                                     BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kSendFlag_NoAutoRequestAck });
+                                     BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }
     else
     {

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -258,11 +258,11 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
 
     // send a malicious packet
-    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New(), SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+    ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New(), SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet
-    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New(), SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+    ec1->SendMessage(0x0001, 0x0001, System::PacketBuffer::New(), SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -265,7 +265,7 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
     gSendMessageCount = 0;
 
     err = exchange->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, std::move(buffer),
-                                Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+                                Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // 1 tick is 64 ms, sleep 65 ms to trigger first re-transmit

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -72,7 +72,7 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
     err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, std::move(payload),
-                                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+                                    Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -79,7 +79,7 @@ void EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
 
     // Send an Echo Response back to the sender.
     ec->SendMessage(kProtocol_Echo, kEchoMessageType_EchoResponse, std::move(response),
-                    Messaging::SendFlags(Messaging::SendMessageFlags::kSendFlag_None));
+                    Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
 
     // Discard the exchange context.
     ec->Close();


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
This is the follow-up of the review comments in #4048. The actual flag name should be SendMessageFlags::NoAutoRequestAck and similar for all the other flags. As in, the "kSendFlag_" part is redundant with the enum class name already.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Remove prefix kSendFlag_ from enum class SendMessageFlag and kExchangeFlag_ from ExFlagValues

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4201

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
