### PR TITLE
[mDNS] Add commission advertiser

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -31,6 +31,19 @@ using namespace ::chip::Inet;
 using namespace ::chip::Transport;
 using namespace ::chip::DeviceLayer;
 
+namespace {
+
+CHIP_ERROR AdvertiseOperational()
+{
+    constexpr uint64_t kTestFabricId = 5544332211;
+    return chip::Mdns::ServiceAdvertiser::Instance().AdvertiseOperational(chip::Mdns::OperationalAdvertisingParameters()
+                                                                              .SetFabricId(kTestFabricId)
+                                                                              .SetNodeId(chip::kTestDeviceNodeId)
+                                                                              .SetPort(CHIP_PORT));
+}
+
+} // namespace
+
 namespace chip {
 
 RendezvousServer::RendezvousServer() : mRendezvousSession(this) {}
@@ -97,9 +110,9 @@ void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)
 
     case RendezvousSessionDelegate::NetworkProvisioningSuccess:
         ChipLogProgress(AppServer, "Device was assigned network credentials");
-        if (chip::Mdns::ServiceAdvertiser::Instance().Start(&DeviceLayer::InetLayer, chip::Mdns::kMdnsPort) != CHIP_NO_ERROR)
+        if (AdvertiseOperational() != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "Failed to start mDNS advertisement");
+            ChipLogError(AppServer, "Failed to start operational mDNS advertisement");
         }
         if (mDelegate != nullptr)
         {

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -66,7 +66,9 @@ public:
     CHIP_ERROR GetProductRevision(uint16_t & productRev);
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize, size_t & serialNumLen);
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf);
+    CHIP_ERROR GetPrimaryWiFiMACAddress(uint64_t & macAddress);
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR GetPrimary802154MACAddress(uint64_t & macAddress);
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
     CHIP_ERROR GetFirmwareRevision(char * buf, size_t bufSize, size_t & outLen);
     CHIP_ERROR GetFirmwareBuildTime(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth, uint8_t & hour, uint8_t & minute,
@@ -235,9 +237,47 @@ inline CHIP_ERROR ConfigurationManager::GetPrimaryWiFiMACAddress(uint8_t * buf)
     return static_cast<ImplClass *>(this)->_GetPrimaryWiFiMACAddress(buf);
 }
 
+inline CHIP_ERROR ConfigurationManager::GetPrimaryWiFiMACAddress(uint64_t & macAddress)
+{
+    uint8_t mac[6];
+    CHIP_ERROR error = static_cast<ImplClass *>(this)->_GetPrimaryWiFiMACAddress(mac);
+
+    if (error != CHIP_NO_ERROR)
+    {
+        return error;
+    }
+
+    macAddress = 0;
+    for (uint8_t val : mac)
+    {
+        macAddress |= val;
+        macAddress <<= 8;
+    }
+    return CHIP_NO_ERROR;
+}
+
 inline CHIP_ERROR ConfigurationManager::GetPrimary802154MACAddress(uint8_t * buf)
 {
     return static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(buf);
+}
+
+inline CHIP_ERROR ConfigurationManager::GetPrimary802154MACAddress(uint64_t & macAddress)
+{
+    uint8_t mac[8];
+    CHIP_ERROR error = static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(mac);
+
+    if (error != CHIP_NO_ERROR)
+    {
+        return error;
+    }
+
+    macAddress = 0;
+    for (uint8_t val : mac)
+    {
+        macAddress |= val;
+        macAddress <<= 8;
+    }
+    return CHIP_NO_ERROR;
 }
 
 inline CHIP_ERROR ConfigurationManager::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth)

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -51,20 +51,58 @@ public:
         mPort = port;
         return *this;
     }
-    uint64_t GetPort() const { return mPort; }
-
-    OperationalAdvertisingParameters & EnableIpV4(bool enable)
-    {
-        mEnableIPv4 = enable;
-        return *this;
-    }
-    bool IsIPv4Enabled() const { return mEnableIPv4; }
+    uint16_t GetPort() const { return mPort; }
 
 private:
     uint64_t mFabricId = 0;
     uint64_t mNodeId   = 0;
     uint16_t mPort     = CHIP_PORT;
-    bool mEnableIPv4   = true;
+};
+
+class CommissionAdvertisingParameters
+{
+public:
+    CommissionAdvertisingParameters & SetDiscriminator(uint16_t discriminator)
+    {
+        mDiscriminator = discriminator;
+        return *this;
+    }
+    uint16_t GetDiscriminator() const { return mDiscriminator; }
+
+    CommissionAdvertisingParameters & SetVendorId(uint16_t vendorId)
+    {
+        mVendorId = vendorId;
+        return *this;
+    }
+    uint16_t GetVendorId() const { return mVendorId; }
+
+    CommissionAdvertisingParameters & SetProductId(uint16_t productId)
+    {
+        mProductId = productId;
+        return *this;
+    }
+    uint16_t GetProductId() const { return mProductId; }
+
+    CommissionAdvertisingParameters & SetIdentifier(uint64_t identifier)
+    {
+        mIdentifier = identifier;
+        return *this;
+    }
+    uint64_t GetIdentifier() const { return mIdentifier; }
+
+    CommissionAdvertisingParameters & SetPort(uint16_t port)
+    {
+        mPort = port;
+        return *this;
+    }
+    uint16_t GetPort() const { return mPort; }
+
+private:
+    uint16_t mDiscriminator;
+    uint16_t mVendorId;
+    uint16_t mProductId;
+    uint64_t mIdentifier;
+    uint16_t mPort = CHIP_PORT;
 };
 
 /// Handles advertising of CHIP nodes
@@ -75,10 +113,13 @@ public:
 
     /// Starts the advertiser. Items 'Advertised' will become visible.
     /// May be called before OR after Advertise() calls.
-    virtual CHIP_ERROR Start(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
+    virtual CHIP_ERROR Start(chip::Inet::InetLayer * inetLayer, uint64_t macAddress, uint16_t port, bool enableIPv4) = 0;
 
     /// Advertises the CHIP node as an operational node
-    virtual CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) = 0;
+    virtual CHIP_ERROR AdvertiseOperational(const OperationalAdvertisingParameters & params) = 0;
+
+    /// Advertises the CHIP node as a commission node
+    virtual CHIP_ERROR AdvertiseCommission(const CommissionAdvertisingParameters & params) = 0;
 
     /// Provides the system-wide implementation of the service advertiser
     static ServiceAdvertiser & Instance();

--- a/src/lib/mdns/Advertiser_ImplNone.cpp
+++ b/src/lib/mdns/Advertiser_ImplNone.cpp
@@ -26,15 +26,21 @@ namespace {
 class NoneAdvertiser : public ServiceAdvertiser
 {
 public:
-    CHIP_ERROR Start(chip::Inet::InetLayer * inetLayet, uint16_t port) override
+    CHIP_ERROR Start(chip::Inet::InetLayer * inetLayer, uint64_t macAddress, uint16_t port, bool enableIPv4) override
     {
         ChipLogError(Discovery, "mDNS advertising not available. mDNS start disabled.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
-    CHIP_ERROR Advertise(const OperationalAdvertisingParameters & params) override
+    CHIP_ERROR AdvertiseOperational(const OperationalAdvertisingParameters & params) override
     {
         ChipLogError(Discovery, "mDNS advertising not available. Operational Advertisement failed.");
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR AdvertiseCommission(const CommissionAdvertisingParameters & params) override
+    {
+        ChipLogError(Discovery, "mDNS advertising not available. Commission Advertisement failed.");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 };


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Commission device advertisement is missing from the current advertiser.

 #### Summary of Changes

* Add commission device support in `Advertiser`
* Use mac address as the hostname, which is recommended in the spec.