### PR TITLE
NFC Tag Reading support added

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -20,3 +20,9 @@ The CHIP src directory is structured as follows:
 | setup_payload | QR code setup data encode / decode library         |
 | system        | System Layer -- common APIs for mem, work, etc.    |
 | test_driver   | Framework for on-device testing                    |
+
+
+#### Darwin
+
+##### Near Field Communication Tag Reading
+NFC Tag Reading is disabled by default because a paid Apple developer account is requird to have it enabled. If you want to enable it and you have a paid Apple developer account, go to the CHIPTool iOS target and turn on Near Field Communication Tag Reading under the Capabilities tab.

--- a/src/README.md
+++ b/src/README.md
@@ -21,8 +21,11 @@ The CHIP src directory is structured as follows:
 | system        | System Layer -- common APIs for mem, work, etc.    |
 | test_driver   | Framework for on-device testing                    |
 
-
 #### Darwin
 
 ##### Near Field Communication Tag Reading
-NFC Tag Reading is disabled by default because a paid Apple developer account is requird to have it enabled. If you want to enable it and you have a paid Apple developer account, go to the CHIPTool iOS target and turn on Near Field Communication Tag Reading under the Capabilities tab.
+
+NFC Tag Reading is disabled by default because a paid Apple developer account is
+requird to have it enabled. If you want to enable it and you have a paid Apple
+developer account, go to the CHIPTool iOS target and turn on Near Field
+Communication Tag Reading under the Capabilities tab.

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		B232D8B92514BD0800792CB4 /* CHIPUIViewUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPUIViewUtils.m; sourceTree = "<group>"; };
 		B243A6672513A73600E56FEA /* RootViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RootViewController.h; sourceTree = "<group>"; };
 		B243A6682513A73600E56FEA /* RootViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RootViewController.m; sourceTree = "<group>"; };
+		B27FAB67255D4B980038F0D2 /* CHIPTool.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CHIPTool.entitlements; sourceTree = "<group>"; };
 		B2946A4024C99D53005C87D0 /* WifiViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WifiViewController.h; sourceTree = "<group>"; };
 		B2946A4124C99D53005C87D0 /* WifiViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WifiViewController.m; sourceTree = "<group>"; };
 		B2946A9924C9A7BF005C87D0 /* DefaultsUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DefaultsUtils.h; sourceTree = "<group>"; };
@@ -152,6 +153,7 @@
 		B204A61E244E1D0600C7C0E1 /* CHIPTool */ = {
 			isa = PBXGroup;
 			children = (
+				B27FAB67255D4B980038F0D2 /* CHIPTool.entitlements */,
 				B204A62B244E1D0700C7C0E1 /* Assets.xcassets */,
 				B2F53AE9245B0D140010745E /* LaunchScreen.storyboard */,
 				B204A630244E1D0700C7C0E1 /* Info.plist */,
@@ -477,6 +479,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CHIPTool/CHIPTool.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
@@ -499,6 +502,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CHIPTool/CHIPTool.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";

--- a/src/darwin/CHIPTool/CHIPTool/CHIPTool.entitlements
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPTool.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/src/darwin/CHIPTool/CHIPTool/Info.plist
+++ b/src/darwin/CHIPTool/CHIPTool/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NFCReaderUsageDescription</key>
+	<string>To read a setup payload code via NFC code</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Used to connect to the peripheral</string>
 	<key>NSCameraUsageDescription</key>

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.h
@@ -17,10 +17,10 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <CHIP/CHIP.h>
-#import <UIKit/UIKit.h>
 #import <CoreNFC/CoreNFC.h>
+#import <UIKit/UIKit.h>
 
-@interface QRCodeViewController
-    : UIViewController <AVCaptureMetadataOutputObjectsDelegate, CHIPDeviceControllerDelegate, CHIPDevicePairingDelegate, NFCNDEFReaderSessionDelegate>
+@interface QRCodeViewController : UIViewController <AVCaptureMetadataOutputObjectsDelegate, CHIPDeviceControllerDelegate,
+                                      CHIPDevicePairingDelegate, NFCNDEFReaderSessionDelegate>
 
 @end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.h
@@ -18,8 +18,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <CHIP/CHIP.h>
 #import <UIKit/UIKit.h>
+#import <CoreNFC/CoreNFC.h>
 
 @interface QRCodeViewController
-    : UIViewController <AVCaptureMetadataOutputObjectsDelegate, CHIPDeviceControllerDelegate, CHIPDevicePairingDelegate>
+    : UIViewController <AVCaptureMetadataOutputObjectsDelegate, CHIPDeviceControllerDelegate, CHIPDevicePairingDelegate, NFCNDEFReaderSessionDelegate>
 
 @end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -70,7 +70,7 @@
 @property (readwrite) CHIPDeviceController * chipController;
 @property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
 
-@property (strong, nonatomic) NFCNDEFReaderSession *session;
+@property (strong, nonatomic) NFCNDEFReaderSession * session;
 @end
 
 @implementation QRCodeViewController {
@@ -104,7 +104,7 @@
 
     // Title
     UILabel * titleLabel = [CHIPUIViewUtils addTitle:@"QR Code Parser" toView:self.view];
-    
+
     // stack view
     UIStackView * stackView = [UIStackView new];
     stackView.axis = UILayoutConstraintAxisVertical;
@@ -132,7 +132,7 @@
     [manualEntryView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [manualEntryView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
     [manualEntryView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:30].active = YES;
-    
+
     _nfcScanButton = [UIButton new];
     [_nfcScanButton setTitle:@"Scan NFC Tag" forState:UIControlStateNormal];
     [_nfcScanButton addTarget:self action:@selector(startScanningNFCTags:) forControlEvents:UIControlEventTouchDown];
@@ -142,7 +142,7 @@
     _nfcScanButton.clipsToBounds = YES;
     _nfcScanButton.backgroundColor = UIColor.systemBlueColor;
     [stackView addArrangedSubview:_nfcScanButton];
-    
+
     _nfcScanButton.translatesAutoresizingMaskIntoConstraints = false;
     [_nfcScanButton.leadingAnchor constraintEqualToAnchor:stackView.leadingAnchor].active = YES;
     [_nfcScanButton.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
@@ -306,22 +306,24 @@
 
 // MARK: NFCNDEFReaderSessionDelegate
 
-- (void) readerSession:(nonnull NFCNDEFReaderSession *)session didDetectNDEFs:(nonnull NSArray<NFCNDEFMessage *> *)messages {
+- (void)readerSession:(nonnull NFCNDEFReaderSession *)session didDetectNDEFs:(nonnull NSArray<NFCNDEFMessage *> *)messages
+{
     [_session invalidateSession];
-    NSString *errorMessage;
+    NSString * errorMessage;
     if (messages.count == 1) {
-        for (NFCNDEFMessage *message in messages) {
+        for (NFCNDEFMessage * message in messages) {
             if (message.records.count == 1) {
-                for (NFCNDEFPayload *payload in message.records) {
-                    NSString *payloadType = [[NSString alloc] initWithData:payload.type encoding:NSUTF8StringEncoding];
+                for (NFCNDEFPayload * payload in message.records) {
+                    NSString * payloadType = [[NSString alloc] initWithData:payload.type encoding:NSUTF8StringEncoding];
                     if ([payloadType isEqualToString:@"U"]) {
-                        NSURL *payloadURI = [payload wellKnownTypeURIPayload];
+                        NSURL * payloadURI = [payload wellKnownTypeURIPayload];
                         NSLog(@"Payload text:%@", payloadURI);
                         if (payloadURI) {
                             /* CHIP Issue #415
                              Once #415 goes in, there will b no need to replace _ with spaces.
                             */
-                            NSString *qrCode = [[payloadURI absoluteString]stringByReplacingOccurrencesOfString:@"_" withString:@" "];
+                            NSString * qrCode = [[payloadURI absoluteString] stringByReplacingOccurrencesOfString:@"_"
+                                                                                                       withString:@" "];
                             NSLog(@"Scanned code string:%@", qrCode);
                             [self scannedQRCode:qrCode];
                         }
@@ -337,19 +339,20 @@
         errorMessage = @"Only one message in NFC tag is accepted.";
     }
     if ([errorMessage length] > 0) {
-        NSError *error = [[NSError alloc] initWithDomain:@"com.chiptool.nfctagscanning"
-                                                    code:1
-                                                userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        NSError * error = [[NSError alloc] initWithDomain:@"com.chiptool.nfctagscanning"
+                                                     code:1
+                                                 userInfo:@{ NSLocalizedDescriptionKey : errorMessage }];
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DISPATCH_TIME_NOW), dispatch_get_main_queue(), ^{
             [self showError:error];
         });
     }
 }
 
-- (void)readerSession:(nonnull NFCNDEFReaderSession *)session didInvalidateWithError:(nonnull NSError *)error {
-    NSLog(@"If no NFC reading UI is appearing, target may me missing the appropriate capability. Turn on Near Field Communication Tag Reading under the Capabilities tab for the project’s target. A paid developer account is needed for this.");
+- (void)readerSession:(nonnull NFCNDEFReaderSession *)session didInvalidateWithError:(nonnull NSError *)error
+{
+    NSLog(@"If no NFC reading UI is appearing, target may me missing the appropriate capability. Turn on Near Field Communication "
+          @"Tag Reading under the Capabilities tab for the project’s target. A paid developer account is needed for this.");
     _session = nil;
-
 }
 
 // MARK: CHIPDeviceControllerDelegate
@@ -736,7 +739,9 @@
 - (IBAction)startScanningNFCTags:(id)sender
 {
     if (!_session) {
-        _session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT) invalidateAfterFirstRead:NO];
+        _session = [[NFCNDEFReaderSession alloc] initWithDelegate:self
+                                                            queue:dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT)
+                                         invalidateAfterFirstRead:NO];
     }
     [_session beginSession];
 }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -50,6 +50,9 @@
 @property (strong, nonatomic) UITextField * manualCodeTextField;
 @property (strong, nonatomic) UIButton * doneManualCodeButton;
 
+@property (strong, nonatomic) UIButton * nfcScanButton;
+@property (readwrite) BOOL sessionIsActive;
+
 @property (strong, nonatomic) UIView * setupPayloadView;
 @property (strong, nonatomic) UILabel * manualCodeLabel;
 @property (strong, nonatomic) UIButton * resetButton;
@@ -66,6 +69,8 @@
 
 @property (readwrite) CHIPDeviceController * chipController;
 @property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
+
+@property (strong, nonatomic) NFCNDEFReaderSession *session;
 @end
 
 @implementation QRCodeViewController {
@@ -99,6 +104,19 @@
 
     // Title
     UILabel * titleLabel = [CHIPUIViewUtils addTitle:@"QR Code Parser" toView:self.view];
+    
+    // stack view
+    UIStackView * stackView = [UIStackView new];
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.spacing = 15;
+    [self.view addSubview:stackView];
+
+    stackView.translatesAutoresizingMaskIntoConstraints = false;
+    [stackView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:30].active = YES;
+    [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
+    [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
 
     // Manual entry view
     _manualCodeTextField = [UITextField new];
@@ -108,19 +126,34 @@
     _manualCodeTextField.keyboardType = UIKeyboardTypeNumberPad;
     [_doneManualCodeButton setTitle:@"Go" forState:UIControlStateNormal];
     UIView * manualEntryView = [CHIPUIViewUtils viewWithUITextField:_manualCodeTextField button:_doneManualCodeButton];
-    [self.view addSubview:manualEntryView];
+    [stackView addArrangedSubview:manualEntryView];
 
     manualEntryView.translatesAutoresizingMaskIntoConstraints = false;
     [manualEntryView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [manualEntryView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
     [manualEntryView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:30].active = YES;
+    
+    _nfcScanButton = [UIButton new];
+    [_nfcScanButton setTitle:@"Scan NFC Tag" forState:UIControlStateNormal];
+    [_nfcScanButton addTarget:self action:@selector(startScanningNFCTags:) forControlEvents:UIControlEventTouchDown];
+    _nfcScanButton.titleLabel.font = [UIFont systemFontOfSize:17];
+    _nfcScanButton.titleLabel.textColor = [UIColor blackColor];
+    _nfcScanButton.layer.cornerRadius = 5;
+    _nfcScanButton.clipsToBounds = YES;
+    _nfcScanButton.backgroundColor = UIColor.systemBlueColor;
+    [stackView addArrangedSubview:_nfcScanButton];
+    
+    _nfcScanButton.translatesAutoresizingMaskIntoConstraints = false;
+    [_nfcScanButton.leadingAnchor constraintEqualToAnchor:stackView.leadingAnchor].active = YES;
+    [_nfcScanButton.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+    [_nfcScanButton.heightAnchor constraintEqualToConstant:40].active = YES;
 
     // Results view
     _setupPayloadView = [UIView new];
     [self.view addSubview:_setupPayloadView];
 
     _setupPayloadView.translatesAutoresizingMaskIntoConstraints = false;
-    [_setupPayloadView.topAnchor constraintEqualToAnchor:manualEntryView.bottomAnchor constant:10].active = YES;
+    [_setupPayloadView.topAnchor constraintEqualToAnchor:stackView.bottomAnchor constant:10].active = YES;
     [_setupPayloadView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [_setupPayloadView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
     [_setupPayloadView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:-30].active = YES;
@@ -141,7 +174,7 @@
     [self.view addSubview:_qrCodeViewPreview];
 
     _qrCodeViewPreview.translatesAutoresizingMaskIntoConstraints = false;
-    [_qrCodeViewPreview.topAnchor constraintEqualToAnchor:manualEntryView.bottomAnchor constant:30].active = YES;
+    [_qrCodeViewPreview.topAnchor constraintEqualToAnchor:_nfcScanButton.bottomAnchor constant:30].active = YES;
     [_qrCodeViewPreview.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [_qrCodeViewPreview.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
     [_qrCodeViewPreview.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:-50].active = YES;
@@ -151,12 +184,11 @@
     _errorLabel.text = @"Error Text";
     _errorLabel.textColor = UIColor.blackColor;
     _errorLabel.font = [UIFont systemFontOfSize:17];
-    [self.view addSubview:_errorLabel];
+    [stackView addArrangedSubview:_errorLabel];
 
     _errorLabel.translatesAutoresizingMaskIntoConstraints = false;
     [_errorLabel.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [_errorLabel.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
-    [_errorLabel.topAnchor constraintEqualToAnchor:manualEntryView.bottomAnchor constant:40].active = YES;
 
     // Reset button
     _resetButton = [UIButton new];
@@ -243,6 +275,8 @@
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
+    [_session invalidateSession];
+    _session = nil;
 }
 
 - (void)dismissKeyboard
@@ -268,6 +302,51 @@
 
     [self manualCodeInitialState];
     [self qrCodeInitialState];
+}
+
+// MARK: NFCNDEFReaderSessionDelegate
+
+- (void) readerSession:(nonnull NFCNDEFReaderSession *)session didDetectNDEFs:(nonnull NSArray<NFCNDEFMessage *> *)messages {
+    [_session invalidateSession];
+    NSString *errorMessage;
+    if (messages.count == 1) {
+        for (NFCNDEFMessage *message in messages) {
+            if (message.records.count == 1) {
+                for (NFCNDEFPayload *payload in message.records) {
+                    NSString *payloadType = [[NSString alloc] initWithData:payload.type encoding:NSUTF8StringEncoding];
+                    if ([payloadType isEqualToString:@"T"]) {
+                        NSLocale *currentLocale;;
+                        NSString *payloadText = [payload wellKnownTypeTextPayloadWithLocale:&currentLocale];
+                        NSLog(@"Payload text:%@", payloadText);
+                        if (payloadText) {
+                            NSLog(@"Scanned code string:%@", payloadText);
+                            [self scannedQRCode:payloadText];
+                        }
+                    } else {
+                        errorMessage = @"Record must be of type text.";
+                    }
+                }
+            } else {
+                errorMessage = @"Only one record in NFC tag is accepted.";
+            }
+        }
+    } else {
+        errorMessage = @"Only one message in NFC tag is accepted.";
+    }
+    if ([errorMessage length] > 0) {
+        NSError *error = [[NSError alloc] initWithDomain:@"com.chiptool.nfctagscanning"
+                                                    code:1
+                                                userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DISPATCH_TIME_NOW), dispatch_get_main_queue(), ^{
+            [self showError:error];
+        });
+    }
+}
+
+- (void)readerSession:(nonnull NFCNDEFReaderSession *)session didInvalidateWithError:(nonnull NSError *)error {
+    NSLog(@"If no NFC reading UI is appearing, target may me missing the appropriate capability. Turn on Near Field Communication Tag Reading under the Capabilities tab for the project’s target. A paid developer account is needed for this.");
+    _session = nil;
+
 }
 
 // MARK: CHIPDeviceControllerDelegate
@@ -591,6 +670,7 @@
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self->_captureSession stopRunning];
+        [self->_session invalidateSession];
     });
     CHIPQRCodeSetupPayloadParser * parser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase41Representation:qrCode];
     NSError * error;
@@ -648,6 +728,14 @@
     // reset the view and remove any preferences that were stored from scanning the QRCode
     [self manualCodeInitialState];
     [self qrCodeInitialState];
+}
+
+- (IBAction)startScanningNFCTags:(id)sender
+{
+    if (!_session) {
+        _session = [[NFCNDEFReaderSession alloc] initWithDelegate:self queue:dispatch_queue_create(NULL, DISPATCH_QUEUE_CONCURRENT) invalidateAfterFirstRead:NO];
+    }
+    [_session beginSession];
 }
 
 - (IBAction)enteredManualCode:(id)sender

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -314,13 +314,16 @@
             if (message.records.count == 1) {
                 for (NFCNDEFPayload *payload in message.records) {
                     NSString *payloadType = [[NSString alloc] initWithData:payload.type encoding:NSUTF8StringEncoding];
-                    if ([payloadType isEqualToString:@"T"]) {
-                        NSLocale *currentLocale;;
-                        NSString *payloadText = [payload wellKnownTypeTextPayloadWithLocale:&currentLocale];
-                        NSLog(@"Payload text:%@", payloadText);
-                        if (payloadText) {
-                            NSLog(@"Scanned code string:%@", payloadText);
-                            [self scannedQRCode:payloadText];
+                    if ([payloadType isEqualToString:@"U"]) {
+                        NSURL *payloadURI = [payload wellKnownTypeURIPayload];
+                        NSLog(@"Payload text:%@", payloadURI);
+                        if (payloadURI) {
+                            /* CHIP Issue #415
+                             Once #415 goes in, there will b no need to replace _ with spaces.
+                            */
+                            NSString *qrCode = [[payloadURI absoluteString]stringByReplacingOccurrencesOfString:@"_" withString:@" "];
+                            NSLog(@"Scanned code string:%@", qrCode);
+                            [self scannedQRCode:qrCode];
                         }
                     } else {
                         errorMessage = @"Record must be of type text.";


### PR DESCRIPTION
#### Problem
 There is no support for NFC tag reading as of yet in the iOS demo app

#### Summary of Changes
This change adds UI to the iOS app to scan an NFC tag and then follows the same flow as that of QR code reading.

Caveat:
- This change is disabled by default because a paid developer account is required to have the NFC reading capability. See doc on how to enable this capability for flow to work

 Fixes #3626 
