### PR TITLE
Fix issue in call to PairDevice() API while pairing in progress

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -569,7 +569,8 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        if (mRendezvousSession != nullptr)
+        // Delete the current rendezvous session only if a device is not currently being paired.
+        if (mDeviceBeingPaired == kNumMaxActiveDevices && mRendezvousSession != nullptr)
         {
             chip::Platform::Delete(mRendezvousSession);
             mRendezvousSession = nullptr;


### PR DESCRIPTION
 #### Problem
`DeviceCommissioner::PairDevice()` API sometimes crashes if it is called while a device is currently being paired.
 
 #### Summary of Changes
The `PairDevice()` function was deleting the current instance of `mRendezvousSession`. This instance is shared with BLE layer, and at the time of crash, the BLE thread tried to access it after it was freed.

The code change checks if there's a device currently being paired. If so, it does not delete the current `mRendezvousSession`.
