### PR TITLE
Fix npm modules install in docker

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -116,3 +116,6 @@ RUN set -x \
     && cd .. \
     && rm -rf node_js \
     && : # last line
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin


### PR DESCRIPTION
 #### Problem
Npm dependencies needs to be installed in the docker container for zap to work. This cannot happen for now in all 'chip-build*` containers because of an `EACCESS` error when trying to install those dependencies.

 #### Summary of Changes
Add ENV variable to `chip-build` dockerfile to allow npm install. As seen on https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#global-npm-dependencies

 Fix #3928 
 
Docker containers need to be updated after the merge of this PR. As such no test were run directly with github CI. However this fix seems to run without any issue on a local docker container.
 