### PR TITLE
Use enum class to define Echo message type to align with other protocols

### DIFF
--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -264,7 +264,7 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
 
     gSendMessageCount = 0;
 
-    err = exchange->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, std::move(buffer),
+    err = exchange->SendMessage(kProtocol_Echo, static_cast<uint8_t>(Echo::MsgType::EchoRequest), std::move(buffer),
                                 Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -50,7 +50,7 @@ constexpr size_t kMaxEchoCount = 3;
 constexpr int32_t gEchoInterval = 1000;
 
 // The EchoClient object.
-chip::Protocols::EchoClient gEchoClient;
+chip::Protocols::Echo::EchoClient gEchoClient;
 
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -42,7 +42,7 @@
 namespace {
 
 // The EchoServer object.
-chip::Protocols::EchoServer gEchoServer;
+chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
 chip::SecureSessionMgr gSessionManager;

--- a/src/protocols/common/Constants.h
+++ b/src/protocols/common/Constants.h
@@ -42,7 +42,7 @@ namespace Common {
 /**
  * Common Profile Message Types
  */
-enum class MsgType
+enum class MsgType : uint8_t
 {
     // Status Report contians operation results that a responder sends as a reply for requests sent from an initiator.
     StatusReport = 1

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -36,11 +36,15 @@
 
 namespace chip {
 namespace Protocols {
+namespace Echo {
 
-enum
+/**
+ * Echo Protocol Message Types
+ */
+enum class MsgType
 {
-    kEchoMessageType_EchoRequest  = 1,
-    kEchoMessageType_EchoResponse = 2
+    EchoRequest  = 1,
+    EchoResponse = 2
 };
 
 using EchoFunct = void (*)(Messaging::ExchangeContext * ec, System::PacketBufferHandle payload);
@@ -145,5 +149,6 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
 };
 
+} // namespace Echo
 } // namespace Protocols
 } // namespace chip

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -41,7 +41,7 @@ namespace Echo {
 /**
  * Echo Protocol Message Types
  */
-enum class MsgType
+enum class MsgType : uint8_t
 {
     EchoRequest  = 1,
     EchoResponse = 2

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -27,6 +27,7 @@
 
 namespace chip {
 namespace Protocols {
+namespace Echo {
 
 CHIP_ERROR EchoClient::Init(Messaging::ExchangeManager * exchangeMgr, SecureSessionHandle session)
 {
@@ -71,7 +72,7 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
     }
 
     // Send an Echo Request message.  Discard the exchange context if the send fails.
-    err = mExchangeCtx->SendMessage(kProtocol_Echo, kEchoMessageType_EchoRequest, std::move(payload),
+    err = mExchangeCtx->SendMessage(kProtocol_Echo, static_cast<uint8_t>(MsgType::EchoRequest), std::move(payload),
                                     Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
 
     if (err != CHIP_NO_ERROR)
@@ -94,7 +95,7 @@ void EchoClient::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
 
     // Verify that the message is an Echo Response.
     // If not, close the exchange and free the payload.
-    if (protocolId != kProtocol_Echo || msgType != kEchoMessageType_EchoResponse)
+    if (protocolId != kProtocol_Echo || msgType != static_cast<uint8_t>(MsgType::EchoResponse))
     {
         ec->Close();
         mExchangeCtx = nullptr;
@@ -120,5 +121,6 @@ void EchoClient::OnResponseTimeout(Messaging::ExchangeContext * ec)
     ChipLogProgress(Echo, "Time out! failed to receive echo response from Exchange: %p", ec);
 }
 
+} // namespace Echo
 } // namespace Protocols
 } // namespace chip

--- a/src/protocols/echo/EchoServer.cpp
+++ b/src/protocols/echo/EchoServer.cpp
@@ -27,6 +27,7 @@
 
 namespace chip {
 namespace Protocols {
+namespace Echo {
 
 CHIP_ERROR EchoServer::Init(Messaging::ExchangeManager * exchangeMgr)
 {
@@ -38,7 +39,7 @@ CHIP_ERROR EchoServer::Init(Messaging::ExchangeManager * exchangeMgr)
     OnEchoRequestReceived = nullptr;
 
     // Register to receive unsolicited Echo Request messages from the exchange manager.
-    mExchangeMgr->RegisterUnsolicitedMessageHandler(kProtocol_Echo, kEchoMessageType_EchoRequest, this);
+    mExchangeMgr->RegisterUnsolicitedMessageHandler(kProtocol_Echo, static_cast<uint8_t>(MsgType::EchoRequest), this);
 
     return CHIP_NO_ERROR;
 }
@@ -47,7 +48,7 @@ void EchoServer::Shutdown()
 {
     if (mExchangeMgr != nullptr)
     {
-        mExchangeMgr->UnregisterUnsolicitedMessageHandler(kProtocol_Echo, kEchoMessageType_EchoRequest);
+        mExchangeMgr->UnregisterUnsolicitedMessageHandler(kProtocol_Echo, static_cast<uint8_t>(MsgType::EchoRequest));
         mExchangeMgr = nullptr;
     }
 }
@@ -78,12 +79,13 @@ void EchoServer::OnMessageReceived(Messaging::ExchangeContext * ec, const Packet
     response->EnsureReservedSize(CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 
     // Send an Echo Response back to the sender.
-    ec->SendMessage(kProtocol_Echo, kEchoMessageType_EchoResponse, std::move(response),
+    ec->SendMessage(kProtocol_Echo, static_cast<uint8_t>(MsgType::EchoResponse), std::move(response),
                     Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
 
     // Discard the exchange context.
     ec->Close();
 }
 
+} // namespace Echo
 } // namespace Protocols
 } // namespace chip

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -42,7 +42,7 @@ namespace SecureChannel {
 /**
  * SecureChannel Protocol Message Types
  */
-enum class MsgType
+enum class MsgType : uint8_t
 {
     // Message Counter Synchronization Protocol Message Types
     MsgCounterSyncReq = 0x00,

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -251,7 +251,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     payloadHeader.SetProtocolID(chip::Protocols::kProtocol_Echo);
 
     // Set the message type for this header.
-    payloadHeader.SetMessageType(chip::Protocols::kEchoMessageType_EchoRequest);
+    payloadHeader.SetMessageType(static_cast<uint8_t>(chip::Protocols::Echo::MsgType::EchoRequest));
 
     payloadHeader.SetInitiator(true);
 
@@ -320,10 +320,10 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     payloadHeader.SetExchangeID(0);
 
     // Set the protocol ID for this header.
-    payloadHeader.SetProtocolID(chip::Protocols::kProtocol_Echo);
+    payloadHeader.SetProtocolID(Protocols::kProtocol_Echo);
 
     // Set the message type for this header.
-    payloadHeader.SetMessageType(chip::Protocols::kEchoMessageType_EchoRequest);
+    payloadHeader.SetMessageType(static_cast<uint8_t>(Protocols::Echo::MsgType::EchoRequest));
 
     payloadHeader.SetInitiator(true);
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We have decided to use enum class instead of unanimous enum to define message type in other protocols for better type safety. The con is we need to static_cast message type to unit8_t as we pass it to messaging layer. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Use enum class to define Echo message type to align with other protocols
2. Put Echo protocol implementation under namespace 'Echo

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->



<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
