### PR TITLE
[linux] BLE central implementation

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -106,6 +106,12 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
     else
     {
 #if CONFIG_DEVICE_LAYER
+#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+        // By default, Linux device is configured as a BLE peripheral while the controller needs a BLE central.
+        err = DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(/* BLE adapter ID */ 0, /* BLE central */ true);
+        SuccessOrExit(err);
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
         err = DeviceLayer::PlatformMgr().InitChipStack();
         SuccessOrExit(err);
 

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -627,7 +627,7 @@ void BLEManagerImpl::DriveBLEState()
     // Configure BLE scanning
     if (mBLEScanConfig.mDiscriminator && !GetFlag(mFlags, kFlag_Scanning))
     {
-        err = StartDiscovery(static_cast<BluezEndpoint *>(mpAppState), { mBLEScanConfig.mDiscriminator, /* mAutoConnect= */ true });
+        err = StartDiscovery(static_cast<BluezEndpoint *>(mpAppState), { mBLEScanConfig.mDiscriminator });
         SuccessOrExit(err);
         SetFlag(mFlags, kFlag_Scanning);
     }

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -344,9 +344,9 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
     bool result = false;
 
     VerifyOrExit(Ble::UUIDsMatch(svcId, &CHIP_BLE_SVC_ID),
-                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid service ID"));
+                 ChipLogError(DeviceLayer, "SubscribeCharacteristic() called with invalid service ID"));
     VerifyOrExit(Ble::UUIDsMatch(charId, &ChipUUID_CHIPoBLEChar_TX),
-                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
+                 ChipLogError(DeviceLayer, "SubscribeCharacteristic() called with invalid characteristic ID"));
 
     result = BluezSubscribeCharacteristic(conId);
 exit:
@@ -358,9 +358,9 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
     bool result = false;
 
     VerifyOrExit(Ble::UUIDsMatch(svcId, &CHIP_BLE_SVC_ID),
-                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid service ID"));
+                 ChipLogError(DeviceLayer, "UnsubscribeCharacteristic() called with invalid service ID"));
     VerifyOrExit(Ble::UUIDsMatch(charId, &ChipUUID_CHIPoBLEChar_TX),
-                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
+                 ChipLogError(DeviceLayer, "UnsubscribeCharacteristic() called with invalid characteristic ID"));
 
     result = BluezUnsubscribeCharacteristic(conId);
 exit:
@@ -410,8 +410,6 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::HandleNewConnection(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogProgress(Ble, "New BLE connection: %p", conId);
-
     if (sInstance.mIsCentral)
     {
         ChipDeviceEvent event;
@@ -445,7 +443,7 @@ void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
     CHIP_ERROR err                 = CHIP_NO_ERROR;
     System::PacketBufferHandle buf = PacketBuffer::New();
 
-    ChipLogProgress(Ble, "Indication received, conn = %p", conId);
+    ChipLogProgress(DeviceLayer, "Indication received, conn = %p", conId);
 
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
     VerifyOrExit(buf->AvailableDataLength() >= len, err = CHIP_ERROR_BUFFER_TOO_SMALL);

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -63,7 +63,6 @@ CHIP_ERROR BLEManagerImpl::_Init()
     err = BleLayer::Init(this, this, this, &SystemLayer);
     SuccessOrExit(err);
 
-    // TODO: for chip-tool set mIsCentral   = true;
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     mFlags       = (CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART && !mIsCentral) ? kFlag_AdvertisingEnabled : 0;
     mAppState    = nullptr;

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include <support/CodeUtils.h>
 
 #include <type_traits>
+#include <utility>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
@@ -246,19 +247,37 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         DriveBLEState();
         break;
     default:
+        HandlePlatformSpecificBLEEvent(event);
         break;
     }
-
-    HandlePlatformSpecificBLEEvent(event);
 }
 
 void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEvent)
 {
     CHIP_ERROR err         = CHIP_NO_ERROR;
     bool controlOpComplete = false;
-    ChipLogProgress(DeviceLayer, "HandlePlatformSpecificBLEEvent , %d", apEvent->Type);
+    ChipLogProgress(DeviceLayer, "HandlePlatformSpecificBLEEvent %d", apEvent->Type);
     switch (apEvent->Type)
     {
+    case DeviceEventType::kPlatformLinuxBLECentralConnected:
+        if (OnConnectionComplete != nullptr)
+            OnConnectionComplete(mBLEScanConfig.mAppState, apEvent->Platform.BLECentralConnected.mConnection);
+        break;
+    case DeviceEventType::kPlatformLinuxBLEWriteComplete:
+        HandleWriteConfirmation(apEvent->Platform.BLEWriteComplete.mConnection, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX);
+        break;
+    case DeviceEventType::kPlatformLinuxBLESubscribeOpComplete:
+        if (apEvent->Platform.BLESubscribeOpComplete.mIsSubscribed)
+            HandleSubscribeComplete(apEvent->Platform.BLESubscribeOpComplete.mConnection, &CHIP_BLE_SVC_ID,
+                                    &ChipUUID_CHIPoBLEChar_TX);
+        else
+            HandleUnsubscribeComplete(apEvent->Platform.BLESubscribeOpComplete.mConnection, &CHIP_BLE_SVC_ID,
+                                      &ChipUUID_CHIPoBLEChar_TX);
+        break;
+    case DeviceEventType::kPlatformLinuxBLEIndicationReceived:
+        HandleIndicationReceived(apEvent->Platform.BLEIndicationReceived.mConnection, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX,
+                                 PacketBufferHandle::Adopt(apEvent->Platform.BLEIndicationReceived.mData));
+        break;
     case DeviceEventType::kPlatformLinuxBLEPeripheralAdvConfiguredComplete:
         VerifyOrExit(apEvent->Platform.BLEPeripheralAdvConfiguredComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
         SetFlag(sInstance.mFlags, kFlag_AdvertisingConfigured);
@@ -322,14 +341,30 @@ uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
 
 bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
-    ChipLogError(DeviceLayer, "BLEManagerImpl::SubscribeCharacteristic() not supported");
-    return true;
+    bool result = false;
+
+    VerifyOrExit(Ble::UUIDsMatch(svcId, &CHIP_BLE_SVC_ID),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid service ID"));
+    VerifyOrExit(Ble::UUIDsMatch(charId, &ChipUUID_CHIPoBLEChar_TX),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
+
+    result = BluezSubscribeCharacteristic(conId);
+exit:
+    return result;
 }
 
 bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
 {
-    ChipLogError(DeviceLayer, "BLEManagerImpl::UnsubscribeCharacteristic() not supported");
-    return true;
+    bool result = false;
+
+    VerifyOrExit(Ble::UUIDsMatch(svcId, &CHIP_BLE_SVC_ID),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid service ID"));
+    VerifyOrExit(Ble::UUIDsMatch(charId, &ChipUUID_CHIPoBLEChar_TX),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
+
+    result = BluezUnsubscribeCharacteristic(conId);
+exit:
+    return result;
 }
 
 bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
@@ -347,8 +382,16 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
                                       chip::System::PacketBufferHandle pBuf)
 {
-    ChipLogError(Ble, "SendWriteRequest: Not implemented");
-    return true;
+    bool result = false;
+
+    VerifyOrExit(Ble::UUIDsMatch(svcId, &CHIP_BLE_SVC_ID),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid service ID"));
+    VerifyOrExit(Ble::UUIDsMatch(charId, &ChipUUID_CHIPoBLEChar_RX),
+                 ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
+
+    result = BluezSendWriteRequest(conId, std::move(pBuf));
+exit:
+    return result;
 }
 
 bool BLEManagerImpl::SendReadRequest(BLE_CONNECTION_OBJECT conId, const Ble::ChipBleUUID * svcId, const Ble::ChipBleUUID * charId,
@@ -365,9 +408,59 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
     return true;
 }
 
-void BLEManagerImpl::CHIPoBluez_NewConnection(BLE_CONNECTION_OBJECT conId)
+void BLEManagerImpl::HandleNewConnection(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogProgress(Ble, "CHIPoBluez_NewConnection: %p", conId);
+    ChipLogProgress(Ble, "New BLE connection: %p", conId);
+
+    if (sInstance.mIsCentral)
+    {
+        ChipDeviceEvent event;
+        event.Type                                     = DeviceEventType::kPlatformLinuxBLECentralConnected;
+        event.Platform.BLECentralConnected.mConnection = conId;
+        PlatformMgr().PostEvent(&event);
+    }
+}
+
+void BLEManagerImpl::HandleWriteComplete(BLE_CONNECTION_OBJECT conId)
+{
+    ChipDeviceEvent event;
+    event.Type                                  = DeviceEventType::kPlatformLinuxBLEWriteComplete;
+    event.Platform.BLEWriteComplete.mConnection = conId;
+    PlatformMgr().PostEvent(&event);
+}
+
+void BLEManagerImpl::HandleSubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool subscribed)
+{
+    ChipDeviceEvent event;
+    event.Type                                          = DeviceEventType::kPlatformLinuxBLESubscribeOpComplete;
+    event.Platform.BLESubscribeOpComplete.mConnection   = conId;
+    event.Platform.BLESubscribeOpComplete.mIsSubscribed = subscribed;
+    PlatformMgr().PostEvent(&event);
+}
+
+void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
+{
+    using DataLength = decltype(std::declval<PacketBuffer>().AvailableDataLength());
+
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    System::PacketBufferHandle buf = PacketBuffer::New();
+
+    ChipLogProgress(Ble, "Indication received, conn = %p", conId);
+
+    VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(buf->AvailableDataLength() >= len, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(buf->Start(), value, len);
+    buf->SetDataLength(static_cast<DataLength>(len));
+
+    ChipDeviceEvent event;
+    event.Type                                       = DeviceEventType::kPlatformLinuxBLEIndicationReceived;
+    event.Platform.BLEIndicationReceived.mConnection = conId;
+    event.Platform.BLEIndicationReceived.mData       = buf.Release_ForNow();
+    PlatformMgr().PostEvent(&event);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %s", ErrorStr(err));
 }
 
 void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
@@ -486,7 +579,7 @@ void BLEManagerImpl::DriveBLEState()
     }
 
     // Register the CHIPoBLE application with the Bluez BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
+    if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
     {
         err = BluezGattsAppRegister(static_cast<BluezEndpoint *>(mpAppState));
         SetFlag(mFlags, kFlag_ControlOpInProgress);

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -94,7 +94,10 @@ public:
     CHIP_ERROR ConfigureBle(uint32_t aNodeId, bool aIsCentral);
 
     // Driven by BlueZ IO
-    static void CHIPoBluez_NewConnection(BLE_CONNECTION_OBJECT user_data);
+    static void HandleNewConnection(BLE_CONNECTION_OBJECT conId);
+    static void HandleWriteComplete(BLE_CONNECTION_OBJECT conId);
+    static void HandleSubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool subscribed);
+    static void HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
     static void HandleRXCharWrite(BLE_CONNECTION_OBJECT user_data, const uint8_t * value, size_t len);
     static void CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -117,7 +117,6 @@ struct IOChannel
 struct BluezDiscoveryRequest
 {
     uint16_t mDiscriminator;
-    bool mAutoConnect;
 };
 
 struct BluezEndpoint

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -50,14 +50,13 @@
 
 #pragma once
 
-#include "BLEManagerImpl.h"
-#include <stdbool.h>
-#include <stdint.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
-#include "ble/CHIPBleServiceData.h"
-#include "platform/CHIPDeviceConfig.h"
-#include "platform/Linux/dbus/bluez/DbusBluez.h"
+#include <ble/CHIPBleServiceData.h>
+#include <platform/CHIPDeviceConfig.h>
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
+
+#include <cstdint>
 
 namespace chip {
 namespace DeviceLayer {
@@ -81,7 +80,7 @@ namespace Internal {
 #define CHIP_BLE_BASE_SERVICE_UUID_STRING "-0000-1000-8000-00805f9b34fb"
 #define CHIP_BLE_SERVICE_PREFIX_LENGTH 8
 #define CHIP_BLE_BASE_SERVICE_PREFIX "0000"
-#define CHIP_BLE_UUID_SERVICE_SHORT_STRING "fffb"
+#define CHIP_BLE_UUID_SERVICE_SHORT_STRING "feaf"
 
 #define CHIP_BLE_UUID_SERVICE_STRING                                                                                               \
     CHIP_BLE_BASE_SERVICE_PREFIX CHIP_BLE_UUID_SERVICE_SHORT_STRING CHIP_BLE_BASE_SERVICE_UUID_STRING
@@ -94,8 +93,6 @@ namespace Internal {
 #define BLUEZ_ADV_FLAGS_EDR_UNSUPPORTED (1 << 2)
 #define BLUEZ_ADV_FLAGS_LE_EDR_CONTROLLER (1 << 3)
 #define BLUEZ_ADV_FLAGS_LE_EDR_HOST (1 << 4)
-
-#define CHAR_TO_BLUEZ(c) (static_cast<uint8_t>(((c) <= '9') ? (c) - '0' : tolower((c)) - 'a' + 10))
 
 enum BluezAddressType
 {
@@ -116,23 +113,6 @@ struct IOChannel
     GIOChannel * mpChannel;
     guint mWatch;
 };
-
-struct CHIPIdInfo
-{
-    uint8_t mMajor;
-    uint8_t mMinor;
-    uint16_t mVendorId;
-    uint16_t mProductId;
-    uint64_t mDeviceId;
-    uint8_t mPairingStatus;
-} __attribute__((packed));
-
-struct CHIPServiceData
-{
-    uint8_t mDataBlock0Len;
-    uint8_t mDataBlock0Type;
-    CHIPIdInfo mIdInfo;
-} __attribute__((packed));
 
 struct BluezDiscoveryRequest
 {
@@ -169,7 +149,6 @@ struct BluezEndpoint
     // map device path to the connection
     GHashTable * mpConnMap;
     uint32_t mNodeId;
-    bool mIsNotify;
     bool mIsCentral;
     char * mpAdvertisingUUID;
     chip::Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -193,7 +193,15 @@ CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint);
 CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint);
 CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint);
 
-CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, BluezDiscoveryRequest aRequest = {});
+/// Write to the CHIP RX characteristic on the remote peripheral device
+bool BluezSendWriteRequest(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBufferHandle apBuf);
+/// Subscribe to the CHIP TX characteristic on the remote peripheral device
+bool BluezSubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
+/// Unsubscribe from the CHIP TX characteristic on the remote peripheral device
+bool BluezUnsubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
+
+CHIP_ERROR
+StartDiscovery(BluezEndpoint * apEndpoint, BluezDiscoveryRequest aRequest = {});
 CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint);
 
 CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -44,6 +44,10 @@ enum PublicPlatformSpecificEventTypes
 enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
+    kPlatformLinuxBLECentralConnected,
+    kPlatformLinuxBLEWriteComplete,
+    kPlatformLinuxBLESubscribeOpComplete,
+    kPlatformLinuxBLEIndicationReceived,
     kPlatformLinuxBLEC1WriteEvent,
     kPlatformLinuxBLEOutOfBuffersEvent,
     kPlatformLinuxBLEPeripheralRegisterAppComplete,
@@ -61,6 +65,24 @@ struct ChipDevicePlatformEvent
 {
     union
     {
+        struct
+        {
+            BLE_CONNECTION_OBJECT mConnection;
+        } BLECentralConnected;
+        struct
+        {
+            BLE_CONNECTION_OBJECT mConnection;
+        } BLEWriteComplete;
+        struct
+        {
+            BLE_CONNECTION_OBJECT mConnection;
+            bool mIsSubscribed;
+        } BLESubscribeOpComplete;
+        struct
+        {
+            BLE_CONNECTION_OBJECT mConnection;
+            chip::System::PacketBuffer * mData;
+        } BLEIndicationReceived;
         struct
         {
             bool mIsSuccess;


### PR DESCRIPTION
 #### Problem
Linux platform layer provides functions for the BLE peripheral, however the BLE central role is only partially implemented. As a result, Linux native controllers, such as `examples/chip-tool` cannot initiate a BLE connection and perform Rendezvous over BLE.
Although `examples/chip-tool` may get deprecated in the future due to #4334, the changes posted here may still be useful if one needs to implement another controller app, or add the controller capabilities to `examples/shell`.

 #### Summary of Changes
* For controller applications, configure BLEManagerImpl for Linux as a BLE central device.
* Implement missing functions needed to discover a device with a specific discriminator and automatically connect to it.
* Finish implementation of the BleConnectionDelegate to let the application know that the connection has been established.
* Implement missing pieces needed to communicate over BLE as a BLE central device, such as: sending write request, subscription to a GATT characteristic, indication reception etc.

 Fixes #4113, fixes #2791