### PR TITLE
Use rvalue references for some PacketBufferHandle parameters

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -75,7 +75,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle payload, CommandRoleId aCommandRoleId)
+CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle && payload, CommandRoleId aCommandRoleId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::System::PacketBufferTLVReader reader;

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -129,7 +129,7 @@ public:
 
 protected:
     void MoveToState(const CommandState aTargetState);
-    CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle payload, CommandRoleId aCommandRoleId);
+    CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle && payload, CommandRoleId aCommandRoleId);
     void ClearState();
     const char * GetStateStr() const;
 

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -589,7 +589,7 @@ exit:
     return err;
 }
 
-BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBufferHandle buf)
+BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBufferHandle && buf)
 {
     BLE_ERROR err = BLE_NO_ERROR;
 
@@ -628,7 +628,7 @@ BLE_ERROR BLEEndPoint::SendCharacteristic(PacketBufferHandle buf)
  *  kType_Data(0)       - data packet
  *  kType_Control(1)    - control packet
  */
-void BLEEndPoint::QueueTx(PacketBufferHandle data, PacketType_t type)
+void BLEEndPoint::QueueTx(PacketBufferHandle && data, PacketType_t type)
 {
 #if CHIP_ENABLE_CHIPOBLE_TEST
     ChipLogDebugBleEndPoint(Ble, "%s: data->%p, type %d, len %d", __FUNCTION__, data, type, data->DataLength());
@@ -690,7 +690,7 @@ exit:
     return err;
 }
 
-bool BLEEndPoint::PrepareNextFragment(PacketBufferHandle data, bool & sentAck)
+bool BLEEndPoint::PrepareNextFragment(PacketBufferHandle && data, bool & sentAck)
 {
     // If we have a pending fragment acknowledgement to send, piggyback it on the fragment we're about to transmit.
     if (GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning))
@@ -1451,14 +1451,14 @@ exit:
     return err;
 }
 
-bool BLEEndPoint::SendWrite(PacketBufferHandle buf)
+bool BLEEndPoint::SendWrite(PacketBufferHandle && buf)
 {
     SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
 
     return mBle->mPlatformDelegate->SendWriteRequest(mConnObj, &CHIP_BLE_SVC_ID, &mBle->CHIP_BLE_CHAR_1_ID, std::move(buf));
 }
 
-bool BLEEndPoint::SendIndication(PacketBufferHandle buf)
+bool BLEEndPoint::SendIndication(PacketBufferHandle && buf)
 {
     SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
 

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -166,13 +166,13 @@ private:
     // Transmit path:
     BLE_ERROR DriveSending();
     BLE_ERROR DriveStandAloneAck();
-    bool PrepareNextFragment(PacketBufferHandle data, bool & sentAck);
+    bool PrepareNextFragment(PacketBufferHandle && data, bool & sentAck);
     BLE_ERROR SendNextMessage();
     BLE_ERROR ContinueMessageSend();
     BLE_ERROR DoSendStandAloneAck();
-    BLE_ERROR SendCharacteristic(PacketBufferHandle buf);
-    bool SendIndication(PacketBufferHandle buf);
-    bool SendWrite(PacketBufferHandle buf);
+    BLE_ERROR SendCharacteristic(PacketBufferHandle && buf);
+    bool SendIndication(PacketBufferHandle && buf);
+    bool SendWrite(PacketBufferHandle && buf);
 
     // Receive path:
     BLE_ERROR HandleConnectComplete();
@@ -223,7 +223,7 @@ private:
     inline void QueueTxLock() {}
     inline void QueueTxUnlock() {}
 #endif
-    void QueueTx(PacketBufferHandle data, PacketType_t type);
+    void QueueTx(PacketBufferHandle && data, PacketType_t type);
 };
 
 } /* namespace Ble */

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -547,7 +547,8 @@ INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, chip::System::PacketBuffe
  * @details
  *      Send the ICMP message in \c msg to the destination given in \c addr.
  */
-INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
+INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
+                               uint16_t sendFlags)
 {
     IPPacketInfo pktInfo;
     pktInfo.Clear();

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -512,7 +512,7 @@ void RawEndPoint::Free()
  *  A synonym for <tt>SendTo(addr, INET_NULL_INTERFACEID, msg,
  *  sendFlags)</tt>.
  */
-INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, chip::System::PacketBufferHandle msg, uint16_t sendFlags)
+INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
 {
     return SendTo(addr, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
 }
@@ -547,7 +547,7 @@ INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, chip::System::PacketBuffe
  * @details
  *      Send the ICMP message in \c msg to the destination given in \c addr.
  */
-INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle msg, uint16_t sendFlags)
+INET_ERROR RawEndPoint::SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
 {
     IPPacketInfo pktInfo;
     pktInfo.Clear();
@@ -829,7 +829,7 @@ InterfaceId RawEndPoint::GetBoundInterface()
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-void RawEndPoint::HandleDataReceived(System::PacketBufferHandle msg)
+void RawEndPoint::HandleDataReceived(System::PacketBufferHandle && msg)
 {
     IPEndPointBasis::HandleDataReceived(std::move(msg));
 }

--- a/src/inet/RawEndPoint.h
+++ b/src/inet/RawEndPoint.h
@@ -75,8 +75,8 @@ public:
     INET_ERROR BindInterface(IPAddressType addrType, InterfaceId intfId);
     InterfaceId GetBoundInterface();
     INET_ERROR Listen();
-    INET_ERROR SendTo(const IPAddress & addr, chip::System::PacketBufferHandle msg, uint16_t sendFlags = 0);
-    INET_ERROR SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle msg, uint16_t sendFlags = 0);
+    INET_ERROR SendTo(const IPAddress & addr, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    INET_ERROR SendTo(const IPAddress & addr, InterfaceId intfId, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
     INET_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle msg, uint16_t sendFlags = 0);
     INET_ERROR SetICMPFilter(uint8_t numICMPTypes, const uint8_t * aICMPTypes);
     void Close();
@@ -95,7 +95,7 @@ private:
     uint8_t NumICMPTypes;
     const uint8_t * ICMPTypes;
 
-    void HandleDataReceived(chip::System::PacketBufferHandle msg);
+    void HandleDataReceived(chip::System::PacketBufferHandle && msg);
     INET_ERROR GetPCB(IPAddressType addrType);
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -452,7 +452,7 @@ void UDPEndPoint::Free()
 /**
  *  A synonym for <tt>SendTo(addr, port, INET_NULL_INTERFACEID, msg, sendFlags)</tt>.
  */
-INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle msg, uint16_t sendFlags)
+INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags)
 {
     return SendTo(addr, port, INET_NULL_INTERFACEID, std::move(msg), sendFlags);
 }
@@ -491,7 +491,7 @@ INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, chip::Syst
  *      identifier for IPv6 link-local destinations) and \c port with the
  *      transmit option flags encoded in \c sendFlags.
  */
-INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle msg,
+INET_ERROR UDPEndPoint::SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
                                uint16_t sendFlags)
 {
     IPPacketInfo pktInfo;
@@ -775,7 +775,7 @@ uint16_t UDPEndPoint::GetBoundPort()
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
-void UDPEndPoint::HandleDataReceived(System::PacketBufferHandle msg)
+void UDPEndPoint::HandleDataReceived(System::PacketBufferHandle && msg)
 {
     IPEndPointBasis::HandleDataReceived(std::move(msg));
 }

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -57,8 +57,8 @@ public:
     InterfaceId GetBoundInterface();
     uint16_t GetBoundPort();
     INET_ERROR Listen();
-    INET_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle msg, uint16_t sendFlags = 0);
-    INET_ERROR SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle msg,
+    INET_ERROR SendTo(const IPAddress & addr, uint16_t port, chip::System::PacketBufferHandle && msg, uint16_t sendFlags = 0);
+    INET_ERROR SendTo(const IPAddress & addr, uint16_t port, InterfaceId intfId, chip::System::PacketBufferHandle && msg,
                       uint16_t sendFlags = 0);
     INET_ERROR SendMsg(const IPPacketInfo * pktInfo, chip::System::PacketBufferHandle msg, uint16_t sendFlags = 0);
     void Close();
@@ -74,7 +74,7 @@ private:
     void Init(InetLayer * inetLayer);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-    void HandleDataReceived(chip::System::PacketBufferHandle msg);
+    void HandleDataReceived(chip::System::PacketBufferHandle && msg);
     INET_ERROR GetPCB(IPAddressType addrType4);
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static void LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct pbuf * p, const ip_addr_t * addr, u16_t port);

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -295,7 +295,7 @@ static bool HandleICMPDataReceived(PacketBufferHandle aBuffer, uint16_t aHeaderL
     return (lStatus);
 }
 
-bool HandleICMPv4DataReceived(PacketBufferHandle aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer)
+bool HandleICMPv4DataReceived(PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer)
 {
     const uint16_t lICMPHeaderLength = sizeof(ICMPv4EchoHeader);
     bool lStatus;
@@ -305,7 +305,7 @@ bool HandleICMPv4DataReceived(PacketBufferHandle aBuffer, TransferStats & aStats
     return (lStatus);
 }
 
-bool HandleICMPv6DataReceived(PacketBufferHandle aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer)
+bool HandleICMPv6DataReceived(PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket, bool aCheckBuffer)
 {
     const uint16_t lICMPHeaderLength = sizeof(ICMPv6EchoHeader);
     bool lStatus;

--- a/src/inet/tests/TestInetLayerCommon.hpp
+++ b/src/inet/tests/TestInetLayerCommon.hpp
@@ -140,9 +140,9 @@ extern bool HandleDataReceived(const System::PacketBufferHandle & aBuffer, Trans
                                bool aCheckBuffer, uint8_t aFirstValue);
 extern bool HandleDataReceived(const System::PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                bool aCheckBuffer);
-extern bool HandleICMPv4DataReceived(System::PacketBufferHandle aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleICMPv4DataReceived(System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                      bool aCheckBuffer);
-extern bool HandleICMPv6DataReceived(System::PacketBufferHandle aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleICMPv6DataReceived(System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                      bool aCheckBuffer);
 
 // Timer Callback Handler

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -90,7 +90,7 @@ public:
      *         Other CHIP_ERROR codes as returned by the lower layers.
      *
      */
-    CHIP_ERROR SendEchoRequest(System::PacketBufferHandle payload);
+    CHIP_ERROR SendEchoRequest(System::PacketBufferHandle && payload);
 
 private:
     Messaging::ExchangeManager * mExchangeMgr = nullptr;

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -51,7 +51,7 @@ void EchoClient::Shutdown()
     }
 }
 
-CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle payload)
+CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -158,7 +158,7 @@ uint16_t PacketBuffer::ReservedSize() const
     return static_cast<uint16_t>(kDelta - CHIP_SYSTEM_PACKETBUFFER_HEADER_SIZE);
 }
 
-void PacketBuffer::AddToEnd(PacketBufferHandle aPacketHandle)
+void PacketBuffer::AddToEnd(PacketBufferHandle && aPacketHandle)
 {
     PacketBuffer * aPacket = aPacketHandle.mBuffer;
     aPacketHandle.mBuffer  = nullptr;

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -197,7 +197,7 @@ public:
      *
      *  @param[in] aPacket - the packet buffer to be added to the end of the current chain.
      */
-    void AddToEnd(PacketBufferHandle aPacket);
+    void AddToEnd(PacketBufferHandle && aPacket);
 
     /**
      * Move data from subsequent buffers in the chain into the current buffer until it is full.

--- a/src/system/TLVPacketBufferBackingStore.h
+++ b/src/system/TLVPacketBufferBackingStore.h
@@ -38,7 +38,7 @@ class TLVPacketBufferBackingStore : public chip::TLV::TLVBackingStore
 {
 public:
     TLVPacketBufferBackingStore() : mHeadBuffer(nullptr), mCurrentBuffer(nullptr), mUseChainedBuffers(false) {}
-    TLVPacketBufferBackingStore(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    TLVPacketBufferBackingStore(chip::System::PacketBufferHandle && buffer, bool useChainedBuffers = false)
     {
         Init(std::move(buffer), useChainedBuffers);
     }
@@ -55,13 +55,13 @@ public:
      *
      * @note This must take place before initializing a TLV class with this backing store.
      */
-    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    void Init(chip::System::PacketBufferHandle && buffer, bool useChainedBuffers = false)
     {
         mHeadBuffer        = std::move(buffer);
         mCurrentBuffer     = mHeadBuffer.Retain();
         mUseChainedBuffers = useChainedBuffers;
     }
-    void Adopt(chip::System::PacketBufferHandle buffer) { Init(std::move(buffer), mUseChainedBuffers); }
+    void Adopt(chip::System::PacketBufferHandle && buffer) { Init(std::move(buffer), mUseChainedBuffers); }
 
     /**
      * Release ownership of the backing packet buffer.
@@ -98,7 +98,7 @@ public:
      *                       If true, advance to the next buffer in the chain once all data
      *                       in the current buffer has been consumed.
      */
-    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    void Init(chip::System::PacketBufferHandle && buffer, bool useChainedBuffers = false)
     {
         mBackingStore.Init(std::move(buffer), useChainedBuffers);
         chip::TLV::TLVReader::Init(mBackingStore);
@@ -120,7 +120,7 @@ public:
      *                       in the current buffer has been consumed. Once all existing buffers
      *                       have been used, new PacketBuffers will be allocated as necessary.
      */
-    void Init(chip::System::PacketBufferHandle buffer, bool useChainedBuffers = false)
+    void Init(chip::System::PacketBufferHandle && buffer, bool useChainedBuffers = false)
     {
         mBackingStore.Init(std::move(buffer), useChainedBuffers);
         chip::TLV::TLVWriter::Init(mBackingStore);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -93,14 +93,14 @@ Transport::Type SecureSessionMgr::GetTransportType(NodeId peerNodeId)
     return Transport::Type::kUndefined;
 }
 
-CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, System::PacketBufferHandle msgBuf)
+CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, System::PacketBufferHandle && msgBuf)
 {
     PayloadHeader unusedPayloadHeader;
     return SendMessage(session, unusedPayloadHeader, std::move(msgBuf));
 }
 
 CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
-                                         System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot)
+                                         System::PacketBufferHandle && msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot)
 {
     PacketHeader ununsedPacketHeader;
     return SendMessage(session, payloadHeader, ununsedPacketHeader, std::move(msgBuf), bufferRetainSlot,

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -180,8 +180,8 @@ public:
      *   returns success, the encrypted data that was sent, as well as various other information needed
      *   to retransmit it, will be stored in *bufferRetainSlot.
      */
-    CHIP_ERROR SendMessage(SecureSessionHandle session, System::PacketBufferHandle msgBuf);
-    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle msgBuf,
+    CHIP_ERROR SendMessage(SecureSessionHandle session, System::PacketBufferHandle && msgBuf);
+    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf,
                            EncryptedPacketBufferHandle * bufferRetainSlot = nullptr);
     CHIP_ERROR SendEncryptedMessage(SecureSessionHandle session, EncryptedPacketBufferHandle msgBuf,
                                     EncryptedPacketBufferHandle * bufferRetainSlot);

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -59,7 +59,8 @@ class TransportMgrBase
 public:
     CHIP_ERROR Init(Transport::Base * transport);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
+                           System::PacketBufferHandle && msgBuf)
     {
         return mTransport->SendMessage(header, address, std::move(msgBuf));
     }

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -59,7 +59,7 @@ class TransportMgrBase
 public:
     CHIP_ERROR Init(Transport::Base * transport);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
     {
         return mTransport->SendMessage(header, address, std::move(msgBuf));
     }

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -163,7 +163,7 @@ private:
      * @param msgBuf the data to send.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf)
+    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle && msgBuf)
     {
         Base * base = &std::get<N>(mTransports);
         if (base->CanSendToPeer(address))


### PR DESCRIPTION
#### Problem

Using `PacketBufferHandle` rather than raw `PacketBuffer*` imposes
some overhead on argument passing.

#### Summary of Changes

Parameters converted from by-value to by-rvalue-reference only where
the function unconditionally (and clearly) moves the handle out of
the parameter.

part of #2707 - Figure out a way to express PacketBuffer ownership in the type system
