### PR TITLE
Refactor messaging layer tests.

### DIFF
--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -22,6 +22,8 @@ chip_test_suite("tests") {
   output_name = "libMessagingLayerTests"
 
   sources = [
+    "MessagingContext.cpp",
+    "MessagingContext.h",
     "TestExchangeMgr.cpp",
     "TestMessagingLayer.h",
     "TestReliableMessageProtocol.cpp",

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <messaging/tests/MessagingContext.h>
+
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+
+namespace chip {
+namespace Test {
+
+CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transport)
+{
+    CHIP_ERROR err = IOContext::Init(suite);
+    SuccessOrExit(err);
+
+    err = mSecureSessionMgr.Init(GetSourceNodeId(), &GetSystemLayer(), transport);
+    SuccessOrExit(err);
+
+    err = mExchangeManager.Init(&mSecureSessionMgr);
+    SuccessOrExit(err);
+
+    err = mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer);
+    SuccessOrExit(err);
+
+    err = mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+// Shutdown all layers, finalize operations
+CHIP_ERROR MessagingContext::Shutdown()
+{
+    CHIP_ERROR err = IOContext::Shutdown();
+
+    return err;
+}
+
+Messaging::ExchangeContext * MessagingContext::NewExchangeToPeer(Messaging::ExchangeDelegate * delegate)
+{
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    return mExchangeManager.NewContext({ GetDestinationNodeId(), GetPeerKeyId() }, delegate);
+}
+
+Messaging::ExchangeContext * MessagingContext::NewExchangeToLocal(Messaging::ExchangeDelegate * delegate)
+{
+    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
+    return mExchangeManager.NewContext({ GetSourceNodeId(), GetLocalKeyId() }, delegate);
+}
+
+} // namespace Test
+} // namespace chip

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/tests/NetworkTestHelpers.h>
+
+namespace chip {
+namespace Test {
+
+/**
+ * @brief The context of test cases for messaging layer. It wil initialize network layer and system layer, and create
+ *        two secure sessions, connected with each other. Exchanges can be created for each secure session.
+ */
+class MessagingContext : public IOContext
+{
+public:
+    MessagingContext() :
+        mPeer(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT)),
+        mPairingPeerToLocal(Optional<NodeId>::Value(GetSourceNodeId()), GetLocalKeyId(), GetPeerKeyId()),
+        mPairingLocalToPeer(Optional<NodeId>::Value(GetDestinationNodeId()), GetPeerKeyId(), GetLocalKeyId())
+    {}
+
+    /// Initialize the underlying layers and test suite pointer
+    CHIP_ERROR Init(nlTestSuite * suite, TransportMgrBase * transport);
+
+    // Shutdown all layers, finalize operations
+    CHIP_ERROR Shutdown();
+
+    static Inet::IPAddress GetAddress()
+    {
+        Inet::IPAddress addr;
+        Inet::IPAddress::FromString("127.0.0.1", addr);
+        return addr;
+    }
+    static constexpr NodeId GetSourceNodeId() { return 123654; }
+    static constexpr NodeId GetDestinationNodeId() { return 111222333; }
+
+    static constexpr uint16_t GetLocalKeyId() { return 1; }
+    static constexpr uint16_t GetPeerKeyId() { return 2; }
+
+    SecureSessionMgr & GetSecureSessionManager() { return mSecureSessionMgr; }
+    Messaging::ExchangeManager & GetExchangeManager() { return mExchangeManager; }
+
+    Messaging::ExchangeContext * NewExchangeToPeer(Messaging::ExchangeDelegate * delegate);
+    Messaging::ExchangeContext * NewExchangeToLocal(Messaging::ExchangeDelegate * delegate);
+
+private:
+    SecureSessionMgr mSecureSessionMgr;
+    Messaging::ExchangeManager mExchangeManager;
+
+    Optional<Transport::PeerAddress> mPeer;
+    SecurePairingUsingTestSecret mPairingPeerToLocal;
+    SecurePairingUsingTestSecret mPairingLocalToPeer;
+};
+
+} // namespace Test
+} // namespace chip

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -27,11 +27,11 @@
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
+#include <messaging/tests/MessagingContext.h>
 #include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -46,12 +46,9 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
 
-using TestContext = chip::Test::IOContext;
+using TestContext = chip::Test::MessagingContext;
 
 TestContext sContext;
-
-constexpr NodeId kSourceNodeId      = 123654;
-constexpr NodeId kDestinationNodeId = 111222333;
 
 class LoopbackTransport : public Transport::Base
 {
@@ -68,6 +65,8 @@ public:
     bool CanSendToPeer(const PeerAddress & address) override { return true; }
 };
 
+TransportMgr<LoopbackTransport> gTransportMgr;
+
 class MockAppDelegate : public ExchangeDelegate
 {
 public:
@@ -82,135 +81,51 @@ public:
     bool IsOnMessageReceivedCalled = false;
 };
 
-void CheckSimpleInitTest(nlTestSuite * inSuite, void * inContext)
-{
-    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-
-    TransportMgr<LoopbackTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-    CHIP_ERROR err;
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-}
-
-class TestSessMgrCallback : public SecureSessionMgrDelegate
-{
-public:
-    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
-                           System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr) override
-    {
-        ReceiveHandlerCallCount++;
-    }
-
-    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override
-    {
-        mSecureSession = session;
-        NewConnectionHandlerCallCount++;
-    }
-    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override {}
-
-    SecureSessionHandle mSecureSession;
-    int ReceiveHandlerCallCount       = 0;
-    int NewConnectionHandlerCallCount = 0;
-};
-
 void CheckNewContextTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    TransportMgr<LoopbackTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-    CHIP_ERROR err;
-
-    TestSessMgrCallback callback;
-    secureSessionMgr.SetDelegate(&callback);
-
-    IPAddress addr;
-    IPAddress::FromString("127.0.0.1", addr);
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    Optional<Transport::PeerAddress> peer1(Transport::PeerAddress::UDP(addr, 1));
-    err = secureSessionMgr.NewPairing(peer1, kDestinationNodeId, &pairing1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    SecureSessionHandle sessionFromSourceToDestination = callback.mSecureSession;
-
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    Optional<Transport::PeerAddress> peer2(Transport::PeerAddress::UDP(addr, 2));
-    err = secureSessionMgr.NewPairing(peer2, kSourceNodeId, &pairing2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    SecureSessionHandle sessionFromDestinationToSource = callback.mSecureSession;
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     MockAppDelegate mockAppDelegate;
-
-    ExchangeContext * ec1 = exchangeMgr.NewContext(sessionFromDestinationToSource, &mockAppDelegate);
+    ExchangeContext * ec1 = ctx.NewExchangeToLocal(&mockAppDelegate);
     NL_TEST_ASSERT(inSuite, ec1 != nullptr);
     NL_TEST_ASSERT(inSuite, ec1->IsInitiator() == true);
     NL_TEST_ASSERT(inSuite, ec1->GetExchangeId() != 0);
-    NL_TEST_ASSERT(inSuite, ec1->GetSecureSession() == sessionFromDestinationToSource);
+    auto sessionPeerToLocal = ctx.GetSecureSessionManager().GetPeerConnectionState(ec1->GetSecureSession());
+    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerNodeId() == ctx.GetSourceNodeId());
+    NL_TEST_ASSERT(inSuite, sessionPeerToLocal->GetPeerKeyID() == ctx.GetLocalKeyId());
     NL_TEST_ASSERT(inSuite, ec1->GetDelegate() == &mockAppDelegate);
 
-    ExchangeContext * ec2 = exchangeMgr.NewContext(sessionFromSourceToDestination, &mockAppDelegate);
+    ExchangeContext * ec2 = ctx.NewExchangeToPeer(&mockAppDelegate);
     NL_TEST_ASSERT(inSuite, ec2 != nullptr);
     NL_TEST_ASSERT(inSuite, ec2->GetExchangeId() > ec1->GetExchangeId());
-    NL_TEST_ASSERT(inSuite, ec2->GetSecureSession() == sessionFromSourceToDestination);
+    auto sessionLocalToPeer = ctx.GetSecureSessionManager().GetPeerConnectionState(ec2->GetSecureSession());
+    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerNodeId() == ctx.GetDestinationNodeId());
+    NL_TEST_ASSERT(inSuite, sessionLocalToPeer->GetPeerKeyID() == ctx.GetPeerKeyId());
 }
 
 void CheckUmhRegistrationTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    TransportMgr<LoopbackTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
     CHIP_ERROR err;
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     MockAppDelegate mockAppDelegate;
 
-    err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0001, &mockAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandler(0x0001, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0002, 0x0001, &mockAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandler(0x0002, 0x0001, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = exchangeMgr.UnregisterUnsolicitedMessageHandler(0x0001);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandler(0x0001);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = exchangeMgr.UnregisterUnsolicitedMessageHandler(0x0002);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandler(0x0002);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
-    err = exchangeMgr.UnregisterUnsolicitedMessageHandler(0x0002, 0x0001);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandler(0x0002, 0x0001);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = exchangeMgr.UnregisterUnsolicitedMessageHandler(0x0002, 0x0002);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandler(0x0002, 0x0002);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 
@@ -218,44 +133,16 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    TransportMgr<LoopbackTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
     CHIP_ERROR err;
-
-    TestSessMgrCallback callback;
-    secureSessionMgr.SetDelegate(&callback);
-
-    IPAddress addr;
-    IPAddress::FromString("127.0.0.1", addr);
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    Optional<Transport::PeerAddress> peer1(Transport::PeerAddress::UDP(addr, 1));
-    err = secureSessionMgr.NewPairing(peer1, kDestinationNodeId, &pairing1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    SecureSessionHandle sessionFromSourceToDestination = callback.mSecureSession;
-
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    Optional<Transport::PeerAddress> peer2(Transport::PeerAddress::UDP(addr, 2));
-    err = secureSessionMgr.NewPairing(peer2, kSourceNodeId, &pairing2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // create solicited exchange
     MockAppDelegate mockSolicitedAppDelegate;
-    ExchangeContext * ec1 = exchangeMgr.NewContext(sessionFromSourceToDestination, &mockSolicitedAppDelegate);
+    ExchangeContext * ec1 = ctx.NewExchangeToPeer(&mockSolicitedAppDelegate);
 
     // create unsolicited exchange
     MockAppDelegate mockUnsolicitedAppDelegate;
-    err = exchangeMgr.RegisterUnsolicitedMessageHandler(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandler(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // send a malicious packet
     ec1->SendMessage(0x0001, 0x0002, System::PacketBuffer::New(), SendFlags(Messaging::SendMessageFlags::kNone));
@@ -274,7 +161,6 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
 // clang-format off
 const nlTest sTests[] =
 {
-    NL_TEST_DEF("Test ExchangeMgr::Init",                     CheckSimpleInitTest),
     NL_TEST_DEF("Test ExchangeMgr::NewContext",               CheckNewContextTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckUmhRegistrationTest", CheckUmhRegistrationTest),
     NL_TEST_DEF("Test ExchangeMgr::CheckExchangeMessages",    CheckExchangeMessages),
@@ -301,7 +187,11 @@ nlTestSuite sSuite =
  */
 int Initialize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Init(&sSuite);
+    CHIP_ERROR err = gTransportMgr.Init("LOOPBACK");
+    if (err != CHIP_NO_ERROR)
+        return FAILURE;
+
+    err = reinterpret_cast<TestContext *>(aContext)->Init(&sSuite, &gTransportMgr);
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -33,7 +33,6 @@
 #include <support/ReturnMacros.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
-#include <transport/raw/tests/NetworkTestHelpers.h>
 
 #include <nlbyteorder.h>
 #include <nlunit-test.h>
@@ -43,6 +42,7 @@
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
+#include <messaging/tests/MessagingContext.h>
 
 namespace {
 
@@ -52,13 +52,11 @@ using namespace chip::Transport;
 using namespace chip::Messaging;
 using namespace chip::Protocols;
 
-using TestContext = chip::Test::IOContext;
+using TestContext = chip::Test::MessagingContext;
 
 TestContext sContext;
 
-const char PAYLOAD[]                = "Hello!";
-constexpr NodeId kSourceNodeId      = 123654;
-constexpr NodeId kDestinationNodeId = 111222333;
+const char PAYLOAD[] = "Hello!";
 
 int gSendMessageCount = 0;
 
@@ -86,6 +84,8 @@ public:
 
     bool CanSendToPeer(const PeerAddress & address) override { return true; }
 };
+
+TransportMgr<OutgoingTransport> gTransportMgr;
 
 class MockAppDelegate : public ExchangeDelegate
 {
@@ -129,28 +129,11 @@ void CheckAddClearRetrans(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    TransportMgr<OutgoingTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-    CHIP_ERROR err;
-
-    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     MockAppDelegate mockAppDelegate;
-
-    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
-    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockAppDelegate);
+    ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockAppDelegate);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
-    ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();
+    ReliableMessageManager * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
     ReliableMessageContext * rc = exchange->GetReliableMessageContext();
     NL_TEST_ASSERT(inSuite, rm != nullptr);
     NL_TEST_ASSERT(inSuite, rc != nullptr);
@@ -167,28 +150,13 @@ void CheckFailRetrans(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    TransportMgr<OutgoingTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-    CHIP_ERROR err;
-
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     MockAppDelegate mockAppDelegate;
-
-    // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
-    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockAppDelegate);
+    ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockAppDelegate);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
-    ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();
+    ReliableMessageManager * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
     ReliableMessageContext * rc = exchange->GetReliableMessageContext();
     NL_TEST_ASSERT(inSuite, rm != nullptr);
     NL_TEST_ASSERT(inSuite, rc != nullptr);
@@ -218,39 +186,14 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
     memmove(buffer->Start(), PAYLOAD, payload_len);
     buffer->SetDataLength(payload_len);
 
-    IPAddress addr;
-    IPAddress::FromString("127.0.0.1", addr);
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    TransportMgr<OutgoingTransport> transportMgr;
-    SecureSessionMgr secureSessionMgr;
-
-    err = transportMgr.Init("LOOPBACK");
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    ExchangeManager exchangeMgr;
-    err = exchangeMgr.Init(&secureSessionMgr);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
-
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
     MockAppDelegate mockSender;
-
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
-    ExchangeContext * exchange = exchangeMgr.NewContext({ kDestinationNodeId, kAnyKeyId }, &mockSender);
+    ExchangeContext * exchange = ctx.NewExchangeToPeer(&mockSender);
     NL_TEST_ASSERT(inSuite, exchange != nullptr);
 
-    ReliableMessageManager * rm = exchangeMgr.GetReliableMessageMgr();
+    ReliableMessageManager * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
     ReliableMessageContext * rc = exchange->GetReliableMessageContext();
     NL_TEST_ASSERT(inSuite, rm != nullptr);
     NL_TEST_ASSERT(inSuite, rc != nullptr);
@@ -313,7 +256,11 @@ nlTestSuite sSuite =
  */
 int Initialize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Init(&sSuite);
+    CHIP_ERROR err = gTransportMgr.Init("LOOPBACK");
+    if (err != CHIP_NO_ERROR)
+        return FAILURE;
+
+    err = reinterpret_cast<TestContext *>(aContext)->Init(&sSuite, &gTransportMgr);
     return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
 }
 


### PR DESCRIPTION
Extract initialization codes into a helper class

Reduce duplicated codes.