### PR TITLE
Fix crash caused by SecureSessionMgr::SendMessage() changes

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -228,8 +228,11 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     msgLen   = static_cast<uint16_t>(msgBuf->DataLength() + headerSize);
 
     // Retain the PacketBuffer in case it's needed for retransmissions.
-    encryptedMsg        = msgBuf.Retain();
-    encryptedMsg.mMsgId = packetHeader.GetMessageId();
+    if (bufferRetainSlot != nullptr)
+    {
+        encryptedMsg        = msgBuf.Retain();
+        encryptedMsg.mMsgId = packetHeader.GetMessageId();
+    }
 
     ChipLogProgress(Inet, "Sending msg from %llu to %llu", mLocalNodeId, state->GetPeerNodeId());
 


### PR DESCRIPTION
 #### Problem
ESP32 device crashes when cluster on/off command is sent to it.

Crash log:

```
0x4014ceb2: ip4_output_if_opt_src at ../esp-idf/components/lwip/lwip/src/core/ipv4/ip4.c:979 (discriminator 1)

0x4014d0b1: ip4_output_if_src at ../esp-idf/components/lwip/lwip/src/core/ipv4/ip4.c:907

0x4014a364: udp_sendto_if_src at ../esp-idf/components/lwip/lwip/src/core/udp.c:913 (discriminator 4)

0x4014a42a: udp_sendto_if at ../esp-idf/components/lwip/lwip/src/core/udp.c:712

0x4014a53b: udp_sendto at ../esp-idf/components/lwip/lwip/src/core/udp.c:619

0x4013d1f8: chip::Inet::UDPEndPoint::SendMsg(chip::Inet::IPPacketInfo const*, chip::System::PacketBufferHandle, unsigned short) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/inet/UDPEndPoint.cpp:583

0x40139de1: chip::Transport::UDP::SendMessage(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/transport/raw/UDP.cpp:115

0x400fecaa: chip::Transport::Tuple<chip::Transport::UDP, chip::Transport::UDP>::SendMessage(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle) at ./connectedhomeip/examples/all-clusters-app/esp32/third_party/connectedhomeip/src/transport/raw/Tuple.h:171
 (inlined by) ?? at ./connectedhomeip/examples/all-clusters-app/esp32/third_party/connectedhomeip/src/transport/raw/Tuple.h:173
 (inlined by) chip::Transport::Tuple<chip::Transport::UDP, chip::Transport::UDP>::SendMessage(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle) at ./connectedhomeip/examples/all-clusters-app/esp32/third_party/connectedhomeip/src/transport/raw/Tuple.h:86

0x40137461: chip::SecureSessionMgr::SendMessage(chip::PayloadHeader&, chip::PacketHeader&, unsigned long long, chip::System::PacketBufferHandle, chip::EncryptedPacketBufferHandle*, chip::SecureSessionMgr::EncryptionState) at ./connectedhomeip/examples/all-clusters-app/esp32/third_party/connectedhomeip/src/transport/TransportMgr.h:64
 (inlined by) chip::SecureSessionMgr::SendMessage(chip::PayloadHeader&, chip::PacketHeader&, unsigned long long, chip::System::PacketBufferHandle, chip::EncryptedPacketBufferHandle*, chip::SecureSessionMgr::EncryptionState) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:241
```

 #### Summary of Changes
There were some recent changes to SecureSessionMgr::Send() API to retain buffer if it's needed for retransmission. This change checks if the caller needs to retain the buffer before calling the `Retain()`.