### PR TITLE
Add sanitizers and fix memory overflow bug in attribute storage.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -228,8 +228,27 @@ config("runtime_default") {
   }
 }
 
+# To use different sanitizer options, use `gn args .` in the out folder and
+# use settings like:
+#
+#   is_clang=true
+#   is_debug=true
+#   optimize_for_size=false
+#   default_configs_sanitize = [ "//build/config/compiler:sanitize_address" ]
+#
 config("sanitize_default") {
 }
+
+config("sanitize_address") {
+  cflags = [ "-fsanitize=address" ]
+  ldflags = cflags
+}
+
+config("sanitize_memory") {
+  cflags = [ "-fsanitize=memory" ]
+  ldflags = cflags
+}
+
 
 config("fuzzing_default") {
 }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -249,7 +249,6 @@ config("sanitize_memory") {
   ldflags = cflags
 }
 
-
 config("fuzzing_default") {
 }
 

--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -356,7 +356,7 @@
 #define ATTRIBUTE_SINGLETONS_SIZE (6)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE 150
+#define ATTRIBUTE_MAX_SIZE 155
 
 // Array of endpoints that are supported
 #define FIXED_ENDPOINT_ARRAY                                                                                                       \

--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -356,7 +356,7 @@
 #define ATTRIBUTE_SINGLETONS_SIZE (6)
 
 // Total size of attribute storage
-#define ATTRIBUTE_MAX_SIZE 155
+#define ATTRIBUTE_MAX_SIZE 150
 
 // Array of endpoints that are supported
 #define FIXED_ENDPOINT_ARRAY                                                                                                       \

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -523,6 +523,12 @@ EmberAfStatus emAfReadOrWriteAttribute(EmberAfAttributeSearchRecord * attRecord,
                                 uint8_t * attributeLocation =
                                     (am->mask & ATTRIBUTE_MASK_SINGLETON ? singletonAttributeLocation(am)
                                                                          : attributeData + attributeOffsetIndex);
+
+                                if (attributeOffsetIndex + readLength > sizeof(attributeData))
+                                {
+                                    return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
+                                }
+
                                 uint8_t *src, *dst;
                                 if (write)
                                 {

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -298,16 +298,16 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         // Reset message back to start
         msgIndex          = cmd->payloadStartIndex;
         appResponseLength = (cmd->mfgSpecific ? 4 : 2);
-        /* fall through */
-    // DO NOT BREAK from this case
+        [[fallthrough]];
+        // DO NOT BREAK from this case
 
-    // the format of the write attributes cmd is:
-    // ([attr ID:2] [data type:1] [data:N]) * N
-    // the format of the write attributes response is:
-    // ([status 1] [attr ID 2]) * n
-    // ONLY errors are reported unless all are successful then a single success
-    // is sent. write attr no response is handled by just executing the same
-    // code but not setting the flag that sends the response at the end.
+        // the format of the write attributes cmd is:
+        // ([attr ID:2] [data type:1] [data:N]) * N
+        // the format of the write attributes response is:
+        // ([status 1] [attr ID 2]) * n
+        // ONLY errors are reported unless all are successful then a single success
+        // is sent. write attr no response is handled by just executing the same
+        // code but not setting the flag that sends the response at the end.
     case ZCL_WRITE_ATTRIBUTES_NO_RESPONSE_COMMAND_ID:
     case ZCL_WRITE_ATTRIBUTES_COMMAND_ID: {
         uint8_t numFailures = 0;


### PR DESCRIPTION
#### Problem
Address sanitizers found a out of bound access in attribute storage.
Apparently the storage array size was insufficient to store all attributes declared

#### Solution
Add a check to detect this at runtime rather than just sanitizers
Increased the attribute storage size by 5 bytes to have space for the extra attribute
Add support for clang sanitizers (and clang fallthrough compile option as a sideffect) for us to be able to run sanitizers on linux builds.

 Fixes #4371