### PR TITLE
Optimize TransportMgrBase::HandleMessageReceived, reduce void* usage

### DIFF
--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -38,8 +38,9 @@ static_library("transport") {
     "SecureSessionMgr.cpp",
     "SecureSessionMgr.h",
     "SessionEstablishmentDelegate.h",
-    "TransportMgr.cpp",
     "TransportMgr.h",
+    "TransportMgrBase.cpp",
+    "TransportMgrBase.h",
   ]
 
   if (chip_config_network_layer_ble) {

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -29,6 +29,7 @@
 
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
+#include <transport/TransportMgrBase.h>
 #include <transport/raw/Base.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -54,32 +55,6 @@ public:
                                    System::PacketBufferHandle msgBuf) = 0;
 };
 
-class TransportMgrBase
-{
-public:
-    CHIP_ERROR Init(Transport::Base * transport);
-
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                           System::PacketBufferHandle && msgBuf)
-    {
-        return mTransport->SendMessage(header, address, std::move(msgBuf));
-    }
-
-    void Disconnect(const Transport::PeerAddress & address) { mTransport->Disconnect(address); }
-
-    void SetSecureSessionMgr(TransportMgrDelegate * secureSessionMgr) { mSecureSessionMgr = secureSessionMgr; }
-
-    void SetRendezvousSession(TransportMgrDelegate * rendezvousSessionMgr) { mRendezvous = rendezvousSessionMgr; }
-
-private:
-    static void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                      System::PacketBufferHandle msg, TransportMgrBase * dispatcher);
-
-    TransportMgrDelegate * mSecureSessionMgr = nullptr;
-    TransportMgrDelegate * mRendezvous       = nullptr;
-    Transport::Base * mTransport             = nullptr;
-};
-
 template <typename... TransportTypes>
 class TransportMgr : public TransportMgrBase
 {
@@ -89,7 +64,7 @@ public:
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
-        err = mTransport.Init(std::forward<Args>(transportInitArgs)...);
+        err = mTransport.Init(this, std::forward<Args>(transportInitArgs)...);
         SuccessOrExit(err);
         err = TransportMgrBase::Init(&mTransport);
     exit:
@@ -99,7 +74,7 @@ public:
     template <typename... Args>
     CHIP_ERROR ResetTransport(Args &&... transportInitArgs)
     {
-        return mTransport.Init(std::forward<Args>(transportInitArgs)...);
+        return mTransport.Init(this, std::forward<Args>(transportInitArgs)...);
     }
 
 private:

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,26 +14,24 @@
  *    See the License for the specific language governing permissions and
  */
 
-/**
- * @file
- *   This file implements a stateless TransportMgr, it will took a raw message
- * buffer from transports, and then extract the message header without decode it.
- * For secure messages, it will pass it to the SecureSessionMgr, and for unsecure
- * messages (rendezvous messages), it will pass it to RendezvousSession.
- *   When sending messages, it will encode the packet header, and pass it to the
- * transports.
- *   The whole process is fully stateless.
- */
+#include <transport/TransportMgrBase.h>
 
+#include <support/CodeUtils.h>
 #include <transport/TransportMgr.h>
-
-#include <transport/RendezvousSession.h>
-#include <transport/SecureSessionMgr.h>
 #include <transport/raw/Base.h>
-#include <transport/raw/MessageHeader.h>
-#include <transport/raw/PeerAddress.h>
 
 namespace chip {
+
+CHIP_ERROR TransportMgrBase::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
+                                         System::PacketBufferHandle && msgBuf)
+{
+    return mTransport->SendMessage(header, address, std::move(msgBuf));
+}
+
+void TransportMgrBase::Disconnect(const Transport::PeerAddress & address)
+{
+    mTransport->Disconnect(address);
+}
 
 CHIP_ERROR TransportMgrBase::Init(Transport::Base * transport)
 {
@@ -42,16 +40,15 @@ CHIP_ERROR TransportMgrBase::Init(Transport::Base * transport)
         return CHIP_ERROR_INCORRECT_STATE;
     }
     mTransport = transport;
-    mTransport->SetMessageReceiveHandler(HandleMessageReceived, this);
+    mTransport->SetDelegate(this);
     ChipLogDetail(Inet, "TransportMgr initialized");
     return CHIP_NO_ERROR;
 }
 
 void TransportMgrBase::HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                             System::PacketBufferHandle msg, TransportMgrBase * dispatcher)
+                                             System::PacketBufferHandle && msg)
 {
-    TransportMgrDelegate * handler =
-        packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? dispatcher->mSecureSessionMgr : dispatcher->mRendezvous;
+    TransportMgrDelegate * handler = packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? mSecureSessionMgr : mRendezvous;
     if (handler != nullptr)
     {
         handler->OnMessageReceived(packetHeader, peerAddress, std::move(msg));
@@ -64,4 +61,5 @@ void TransportMgrBase::HandleMessageReceived(const PacketHeader & packetHeader, 
                      packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? "Encrypted" : "Unencrypted", addrBuffer);
     }
 }
+
 } // namespace chip

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR TransportMgrBase::Init(Transport::Base * transport)
 }
 
 void TransportMgrBase::HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                             System::PacketBufferHandle && msg)
+                                             System::PacketBufferHandle msg)
 {
     TransportMgrDelegate * handler = packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? mSecureSessionMgr : mRendezvous;
     if (handler != nullptr)

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -1,0 +1,55 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ */
+
+#pragma once
+
+#include <support/CodeUtils.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/raw/Base.h>
+#include <transport/raw/MessageHeader.h>
+#include <transport/raw/PeerAddress.h>
+
+namespace chip {
+
+namespace Transport {
+class Base;
+}
+
+class TransportMgrDelegate;
+
+class TransportMgrBase : public Transport::RawTransportDelegate
+{
+public:
+    CHIP_ERROR Init(Transport::Base * transport);
+
+    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
+                           System::PacketBufferHandle && msgBuf);
+
+    void Disconnect(const Transport::PeerAddress & address);
+
+    void SetSecureSessionMgr(TransportMgrDelegate * secureSessionMgr) { mSecureSessionMgr = secureSessionMgr; }
+
+    void SetRendezvousSession(TransportMgrDelegate * rendezvousSessionMgr) { mRendezvous = rendezvousSessionMgr; }
+
+    void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+                               System::PacketBufferHandle && msg) override;
+
+    TransportMgrDelegate * mSecureSessionMgr = nullptr;
+    TransportMgrDelegate * mRendezvous       = nullptr;
+    Transport::Base * mTransport             = nullptr;
+};
+
+} // namespace chip

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -45,8 +45,9 @@ public:
     void SetRendezvousSession(TransportMgrDelegate * rendezvousSessionMgr) { mRendezvous = rendezvousSessionMgr; }
 
     void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                               System::PacketBufferHandle && msg) override;
+                               System::PacketBufferHandle msg) override;
 
+private:
     TransportMgrDelegate * mSecureSessionMgr = nullptr;
     TransportMgrDelegate * mRendezvous       = nullptr;
     Transport::Base * mTransport             = nullptr;

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -33,6 +33,14 @@
 namespace chip {
 namespace Transport {
 
+class RawTransportDelegate
+{
+public:
+    virtual ~RawTransportDelegate() {}
+    virtual void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+                                       System::PacketBufferHandle && msg) = 0;
+};
+
 /**
  * Transport class base, defining common methods among transports (message
  * packing by encoding and decoding headers) and generic message transport
@@ -44,19 +52,12 @@ public:
     virtual ~Base() {}
 
     /**
-     * Sets the message receive handler and associated argument
+     * Sets the owner of the transport
      *
-     * @param[in] handler The callback to call when a message is received
      * @param[in] param   The argument to pass in to the handler function
      *
      */
-    template <class T>
-    void SetMessageReceiveHandler(void (*handler)(const PacketHeader &, const PeerAddress &, System::PacketBufferHandle, T *),
-                                  T * param)
-    {
-        mMessageReceivedArgument = param;
-        OnMessageReceived        = reinterpret_cast<MessageReceiveHandler>(handler);
-    }
+    void SetDelegate(RawTransportDelegate * delegate) { mDelegate = delegate; }
 
     /**
      * @brief Send a message to the specified target.
@@ -89,25 +90,10 @@ protected:
      */
     void HandleMessageReceived(const PacketHeader & header, const PeerAddress & source, System::PacketBufferHandle buffer)
     {
-        if (OnMessageReceived)
-        {
-            OnMessageReceived(header, source, std::move(buffer), mMessageReceivedArgument);
-        }
+        mDelegate->HandleMessageReceived(header, source, std::move(buffer));
     }
 
-    /**
-     * This function is the application callback that is invoked when a message is received over a
-     * Chip connection.
-     *
-     * @param[in]    msgBuf        A handle to the packet buffer holding the message.
-     *
-     * Callback *MUST* free msgBuf as a result of handling.
-     */
-    typedef void (*MessageReceiveHandler)(const PacketHeader & header, const PeerAddress & source,
-                                          System::PacketBufferHandle msgBuf, void * param);
-
-    MessageReceiveHandler OnMessageReceived = nullptr; ///< Callback on message receiving
-    void * mMessageReceivedArgument         = nullptr; ///< Argument for callback
+    RawTransportDelegate * mDelegate;
 };
 
 } // namespace Transport

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -38,7 +38,7 @@ class RawTransportDelegate
 public:
     virtual ~RawTransportDelegate() {}
     virtual void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                       System::PacketBufferHandle && msg) = 0;
+                                       System::PacketBufferHandle msg) = 0;
 };
 
 /**
@@ -52,9 +52,9 @@ public:
     virtual ~Base() {}
 
     /**
-     * Sets the owner of the transport
+     * Sets the delegate of the transport
      *
-     * @param[in] param   The argument to pass in to the handler function
+     * @param[in] delegate  The argument to pass in to the handler function
      *
      */
     void SetDelegate(RawTransportDelegate * delegate) { mDelegate = delegate; }
@@ -88,7 +88,7 @@ protected:
      * Method used by subclasses to notify that a packet has been received after
      * any associated headers have been decoded.
      */
-    void HandleMessageReceived(const PacketHeader & header, const PeerAddress & source, System::PacketBufferHandle buffer)
+    void HandleMessageReceived(const PacketHeader & header, const PeerAddress & source, System::PacketBufferHandle && buffer)
     {
         mDelegate->HandleMessageReceived(header, source, std::move(buffer));
     }

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -97,7 +97,8 @@ public:
      * Transports are assumed to have an Init call with EXACTLY one argument. This method MUST initialize
      * all underlying transports.
      *
-     * @param args initialization arguments, forwarded as-is to the underlying transports.
+     * @param delegate the delegate to handle messages.
+     * @param args     initialization arguments, forwarded as-is to the underlying transports.
      */
     template <typename... Args, typename std::enable_if<(sizeof...(Args) == sizeof...(TransportTypes))>::type * = nullptr>
     CHIP_ERROR Init(RawTransportDelegate * delegate, Args &&... args)
@@ -216,17 +217,6 @@ private:
      * Provided to ensure that recursive InitImpl finishes compiling.
      */
     CHIP_ERROR InitImpl(RawTransportDelegate * delegate) { return CHIP_NO_ERROR; }
-
-    /**
-     * Handler passed to all underlying transports at init time.
-     *
-     * Calls the underlying Base message receive handler whenever any of the underlying transports
-     * receives a message.
-     */
-    static void OnMessageReceive(const PacketHeader & header, const PeerAddress & source, System::PacketBufferHandle msg, Tuple * t)
-    {
-        t->HandleMessageReceived(header, source, std::move(msg));
-    }
 
     std::tuple<TransportTypes...> mTransports;
 };

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -100,9 +100,9 @@ public:
      * @param args initialization arguments, forwarded as-is to the underlying transports.
      */
     template <typename... Args, typename std::enable_if<(sizeof...(Args) == sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR Init(Args &&... args)
+    CHIP_ERROR Init(RawTransportDelegate * delegate, Args &&... args)
     {
-        return InitImpl(std::forward<Args>(args)...);
+        return InitImpl(delegate, std::forward<Args>(args)...);
     }
 
 private:
@@ -195,7 +195,7 @@ private:
      * @param rest tail arguments to be passed to the rest of transport Init methods.
      */
     template <typename InitArg, typename... Rest>
-    CHIP_ERROR InitImpl(InitArg && arg, Rest &&... rest)
+    CHIP_ERROR InitImpl(RawTransportDelegate * delegate, InitArg && arg, Rest &&... rest)
     {
         auto transport = &std::get<sizeof...(TransportTypes) - sizeof...(Rest) - 1>(mTransports);
 
@@ -205,9 +205,9 @@ private:
             return err;
         }
 
-        transport->SetMessageReceiveHandler(&OnMessageReceive, this);
+        transport->SetDelegate(delegate);
 
-        return InitImpl(std::forward<Rest>(rest)...);
+        return InitImpl(delegate, std::forward<Rest>(rest)...);
     }
 
     /**
@@ -215,7 +215,7 @@ private:
      *
      * Provided to ensure that recursive InitImpl finishes compiling.
      */
-    CHIP_ERROR InitImpl() { return CHIP_NO_ERROR; }
+    CHIP_ERROR InitImpl(RawTransportDelegate * delegate) { return CHIP_NO_ERROR; }
 
     /**
      * Handler passed to all underlying transports at init time.

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -50,6 +50,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/inet/tests:helpers",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/transport",
     "${chip_root}/src/transport/raw",
     "${nlio_root}:nlio",
     "${nlunit_test_root}:nlunit-test",

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -26,6 +26,7 @@
 #include <core/CHIPCore.h>
 #include <support/CodeUtils.h>
 #include <support/UnitTestRegistration.h>
+#include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
 
 #include <nlbyteorder.h>
@@ -51,19 +52,29 @@ TestContext sContext;
 const char PAYLOAD[]        = "Hello!";
 int ReceiveHandlerCallCount = 0;
 
-void MessageReceiveHandler(const PacketHeader & header, const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf,
-                           nlTestSuite * inSuite)
+class MockTransportMgrDelegate : public TransportMgrDelegate
 {
-    NL_TEST_ASSERT(inSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
-    NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
-    NL_TEST_ASSERT(inSuite, header.GetMessageId() == kMessageId);
+public:
+    MockTransportMgrDelegate(nlTestSuite * inSuite) : mSuite(inSuite) {}
+    ~MockTransportMgrDelegate() override {}
 
-    size_t data_len = msgBuf->DataLength();
-    int compare     = memcmp(msgBuf->Start(), PAYLOAD, data_len);
-    NL_TEST_ASSERT(inSuite, compare == 0);
+    void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
+                           System::PacketBufferHandle msgBuf) override
+    {
+        NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
+        NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
+        NL_TEST_ASSERT(mSuite, header.GetMessageId() == kMessageId);
 
-    ReceiveHandlerCallCount++;
-}
+        size_t data_len = msgBuf->DataLength();
+        int compare     = memcmp(msgBuf->Start(), PAYLOAD, data_len);
+        NL_TEST_ASSERT(mSuite, compare == 0);
+
+        ReceiveHandlerCallCount++;
+    }
+
+private:
+    nlTestSuite * mSuite;
+};
 
 } // namespace
 
@@ -110,7 +121,12 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext, const IPAddress &
     err = udp.Init(Transport::UdpListenParameters(&ctx.GetInetLayer()).SetAddressType(addr.Type()));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    udp.SetMessageReceiveHandler(MessageReceiveHandler, inSuite);
+    MockTransportMgrDelegate gMockTransportMgrDelegate(inSuite);
+    TransportMgrBase gTransportMgrBase;
+    gTransportMgrBase.SetSecureSessionMgr(&gMockTransportMgrDelegate);
+    gTransportMgrBase.SetRendezvousSession(&gMockTransportMgrDelegate);
+    gTransportMgrBase.Init(&udp);
+
     ReceiveHandlerCallCount = 0;
 
     PacketHeader header;


### PR DESCRIPTION
In `HandleMessageReceived`, Use typed ptr `TransportMgrBase*` instead of function pointer and void *