### PR TITLE
Refactor message encryption and pairing code

### DIFF
--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -35,9 +35,10 @@ namespace chip {
 
 RendezvousServer::RendezvousServer() : mRendezvousSession(this) {}
 
-CHIP_ERROR RendezvousServer::Init(const RendezvousParameters & params, TransportMgrBase * transportMgr)
+CHIP_ERROR RendezvousServer::Init(const RendezvousParameters & params, TransportMgrBase * transportMgr,
+                                  SecureSessionMgr * sessionMgr)
 {
-    return mRendezvousSession.Init(params, transportMgr);
+    return mRendezvousSession.Init(params, transportMgr, sessionMgr);
 }
 
 void RendezvousServer::OnRendezvousError(CHIP_ERROR err)
@@ -62,15 +63,6 @@ void RendezvousServer::OnRendezvousMessageReceived(const PacketHeader & packetHe
 void RendezvousServer::OnRendezvousComplete()
 {
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
-    if (mRendezvousSession.GetRemoteNodeId().HasValue())
-    {
-        SessionManager().NewPairing(Optional<Transport::PeerAddress>{}, mRendezvousSession.GetRemoteNodeId().Value(),
-                                    &mRendezvousSession.GetPairingSession());
-    }
-    else
-    {
-        ChipLogError(AppServer, "Commissioner did not assign a node ID to the device!!!");
-    }
 }
 
 void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -28,7 +28,7 @@ class RendezvousServer : public RendezvousSessionDelegate
 public:
     RendezvousServer();
 
-    CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr);
+    CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr);
     void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; };
 
     //////////////// RendezvousSessionDelegate Implementation ///////////////////

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -202,6 +202,8 @@ void InitServer(AppDelegate * delegate)
     err = gSessions.Init(chip::kTestDeviceNodeId, &DeviceLayer::SystemLayer, &gTransports);
     SuccessOrExit(err);
 
+    gSessions.SetDelegate(&gCallbacks);
+
     // This flag is used to bypass BLE in the cirque test
     // Only in the cirque test this is enabled with --args='bypass_rendezvous=true'
     if (isRendezvousBypassed())
@@ -223,17 +225,13 @@ void InitServer(AppDelegate * delegate)
 #else
         params.SetSetupPINCode(pinCode);
 #endif // CONFIG_NETWORK_LAYER_BLE
-        SuccessOrExit(err = gRendezvousServer.Init(params, &gTransports));
+        SuccessOrExit(err = gRendezvousServer.Init(params, &gTransports, &gSessions));
     }
 
 #if CHIP_ENABLE_MDNS
     err = InitMdns();
     SuccessOrExit(err);
 #endif
-
-    gSessions.SetDelegate(&gCallbacks);
-    err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing);
-    SuccessOrExit(err);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -355,7 +355,7 @@ void DeviceController::OnNewConnection(SecureSessionHandle session, SecureSessio
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to process received message: err %d", err);
+        ChipLogError(Controller, "OnNewConnection: Failed to process received message: err %d", err);
     }
 }
 
@@ -374,7 +374,7 @@ void DeviceController::OnConnectionExpired(SecureSessionHandle session, SecureSe
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to process received message: err %d", err);
+        ChipLogError(Controller, "OnConnectionExpired: Failed to process received message: err %d", err);
     }
 }
 
@@ -395,7 +395,7 @@ void DeviceController::OnMessageReceived(const PacketHeader & header, const Payl
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to process received message: err %d", err);
+        ChipLogError(Controller, "OnMessageReceived: Failed to process received message: err %d", err);
     }
     return;
 }
@@ -559,7 +559,8 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     mIsIPRendezvous    = (params.GetPeerAddress().GetTransportType() != Transport::Type::kBle);
     mRendezvousSession = chip::Platform::New<RendezvousSession>(this);
     VerifyOrExit(mRendezvousSession != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    err = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId).SetRemoteNodeId(remoteDeviceId), mTransportMgr);
+    err = mRendezvousSession->Init(params.SetLocalNodeId(mLocalDeviceId).SetRemoteNodeId(remoteDeviceId), mTransportMgr,
+                                   mSessionManager);
     SuccessOrExit(err);
 
     device->Init(mTransportMgr, mSessionManager, mInetLayer, mListenPort, remoteDeviceId, remotePort, interfaceId);

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -27,6 +27,8 @@ static_library("transport") {
     "RendezvousSession.cpp",
     "RendezvousSession.h",
     "RendezvousSessionDelegate.h",
+    "SecureMessageCodec.cpp",
+    "SecureMessageCodec.h",
     "SecurePairingSession.cpp",
     "SecurePairingSession.h",
     "SecureSession.cpp",

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <transport/SecureSession.h>
+#include <transport/raw/Base.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -56,6 +57,9 @@ public:
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     PeerAddress & GetPeerAddress() { return mPeerAddress; }
     void SetPeerAddress(const PeerAddress & address) { mPeerAddress = address; }
+
+    void SetTransport(Transport::Base * transport) { mTransport = transport; }
+    Transport::Base * GetTransport() { return mTransport; }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }
     void SetPeerNodeId(NodeId peerNodeId) { mPeerNodeId = peerNodeId; }
@@ -95,11 +99,12 @@ public:
 
 private:
     PeerAddress mPeerAddress;
-    NodeId mPeerNodeId         = kUndefinedNodeId;
-    uint32_t mSendMessageIndex = 0;
-    uint16_t mPeerKeyID        = UINT16_MAX;
-    uint16_t mLocalKeyID       = UINT16_MAX;
-    uint64_t mLastActityTimeMs = 0;
+    NodeId mPeerNodeId           = kUndefinedNodeId;
+    uint32_t mSendMessageIndex   = 0;
+    uint16_t mPeerKeyID          = UINT16_MAX;
+    uint16_t mLocalKeyID         = UINT16_MAX;
+    uint64_t mLastActityTimeMs   = 0;
+    Transport::Base * mTransport = nullptr;
     SecureSession mSecureSession;
 };
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -197,16 +197,7 @@ void RendezvousSession::OnRendezvousConnectionOpened()
 
 void RendezvousSession::OnRendezvousConnectionClosed()
 {
-    if (mParams.IsController())
-    {
-        return;
-    }
-
-    CHIP_ERROR err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
-    if (err != CHIP_NO_ERROR)
-    {
-        OnPairingError(err);
-    }
+    ReleasePairingSessionHandle();
 }
 
 void RendezvousSession::OnRendezvousError(CHIP_ERROR err)

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -25,6 +25,7 @@
 #include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 #include <transport/RendezvousSession.h>
+#include <transport/SecureMessageCodec.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/PeerAddress.h>
@@ -33,7 +34,6 @@
 #include <transport/BLE.h>
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-static const size_t kMax_SecureSDU_Length          = 1024;
 static constexpr uint32_t kSpake2p_Iteration_Count = 100;
 static const char * kSpake2pKeyExchangeSalt        = "SPAKE2P Key Exchange Salt";
 
@@ -120,45 +120,11 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
     PayloadHeader payloadHeader;
     payloadHeader.SetProtocolID(static_cast<uint16_t>(protocol)).SetMessageType(msgType);
 
-    const uint16_t headerSize = payloadHeader.EncodeSizeBytes();
-
-    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    VerifyOrReturnError(CanCastTo<uint16_t>(headerSize + msgBuf->TotalLength()), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-
     PacketHeader packetHeader;
-    packetHeader
-        .SetSourceNodeId(mParams.GetLocalNodeId())           //
-        .SetDestinationNodeId(mParams.GetRemoteNodeId())     //
-        .SetMessageId(mSecureMessageIndex)                   //
-        .SetEncryptionKeyID(mPairingSession.GetLocalKeyId()) //
-        .SetPayloadLength(static_cast<uint16_t>(headerSize + msgBuf->TotalLength()));
+    ReturnErrorOnFailure(SecureMessageCodec::Encode(mParams.GetLocalNodeId().ValueOr(kUndefinedNodeId),
+                                                    &mPairingSession.PeerConnection(), payloadHeader, packetHeader, msgBuf));
 
-    VerifyOrReturnError(msgBuf->EnsureReservedSize(headerSize), CHIP_ERROR_NO_MEMORY);
-
-    msgBuf->SetStart(msgBuf->Start() - headerSize);
-
-    MessageAuthenticationCode mac;
-    uint16_t actualEncodedHeaderSize = 0;
-    uint8_t * data                   = msgBuf->Start();
-    uint16_t totalLen                = msgBuf->TotalLength();
-
-    ReturnErrorOnFailure(payloadHeader.Encode(data, totalLen, &actualEncodedHeaderSize));
-    ReturnErrorOnFailure(mSecureSession.Encrypt(data, totalLen, data, packetHeader, mac));
-
-    uint16_t taglen = 0;
-    ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], kMaxTagLen, &taglen));
-
-    VerifyOrReturnError(CanCastTo<uint16_t>(totalLen + taglen), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-
-    msgBuf->SetDataLength(static_cast<uint16_t>(totalLen + taglen));
-
-    ReturnErrorOnFailure(mTransport->SendMessage(packetHeader, Transport::PeerAddress::BLE(), std::move(msgBuf)));
-
-    mSecureMessageIndex++;
-
-    return CHIP_NO_ERROR;
+    return mTransport->SendMessage(packetHeader, Transport::PeerAddress::BLE(), std::move(msgBuf));
 }
 
 void RendezvousSession::OnPairingError(CHIP_ERROR err)
@@ -168,23 +134,15 @@ void RendezvousSession::OnPairingError(CHIP_ERROR err)
 
 void RendezvousSession::OnPairingComplete()
 {
-    CHIP_ERROR err = mPairingSession.DeriveSecureSession(reinterpret_cast<const unsigned char *>(kSpake2pI2RSessionInfo),
-                                                         strlen(kSpake2pI2RSessionInfo), mSecureSession);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Ble, "Failed to initialize a secure session: %s", ErrorStr(err));
-        return;
-    }
-
     // TODO: This check of BLE transport should be removed in the future, after we have network provisioning cluster and ble becomes
     // a transport.
     if (mParams.GetPeerAddress().GetTransportType() != Transport::Type::kBle || // For rendezvous initializer
         mPeerAddress.GetTransportType() != Transport::Type::kBle)               // For rendezvous target
     {
-        if (mRendezvousRemoteNodeId.HasValue() && !mParams.HasRemoteNodeId())
+        if (!mParams.HasRemoteNodeId())
         {
-            ChipLogProgress(Ble, "Completed rendezvous with %llu", mRendezvousRemoteNodeId.Value());
-            mParams.SetRemoteNodeId(mRendezvousRemoteNodeId.Value());
+            ChipLogProgress(Ble, "Completed rendezvous with %llu", mPairingSession.GetPeerNodeId());
+            mParams.SetRemoteNodeId(mPairingSession.GetPeerNodeId());
         }
         UpdateState(State::kRendezvousComplete);
         if (!mParams.IsController())
@@ -228,9 +186,6 @@ void RendezvousSession::OnRendezvousConnectionClosed()
     {
         return;
     }
-
-    mSecureSession.Reset();
-    mRendezvousRemoteNodeId.ClearValue();
 
     CHIP_ERROR err = WaitForPairing(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
     if (err != CHIP_NO_ERROR)
@@ -314,7 +269,6 @@ void RendezvousSession::OnRendezvousMessageReceived(const PacketHeader & packetH
         if (packetHeader.GetSourceNodeId().HasValue())
         {
             ChipLogProgress(Ble, "Received rendezvous message from %llu", packetHeader.GetSourceNodeId().Value());
-            mRendezvousRemoteNodeId.SetValue(packetHeader.GetSourceNodeId().Value());
         }
         err = HandlePairingMessage(packetHeader, peerAddress, std::move(msgBuf));
         break;
@@ -350,11 +304,6 @@ CHIP_ERROR RendezvousSession::HandlePairingMessage(const PacketHeader & packetHe
 CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHeader, const PeerAddress & peerAddress,
                                                   PacketBufferHandle msgBuf)
 {
-    uint16_t headerSize = 0;
-    uint8_t * plainText = nullptr;
-    uint16_t taglen     = 0;
-    uint16_t payloadlen = 0;
-
     ReturnErrorCodeIf(msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Check if the source and destination node IDs match with what we already know
@@ -370,35 +319,7 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
     }
 
     PayloadHeader payloadHeader;
-    headerSize = payloadHeader.EncodeSizeBytes();
-
-    uint8_t * data = msgBuf->Start();
-    uint16_t len   = msgBuf->TotalLength();
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
-    /* This is a workaround for the case where PacketBuffer payload is not
-       allocated as an inline buffer to PacketBuffer structure */
-    System::PacketBufferHandle origMsg;
-
-    origMsg = std::move(msgBuf);
-    msgBuf  = PacketBuffer::NewWithAvailableSize(len);
-
-    ReturnErrorCodeIf(msgBuf.IsNull(), CHIP_ERROR_NO_MEMORY);
-
-    msgBuf->SetDataLength(len);
-#endif
-    plainText = msgBuf->Start();
-
-    payloadlen = packetHeader.GetPayloadLength();
-    VerifyOrReturnError(payloadlen <= len, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-
-    MessageAuthenticationCode mac;
-    ReturnErrorOnFailure(mac.Decode(packetHeader, &data[payloadlen], static_cast<uint16_t>(len - payloadlen), &taglen));
-
-    len = static_cast<uint16_t>(len - taglen);
-    msgBuf->SetDataLength(len);
-
-    ReturnErrorOnFailure(mSecureSession.Decrypt(data, len, plainText, packetHeader, mac));
+    ReturnErrorOnFailure(SecureMessageCodec::Decode(&mPairingSession.PeerConnection(), payloadHeader, packetHeader, msgBuf));
 
     // Use the node IDs from the packet header only after it's successfully decrypted
     if (packetHeader.GetDestinationNodeId().HasValue() && !mParams.HasLocalNodeId())
@@ -412,13 +333,6 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
         ChipLogProgress(Ble, "Received rendezvous message from %llu", packetHeader.GetSourceNodeId().Value());
         mParams.SetRemoteNodeId(packetHeader.GetSourceNodeId().Value());
     }
-
-    uint16_t decodedSize = 0;
-    ReturnErrorOnFailure(payloadHeader.Decode(plainText, len, &decodedSize));
-
-    ReturnErrorCodeIf(headerSize != decodedSize, CHIP_ERROR_INCORRECT_STATE);
-
-    msgBuf->ConsumeHead(headerSize);
 
     if (payloadHeader.GetProtocolID() == Protocols::kProtocol_NetworkProvisioning)
     {
@@ -439,7 +353,8 @@ CHIP_ERROR RendezvousSession::WaitForPairing(Optional<NodeId> nodeId, uint32_t s
 CHIP_ERROR RendezvousSession::Pair(Optional<NodeId> nodeId, uint32_t setupPINCode)
 {
     UpdateState(State::kSecurePairing);
-    return mPairingSession.Pair(mParams.GetPeerAddress(), setupPINCode, nodeId, mNextKeyId++, this);
+    return mPairingSession.Pair(mParams.GetPeerAddress(), setupPINCode, nodeId, mParams.GetRemoteNodeId().ValueOr(kUndefinedNodeId),
+                                mNextKeyId++, this);
 }
 
 void RendezvousSession::SendNetworkCredentials(const char * ssid, const char * passwd)

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -372,7 +372,11 @@ void RendezvousSession::ReleasePairingSessionHandle()
         Transport::PeerConnectionState * state = mSecureSessionMgr->GetPeerConnectionState(*mPairingSessionHandle);
         if (state != nullptr)
         {
+            // Reset the transport and peer address in the active secure channel
+            // This will allow the regular transport (e.g. UDP) to take over the existing secure channel
+            PeerAddress addr;
             state->SetTransport(nullptr);
+            state->SetPeerAddress(addr);
         }
         chip::Platform::Delete(mPairingSessionHandle);
         mPairingSessionHandle = nullptr;
@@ -399,11 +403,13 @@ CHIP_ERROR RendezvousSession::Pair(Optional<NodeId> nodeId, uint32_t setupPINCod
 void RendezvousSession::SendNetworkCredentials(const char * ssid, const char * passwd)
 {
     mNetworkProvision.SendNetworkCredentials(ssid, passwd);
+    ReleasePairingSessionHandle();
 }
 
 void RendezvousSession::SendThreadCredentials(const DeviceLayer::Internal::DeviceNetworkInfo & threadData)
 {
     mNetworkProvision.SendThreadCredentials(threadData);
+    ReleasePairingSessionHandle();
 }
 
 void RendezvousSession::SendOperationalCredentials() {}

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -161,6 +161,9 @@ private:
 
     RendezvousSession::State mCurrentState = State::kInit;
     void UpdateState(RendezvousSession::State newState, CHIP_ERROR err = CHIP_NO_ERROR);
+
+    void InitPairingSessionHandle();
+    void ReleasePairingSessionHandle();
 };
 
 } // namespace chip

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -151,12 +151,9 @@ private:
 
     SecurePairingSession mPairingSession;
     NetworkProvisioning mNetworkProvision;
-    SecureSession mSecureSession;
     Transport::PeerAddress mPeerAddress; // Current peer address we are doing rendezvous with.
-    Optional<NodeId> mRendezvousRemoteNodeId;
     TransportMgrBase * mTransportMgr;
-    uint32_t mSecureMessageIndex = 0;
-    uint16_t mNextKeyId          = 0;
+    uint16_t mNextKeyId = 0;
 
     RendezvousSession::State mCurrentState = State::kInit;
     void UpdateState(RendezvousSession::State newState, CHIP_ERROR err = CHIP_NO_ERROR);

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -39,6 +39,7 @@ class CHIPDeviceEvent;
 }
 
 class SecureSessionMgr;
+class SecureSessionHandle;
 
 /**
  * RendezvousSession establishes and maintains the first connection between
@@ -86,9 +87,10 @@ public:
      *
      * @param params       The RendezvousParameters
      * @param transportMgr The transport to use
+     * @param sessionMgr   Pointer to secure session manager
      * @ return CHIP_ERROR  The result of the initialization
      */
-    CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr);
+    CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr);
 
     /**
      * @brief
@@ -153,7 +155,9 @@ private:
     NetworkProvisioning mNetworkProvision;
     Transport::PeerAddress mPeerAddress; // Current peer address we are doing rendezvous with.
     TransportMgrBase * mTransportMgr;
-    uint16_t mNextKeyId = 0;
+    uint16_t mNextKeyId                         = 0;
+    SecureSessionMgr * mSecureSessionMgr        = nullptr;
+    SecureSessionHandle * mPairingSessionHandle = nullptr;
 
     RendezvousSession::State mCurrentState = State::kInit;
     void UpdateState(RendezvousSession::State newState, CHIP_ERROR err = CHIP_NO_ERROR);

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -1,0 +1,139 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines functions for encoding and decoding CHIP messages.
+ *      The encoded messages contain CHIP packet header, encrypted payload
+ *      header, encrypted payload and message authentication code, as per
+ *      CHIP specifications.
+ *
+ */
+
+#include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
+#include <transport/SecureMessageCodec.h>
+
+// Maximum length of application data that can be encrypted as one block.
+// The limit is derived from IPv6 MTU (1280 bytes) - expected header overheads.
+// This limit would need additional reviews once we have formalized Secure Transport header.
+//
+// TODO: this should be checked within the transport message sending instead of the session management layer.
+static const size_t kMax_SecureSDU_Length = 1024;
+
+namespace chip {
+
+using System::PacketBuffer;
+using System::PacketBufferHandle;
+
+namespace SecureMessageCodec {
+
+CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, PayloadHeader & payloadHeader,
+                  PacketHeader & packetHeader, System::PacketBufferHandle & msgBuf)
+{
+    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
+    uint32_t msgId = state->GetSendMessageIndex();
+
+    static_assert(std::is_same<decltype(msgBuf->TotalLength()), uint16_t>::value,
+                  "Addition to generate payloadLength might overflow");
+
+    uint16_t headerSize = payloadHeader.EncodeSizeBytes();
+
+    // Make sure it's big enough to add two 16-bit ints without overflowing.
+    uint32_t payloadLength = static_cast<uint32_t>(headerSize + msgBuf->TotalLength());
+    VerifyOrReturnError(CanCastTo<uint16_t>(payloadLength), CHIP_ERROR_NO_MEMORY);
+
+    packetHeader
+        .SetSourceNodeId(localNodeId)                 //
+        .SetDestinationNodeId(state->GetPeerNodeId()) //
+        .SetMessageId(msgId)                          //
+        .SetEncryptionKeyID(state->GetLocalKeyID())   //
+        .SetPayloadLength(static_cast<uint16_t>(payloadLength));
+    packetHeader.GetFlags().Set(Header::FlagValues::kSecure);
+
+    VerifyOrReturnError(msgBuf->EnsureReservedSize(headerSize), CHIP_ERROR_NO_MEMORY);
+
+    msgBuf->SetStart(msgBuf->Start() - headerSize);
+    uint8_t * data    = msgBuf->Start();
+    uint16_t totalLen = msgBuf->TotalLength();
+
+    uint16_t actualEncodedHeaderSize;
+    ReturnErrorOnFailure(payloadHeader.Encode(data, totalLen, &actualEncodedHeaderSize));
+
+    MessageAuthenticationCode mac;
+    ReturnErrorOnFailure(state->GetSecureSession().Encrypt(data, totalLen, data, packetHeader, mac));
+
+    uint16_t taglen = 0;
+    ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], kMaxTagLen, &taglen));
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(totalLen + taglen), CHIP_ERROR_INTERNAL);
+    msgBuf->SetDataLength(static_cast<uint16_t>(totalLen + taglen));
+
+    ChipLogDetail(Inet, "Secure message was encrypted: Msg ID %u", msgId);
+
+    state->IncrementSendMessageIndex();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Decode(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
+                  System::PacketBufferHandle & msg)
+{
+    ReturnErrorCodeIf(msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t * data = msg->Start();
+    uint16_t len   = msg->TotalLength();
+
+    PacketBufferHandle origMsg;
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+    /* This is a workaround for the case where PacketBuffer payload is not
+        allocated as an inline buffer to PacketBuffer structure */
+    origMsg = std::move(msg);
+    msg     = PacketBuffer::NewWithAvailableSize(len);
+    VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_NO_MEMORY);
+    msg->SetDataLength(len);
+#endif
+
+    uint16_t payloadlen = packetHeader.GetPayloadLength();
+    VerifyOrReturnError(payloadlen <= len, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
+    uint16_t taglen = 0;
+    MessageAuthenticationCode mac;
+    ReturnErrorOnFailure(mac.Decode(packetHeader, &data[payloadlen], static_cast<uint16_t>(len - payloadlen), &taglen));
+
+    len = static_cast<uint16_t>(len - taglen);
+    msg->SetDataLength(len);
+
+    uint8_t * plainText = msg->Start();
+    ReturnErrorOnFailure(state->GetSecureSession().Decrypt(data, len, plainText, packetHeader, mac));
+
+    uint16_t decodedSize = 0;
+    ReturnErrorOnFailure(payloadHeader.Decode(plainText, len, &decodedSize));
+    uint16_t headerSize = payloadHeader.EncodeSizeBytes();
+    VerifyOrReturnError(headerSize == decodedSize, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
+    msg->ConsumeHead(headerSize);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace SecureMessageCodec
+
+} // namespace chip

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
     ReturnErrorOnFailure(state->GetSecureSession().Encrypt(data, totalLen, data, packetHeader, mac));
 
     uint16_t taglen = 0;
-    ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], kMaxTagLen, &taglen));
+    ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], msgBuf->AvailableDataLength(), &taglen));
 
     VerifyOrReturnError(CanCastTo<uint16_t>(totalLen + taglen), CHIP_ERROR_INTERNAL);
     msgBuf->SetDataLength(static_cast<uint16_t>(totalLen + taglen));

--- a/src/transport/SecureMessageCodec.h
+++ b/src/transport/SecureMessageCodec.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/transport/SecureMessageCodec.h
+++ b/src/transport/SecureMessageCodec.h
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines functions for encoding and decoding CHIP messages.
+ *      The encoded messages contain CHIP packet header, encrypted payload
+ *      header, encrypted payload and message authentication code, as per
+ *      CHIP specifications.
+ *
+ */
+
+#pragma once
+
+#include <transport/PeerConnectionState.h>
+
+namespace chip {
+
+namespace SecureMessageCodec {
+
+/**
+ * @brief
+ *  Attach payload header to the message and encrypt the message buffer using
+ *  key from the connection state.
+ *
+ * @param localNodeId   Node Id of local node
+ * @param state         The connection state with peer node
+ * @param payloadHeader Reference to the payload header that should be inserted in
+ *                      the message
+ * @param packetHeader  Reference to the packet header that contains unencrypted
+ *                      portion of the message header
+ * @param msgBuf        The message buffer that contains the unencrypted message. If
+ *                      the operation is successuful, this buffer will contain the
+ *                      encrypted message.
+ * @ return CHIP_ERROR  The result of the encode operation
+ */
+CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, PayloadHeader & payloadHeader,
+                  PacketHeader & packetHeader, System::PacketBufferHandle & msgBuf);
+
+/**
+ * @brief
+ *  Decrypt the message, perform message integrity check, and decode the payload header.
+ *
+ * @param state         The connection state with peer node
+ * @param payloadHeader Reference to the payload header that should be inserted in
+ *                      the message
+ * @param packetHeader  Reference to the packet header that contains unencrypted
+ *                      portion of the message header
+ * @param msgBuf        The message buffer that contains the encrypted message. If
+ *                      the operation is successuful, this buffer will contain the
+ *                      unencrypted message.
+ * @ return CHIP_ERROR  The result of the decode operation
+ */
+CHIP_ERROR Decode(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, const PacketHeader & packetHeader,
+                  System::PacketBufferHandle & msgBuf);
+} // namespace SecureMessageCodec
+
+} // namespace chip

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -73,13 +73,10 @@ void SecurePairingSession::Clear()
         chip::Platform::MemoryFree(mSalt);
         mSalt = nullptr;
     }
-    mLocalNodeId     = Optional<NodeId>::Value(kUndefinedNodeId);
-    mPeerNodeId      = Optional<NodeId>::Value(kUndefinedNodeId);
-    mLocalKeyId      = 0;
-    mPeerKeyId       = 0;
-    mPeerAddress     = Transport::PeerAddress::Uninitialized();
+    mLocalNodeId     = kUndefinedNodeId;
     mKeLen           = sizeof(mKe);
     mPairingComplete = false;
+    mConnectionState.Reset();
 }
 
 CHIP_ERROR SecurePairingSession::Serialize(SecurePairingSessionSerialized & output)
@@ -131,19 +128,18 @@ CHIP_ERROR SecurePairingSession::ToSerializable(SecurePairingSessionSerializable
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
-    const NodeId localNodeId = mLocalNodeId.ValueOr(kUndefinedNodeId);
-    const NodeId peerNodeId  = mPeerNodeId.ValueOr(kUndefinedNodeId);
+    const NodeId peerNodeId = mConnectionState.GetPeerNodeId();
     VerifyOrExit(CanCastTo<uint16_t>(mKeLen), error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(CanCastTo<uint64_t>(localNodeId), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<uint64_t>(mLocalNodeId), error = CHIP_ERROR_INTERNAL);
     VerifyOrExit(CanCastTo<uint64_t>(peerNodeId), error = CHIP_ERROR_INTERNAL);
 
     memset(&serializable, 0, sizeof(serializable));
     serializable.mKeLen           = static_cast<uint16_t>(mKeLen);
     serializable.mPairingComplete = (mPairingComplete) ? 1 : 0;
-    serializable.mLocalNodeId     = localNodeId;
+    serializable.mLocalNodeId     = mLocalNodeId;
     serializable.mPeerNodeId      = peerNodeId;
-    serializable.mLocalKeyId      = mLocalKeyId;
-    serializable.mPeerKeyId       = mPeerKeyId;
+    serializable.mLocalKeyId      = mConnectionState.GetLocalKeyID();
+    serializable.mPeerKeyId       = mConnectionState.GetPeerKeyID();
 
     memcpy(serializable.mKe, mKe, mKeLen);
 
@@ -162,11 +158,10 @@ CHIP_ERROR SecurePairingSession::FromSerializable(const SecurePairingSessionSeri
     memset(mKe, 0, sizeof(mKe));
     memcpy(mKe, serializable.mKe, mKeLen);
 
-    mLocalNodeId = Optional<NodeId>::Value(serializable.mLocalNodeId);
-    mPeerNodeId  = Optional<NodeId>::Value(serializable.mPeerNodeId);
-
-    mLocalKeyId = serializable.mLocalKeyId;
-    mPeerKeyId  = serializable.mPeerKeyId;
+    mLocalNodeId = serializable.mLocalNodeId;
+    mConnectionState.SetPeerNodeId(serializable.mPeerNodeId);
+    mConnectionState.SetLocalKeyID(serializable.mLocalKeyId);
+    mConnectionState.SetPeerKeyID(serializable.mPeerKeyId);
 
 exit:
     return error;
@@ -185,9 +180,9 @@ CHIP_ERROR SecurePairingSession::Init(Optional<NodeId> myNodeId, uint16_t myKeyI
     err = mCommissioningHash.AddData(Uint8::from_const_char(kSpake2pContext), strlen(kSpake2pContext));
     SuccessOrExit(err);
 
-    mDelegate     = delegate;
-    mLocalNodeId  = myNodeId;
-    mLocalKeyId   = myKeyId;
+    mDelegate    = delegate;
+    mLocalNodeId = myNodeId.ValueOr(kUndefinedNodeId);
+    mConnectionState.SetLocalKeyID(myKeyId);
     mSetupPINCode = setupCode;
 
 exit:
@@ -273,8 +268,11 @@ CHIP_ERROR SecurePairingSession::AttachHeaderAndSend(Protocols::SecureChannel::M
     SuccessOrExit(err);
     VerifyOrExit(headerSize == actualEncodedHeaderSize, err = CHIP_ERROR_INTERNAL);
 
-    err = mDelegate->SendPairingMessage(PacketHeader().SetSourceNodeId(mLocalNodeId).SetEncryptionKeyID(mLocalKeyId), mPeerAddress,
-                                        std::move(msgBuf));
+    err = mDelegate->SendPairingMessage(PacketHeader()
+                                            .SetSourceNodeId(mLocalNodeId)
+                                            .SetDestinationNodeId(mConnectionState.GetPeerNodeId())
+                                            .SetEncryptionKeyID(mConnectionState.GetLocalKeyID()),
+                                        mConnectionState.GetPeerAddress(), std::move(msgBuf));
     SuccessOrExit(err);
 
 exit:
@@ -282,12 +280,14 @@ exit:
 }
 
 CHIP_ERROR SecurePairingSession::Pair(const Transport::PeerAddress peerAddress, uint32_t peerSetUpPINCode,
-                                      Optional<NodeId> myNodeId, uint16_t myKeyId, SecurePairingSessionDelegate * delegate)
+                                      Optional<NodeId> myNodeId, NodeId peerNodeId, uint16_t myKeyId,
+                                      SecurePairingSessionDelegate * delegate)
 {
     CHIP_ERROR err = Init(myNodeId, myKeyId, peerSetUpPINCode, delegate);
     SuccessOrExit(err);
 
-    mPeerAddress = peerAddress;
+    mConnectionState.SetPeerAddress(peerAddress);
+    mConnectionState.SetPeerNodeId(peerNodeId);
 
     err = SendPBKDFParamRequest();
     SuccessOrExit(err);
@@ -363,6 +363,11 @@ CHIP_ERROR SecurePairingSession::HandlePBKDFParamRequest(const PacketHeader & he
     // Update commissioning hash with the received pbkdf2 param request
     err = mCommissioningHash.AddData(req, reqlen);
     SuccessOrExit(err);
+
+    if (header.GetSourceNodeId().HasValue() && mConnectionState.GetPeerNodeId() == kUndefinedNodeId)
+    {
+        mConnectionState.SetPeerNodeId(header.GetSourceNodeId().Value());
+    }
 
     err = SendPBKDFParamResponse();
     SuccessOrExit(err);
@@ -471,6 +476,11 @@ CHIP_ERROR SecurePairingSession::HandlePBKDFParamResponse(const PacketHeader & h
         SuccessOrExit(err);
     }
 
+    if (header.GetSourceNodeId().HasValue() && mConnectionState.GetPeerNodeId() == kUndefinedNodeId)
+    {
+        mConnectionState.SetPeerNodeId(header.GetSourceNodeId().Value());
+    }
+
     err = SendMsg1();
     SuccessOrExit(err);
 
@@ -549,8 +559,11 @@ CHIP_ERROR SecurePairingSession::HandleMsg1_and_SendMsg2(const PacketHeader & he
     err = mSpake2p.ComputeRoundTwo(buf, buf_len, verifier, &verifier_len);
     SuccessOrExit(err);
 
-    mPeerKeyId  = header.GetEncryptionKeyID();
-    mPeerNodeId = header.GetSourceNodeId();
+    mConnectionState.SetPeerKeyID(header.GetEncryptionKeyID());
+    if (header.GetSourceNodeId().HasValue() && mConnectionState.GetPeerNodeId() == kUndefinedNodeId)
+    {
+        mConnectionState.SetPeerNodeId(header.GetSourceNodeId().Value());
+    }
 
     // Make sure our addition doesn't overflow.
     VerifyOrExit(UINTMAX_MAX - verifier_len >= Y_len, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
@@ -610,8 +623,11 @@ CHIP_ERROR SecurePairingSession::HandleMsg2_and_SendMsg3(const PacketHeader & he
     VerifyOrExit(CanCastTo<uint16_t>(verifier_len_raw), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     verifier_len = static_cast<uint16_t>(verifier_len_raw);
 
-    mPeerKeyId  = header.GetEncryptionKeyID();
-    mPeerNodeId = header.GetSourceNodeId();
+    mConnectionState.SetPeerKeyID(header.GetEncryptionKeyID());
+    if (header.GetSourceNodeId().HasValue() && mConnectionState.GetPeerNodeId() == kUndefinedNodeId)
+    {
+        mConnectionState.SetPeerNodeId(header.GetSourceNodeId().Value());
+    }
 
     resp = System::PacketBuffer::NewWithAvailableSize(verifier_len);
     VerifyOrExit(!resp.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
@@ -645,6 +661,10 @@ CHIP_ERROR SecurePairingSession::HandleMsg2_and_SendMsg3(const PacketHeader & he
 
     mPairingComplete = true;
 
+    err = DeriveSecureSession(reinterpret_cast<const unsigned char *>(kSpake2pI2RSessionInfo), strlen(kSpake2pI2RSessionInfo),
+                              mConnectionState.GetSecureSession());
+    SuccessOrExit(err);
+
     // Call delegate to indicate pairing completion
     mDelegate->OnPairingComplete();
 
@@ -672,8 +692,9 @@ CHIP_ERROR SecurePairingSession::HandleMsg3(const PacketHeader & header, const S
     VerifyOrExit(hash != nullptr, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
     VerifyOrExit(msg->DataLength() == kMAX_Hash_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
-    VerifyOrExit(header.GetSourceNodeId() == mPeerNodeId, err = CHIP_ERROR_WRONG_NODE_ID);
-    VerifyOrExit(header.GetEncryptionKeyID() == mPeerKeyId, err = CHIP_ERROR_INVALID_KEY_ID);
+    VerifyOrExit(header.GetSourceNodeId().ValueOr(kUndefinedNodeId) == mConnectionState.GetPeerNodeId(),
+                 err = CHIP_ERROR_WRONG_NODE_ID);
+    VerifyOrExit(header.GetEncryptionKeyID() == mConnectionState.GetPeerKeyID(), err = CHIP_ERROR_INVALID_KEY_ID);
 
     err = mSpake2p.KeyConfirm(hash, kMAX_Hash_Length);
     if (err != CHIP_NO_ERROR)
@@ -686,6 +707,10 @@ CHIP_ERROR SecurePairingSession::HandleMsg3(const PacketHeader & header, const S
     SuccessOrExit(err);
 
     mPairingComplete = true;
+
+    err = DeriveSecureSession(reinterpret_cast<const unsigned char *>(kSpake2pI2RSessionInfo), strlen(kSpake2pI2RSessionInfo),
+                              mConnectionState.GetSecureSession());
+    SuccessOrExit(err);
 
     // Call delegate to indicate pairing completion
     mDelegate->OnPairingComplete();
@@ -756,7 +781,16 @@ CHIP_ERROR SecurePairingSession::HandlePeerMessage(const PacketHeader & packetHe
     VerifyOrExit(payloadHeader.GetProtocolID() == Protocols::kProtocol_SecureChannel, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
     VerifyOrExit(payloadHeader.GetMessageType() == (uint8_t) mNextExpectedMsg, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
-    mPeerAddress = peerAddress;
+    mConnectionState.SetPeerAddress(peerAddress);
+
+    if (mLocalNodeId == kUndefinedNodeId)
+    {
+        mLocalNodeId = packetHeader.GetDestinationNodeId().ValueOr(kUndefinedNodeId);
+    }
+    else if (packetHeader.GetDestinationNodeId().HasValue())
+    {
+        VerifyOrExit(mLocalNodeId == packetHeader.GetDestinationNodeId().Value(), err = CHIP_ERROR_WRONG_NODE_ID);
+    }
 
     switch (static_cast<Protocols::SecureChannel::MsgType>(payloadHeader.GetMessageType()))
     {

--- a/src/transport/SecurePairingSession.cpp
+++ b/src/transport/SecurePairingSession.cpp
@@ -39,6 +39,7 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
+#include <transport/SecureSessionMgr.h>
 
 namespace chip {
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -144,9 +144,9 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
 
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
-    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(!msgBuf->HasChainedBuffer(), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(msgBuf->TotalLength() < kMax_SecureSDU_Length, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
     // Find an active connection to the specified peer node
     state = GetPeerConnectionState(session);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -144,6 +144,10 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
 
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
+    VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+
     // Find an active connection to the specified peer node
     state = GetPeerConnectionState(session);
     VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -205,7 +205,8 @@ public:
      *   establishes the security keys for secure communication with the
      *   peer node.
      */
-    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, SecurePairingSession * pairing);
+    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, SecurePairingSession * pairing,
+                          Transport::Base * transport = nullptr);
 
     /**
      * @brief
@@ -222,6 +223,14 @@ public:
      * @param transportMgr   Transport to use
      */
     CHIP_ERROR Init(NodeId localNodeId, System::Layer * systemLayer, TransportMgrBase * transportMgr);
+
+    /**
+     * @brief
+     *   Set local node ID
+     *
+     * @param localNodeId    Node id for the current node
+     */
+    void SetLocalNodeID(NodeId nodeId) { mLocalNodeId = nodeId; }
 
     /**
      * @brief
@@ -266,9 +275,6 @@ private:
 
     SecureSessionMgrDelegate * mCB   = nullptr;
     TransportMgrBase * mTransportMgr = nullptr;
-
-    CHIP_ERROR EncryptPayload(Transport::PeerConnectionState * state, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
-                              System::PacketBufferHandle & msgBuf);
 
     CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                            System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -228,7 +228,7 @@ public:
      * @brief
      *   Set local node ID
      *
-     * @param localNodeId    Node id for the current node
+     * @param nodeId    Node id for the current node
      */
     void SetLocalNodeID(NodeId nodeId) { mLocalNodeId = nodeId; }
 

--- a/src/transport/tests/TestSecurePairingSession.cpp
+++ b/src/transport/tests/TestSecurePairingSession.cpp
@@ -80,10 +80,10 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     SecurePairingSession pairing;
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 0, nullptr) !=
+                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0, nullptr) !=
                        CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 0, &delegate) ==
+                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0, &delegate) ==
                        CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, delegate.mNumMessageSend == 1);
@@ -93,8 +93,8 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     SecurePairingSession pairing1;
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 0, &delegate) ==
-                       CHIP_ERROR_BAD_REQUEST);
+                   pairing1.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0,
+                                 &delegate) == CHIP_ERROR_BAD_REQUEST);
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SecurePairingSession & pairingCommissioner,
@@ -111,7 +111,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
                    pairingAccessory.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0,
                                                    &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(2), 0,
+                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(2), 1, 0,
                                             &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumMessageSend == 2);


### PR DESCRIPTION
 #### Problem
The packet encryption/decryption code is duplicated in `SecureSessionMgr` and `RendezvousSession` classes. The code can use some refactoring.

 #### Summary of Changes
- Extract message encryption/decryption to its own functions.
  These can be reused for pairing, and CASE based session setup.
- Cleanup pairing and rendezvous code to use the new functions.
- Use `SecureSessionMgr` to send encrypted messages generated by Rendezvous process.
