### PR TITLE
Remove 'postCreateCommand' for vsenv docker.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,6 @@
     "settings": {
         "terminal.integrated.shell.linux": "/bin/bash"
     },
-    "postCreateCommand": "source /usr/share/bash-completion/bash_completion && source /etc/bash_completion.d/git-prompt && sudo chgrp docker /var/run/docker.sock",
     "remoteEnv": {
         "GIT_PS1_SHOWDIRTYSTATE": "1",
         "GIT_PS1_SHOWSTASHSTATE": "1",


### PR DESCRIPTION
#### Problem
Post-vscode container build always fails on my machine. 

 #### Summary of Changes

Running sudo commands as part of the container build seems wrong. Removed the entire post command.