### PR TITLE
[thread] Allow to specify dataset timestamp

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -41,7 +41,6 @@
 #include <platform/EFR32/ThreadStackManagerImpl.h>
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
-#include <platform/internal/DeviceNetworkInfo.h>
 #endif
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -41,7 +41,6 @@
 #include <platform/EFR32/ThreadStackManagerImpl.h>
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
-#include <platform/internal/DeviceNetworkInfo.h>
 #endif
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000

--- a/examples/lock-app/qpg6100/src/AppTask.cpp
+++ b/examples/lock-app/qpg6100/src/AppTask.cpp
@@ -38,7 +38,6 @@ using namespace chip::DeviceLayer;
 #if CHIP_ENABLE_OPENTHREAD
 #include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
-#include <platform/internal/DeviceNetworkInfo.h>
 #include <platform/qpg6100/ThreadStackManagerImpl.h>
 #define JOINER_START_TRIGGER_TIMEOUT 1500
 #endif

--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -102,8 +102,8 @@ public:
     /**< The Thread master key (NOT NULL-terminated). */
     uint8_t ThreadPSKc[kThreadPSKcLength];
     /**< The Thread pre-shared commissioner key (NOT NULL-terminated). */
-    uint16_t ThreadPANId;  /**< The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified */
-    uint8_t ThreadChannel; /**< The Thread channel (currently [11..26]), or kThreadChannel_NotSpecified */
+    uint16_t ThreadPANId;            /**< The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified */
+    uint8_t ThreadChannel;           /**< The Thread channel (currently [11..26]), or kThreadChannel_NotSpecified */
     uint64_t ThreadDatasetTimestamp; /**< Thread active dataset timestamp */
 };
 

--- a/src/include/platform/internal/DeviceNetworkInfo.h
+++ b/src/include/platform/internal/DeviceNetworkInfo.h
@@ -54,7 +54,7 @@ enum
 /**
  * WiFi Security Modes.
  */
-enum WiFiAuthSecurityType
+enum WiFiAuthSecurityType : int8_t
 {
     kWiFiSecurityType_NotSpecified = -1,
 
@@ -77,6 +77,14 @@ class DeviceNetworkInfo
 public:
     uint32_t NetworkId; /**< The network id assigned to the network by the device. */
 
+    struct
+    {
+        bool NetworkId : 1;           /**< True if the NetworkId field is present. */
+        bool ThreadExtendedPANId : 1; /**< True if the ThreadExtendedPANId field is present. */
+        bool ThreadMeshPrefix : 1;    /**< True if the ThreadMeshPrefix field is present. */
+        bool ThreadPSKc : 1;          /**< True if the ThreadPSKc field is present. */
+    } FieldPresent;
+
     // ---- WiFi-specific Fields ----
     char WiFiSSID[kMaxWiFiSSIDLength + 1]; /**< The WiFi SSID as a NULL-terminated string. */
     uint8_t WiFiKey[kMaxWiFiKeyLength];    /**< The WiFi key (NOT NULL-terminated). */
@@ -96,14 +104,7 @@ public:
     /**< The Thread pre-shared commissioner key (NOT NULL-terminated). */
     uint16_t ThreadPANId;  /**< The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified */
     uint8_t ThreadChannel; /**< The Thread channel (currently [11..26]), or kThreadChannel_NotSpecified */
-
-    struct
-    {
-        bool NetworkId : 1;           /**< True if the NetworkId field is present. */
-        bool ThreadExtendedPANId : 1; /**< True if the ThreadExtendedPANId field is present. */
-        bool ThreadMeshPrefix : 1;    /**< True if the ThreadMeshPrefix field is present. */
-        bool ThreadPSKc : 1;          /**< True if the ThreadPSKc field is present. */
-    } FieldPresent;
+    uint64_t ThreadDatasetTimestamp; /**< Thread active dataset timestamp */
 };
 
 } // namespace Internal

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -249,6 +249,12 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvis
         newDataset.mComponents.mIsChannelPresent = true;
     }
 
+    if (netInfo.ThreadDatasetTimestamp != 0)
+    {
+        newDataset.mActiveTimestamp                      = netInfo.ThreadDatasetTimestamp;
+        newDataset.mComponents.mIsActiveTimestampPresent = true;
+    }
+
     // Set the dataset as the active dataset for the node.
     Impl()->LockThreadStack();
     otErr = otDatasetSetActive(mOTInst, &newDataset);


### PR DESCRIPTION
 #### Problem
4008 removed setting Thread Dataset Active Timestamp to make sure that a provisioned device collects missing Thread settings from a border router. The problem is it may be too restrictive, since it's now impossible to start the device as a Thread leader as the leader role requires that the timestamp be initialized.

 #### Summary of Changes
* Extend the DeviceNetworkInfo structure to allow to specify the Thread Dataset Active Timestamp.
* Slightly optimize the structure size.
