### PR TITLE
Fix crashes when BLE rendezvous disconnects unexpectedly

### DIFF
--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -230,14 +230,18 @@ void BLE::OnBleEndPointConnectionClosed(BLEEndPoint * endPoint, BLE_ERROR err)
     BLE * ble   = reinterpret_cast<BLE *>(endPoint->mAppState);
     ble->mState = State::kNotReady;
 
+    // Already closed, avoid closing again in our destructor.
+    ble->mBleEndPoint = nullptr;
+
     if (ble->mDelegate)
     {
         if (err != BLE_NO_ERROR)
         {
             ble->mDelegate->OnRendezvousError(err);
+        } else {
+            // OnRendezvousError may delete |ble|; don't call both callbacks.
+            ble->mDelegate->OnRendezvousConnectionClosed();
         }
-
-        ble->mDelegate->OnRendezvousConnectionClosed();
     }
 }
 

--- a/src/transport/BLE.cpp
+++ b/src/transport/BLE.cpp
@@ -238,7 +238,9 @@ void BLE::OnBleEndPointConnectionClosed(BLEEndPoint * endPoint, BLE_ERROR err)
         if (err != BLE_NO_ERROR)
         {
             ble->mDelegate->OnRendezvousError(err);
-        } else {
+        }
+        else
+        {
             // OnRendezvousError may delete |ble|; don't call both callbacks.
             ble->mDelegate->OnRendezvousConnectionClosed();
         }


### PR DESCRIPTION
In BLE::OnBleEndPointConnectionClosed, the endpoint is already closed.
We try to close it again in the Transport::BLE destructor, which can crash.
Clear the endpoint in OnBleEndPointConnectionClosed to avoid this case.

In addition, the OnRendezvousError callback in the typical case stops
the rendezvous process which immediately destroys the transport. We
therefore can't call OnRendezvousConnectionClosed afterwards; |this| is
already freed and we just need to return.