### PR TITLE
Fix leak of DeviceTransportMgr in CHIPDeviceController

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -192,6 +192,11 @@ CHIP_ERROR DeviceController::Shutdown()
         mSessionManager = nullptr;
     }
 
+    if (mTransportMgr != nullptr) {
+        chip::Platform::Delete(mTransportMgr);
+        mTransportMgr = nullptr;
+    }
+
     ReleaseAllDevices();
 
 exit:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -192,7 +192,8 @@ CHIP_ERROR DeviceController::Shutdown()
         mSessionManager = nullptr;
     }
 
-    if (mTransportMgr != nullptr) {
+    if (mTransportMgr != nullptr)
+    {
         chip::Platform::Delete(mTransportMgr);
         mTransportMgr = nullptr;
     }


### PR DESCRIPTION
DeviceTransportMgr is created in Init() but not deleted in Shutdown().