### PR TITLE
Fix warnings -Wstack-usage with clang

### DIFF
--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -46,8 +46,10 @@ static uint32_t shortPayloadRepresentation(const SetupPayload & payload)
 }
 
 // TODO: issue #3663 - Unbounded stack in src/setup_payload
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstack-usage="
+#endif
 
 static std::string decimalStringWithPadding(uint32_t number, int minLength)
 {
@@ -56,7 +58,9 @@ static std::string decimalStringWithPadding(uint32_t number, int minLength)
     return std::string(buf);
 }
 
+#if !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 
 CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(std::string & outDecimalString)
 {

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -209,8 +209,10 @@ static CHIP_ERROR generateBitSet(SetupPayload & payload, uint8_t * bits, uint8_t
 }
 
 // TODO: issue #3663 - Unbounded stack in payloadBase41RepresentationWithTLV()
+#if !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstack-usage="
+#endif
 
 static CHIP_ERROR payloadBase41RepresentationWithTLV(SetupPayload & setupPayload, string & base41Representation, size_t bitsetSize,
                                                      uint8_t * tlvDataStart, size_t tlvDataLengthInBytes)
@@ -253,4 +255,6 @@ exit:
     return err;
 }
 
+#if !defined(__clang__)
 #pragma GCC diagnostic pop // -Wstack-usage
+#endif


### PR DESCRIPTION
This fixes the following warnings with clang:
    
src/setup_payload/ManualSetupPayloadGenerator.cpp:50:32: error: unknown warning group '-Wstack-usage=', ignored [-Werror,-Wunknown-warning-option]
                               ^
1 error generated.
