### PR TITLE
Fix warnings -Wunused-variable in release

### DIFF
--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -19,6 +19,8 @@
 
 #include <support/Pool.h>
 
+#include <nlassert.h>
+
 namespace chip {
 
 StaticAllocatorBitmap::StaticAllocatorBitmap(void * storage, std::atomic<tBitChunkType> * usage, size_t capacity,
@@ -67,7 +69,7 @@ void StaticAllocatorBitmap::Deallocate(void * element)
     assert(index < Capacity());
 
     auto value = mUsage[word].fetch_and(~(kBit1 << offset));
-    assert((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
+    nlASSERT((value & (kBit1 << offset)) != 0); // assert fail when free an unused slot
     mAllocated--;
 }
 


### PR DESCRIPTION
This fixes the following warning in release builds:

```
src/lib/support/Pool.cpp:69:10: error: unused variable 'value' [-Werror,-Wunused-variable]
    auto value = mUsage[word].fetch_and(~(kBit1 << offset));
```

Switch to nlassert since this macro doesn't cause unused variable
warnings when assertions are disabled.
