### PR TITLE
Add missing <inttypes.h> include

### DIFF
--- a/src/app/server/QRCodeUtil.cpp
+++ b/src/app/server/QRCodeUtil.cpp
@@ -18,8 +18,9 @@
 
 #include <app/server/QRCodeUtil.h>
 
-#include <platform/CHIPDeviceLayer.h>
+#include <inttypes.h>
 
+#include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CodeUtils.h>
 #include <support/ScopedBuffer.h>


### PR DESCRIPTION
This fixes the following compile error on some systems:

src/app/server/QRCodeUtil.cpp:42:55:
error: expected ')'
        ChipLogProgress(AppServer, "SetupPINCode: [%" PRIu32 "]",
	setupPinCode);