### PR TITLE
[openthread] set secure data request based on OpenThread version

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -28,6 +28,7 @@
 
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
+#include <openthread/instance.h>
 #include <openthread/joiner.h>
 #include <openthread/link.h>
 #include <openthread/netdata.h>
@@ -748,7 +749,6 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
                         "LinkFrameCounter:  %10d\n"
                         "MleFrameCounter:   %10d\n"
                         "RxOnWhenIdle:      %c\n"
-                        "SecureDataRequest: %c\n"
                         "FullFunction:      %c\n"
                         "FullNetworkData:   %c\n"
                         "IsChild:           %c%s\n",
@@ -756,8 +756,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThread
                         neighbor->mExtAddress.m8[3], neighbor->mExtAddress.m8[4], neighbor->mExtAddress.m8[5],
                         neighbor->mExtAddress.m8[6], neighbor->mExtAddress.m8[7], neighbor->mRloc16, neighbor->mAge,
                         neighbor->mLinkQualityIn, neighbor->mAverageRssi, neighbor->mLastRssi, neighbor->mLinkFrameCounter,
-                        neighbor->mMleFrameCounter, neighbor->mRxOnWhenIdle ? 'Y' : 'n', neighbor->mSecureDataRequest ? 'Y' : 'n',
-#if OPENTHREA_API_VERSION
+                        neighbor->mMleFrameCounter, neighbor->mRxOnWhenIdle ? 'Y' : 'n',
+#if OPENTHREAD_API_VERSION
                         neighbor->mFullThreadDevice ? 'Y' : 'n',
 #else
                         'n',
@@ -839,6 +839,8 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     otErr = otSetStateChangedCallback(otInst, ImplClass::OnOpenThreadStateChange, NULL);
     VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
 
+    // Secure data request mode bit has been removed from the certain OpenThread version.
+#if OPENTHREAD_API_VERSION < 30
     // Enable use of secure data requests.
     {
         otLinkModeConfig linkMode    = otThreadGetLinkMode(otInst);
@@ -846,6 +848,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
         otErr                        = otThreadSetLinkMode(otInst, linkMode);
         VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
     }
+#endif
 
     // Enable automatic assignment of Thread advertised addresses.
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE


### PR DESCRIPTION
 #### Problem
Thread's MLE Mode flag bit `s` became reserved. This was reflected with the following OpenThread pull request: https://github.com/openthread/openthread/pull/5560

Thread Stack Manager uses OpenThread API which is not available after 30th September 2020.

#### Summary of Changes
Do not set `s` bit through OpenThread API with newer OpenThread versions.

When OpenThread will be updated for all available platforms we can completely remove this check.