### PR TITLE
[nrfconnect] Fix Zephyr compilation flag retrieval

### DIFF
--- a/config/nrfconnect/chip-module/zephyr-util.cmake
+++ b/config/nrfconnect/chip-module/zephyr-util.cmake
@@ -26,11 +26,11 @@ function(zephyr_get_compile_flags VAR LANG)
     # zephyr returns as "non-system" headers (the ones from
     # zephyr_get_include_directories_for_lang) we need to manually replace "-I"
     # with "-isystem".
-    zephyr_get_include_directories_for_lang(${LANG} INCLUDES)
-    list(TRANSFORM INCLUDES REPLACE "-I" "-isystem")
-    zephyr_get_system_include_directories_for_lang(${LANG} SYSTEM_INCLUDES)
-    zephyr_get_compile_definitions_for_lang(${LANG} DEFINES)
-    zephyr_get_compile_options_for_lang(${LANG} FLAGS)
+    zephyr_get_include_directories_for_lang_as_string(${LANG} INCLUDES)
+    string(REGEX REPLACE "(^| )-I" "\\1-isystem" INCLUDES ${INCLUDES})
+    zephyr_get_system_include_directories_for_lang_as_string(${LANG} SYSTEM_INCLUDES)
+    zephyr_get_compile_definitions_for_lang_as_string(${LANG} DEFINES)
+    zephyr_get_compile_options_for_lang_as_string(${LANG} FLAGS)
     set(${VAR} ${INCLUDES} ${SYSTEM_INCLUDES} ${DEFINES} ${FLAGS} ${${VAR}} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
 #### Problem
We have a mechanism to obtain Zephyr compilation flags, so that we can pass some of them (like include paths etc.) to CHIP build system. The mechanism leverages Zephyr-supplied CMake functions which were supposed to return lists of flags. However, in recent Zephyr revisions, they changed behavior of the functions and the build fails.

 #### Summary of Changes
Switch to using functions which return strings of flags which seem to have more stable API.