### PR TITLE
[android] Ask for action after reading CHIP NFC Tag

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import chip.setuppayload.SetupPayloadParser
@@ -146,15 +147,31 @@ class CHIPToolActivity :
 
     val setupPayload = SetupPayloadParser().parseQrCode(uri.toString().toUpperCase())
     val deviceInfo = CHIPDeviceInfo(
-            setupPayload.version,
-            setupPayload.vendorId,
-            setupPayload.productId,
-            setupPayload.discriminator,
-            setupPayload.setupPinCode,
-            setupPayload.optionalQRCodeInfo.mapValues { (_, info) ->  QrCodeInfo(info.tag, info.type, info.data, info.int32) }
+        setupPayload.version,
+        setupPayload.vendorId,
+        setupPayload.productId,
+        setupPayload.discriminator,
+        setupPayload.setupPinCode,
+        setupPayload.optionalQRCodeInfo.mapValues { (_, info) -> QrCodeInfo(info.tag, info.type, info.data, info.int32) }
     )
 
-    onCHIPDeviceInfoReceived(deviceInfo)
+    val buttons = arrayOf(
+        getString(R.string.nfc_tag_action_show),
+        getString(R.string.nfc_tag_action_wifi),
+        getString(R.string.nfc_tag_action_thread))
+
+    AlertDialog.Builder(this)
+        .setTitle(R.string.nfc_tag_action_title)
+        .setItems(buttons) { _, which ->
+          this.networkType = when (which) {
+            1 -> ProvisionNetworkType.WIFI
+            2 -> ProvisionNetworkType.THREAD
+            else -> null
+          }
+          onCHIPDeviceInfoReceived(deviceInfo)
+        }
+        .create()
+        .show()
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -82,4 +82,9 @@
     <string name="enter_thread_master_key_text">00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF</string>
     <string name="enter_thread_save_network_btn">Save network</string>
 
+    <string name="nfc_tag_action_title">CHIP NFC Tag read. Choose an action:</string>
+    <string name="nfc_tag_action_show">Show device information</string>
+    <string name="nfc_tag_action_wifi">Provision into Wi-Fi network</string>
+    <string name="nfc_tag_action_thread">Provision into Thread network</string>
+
 </resources>


### PR DESCRIPTION
 #### Problem
As a result of recent UI changes in the CHIPTool for Android, it only displays device information after scanning the accessory NFC Tag while the information could be also used to initiate the commissioning procedure.

 #### Summary of Changes
When NFC Tag containing commissioning information of a CHIP device is read, ask a user for an action to take:
- display the device information
- provision into a Wi-Fi network
- provision into a Thread network