### PR TITLE
Use C++14 when compiling CHIP for esp32.

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -106,10 +106,11 @@ $(OUTPUT_DIR) :
 fix_cflags = $(filter-out -DHAVE_CONFIG_H,\
                 $(filter-out -D,\
                   $(filter-out IDF_VER%,\
-                    $(sort $(1)) -D$(filter IDF_VER%,$(1))\
-               )))
+                    $(filter-out -std=gnu++11,\
+                      $(sort $(1)) -D$(filter IDF_VER%,$(1))\
+               ))))
 CHIP_CFLAGS = $(call fix_cflags,$(CFLAGS) $(CPPFLAGS))
-CHIP_CXXFLAGS = $(call fix_cflags,$(CXXFLAGS) $(CPPFLAGS))
+CHIP_CXXFLAGS = $(call fix_cflags,$(CXXFLAGS) $(CPPFLAGS)) -std=gnu++14
 
 install-chip : $(OUTPUT_DIR)
 	echo "INSTALL CHIP..."

--- a/examples/all-clusters-app/esp32/Makefile
+++ b/examples/all-clusters-app/esp32/Makefile
@@ -26,7 +26,7 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
                         $(PROJECT_PATH)/../../common/QRCode \
                         $(PROJECT_PATH)/../../common/screen-framework \
 
-CXXFLAGS += -std=c++11 -Os -DLWIP_IPV6_SCOPES=0
+CXXFLAGS += -std=c++14 -Os -DLWIP_IPV6_SCOPES=0
 CPPFLAGS += -Os -DLWIP_IPV6_SCOPES=0 -DCHIP_HAVE_CONFIG_H
 CFLAGS += -Os -DLWIP_IPV6_SCOPES=0
 

--- a/examples/temperature-measurement-app/esp32/Makefile
+++ b/examples/temperature-measurement-app/esp32/Makefile
@@ -26,7 +26,7 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
                         $(PROJECT_PATH)/../../common/QRCode \
                         $(PROJECT_PATH)/../../common/screen-framework \
 
-CXXFLAGS += -std=c++11 -Os -DLWIP_IPV6_SCOPES=0
+CXXFLAGS += -std=c++14 -Os -DLWIP_IPV6_SCOPES=0
 CPPFLAGS += -Os -DLWIP_IPV6_SCOPES=0 -DCHIP_HAVE_CONFIG_H
 CFLAGS += -Os -DLWIP_IPV6_SCOPES=0
 


### PR DESCRIPTION
I couldn't figure out where the -std=-gnu++11 in CXXFLAGS was coming
from in the esp32 build; it might be somewhere in the SDK.  So we just
filter it out, and manually add -std=gnu++14 instead.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We're compiling some CHIP bits with `-std=gnu++11` in esp32 builds, but CHIP wants to use C++14 features.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use `-std=gnu++14` when doing the CHIP compile.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
