### PR TITLE
Add stronger typing for payload header APIs

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -93,11 +93,8 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     // Set the exchange ID for this header.
     payloadHeader.SetExchangeID(mExchangeId);
 
-    // Set the protocol ID for this header.
-    payloadHeader.SetProtocolID(protocolId);
-
-    // Set the message type for this header.
-    payloadHeader.SetMessageType(msgType);
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(protocolId, msgType);
 
     payloadHeader.SetInitiator(IsInitiator());
 
@@ -399,8 +396,7 @@ CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, con
     }
 
     //  The SecureChannel::StandaloneAck message type is only used for CRMP; do not pass such messages to the application layer.
-    if ((protocolId == Protocols::kProtocol_SecureChannel) &&
-        (messageType == static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck)))
+    if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck))
     {
         ExitNow(err = CHIP_NO_ERROR);
     }

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -109,6 +109,18 @@ public:
                            void * msgCtxt = nullptr);
 
     /**
+     * A strongly-message-typed version of SendMessage.
+     */
+    template <typename MessageType, typename = std::enable_if_t<std::is_enum<MessageType>::value>>
+    CHIP_ERROR SendMessage(MessageType msgType, System::PacketBufferHandle && msgPayload, const SendFlags & sendFlags,
+                           void * msgCtxt = nullptr)
+    {
+        static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId, static_cast<uint8_t>(msgType),
+                           std::move(msgPayload), sendFlags, msgCtxt);
+    }
+
+    /**
      *  Handle a received CHIP message on this exchange.
      *
      *  @param[in]    packetHeader  A reference to the PacketHeader object.

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -350,8 +350,7 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     // Send the null message
     if (mExchange != nullptr)
     {
-        err = mExchange->SendMessage(Protocols::kProtocol_SecureChannel,
-                                     static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck), std::move(msgBuf),
+        err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
                                      BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }
     else

--- a/src/protocols/Protocols.h
+++ b/src/protocols/Protocols.h
@@ -54,5 +54,10 @@ enum CHIPProtocolId
     kProtocol_NotSpecified = (kChipVendor_NotSpecified << 16) | 0xFFFF, // The profile ID is either not specified or a wildcard
 };
 
+// Pre-delare our MessageTypeTraits so message type headers know what they are
+// specializing.
+template <typename T>
+struct MessageTypeTraits;
+
 } // namespace Protocols
 } // namespace chip

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <protocols/Protocols.h>
+
 /**
  *   @namespace chip::Protocols::SecureChannel
  *
@@ -42,7 +44,7 @@ namespace SecureChannel {
 /**
  * SecureChannel Protocol Message Types
  */
-enum class MsgType
+enum class MsgType : uint8_t
 {
     // Message Counter Synchronization Protocol Message Types
     MsgCounterSyncReq = 0x00,
@@ -77,5 +79,12 @@ enum class StatusCode
 };
 
 } // namespace SecureChannel
+
+template <>
+struct MessageTypeTraits<SecureChannel::MsgType>
+{
+    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_SecureChannel;
+};
+
 } // namespace Protocols
 } // namespace chip

--- a/src/transport/CASESession.cpp
+++ b/src/transport/CASESession.cpp
@@ -72,9 +72,7 @@ CHIP_ERROR CASESession::AttachHeaderAndSend(Protocols::SecureChannel::MsgType ms
 
     PayloadHeader payloadHeader;
 
-    payloadHeader
-        .SetMessageType(static_cast<uint8_t>(msgType)) //
-        .SetProtocolID(Protocols::kProtocol_SecureChannel);
+    payloadHeader.SetMessageType(msgType);
 
     uint16_t headerSize              = payloadHeader.EncodeSizeBytes();
     uint16_t actualEncodedHeaderSize = 0;

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -254,9 +254,7 @@ CHIP_ERROR PASESession::AttachHeaderAndSend(Protocols::SecureChannel::MsgType ms
 
     PayloadHeader payloadHeader;
 
-    payloadHeader
-        .SetMessageType(static_cast<uint8_t>(msgType)) //
-        .SetProtocolID(Protocols::kProtocol_SecureChannel);
+    payloadHeader.SetMessageType(msgType);
 
     uint16_t headerSize              = payloadHeader.EncodeSizeBytes();
     uint16_t actualEncodedHeaderSize = 0;

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
     VerifyOrReturnError(mPairingSessionHandle != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     PayloadHeader payloadHeader;
-    payloadHeader.SetProtocolID(static_cast<uint16_t>(protocol)).SetMessageType(msgType);
+    payloadHeader.SetMessageType(static_cast<uint16_t>(protocol), msgType);
 
     return mSecureSessionMgr->SendMessage(*mPairingSessionHandle, payloadHeader, std::move(msgBuf));
 }

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -146,13 +146,13 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     uint16_t encodeLen;
     uint16_t decodeLen;
 
-    header.SetMessageType(112).SetExchangeID(2233);
+    header.SetMessageType(0, 112).SetExchangeID(2233);
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
-    header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221).SetInitiator(true);
+    header.SetMessageType(1221, 112).SetExchangeID(2233).SetInitiator(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
-    header.SetMessageType(221).SetExchangeID(3322).SetProtocolID(4567);
+    header.SetMessageType(4567, 221).SetExchangeID(3322);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
@@ -161,19 +161,19 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
     NL_TEST_ASSERT(inSuite, header.IsInitiator());
 
-    header.SetMessageType(112).SetExchangeID(2233).SetProtocolID(1221);
+    header.SetMessageType(1221, 112).SetExchangeID(2233);
     header.SetVendorId(6789);
 
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, sizeof(buffer), &encodeLen) == CHIP_NO_ERROR);
 
-    header.SetMessageType(111).SetExchangeID(222);
+    header.SetMessageType(0, 111).SetExchangeID(222);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
 
-    header.SetMessageType(221).SetExchangeID(3322).SetProtocolID(4567);
+    header.SetMessageType(4567, 221).SetExchangeID(3322);
     header.SetVendorId(8976);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, sizeof(buffer), &decodeLen) == CHIP_NO_ERROR);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -247,11 +247,8 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     // Set the exchange ID for this header.
     payloadHeader.SetExchangeID(0);
 
-    // Set the protocol ID for this header.
-    payloadHeader.SetProtocolID(chip::Protocols::kProtocol_Echo);
-
-    // Set the message type for this header.
-    payloadHeader.SetMessageType(chip::Protocols::Echo::kEchoMessageType_EchoRequest);
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::kProtocol_Echo, chip::Protocols::Echo::kEchoMessageType_EchoRequest);
 
     payloadHeader.SetInitiator(true);
 
@@ -319,11 +316,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     // Set the exchange ID for this header.
     payloadHeader.SetExchangeID(0);
 
-    // Set the protocol ID for this header.
-    payloadHeader.SetProtocolID(Protocols::kProtocol_Echo);
-
-    // Set the message type for this header.
-    payloadHeader.SetMessageType(Protocols::Echo::kEchoMessageType_EchoRequest);
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::kProtocol_Echo, chip::Protocols::Echo::kEchoMessageType_EchoRequest);
 
     payloadHeader.SetInitiator(true);
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Payload header API expects both a protocol id and a message type to be provided.  These can end up out of sync (e.g. a message type for one protocol can get used with a different protocol).

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Define a set of APIs that allow us to just pass in a strongly typed (enum class) message type and derive the protocol from the type of the message type.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Draft for now because it depends on https://github.com/project-chip/connectedhomeip/pull/4428 to pass tests and includes that changeset for the moment.