### PR TITLE
Release pairing session handle on rendezvous error

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -202,6 +202,7 @@ void RendezvousSession::OnRendezvousConnectionClosed()
 
 void RendezvousSession::OnRendezvousError(CHIP_ERROR err)
 {
+    ReleasePairingSessionHandle();
     if (mDelegate != nullptr)
     {
         switch (mCurrentState)


### PR DESCRIPTION
 #### Problem
Pairing session handle is not being freed on Rendezvous error.

 #### Summary of Changes
A recent change stopped calling `RendezvousSession::OnRendezvousConnectionClosed()` on BLE connection errors. This call used to free the pairing session handle. The code, however, still calls `RendezvousSession::OnRendezvousError` on error. Adding the `ReleasePairingSessionHandle` call to this error handling function as well.