### PR TITLE
Initialize key ID to 0 in case of rendezvous bypass mode

### DIFF
--- a/src/transport/SecurePairingSession.h
+++ b/src/transport/SecurePairingSession.h
@@ -301,6 +301,8 @@ public:
         size_t secretLen    = strlen(secret);
         mKeLen              = secretLen;
         memmove(mKe, secret, mKeLen);
+        mConnectionState.SetPeerKeyID(0);
+        mConnectionState.SetLocalKeyID(0);
         mPairingComplete = true;
     }
 


### PR DESCRIPTION
 #### Problem
Unable to control device (m5stack) while using rendezvous bypass mode. The on-off cluster command fails with the following errors on the device.

`E (16493) chip[IN]: Data received on an unknown connection (0). Dropping it!!`

 #### Summary of Changes
In rendezvous bypass, the two nodes do not exchange keys and key ID. The default key ID 0 is used. The connection state was not initialized with the key ID for the test secret. 
