### PR TITLE
ESP32: Fix compilation of applications requiring C++17

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -106,11 +106,10 @@ $(OUTPUT_DIR) :
 fix_cflags = $(filter-out -DHAVE_CONFIG_H,\
                 $(filter-out -D,\
                   $(filter-out IDF_VER%,\
-                    $(filter-out -std=gnu++11,\
-                      $(sort $(1)) -D$(filter IDF_VER%,$(1))\
-               ))))
+                      $(1) -D$(filter IDF_VER%,$(1))\
+               )))
 CHIP_CFLAGS = $(call fix_cflags,$(CFLAGS) $(CPPFLAGS))
-CHIP_CXXFLAGS = $(call fix_cflags,$(CXXFLAGS) $(CPPFLAGS)) -std=gnu++14
+CHIP_CXXFLAGS = $(call fix_cflags,$(CXXFLAGS) $(CPPFLAGS))
 
 install-chip : $(OUTPUT_DIR)
 	echo "INSTALL CHIP..."

--- a/src/lib/support/tests/TestBufferReader.cpp
+++ b/src/lib/support/tests/TestBufferReader.cpp
@@ -35,7 +35,7 @@ static const uint8_t test_buffer[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 
 struct TestReader : public Reader
 {
-    TestReader() : Reader(test_buffer, std::extent<typeof(test_buffer)>::value) {}
+    TestReader() : Reader(test_buffer, std::extent<decltype(test_buffer)>::value) {}
 };
 
 static void TestBufferReader_Basic(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem
Compilation failure of esp32 applications requiring C++17

 #### Summary of Changes
1. Fixed TestBufferReader.cpp to use the standard decltype instead of the non-standard typeof
2. Do not filter out --gnu++11 set by the esp-idf
3. Removed the sorting of flags which was causing the gnu++11 to override c++14/c++17
        given by the application
4. Removed the forcing of any sort of -std in the common component.mk

 Fixes #4440 