### PR TITLE
Remove host builds on Windows

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -138,19 +138,20 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
   declare_args() {
     # Enable building chip with clang.
-    enable_host_clang_build = enable_default_builds
+    enable_host_clang_build = enable_default_builds && host_os != "win"
 
     # Enable building chip with gcc.
-    enable_host_gcc_build = enable_default_builds
+    enable_host_gcc_build = enable_default_builds && host_os != "win"
 
     # Enable building chip with gcc & mbedtls.
-    enable_host_gcc_mbedtls_build = enable_default_builds
+    enable_host_gcc_mbedtls_build = enable_default_builds && host_os != "win"
 
     # Build the chip-tool example.
-    enable_standalone_chip_tool_build = enable_default_builds
+    enable_standalone_chip_tool_build =
+        enable_default_builds && host_os != "win"
 
     # Build the shell example.
-    enable_standalone_shell_build = enable_default_builds
+    enable_standalone_shell_build = enable_default_builds && host_os != "win"
 
     # Build the Linux all clusters app example.
     enable_linux_all_clusters_app_build =


### PR DESCRIPTION
CHIP doesn't have native Windows support at the moment, so only embedded
builds will compile there. Remove the host builds on Windows.