### PR TITLE
Fix typo in recent changes to Linux example app help text

### DIFF
--- a/examples/lighting-app/linux/Options.cpp
+++ b/examples/lighting-app/linux/Options.cpp
@@ -47,7 +47,7 @@ const char * sDeviceOptionHelp = "  --ble-device <number>\n"
                                  "       Enable WiFi management via wpa_supplicant.\n"
                                  "\n"
                                  "  --thread\n"
-                                 "       Enable WiFi management via ot-agent.\n"
+                                 "       Enable Thread management via ot-agent.\n"
                                  "\n";
 
 bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)


### PR DESCRIPTION
 #### Problem

There was a minor typo in the Linux example app help text in https://github.com/project-chip/connectedhomeip/pull/4423

 #### Summary of Changes

Fix the typo