### PR TITLE
[mdns] add scanner iterface

### DIFF
--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/tools.gni")
 
 declare_args() {
   # Set up what advertiser to use for mDNS advertisement
@@ -33,9 +34,15 @@ static_library("mdns") {
   sources = [ "Advertiser.h" ]
 
   if (chip_mdns_advertiser == "none") {
-    sources += [ "Advertiser_ImplNone.cpp" ]
+    sources += [
+      "Advertiser_ImplNone.cpp",
+      "Scanner_ImplNone.cpp",
+    ]
   } else if (chip_mdns_advertiser == "minimal") {
-    sources += [ "Advertiser_ImplMinimalMdns.cpp" ]
+    sources += [
+      "Advertiser_ImplMinimalMdns.cpp",
+      "Scanner_ImplNone.cpp",
+    ]
     public_deps += [ "${chip_root}/src/lib/mdns/minimal" ]
   } else if (chip_mdns_advertiser == "platform") {
     sources += [
@@ -45,5 +52,13 @@ static_library("mdns") {
     public_deps += [ "${chip_root}/src/platform" ]
   } else {
     assert(false, "Unknown mDNS advertiser implementation.")
+  }
+}
+
+if (chip_build_tools) {
+  executable("scanner-example") {
+    sources = [ "ScannerExample.cpp" ]
+
+    public_deps = [ ":mdns" ]
   }
 }

--- a/src/lib/mdns/Scanner.h
+++ b/src/lib/mdns/Scanner.h
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "core/CHIPError.h"
+#include "inet/IPAddress.h"
+#include "inet/InetInterface.h"
+
+namespace chip {
+namespace Mdns {
+
+class ScannerDelegate
+{
+public:
+    virtual void HandleNodeResolved(CHIP_ERROR error, uint64_t nodeId, uint64_t fabricId, const Inet::IPAddress & address) = 0;
+    virtual ~ScannerDelegate() {}
+};
+
+class Scanner
+{
+public:
+    virtual ~Scanner() {}
+
+    // Register the callback delegate to the scanner.
+    virtual CHIP_ERROR RegisterScannerDelegate(ScannerDelegate * delegate) = 0;
+
+    // Passively subscribe an operational node.
+    virtual CHIP_ERROR SubscribeNode(uint64_t nodeId, uint64_t fabricId, Inet::InterfaceId interface = INET_NULL_INTERFACEID,
+                                     Inet::IPAddressType addressType = Inet::kIPAddressType_Any) = 0;
+    // Actively trigger a mdns query for an operational node.
+    virtual CHIP_ERROR ResolveNode(uint64_t nodeId, uint64_t fabricId, Inet::InterfaceId interface = INET_NULL_INTERFACEID,
+                                   Inet::IPAddressType addressType = Inet::kIPAddressType_Any) = 0;
+    // Unsubscribe an operational node. Not calling this function after a node is no longer of interest
+    // may cause resources to leak.
+    virtual CHIP_ERROR UnsubscribeNode(uint64_t nodeId, uint64_t fabricId) = 0;
+
+    static Scanner & Instance();
+};
+
+} // namespace Mdns
+} // namespace chip

--- a/src/lib/mdns/ScannerExample.cpp
+++ b/src/lib/mdns/ScannerExample.cpp
@@ -1,0 +1,50 @@
+#include <inttypes.h>
+#include <string>
+#include <unistd.h>
+
+#include "lib/mdns/Scanner.h"
+#include "platform/CHIPDeviceLayer.h"
+#include "support/CHIPMem.h"
+
+class TestScannerDelegate : public chip::Mdns::ScannerDelegate
+{
+public:
+    void HandleNodeResolved(CHIP_ERROR error, uint64_t nodeId, uint64_t fabricId, const chip::Inet::IPAddress & address) override
+    {
+        char addrBuf[100];
+
+        address.ToString(addrBuf, sizeof(addrBuf));
+        printf("Found nodeId %" PRIX64 " at %s\n", nodeId, addrBuf);
+        chip::Mdns::Scanner::Instance().UnsubscribeNode(nodeId, fabricId);
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+    }
+};
+
+int main(int argc, char * argv[])
+{
+    uint64_t nodeId = 0, fabricId = 0;
+    int opt;
+
+    while ((opt = getopt(argc, argv, "n:f:")) != -1)
+    {
+        switch (opt)
+        {
+        case 'n':
+            nodeId = std::stoull(optarg, 0, 16);
+            break;
+        case 'f':
+            fabricId = std::stoull(optarg, 0, 16);
+            break;
+        default:
+            break;
+        }
+    }
+
+    TestScannerDelegate delegate;
+    chip::Platform::MemoryInit();
+    chip::DeviceLayer::PlatformMgr().InitChipStack();
+    chip::Mdns::Scanner::Instance().RegisterScannerDelegate(&delegate);
+    chip::Mdns::Scanner::Instance().SubscribeNode(nodeId, fabricId);
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    return 0;
+}

--- a/src/lib/mdns/Scanner_ImplNone.cpp
+++ b/src/lib/mdns/Scanner_ImplNone.cpp
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "lib/mdns/Scanner.h"
+
+namespace chip {
+namespace Mdns {
+
+class NoneScanner : public Scanner
+{
+public:
+    CHIP_ERROR RegisterScannerDelegate(ScannerDelegate * delegate) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    CHIP_ERROR SubscribeNode(uint64_t nodeId, uint64_t fabricId, Inet::InterfaceId interface,
+                             Inet::IPAddressType addressType) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR ResolveNode(uint64_t nodeId, uint64_t fabricId, Inet::InterfaceId interface,
+                           Inet::IPAddressType addressType) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR UnsubscribeNode(uint64_t nodeId, uint64_t fabricId) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+};
+
+Scanner & Scanner::Instance()
+{
+    static NoneScanner sScanner;
+    return sScanner;
+}
+
+} // namespace Mdns
+} // namespace chip

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -162,9 +162,9 @@ CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip:
                           chip::Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context);
 
 /**
- * This function resolves the services published by mdns
+ * This function subscribes a service. Any address updates will be passed to the callback.
  *
- * @param[in] browseResult  The service entry returned by @ref ChipMdnsBrowse
+ * @param[in] service       The service to subscribe.
  * @param[in] interface     The interface to send queries.
  * @param[in] callback      The callback for found services.
  * @param[in] context       The user context.
@@ -174,8 +174,35 @@ CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip:
  * @retval Error code                   The resolve fails.
  *
  */
-CHIP_ERROR ChipMdnsResolve(MdnsService * browseResult, chip::Inet::InterfaceId interface, MdnsResolveCallback callback,
-                           void * context);
+CHIP_ERROR ChipMdnsSubscribe(MdnsService * service, chip::Inet::InterfaceId interface, MdnsResolveCallback callback,
+                             void * context);
+
+/**
+ * This function sends an instant mdns query for a device.
+ *
+ * @param[in] service       The service to subscribe.
+ * @param[in] interface     The interface to send queries.
+ * @param[in] callback      The callback for found services.
+ * @param[in] context       The user context.
+ *
+ * @retval CHIP_NO_ERROR                The resolve succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The name, type or callback is nullptr.
+ * @retval Error code                   The resolve fails.
+ *
+ */
+CHIP_ERROR ChipMdnsResolve(MdnsService * service, chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context);
+
+/**
+ * This function unsubscribes a service.
+ *
+ * @param[in] service       The service to unsubscribe.
+ *
+ * @retval CHIP_NO_ERROR                The resolve succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The name, type or callback is nullptr.
+ * @retval CHIP_ERROR_INCORRECT_STATE   The service has not been subscribed yet.
+ *
+ */
+CHIP_ERROR ChipMdnsUnsubscribe(MdnsService * service);
 
 } // namespace Mdns
 } // namespace chip

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -114,8 +114,17 @@ CHIP_ERROR ChipMdnsBrowse(const char * /*type*/, MdnsServiceProtocol /*protocol*
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ChipMdnsResolve(MdnsService * /*service*/, chip::Inet::InterfaceId /*interface*/, MdnsResolveCallback /*callback*/,
-                           void * /*context*/)
+CHIP_ERROR ChipMdnsSubscribe(MdnsService * service, chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsResolve(MdnsService * service, chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsUnsubscribe(MdnsService * service)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -106,12 +106,13 @@ public:
     CHIP_ERROR StopPublish();
     CHIP_ERROR Browse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                       chip::Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context);
-    CHIP_ERROR Resolve(const char * name, const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
-                       chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context);
+    CHIP_ERROR Subscribe(const char * name, const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
+                         chip::Inet::InterfaceId interface, MdnsResolveCallback callback, void * context, bool oneshot);
+    CHIP_ERROR Unsubscribe(const char * name, const char * type, MdnsServiceProtocol protocol);
 
     Poller & GetPoller() { return mPoller; }
 
-    static MdnsAvahi & GetInstance() { return sInstance; }
+    static MdnsAvahi & GetInstance();
 
     ~MdnsAvahi();
 
@@ -129,10 +130,12 @@ private:
         MdnsAvahi * mInstance;
         MdnsResolveCallback mCallback;
         void * mContext;
+        AvahiServiceResolver * mResolver;
+        bool mOneshot;
     };
 
     MdnsAvahi() : mClient(nullptr), mGroup(nullptr) {}
-    static MdnsAvahi sInstance;
+    static MdnsAvahi * sInstance;
 
     static void HandleClientState(AvahiClient * client, AvahiClientState state, void * context);
     void HandleClientState(AvahiClient * client, AvahiClientState state);
@@ -153,6 +156,7 @@ private:
     void * mAsyncReturnContext;
 
     std::set<std::string> mPublishedServices;
+    std::map<std::string, ResolveContext *> mResolveContexts;
     AvahiClient * mClient;
     AvahiEntryGroup * mGroup;
     Poller mPoller;

--- a/src/platform/tests/TestMdns.cpp
+++ b/src/platform/tests/TestMdns.cpp
@@ -26,6 +26,8 @@ static void HandleResolve(void * context, MdnsService * result, CHIP_ERROR error
     NL_TEST_ASSERT(suite, strcmp(result->mTextEntries[0].mKey, "key") == 0);
     NL_TEST_ASSERT(suite, strcmp(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val") == 0);
 
+    ChipMdnsUnsubscribe(result);
+
     exit(0);
 }
 
@@ -39,7 +41,7 @@ static void HandleBrowse(void * context, MdnsService * services, size_t services
         printf("Mdns service size %zu\n", servicesSize);
         printf("Service name %s\n", services->mName);
         printf("Service type %s\n", services->mType);
-        NL_TEST_ASSERT(suite, ChipMdnsResolve(services, INET_NULL_INTERFACEID, HandleResolve, suite) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(suite, ChipMdnsSubscribe(services, INET_NULL_INTERFACEID, HandleResolve, suite) == CHIP_NO_ERROR);
     }
 }
 


### PR DESCRIPTION
This allows the upper layers to locate a device with node and fabric ID.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

We don't have a unified interface to scan devices. This feature is required by the exchange manager to locate
a device with the node and fabric ID.

 #### Summary of Changes

* Add scanner interface
* Implement scanner interface with the platform API.
* Fix unstable static variable initialization order.
* Add and example using the scanner interface to locate a device.