### PR TITLE
Enable Bluetooth, if it is not already on

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/bluetooth/BluetoothManager.kt
@@ -39,6 +39,11 @@ class BluetoothManager {
   }
 
   suspend fun getBluetoothDevice(discriminator: Int): BluetoothDevice? {
+
+    if (! bluetoothAdapter.isEnabled) {
+      bluetoothAdapter.enable();
+    }
+
     val scanner = bluetoothAdapter.bluetoothLeScanner ?: run {
       Log.e(TAG, "No bluetooth scanner found")
       return null


### PR DESCRIPTION
 #### Problem

If Bluetooth adapter is disabled, scanning for CHIP devices fails silently on the Android CHIP app.

 #### Summary of Changes

If the adapter is not enabled, enable it.

 Fixes #4463
