### PR TITLE
[doc] Extend documentation of chip-tool to detail commands.

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -75,6 +75,31 @@ arguments.
 
     $ chip-tool
 
+Example output:
+
+```bash
+Usage:
+  ./chip-tool cluster_name command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Clusters:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * barriercontrol                                                                    |
+  | * basic                                                                             |
+  | * colorcontrol                                                                      |
+  | * doorlock                                                                          |
+  | * groups                                                                            |
+  | * iaszone                                                                           |
+  | * identify                                                                          |
+  | * levelcontrol                                                                      |
+  | * onoff                                                                             |
+  | * pairing                                                                           |
+  | * payload                                                                           |
+  | * scenes                                                                            |
+  | * temperaturemeasurement                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
 ### How to get the list of supported commands for a specific cluster
 
 To get the list of commands for a specific cluster, run the built executable
@@ -123,3 +148,295 @@ To parse an additional data payload, run the built executable with the `payload`
 cluster name and the `parse-additional-data-payload` command
 
     $ chip-tool payload parse-additional-data-payload "#####"
+
+# Command Reference
+
+## Command List
+
+-   [barriercontrol](#barriercontrol)
+-   [basic](#basic)
+-   [colorcontrol](#colorcontrol)
+-   [doorlock](#doorlock)
+-   [groups](#groups)
+-   [iaszone](#iaszone)
+-   [identify](#identify)
+-   [levelcontrol](#levelcontrol)
+-   [onoff](#onoff)
+-   [pairing](#pairing)
+-   [payload](#payload)
+-   [scenes](#scenes)
+-   [temperaturemeasurement](#temperaturemeasurement)
+
+## Command Details
+
+### barriercontrol
+
+```bash
+Usage:
+  ./chip-tool barriercontrol command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * barrier-control-go-to-percent                                                     |
+  | * barrier-control-stop                                                              |
+  | * discover                                                                          |
+  | * read                                                                              |
+  +-------------------------------------------------------------------------------------+
+```
+
+### basic
+
+```bash
+Usage:
+  ./chip-tool basic command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * reset-to-factory-defaults                                                         |
+  | * ping                                                                              |
+  | * discover                                                                          |
+  | * read                                                                              |
+  +-------------------------------------------------------------------------------------+
+```
+
+### colorcontrol
+
+```bash
+Usage:
+  ./chip-tool colorcontrol command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * move-color                                                                        |
+  | * move-color-temperature                                                            |
+  | * move-hue                                                                          |
+  | * move-saturation                                                                   |
+  | * move-to-color                                                                     |
+  | * move-to-color-temperature                                                         |
+  | * move-to-hue                                                                       |
+  | * move-to-hue-and-saturation                                                        |
+  | * move-to-saturation                                                                |
+  | * step-color                                                                        |
+  | * step-color-temperature                                                            |
+  | * step-hue                                                                          |
+  | * step-saturation                                                                   |
+  | * stop-move-step                                                                    |
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * report                                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
+### doorlock
+
+```bash
+Usage:
+  ./chip-tool doorlock command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * clear-all-pins                                                                    |
+  | * clear-all-rfids                                                                   |
+  | * clear-holiday-schedule                                                            |
+  | * clear-pin                                                                         |
+  | * clear-rfid                                                                        |
+  | * clear-weekday-schedule                                                            |
+  | * clear-yearday-schedule                                                            |
+  | * get-holiday-schedule                                                              |
+  | * get-pin                                                                           |
+  | * get-rfid                                                                          |
+  | * get-user-type                                                                     |
+  | * get-weekday-schedule                                                              |
+  | * get-yearday-schedule                                                              |
+  | * lock-door                                                                         |
+  | * set-holiday-schedule                                                              |
+  | * set-pin                                                                           |
+  | * set-rfid                                                                          |
+  | * set-user-type                                                                     |
+  | * set-weekday-schedule                                                              |
+  | * set-yearday-schedule                                                              |
+  | * unlock-door                                                                       |
+  | * unlock-with-timeout                                                               |
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * report                                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
+### groups
+
+```bash
+Usage:
+  ./chip-tool groups command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * add-group                                                                         |
+  | * add-group-if-identifying                                                          |
+  | * get-group-membership                                                              |
+  | * remove-all-groups                                                                 |
+  | * remove-group                                                                      |
+  | * view-group                                                                        |
+  | * discover                                                                          |
+  | * read                                                                              |
+  +-------------------------------------------------------------------------------------+
+```
+
+### iaszone
+
+```bash
+Usage:
+  ./chip-tool iaszone command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * write                                                                             |
+  +-------------------------------------------------------------------------------------+
+```
+
+### identify
+
+```bash
+Usage:
+  ./chip-tool identify command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * identify                                                                          |
+  | * identify-query                                                                    |
+  | * discover                                                                          |
+  | * read                                                                              |
+  +-------------------------------------------------------------------------------------+
+```
+
+### levelcontrol
+
+```bash
+Usage:
+  ./chip-tool levelcontrol command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * move                                                                              |
+  | * move-to-level                                                                     |
+  | * move-to-level-with-on-off                                                         |
+  | * move-with-on-off                                                                  |
+  | * step                                                                              |
+  | * step-with-on-off                                                                  |
+  | * stop                                                                              |
+  | * stop-with-on-off                                                                  |
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * report                                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
+### onoff
+
+```bash
+Usage:
+  ./chip-tool onoff command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * off                                                                               |
+  | * on                                                                                |
+  | * toggle                                                                            |
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * report                                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
+### onoff off [endpoint-id]
+
+Send the OFF command to the ONOFF cluster on the given endpoint.
+
+### onoff on [endpoint-id]
+
+Send the ON command to the ONOFF cluster on the given endpoint.
+
+### onoff toggle [endpoint-id]
+
+Send the TOGGLE command to the ONOFF cluster on the given endpoint.
+
+### onoff discover [endpoint-id]
+
+Send the DISCOVER command to the ONOFF cluster on the given endpoint.
+
+### pairing
+
+```bash
+Usage:
+  ./chip-tool pairing command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * unpair                                                                            |
+  | * bypass                                                                            |
+  | * ble                                                                               |
+  | * softap                                                                            |
+  +-------------------------------------------------------------------------------------+
+```
+
+### payload
+
+```bash
+Usage:
+  ./chip-tool payload command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * parse-setup-payload                                                               |
+  | * parse-additional-data-payload                                                     |
+  +-------------------------------------------------------------------------------------+
+```
+
+### scenes
+
+```bash
+Usage:
+  ./chip-tool scenes command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * add-scene                                                                         |
+  | * get-scene-membership                                                              |
+  | * recall-scene                                                                      |
+  | * remove-all-scenes                                                                 |
+  | * remove-scene                                                                      |
+  | * store-scene                                                                       |
+  | * view-scene                                                                        |
+  | * discover                                                                          |
+  | * read                                                                              |
+  +-------------------------------------------------------------------------------------+
+```
+
+### temperaturemeasurement
+
+```bash
+Usage:
+  ./chip-tool temperaturemeasurement command_name [param1 param2 ...]
+
+  +-------------------------------------------------------------------------------------+
+  | Commands:                                                                           |
+  +-------------------------------------------------------------------------------------+
+  | * discover                                                                          |
+  | * read                                                                              |
+  | * report                                                                            |
+  +-------------------------------------------------------------------------------------+
+```


### PR DESCRIPTION
 #### Problem

The `chip-tool` documentation doesn't provide much detail about the commands it supports.

 #### Summary of Changes
Adding framework to detail all the individual commands and parameters of `chip-tool`.
