### PR TITLE
Fix and enable warnings -Wheader-hygiene

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -169,7 +169,10 @@ config("strict_warnings") {
   }
 
   if (is_clang) {
-    cflags += [ "-Wimplicit-fallthrough" ]
+    cflags += [
+      "-Wimplicit-fallthrough",
+      "-Wheader-hygiene",
+    ]
   }
 
   if (current_os == "linux" || current_os == "android") {

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -46,9 +46,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-using namespace chip;
-using namespace chip::TLV;
-
 #ifndef CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 #define CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK 1
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK

--- a/src/inet/tests/TestInetLayerCommon.hpp
+++ b/src/inet/tests/TestInetLayerCommon.hpp
@@ -38,8 +38,6 @@
 
 #include <system/SystemPacketBuffer.h>
 
-using namespace ::chip;
-
 // Preprocessor Macros
 
 #define SetStatusFailed(aTestStatus)                                                                                               \
@@ -115,7 +113,7 @@ extern uint32_t gSendIntervalMs;
 
 extern const char * gInterfaceName;
 
-extern Inet::InterfaceId gInterfaceId;
+extern chip::Inet::InterfaceId gInterfaceId;
 
 extern uint16_t gSendSize;
 
@@ -131,37 +129,39 @@ extern bool IsSender();
 extern bool IsTesting(const TestStatus & aTestStatus);
 extern bool WasSuccessful(const TestStatus & aTestStatus);
 
-extern System::PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue);
-extern System::PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength);
-extern System::PacketBufferHandle MakeICMPv4DataBuffer(uint16_t aDesiredUserLength);
-extern System::PacketBufferHandle MakeICMPv6DataBuffer(uint16_t aDesiredUserLength);
+extern chip::System::PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength, uint8_t aFirstValue);
+extern chip::System::PacketBufferHandle MakeDataBuffer(uint16_t aDesiredLength);
+extern chip::System::PacketBufferHandle MakeICMPv4DataBuffer(uint16_t aDesiredUserLength);
+extern chip::System::PacketBufferHandle MakeICMPv6DataBuffer(uint16_t aDesiredUserLength);
 
-extern bool HandleDataReceived(const System::PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleDataReceived(const chip::System::PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                bool aCheckBuffer, uint8_t aFirstValue);
-extern bool HandleDataReceived(const System::PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleDataReceived(const chip::System::PacketBufferHandle & aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                bool aCheckBuffer);
-extern bool HandleICMPv4DataReceived(System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleICMPv4DataReceived(chip::System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                      bool aCheckBuffer);
-extern bool HandleICMPv6DataReceived(System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
+extern bool HandleICMPv6DataReceived(chip::System::PacketBufferHandle && aBuffer, TransferStats & aStats, bool aStatsByPacket,
                                      bool aCheckBuffer);
 
 // Timer Callback Handler
 
-extern void HandleSendTimerComplete(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
+extern void HandleSendTimerComplete(chip::System::Layer * aSystemLayer, void * aAppState, chip::System::Error aError);
 
 // Raw Endpoint Callback Handlers
 
-extern void HandleRawMessageReceived(const Inet::IPEndPointBasis * aEndPoint, const System::PacketBufferHandle & aBuffer,
-                                     const Inet::IPPacketInfo * aPacketInfo);
-extern void HandleRawReceiveError(const Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
-                                  const Inet::IPPacketInfo * aPacketInfo);
+extern void HandleRawMessageReceived(const chip::Inet::IPEndPointBasis * aEndPoint,
+                                     const chip::System::PacketBufferHandle & aBuffer,
+                                     const chip::Inet::IPPacketInfo * aPacketInfo);
+extern void HandleRawReceiveError(const chip::Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
+                                  const chip::Inet::IPPacketInfo * aPacketInfo);
 
 // UDP Endpoint Callback Handlers
 
-extern void HandleUDPMessageReceived(const Inet::IPEndPointBasis * aEndPoint, const System::PacketBufferHandle & aBuffer,
-                                     const Inet::IPPacketInfo * aPacketInfo);
-extern void HandleUDPReceiveError(const Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
-                                  const Inet::IPPacketInfo * aPacketInfo);
+extern void HandleUDPMessageReceived(const chip::Inet::IPEndPointBasis * aEndPoint,
+                                     const chip::System::PacketBufferHandle & aBuffer,
+                                     const chip::Inet::IPPacketInfo * aPacketInfo);
+extern void HandleUDPReceiveError(const chip::Inet::IPEndPointBasis * aEndPoint, const INET_ERROR & aError,
+                                  const chip::Inet::IPPacketInfo * aPacketInfo);
 
 } // namespace Common
 

--- a/src/setup_payload/AdditionalDataPayloadParser.cpp
+++ b/src/setup_payload/AdditionalDataPayloadParser.cpp
@@ -33,32 +33,27 @@
 #include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 
-using namespace chip;
-using namespace std;
-using namespace chip::SetupPayload;
-using namespace chip::TLV;
-using namespace chip::TLV::Utilities;
-using namespace chip::Protocols;
+namespace chip {
 
-CHIP_ERROR AdditionalDataPayloadParser::populatePayload(AdditionalDataPayload & outPayload)
+CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayload::AdditionalDataPayload & outPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    TLVReader reader;
-    TLVReader innerReader;
+    TLV::TLVReader reader;
+    TLV::TLVReader innerReader;
 
     reader.Init(mPayloadBufferData, mPayloadBufferLength);
-    err = reader.Next(kTLVType_Structure, AnonymousTag);
+    err = reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag);
     SuccessOrExit(err);
 
     // Open the container
     err = reader.OpenContainer(innerReader);
     SuccessOrExit(err);
 
-    err = innerReader.Next(kTLVType_UTF8String, ContextTag(kRotatingDeviceIdTag));
+    err = innerReader.Next(TLV::kTLVType_UTF8String, TLV::ContextTag(SetupPayload::kRotatingDeviceIdTag));
     SuccessOrExit(err);
 
     // Get the value of the rotating device id
-    char rotatingDeviceId[kRotatingDeviceIdLength];
+    char rotatingDeviceId[SetupPayload::kRotatingDeviceIdLength];
     err = innerReader.GetString(rotatingDeviceId, sizeof(rotatingDeviceId));
     SuccessOrExit(err);
     outPayload.rotatingDeviceId = std::string(rotatingDeviceId);
@@ -70,3 +65,5 @@ CHIP_ERROR AdditionalDataPayloadParser::populatePayload(AdditionalDataPayload & 
 exit:
     return err;
 }
+
+} // namespace chip

--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -31,8 +31,6 @@
 
 #include <climits>
 
-using namespace std;
-
 namespace chip {
 
 static const char codes[]        = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
@@ -42,9 +40,9 @@ static const int kBase41ChunkLen = 3;
 static const int kBytesChunkLen  = 2;
 static const int kRadix          = sizeof(codes) / sizeof(codes[0]);
 
-string base41Encode(const uint8_t * buf, size_t buf_len)
+std::string base41Encode(const uint8_t * buf, size_t buf_len)
 {
-    string result;
+    std::string result;
 
     // eat little-endian uint16_ts from the byte array
     // encode as 3 base41 characters
@@ -192,7 +190,7 @@ static inline CHIP_ERROR decodeChar(char c, uint8_t & value)
     return 0;
 }
 
-CHIP_ERROR base41Decode(string base41, vector<uint8_t> & result)
+CHIP_ERROR base41Decode(std::string base41, std::vector<uint8_t> & result)
 {
     result.clear();
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -29,7 +29,7 @@
 #include <support/logging/CHIPLogging.h>
 #include <support/verhoeff/Verhoeff.h>
 
-using namespace chip;
+namespace chip {
 
 static uint32_t shortPayloadRepresentation(const SetupPayload & payload)
 {
@@ -83,3 +83,5 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(std::
     outDecimalString = decimalString;
     return CHIP_NO_ERROR;
 }
+
+} // namespace chip

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -31,18 +31,17 @@
 #include <string>
 #include <vector>
 
-using namespace chip;
-using namespace std;
+namespace chip {
 
-static CHIP_ERROR checkDecimalStringValidity(string decimalString, string & decimalStringWithoutCheckDigit)
+static CHIP_ERROR checkDecimalStringValidity(std::string decimalString, std::string & decimalStringWithoutCheckDigit)
 {
     if (decimalString.length() < 2)
     {
         ChipLogError(SetupPayload, "Failed decoding base10. Input was empty. %zu", decimalString.length());
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
-    string repWithoutCheckChar = decimalString.substr(0, decimalString.length() - 1);
-    char checkChar             = decimalString.back();
+    std::string repWithoutCheckChar = decimalString.substr(0, decimalString.length() - 1);
+    char checkChar                  = decimalString.back();
 
     if (!Verhoeff10::ValidateCheckChar(checkChar, repWithoutCheckChar.c_str()))
     {
@@ -52,7 +51,7 @@ static CHIP_ERROR checkDecimalStringValidity(string decimalString, string & deci
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR checkCodeLengthValidity(const string & decimalString, bool isLongCode)
+static CHIP_ERROR checkCodeLengthValidity(const std::string & decimalString, bool isLongCode)
 {
     size_t expectedCharLength = isLongCode ? kManualSetupLongCodeCharLength : kManualSetupShortCodeCharLength;
     if (decimalString.length() != expectedCharLength)
@@ -76,7 +75,7 @@ static CHIP_ERROR extractBits(uint32_t number, uint64_t & dest, size_t index, si
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR toNumber(const string & decimalString, uint64_t & dest)
+static CHIP_ERROR toNumber(const std::string & decimalString, uint64_t & dest)
 {
     uint64_t number = 0;
     for (char c : decimalString)
@@ -94,7 +93,7 @@ static CHIP_ERROR toNumber(const string & decimalString, uint64_t & dest)
 }
 
 // Populate numberOfChars into dest from decimalString starting at startIndex (least significant digit = left-most digit)
-static CHIP_ERROR readDigitsFromDecimalString(const string & decimalString, size_t & index, uint64_t & dest,
+static CHIP_ERROR readDigitsFromDecimalString(const std::string & decimalString, size_t & index, uint64_t & dest,
                                               size_t numberOfCharsToRead)
 {
     if (decimalString.length() < numberOfCharsToRead || (numberOfCharsToRead + index > decimalString.length()))
@@ -103,7 +102,7 @@ static CHIP_ERROR readDigitsFromDecimalString(const string & decimalString, size
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
 
-    string decimalSubstring = decimalString.substr(index, numberOfCharsToRead);
+    std::string decimalSubstring = decimalString.substr(index, numberOfCharsToRead);
     index += numberOfCharsToRead;
     return toNumber(decimalSubstring, dest);
 }
@@ -127,7 +126,7 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 {
     CHIP_ERROR result = CHIP_NO_ERROR;
     SetupPayload payload;
-    string representationWithoutCheckDigit;
+    std::string representationWithoutCheckDigit;
 
     result = checkDecimalStringValidity(mDecimalStringRepresentation, representationWithoutCheckDigit);
     if (result != CHIP_NO_ERROR)
@@ -218,3 +217,5 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 
     return result;
 }
+
+} // namespace chip

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -40,13 +40,10 @@
 #include <support/SafeInt.h>
 #include <support/ScopedBuffer.h>
 
-using namespace chip;
-using namespace std;
-using namespace chip::TLV;
-using namespace chip::TLV::Utilities;
+namespace chip {
 
 // Populate numberOfBits into dest from buf starting at startIndex
-static CHIP_ERROR readBits(vector<uint8_t> buf, size_t & index, uint64_t & dest, size_t numberOfBitsToRead)
+static CHIP_ERROR readBits(std::vector<uint8_t> buf, size_t & index, uint64_t & dest, size_t numberOfBitsToRead)
 {
     dest = 0;
     if (index + numberOfBitsToRead > buf.size() * 8 || numberOfBitsToRead > sizeof(uint64_t) * 8)
@@ -69,7 +66,7 @@ static CHIP_ERROR readBits(vector<uint8_t> buf, size_t & index, uint64_t & dest,
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR openTLVContainer(TLVReader & reader, TLVType type, uint64_t tag, TLVReader & containerReader)
+static CHIP_ERROR openTLVContainer(TLV::TLVReader & reader, TLV::TLVType type, uint64_t tag, TLV::TLVReader & containerReader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     VerifyOrExit(reader.GetType() == type, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -84,7 +81,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfoString(TLVReader & reader, OptionalQRCodeInfo & info)
+static CHIP_ERROR retrieveOptionalInfoString(TLV::TLVReader & reader, OptionalQRCodeInfo & info)
 {
     CHIP_ERROR err;
     uint32_t valLength = reader.GetLength();
@@ -96,13 +93,13 @@ static CHIP_ERROR retrieveOptionalInfoString(TLVReader & reader, OptionalQRCodeI
     SuccessOrExit(err);
 
     info.type = optionalQRCodeInfoTypeString;
-    info.data = string(value.Get());
+    info.data = std::string(value.Get());
 
 exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfoInt32(TLVReader & reader, OptionalQRCodeInfo & info)
+static CHIP_ERROR retrieveOptionalInfoInt32(TLV::TLVReader & reader, OptionalQRCodeInfo & info)
 {
     int32_t value;
     CHIP_ERROR err = reader.Get(value);
@@ -115,7 +112,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfoInt64(TLVReader & reader, OptionalQRCodeInfoExtension & info)
+static CHIP_ERROR retrieveOptionalInfoInt64(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
 {
     int64_t value;
     CHIP_ERROR err = reader.Get(value);
@@ -128,7 +125,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfoUInt32(TLVReader & reader, OptionalQRCodeInfoExtension & info)
+static CHIP_ERROR retrieveOptionalInfoUInt32(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
 {
     uint32_t value;
     CHIP_ERROR err = reader.Get(value);
@@ -141,7 +138,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfoUInt64(TLVReader & reader, OptionalQRCodeInfoExtension & info)
+static CHIP_ERROR retrieveOptionalInfoUInt64(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info)
 {
     uint64_t value;
     CHIP_ERROR err = reader.Get(value);
@@ -154,7 +151,7 @@ exit:
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfo(TLVReader & reader, OptionalQRCodeInfo & info, optionalQRCodeInfoType type)
+static CHIP_ERROR retrieveOptionalInfo(TLV::TLVReader & reader, OptionalQRCodeInfo & info, optionalQRCodeInfoType type)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -174,7 +171,7 @@ static CHIP_ERROR retrieveOptionalInfo(TLVReader & reader, OptionalQRCodeInfo & 
     return err;
 }
 
-static CHIP_ERROR retrieveOptionalInfo(TLVReader & reader, OptionalQRCodeInfoExtension & info, optionalQRCodeInfoType type)
+static CHIP_ERROR retrieveOptionalInfo(TLV::TLVReader & reader, OptionalQRCodeInfoExtension & info, optionalQRCodeInfoType type)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -202,29 +199,29 @@ static CHIP_ERROR retrieveOptionalInfo(TLVReader & reader, OptionalQRCodeInfoExt
     return err;
 }
 
-CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPayload, TLVReader & reader)
+CHIP_ERROR QRCodeSetupPayloadParser::retrieveOptionalInfos(SetupPayload & outPayload, TLV::TLVReader & reader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    TLVType type;
+    TLV::TLVType type;
     uint8_t tag;
     while (err == CHIP_NO_ERROR)
     {
         type = reader.GetType();
-        if (type != kTLVType_UTF8String && type != kTLVType_SignedInteger && type != kTLVType_UnsignedInteger)
+        if (type != TLV::kTLVType_UTF8String && type != TLV::kTLVType_SignedInteger && type != TLV::kTLVType_UnsignedInteger)
         {
             err = reader.Next();
             continue;
         }
 
-        tag = static_cast<uint8_t>(TagNumFromTag(reader.GetTag()));
-        VerifyOrExit(IsContextTag(tag) == true || IsProfileTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
+        tag = static_cast<uint8_t>(TLV::TagNumFromTag(reader.GetTag()));
+        VerifyOrExit(TLV::IsContextTag(tag) == true || TLV::IsProfileTag(tag) == true, err = CHIP_ERROR_INVALID_TLV_TAG);
 
         optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
-        if (type == kTLVType_UTF8String)
+        if (type == TLV::kTLVType_UTF8String)
         {
             elemType = optionalQRCodeInfoTypeString;
         }
-        if (type == kTLVType_SignedInteger || type == kTLVType_UnsignedInteger)
+        if (type == TLV::kTLVType_SignedInteger || type == TLV::kTLVType_UnsignedInteger)
         {
             elemType = outPayload.getNumericTypeFor(tag);
         }
@@ -267,17 +264,17 @@ CHIP_ERROR QRCodeSetupPayloadParser::parseTLVFields(SetupPayload & outPayload, u
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    TLVReader rootReader;
+    TLV::TLVReader rootReader;
     rootReader.Init(tlvDataStart, static_cast<uint32_t>(tlvDataLengthInBytes));
     rootReader.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
     err                          = rootReader.Next();
     SuccessOrExit(err);
 
-    if (rootReader.GetType() == kTLVType_Structure)
+    if (rootReader.GetType() == TLV::kTLVType_Structure)
     {
-        TLVReader innerStructureReader;
-        err = openTLVContainer(rootReader, kTLVType_Structure,
-                               ProfileTag(rootReader.ImplicitProfileId, kTag_QRCodeExensionDescriptor), innerStructureReader);
+        TLV::TLVReader innerStructureReader;
+        err = openTLVContainer(rootReader, TLV::kTLVType_Structure,
+                               TLV::ProfileTag(rootReader.ImplicitProfileId, kTag_QRCodeExensionDescriptor), innerStructureReader);
         SuccessOrExit(err);
         err = innerStructureReader.Next();
         SuccessOrExit(err);
@@ -296,7 +293,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR QRCodeSetupPayloadParser::populateTLV(SetupPayload & outPayload, const vector<uint8_t> & buf, size_t & index)
+CHIP_ERROR QRCodeSetupPayloadParser::populateTLV(SetupPayload & outPayload, const std::vector<uint8_t> & buf, size_t & index)
 {
     size_t bitsLeftToRead = (buf.size() * 8) - index;
     size_t tlvBytesLength = (bitsLeftToRead + 7) / 8; // ceil(bitsLeftToRead/8)
@@ -317,11 +314,11 @@ CHIP_ERROR QRCodeSetupPayloadParser::populateTLV(SetupPayload & outPayload, cons
     return parseTLVFields(outPayload, tlvArray.Get(), tlvBytesLength);
 }
 
-static string extractPayload(string inString)
+static std::string extractPayload(std::string inString)
 {
-    string chipSegment;
+    std::string chipSegment;
     char delimiter = '%';
-    vector<size_t> startIndices;
+    std::vector<size_t> startIndices;
     startIndices.push_back(0);
 
     for (size_t i = 0; i < inString.length(); i++)
@@ -335,10 +332,10 @@ static string extractPayload(string inString)
     // Find the first string between delimiters that starts with kQRCodePrefix
     for (size_t i = 0; i < startIndices.size(); i++)
     {
-        size_t startIndex = startIndices[i];
-        size_t endIndex   = (i == startIndices.size() - 1 ? string::npos : startIndices[i + 1] - 1);
-        size_t length     = (endIndex != string::npos ? endIndex - startIndex : string::npos);
-        string segment    = inString.substr(startIndex, length);
+        size_t startIndex   = startIndices[i];
+        size_t endIndex     = (i == startIndices.size() - 1 ? std::string::npos : startIndices[i + 1] - 1);
+        size_t length       = (endIndex != std::string::npos ? endIndex - startIndex : std::string::npos);
+        std::string segment = inString.substr(startIndex, length);
 
         // Find a segment that starts with kQRCodePrefix
         if (segment.find(kQRCodePrefix, 0) == 0 && segment.length() > strlen(kQRCodePrefix))
@@ -358,12 +355,12 @@ static string extractPayload(string inString)
 
 CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 {
-    vector<uint8_t> buf;
+    std::vector<uint8_t> buf;
     CHIP_ERROR err         = CHIP_NO_ERROR;
     size_t indexToReadFrom = 0;
     uint64_t dest;
 
-    string payload = extractPayload(mBase41Representation);
+    std::string payload = extractPayload(mBase41Representation);
     VerifyOrExit(payload.length() != 0, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     err = base41Decode(payload, buf);
@@ -412,3 +409,5 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 exit:
     return err;
 }
+
+} // namespace chip

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -31,10 +31,6 @@
 #include <support/RandUtils.h>
 #include <utility>
 
-using namespace chip;
-using namespace std;
-using namespace chip::TLV;
-
 namespace chip {
 
 bool IsCHIPTag(uint8_t tag)
@@ -105,7 +101,7 @@ bool SetupPayload::isValidManualCode()
     return true;
 }
 
-CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, string data)
+CHIP_ERROR SetupPayload::addOptionalVendorData(uint8_t tag, std::string data)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfo info;
@@ -135,9 +131,9 @@ exit:
     return err;
 }
 
-vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData()
+std::vector<OptionalQRCodeInfo> SetupPayload::getAllOptionalVendorData()
 {
-    vector<OptionalQRCodeInfo> returnedOptionalInfo;
+    std::vector<OptionalQRCodeInfo> returnedOptionalInfo;
     for (auto & entry : optionalVendorData)
     {
         returnedOptionalInfo.push_back(entry.second);
@@ -156,7 +152,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SetupPayload::addSerialNumber(string serialNumber)
+CHIP_ERROR SetupPayload::addSerialNumber(std::string serialNumber)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfoExtension info;
@@ -186,7 +182,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR SetupPayload::getSerialNumber(string & outSerialNumber)
+CHIP_ERROR SetupPayload::getSerialNumber(std::string & outSerialNumber)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     OptionalQRCodeInfoExtension info;
@@ -199,7 +195,7 @@ CHIP_ERROR SetupPayload::getSerialNumber(string & outSerialNumber)
         outSerialNumber = info.data;
         break;
     case (optionalQRCodeInfoTypeUInt32):
-        outSerialNumber = to_string(info.uint32);
+        outSerialNumber = std::to_string(info.uint32);
         break;
     default:
         err = CHIP_ERROR_INVALID_ARGUMENT;
@@ -275,9 +271,9 @@ optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag)
     return elemType;
 }
 
-vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
+std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
 {
-    vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
+    std::vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
     for (auto & entry : optionalExtensionData)
     {
         returnedOptionalInfo.push_back(entry.second);
@@ -288,8 +284,8 @@ vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
 bool SetupPayload::operator==(SetupPayload & input)
 {
     bool isIdentical = true;
-    vector<OptionalQRCodeInfo> inputOptionalVendorData;
-    vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
+    std::vector<OptionalQRCodeInfo> inputOptionalVendorData;
+    std::vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;
 
     VerifyOrExit(this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
                      this->requiresCustomFlow == input.requiresCustomFlow &&

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -22,11 +22,13 @@
 #include "QRCodeSetupPayloadParser.cpp"
 #include "SetupPayload.cpp"
 
+namespace chip {
+
 const uint16_t kSmallBufferSizeInBytes   = 1;
 const uint16_t kDefaultBufferSizeInBytes = 512;
 
-const uint8_t kOptionalDefaultStringTag  = 2;
-const string kOptionalDefaultStringValue = "myData";
+const uint8_t kOptionalDefaultStringTag       = 2;
+const std::string kOptionalDefaultStringValue = "myData";
 
 const uint8_t kOptionalDefaultIntTag    = 3;
 const uint32_t kOptionalDefaultIntValue = 12;
@@ -67,20 +69,20 @@ inline SetupPayload GetDefaultPayloadWithOptionalDefaults()
     return payload;
 }
 
-inline string toBinaryRepresentation(string base41Result)
+inline std::string toBinaryRepresentation(std::string base41Result)
 {
     // Remove the kQRCodePrefix
     base41Result.erase(0, strlen(kQRCodePrefix));
 
     // Decode the base41 encoded string
-    vector<uint8_t> buffer;
+    std::vector<uint8_t> buffer;
     base41Decode(base41Result, buffer);
 
     // Convert it to binary
-    string binaryResult;
+    std::string binaryResult;
     for (size_t i = buffer.size(); i > 0; i--)
     {
-        binaryResult += bitset<8>(buffer[i - 1]).to_string();
+        binaryResult += std::bitset<8>(buffer[i - 1]).to_string();
     }
 
     // Insert spaces after each block
@@ -113,32 +115,32 @@ inline string toBinaryRepresentation(string base41Result)
     return binaryResult;
 }
 
-inline bool CompareBinary(SetupPayload & payload, string & expectedBinary)
+inline bool CompareBinary(SetupPayload & payload, std::string & expectedBinary)
 {
     QRCodeSetupPayloadGenerator generator(payload);
 
-    string result;
+    std::string result;
     uint8_t optionalInfo[kDefaultBufferSizeInBytes];
     generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
 
-    string resultBinary = toBinaryRepresentation(result);
+    std::string resultBinary = toBinaryRepresentation(result);
     return (expectedBinary == resultBinary);
 }
 
 inline bool CompareBinaryLength(SetupPayload & payload, size_t expectedTLVLengthInBytes)
 {
-    string result;
+    std::string result;
     uint8_t optionalInfo[kDefaultBufferSizeInBytes];
 
     SetupPayload basePayload = GetDefaultPayload();
     QRCodeSetupPayloadGenerator baseGenerator(basePayload);
     baseGenerator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
-    string baseBinary = toBinaryRepresentation(result);
+    std::string baseBinary = toBinaryRepresentation(result);
 
     QRCodeSetupPayloadGenerator generator(payload);
     generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
 
-    string resultBinary           = toBinaryRepresentation(result);
+    std::string resultBinary      = toBinaryRepresentation(result);
     size_t resultTLVLengthInBytes = (resultBinary.size() - baseBinary.size()) / 8;
     return (expectedTLVLengthInBytes == resultTLVLengthInBytes);
 }
@@ -146,7 +148,7 @@ inline bool CompareBinaryLength(SetupPayload & payload, size_t expectedTLVLength
 inline bool CheckWriteRead(SetupPayload & inPayload)
 {
     SetupPayload outPayload;
-    string result;
+    std::string result;
 
     QRCodeSetupPayloadGenerator generator(inPayload);
     uint8_t optionalInfo[kDefaultBufferSizeInBytes];
@@ -157,3 +159,5 @@ inline bool CheckWriteRead(SetupPayload & inPayload)
 
     return inPayload == outPayload;
 }
+
+} // namespace chip

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -37,9 +37,9 @@ using namespace chip;
 
 namespace {
 
-bool CheckGenerator(const SetupPayload & payload, string expectedResult)
+bool CheckGenerator(const SetupPayload & payload, std::string expectedResult)
 {
-    string result;
+    std::string result;
     ManualSetupPayloadGenerator generator(payload);
     generator.payloadDecimalStringRepresentation(result);
 
@@ -71,7 +71,7 @@ void TestDecimalRepresentation_PartialPayload(nlTestSuite * inSuite, void * inCo
 {
     SetupPayload payload = GetDefaultPayload();
 
-    string expectedResult = "0000039490";
+    std::string expectedResult = "0000039490";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -81,7 +81,7 @@ void TestDecimalRepresentation_PartialPayload_RequiresCustomFlow(nlTestSuite * i
     SetupPayload payload       = GetDefaultPayload();
     payload.requiresCustomFlow = true;
 
-    string expectedResult = "00000394910000000000";
+    std::string expectedResult = "00000394910000000000";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -93,7 +93,7 @@ void TestDecimalRepresentation_FullPayloadWithZeros(nlTestSuite * inSuite, void 
     payload.vendorID           = 1;
     payload.productID          = 1;
 
-    string expectedResult = "00000394910000100001";
+    std::string expectedResult = "00000394910000100001";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -105,7 +105,7 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros(nlTestSuite * inSuite, vo
     payload.vendorID           = 45367;
     payload.productID          = 14526;
 
-    string expectedResult = "00000394914536714526";
+    std::string expectedResult = "00000394914536714526";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -116,7 +116,7 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow(
     payload.vendorID     = 45367;
     payload.productID    = 14526;
 
-    string expectedResult = "0000039490";
+    std::string expectedResult = "0000039490";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -127,7 +127,7 @@ void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
     payload.setUpPINCode  = 0;
     payload.discriminator = 0;
 
-    string expectedResult = "";
+    std::string expectedResult = "";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -138,7 +138,7 @@ void TestDecimalRepresentation_InvalidPayload(nlTestSuite * inSuite, void * inCo
     payload.discriminator = 0x1f00;
 
     ManualSetupPayloadGenerator generator(payload);
-    string result;
+    std::string result;
     NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_ERROR_INVALID_ARGUMENT);
 }
 
@@ -161,7 +161,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
     {
         // Test short 11 digit code
         ManualSetupPayloadGenerator generator(payload);
-        string result;
+        std::string result;
         NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
 
         SetupPayload outPayload;
@@ -178,7 +178,7 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
     {
         // Test long 21 digit code
         ManualSetupPayloadGenerator generator(payload);
-        string result;
+        std::string result;
         NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
 
         SetupPayload outPayload;
@@ -199,7 +199,7 @@ void assertEmptyPayloadWithError(nlTestSuite * inSuite, CHIP_ERROR actualError, 
 void TestPayloadParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload;
-    string decimalString;
+    std::string decimalString;
 
     decimalString = "00000394914536714526";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
@@ -225,7 +225,7 @@ void TestGenerateAndParser_FullPayload(nlTestSuite * inSuite, void * inContext)
     payload.requiresCustomFlow = true;
 
     ManualSetupPayloadGenerator generator(payload);
-    string result;
+    std::string result;
     NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
 
     SetupPayload outPayload;
@@ -239,7 +239,7 @@ void TestGenerateAndParser_PartialPayload(nlTestSuite * inSuite, void * inContex
     SetupPayload payload = GetDefaultPayload();
 
     ManualSetupPayloadGenerator generator(payload);
-    string result;
+    std::string result;
     NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR);
 
     SetupPayload outPayload;
@@ -252,7 +252,7 @@ void TestPayloadParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
 {
     CHIP_ERROR err;
     SetupPayload payload;
-    string decimalString;
+    std::string decimalString;
 
     decimalString = "0000039490";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
@@ -299,7 +299,7 @@ void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
     SetupPayload inPayload = GetDefaultPayload();
     SetupPayload outPayload;
 
-    string result;
+    std::string result;
     ManualSetupPayloadGenerator generator(inPayload);
     generator.payloadDecimalStringRepresentation(result);
     ManualSetupPayloadParser(result).populatePayload(outPayload);
@@ -315,7 +315,7 @@ void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
     inPayload.productID          = 1;
     SetupPayload outPayload;
 
-    string result;
+    std::string result;
     ManualSetupPayloadGenerator generator(inPayload);
     generator.payloadDecimalStringRepresentation(result);
     ManualSetupPayloadParser(result).populatePayload(outPayload);
@@ -343,7 +343,7 @@ void TestExtractBits(nlTestSuite * inSuite, void * inContext)
 void TestPayloadParser_InvalidEntry(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload;
-    string decimalString;
+    std::string decimalString;
 
     // Empty input
     decimalString = "";
@@ -393,10 +393,10 @@ void TestPayloadParser_InvalidEntry(nlTestSuite * inSuite, void * inContext)
 
 void TestCheckDecimalStringValidity(nlTestSuite * inSuite, void * inContext)
 {
-    string outReprensation;
+    std::string outReprensation;
     char checkDigit;
-    string representationWithoutCheckDigit;
-    string decimalString;
+    std::string representationWithoutCheckDigit;
+    std::string decimalString;
 
     representationWithoutCheckDigit = "";
     NL_TEST_ASSERT(


### PR DESCRIPTION
This fixes a number of warnings of the form:

  ../../src/app/MessageDef/MessageDefHelper.h:49:17: error: using namespace directive in global context in header [-Werror,-Wheader-hygiene]
  using namespace chip;
                  ^
  ../../src/app/MessageDef/MessageDefHelper.h:50:23: error: using namespace directive in global context in header [-Werror,-Wheader-hygiene]
  using namespace chip::TLV;
                        ^
  2 errors generated.

No functional change.