### PR TITLE
Align which template JSON files are used for the examples

### DIFF
--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -19,13 +19,13 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../third_party/zap/repo/zcl-builtin/silabs/zcl.json",
+      "path": "../../../../src/app/zap-templates/zcl/zcl.json",
       "version": "ZCL Test Data",
       "type": "zcl-properties"
     },
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../src/app/zap-templates/chip-templates.json",
+      "path": "../../../../src/app/zap-templates/app-templates.json",
       "version": "chip-v1",
       "type": "gen-templates-json"
     }

--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -19,13 +19,13 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../third_party/zap/repo/zcl-builtin/silabs/zcl.json",
+      "path": "../../../../src/app/zap-templates/zcl/zcl.json",
       "version": "ZCL Test Data",
       "type": "zcl-properties"
     },
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../src/app/zap-templates/chip-templates.json",
+      "path": "../../../../src/app/zap-templates/app-templates.json",
       "version": "chip-v1",
       "type": "gen-templates-json"
     }

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.zap
@@ -19,13 +19,13 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../../third_party/zap/repo/zcl-builtin/silabs/zcl.json",
+      "path": "../../../../src/app/zap-templates/zcl/zcl.json",
       "version": "ZCL Test Data",
       "type": "zcl-properties"
     },
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../../src/app/zap-templates/chip-templates.json",
+      "path": "../../../../src/app/zap-templates/app-templates.json",
       "version": "chip-v1",
       "type": "gen-templates-json"
     }


### PR DESCRIPTION
#### Problem

all-clusters-app was using different JSON files than lighting-app,
lock-app and temperature-measurement.

#### Summary of Changes

Use same JSON files for all example apps.

Fixes #4478
