### PR TITLE
Make stub functions weak so that they can be overriden.

### DIFF
--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -44,7 +44,7 @@ void __attribute__((weak)) emberAf{{asCamelCased name false}}ClusterInitCallback
  *
  * @param tasks   Ver.: always
  */
-void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
+void __attribute__((weak)) emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
 /** @brief Remove From Current App Tasks
  *
@@ -58,7 +58,7 @@ void emberAfAddToCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  *
  * @param tasks   Ver.: always
  */
-void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
+void __attribute__((weak)) emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
 
 /** @brief Allow Network Write Attribute
  *
@@ -93,7 +93,8 @@ void emberAfRemoveFromCurrentAppTasksCallback(EmberAfApplicationTask tasks) {}
  * @param value   Ver.: always
  * @param type   Ver.: always
  */
-EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(EndpointId endpoint, ClusterId clusterId,
+EmberAfAttributeWritePermission __attribute__((weak)) emberAfAllowNetworkWriteAttributeCallback(
+    EndpointId endpoint, ClusterId clusterId,
                                                                           AttributeId attributeId, uint8_t mask,
                                                                           uint16_t manufacturerCode, uint8_t * value, uint8_t type)
 {
@@ -110,7 +111,8 @@ EmberAfAttributeWritePermission emberAfAllowNetworkWriteAttributeCallback(Endpoi
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+bool __attribute__((weak)) emberAfAttributeReadAccessCallback(
+    EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
                                         AttributeId attributeId)
 {
     return true;
@@ -126,7 +128,8 @@ bool emberAfAttributeReadAccessCallback(EndpointId endpoint, ClusterId clusterId
  * @param manufacturerCode   Ver.: always
  * @param attributeId   Ver.: always
  */
-bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
+bool __attribute__((weak)) emberAfAttributeWriteAccessCallback(
+    EndpointId endpoint, ClusterId clusterId, uint16_t manufacturerCode,
                                          AttributeId attributeId)
 {
     return true;
@@ -144,7 +147,8 @@ bool emberAfAttributeWriteAccessCallback(EndpointId endpoint, ClusterId clusterI
  * @param status Specifies either SUCCESS or the nature of the error that was
  * detected in the received command.  Ver.: always
  */
-bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, EmberAfStatus status)
+bool __attribute__((weak)) emberAfDefaultResponseCallback(
+    ClusterId clusterId, CommandId commandId, EmberAfStatus status)
 {
     return false;
 }
@@ -169,7 +173,8 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
  * @param extended Indicates whether the response is in the extended format or
  * not.  Ver.: always
  */
-bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
+bool __attribute__((weak)) emberAfDiscoverAttributesResponseCallback(
+    ClusterId clusterId, bool discoveryComplete, uint8_t * buffer,
                                                uint16_t bufLen, bool extended)
 {
     return false;
@@ -189,7 +194,8 @@ bool emberAfDiscoverAttributesResponseCallback(ClusterId clusterId, bool discove
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+bool __attribute__((weak)) emberAfDiscoverCommandsGeneratedResponseCallback(
+    ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
                                                       CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
@@ -209,7 +215,8 @@ bool emberAfDiscoverCommandsGeneratedResponseCallback(ClusterId clusterId, uint1
  * @param commandIdCount The length of bytes of the list, whish is the same as
  * the number of identifiers.  Ver.: always
  */
-bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
+bool __attribute__((weak)) emberAfDiscoverCommandsReceivedResponseCallback(
+    ClusterId clusterId, uint16_t manufacturerCode, bool discoveryComplete,
                                                      CommandId * commandIds, uint16_t commandIdCount)
 {
     return false;
@@ -228,7 +235,8 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
  *
  * @param cmd   Ver.: always
  */
-bool emberAfPreCommandReceivedCallback(EmberAfClusterCommand * cmd)
+bool __attribute__((weak)) emberAfPreCommandReceivedCallback(
+    EmberAfClusterCommand * cmd)
 {
     return false;
 }
@@ -252,7 +260,8 @@ bool emberAfPreCommandReceivedCallback(EmberAfClusterCommand * cmd)
  * @param status A pointer to the status code value that will be returned to the
  * caller.  Ver.: always
  */
-bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberStatus * status)
+bool __attribute__((weak)) emberAfPreMessageSendCallback(
+    EmberAfMessageStruct * messageStruct, EmberStatus * status)
 {
     return false;
 }
@@ -275,8 +284,10 @@ bool emberAfPreMessageSendCallback(EmberAfMessageStruct * messageStruct, EmberSt
  * @param message   Ver.: always
  * @param status   Ver.: always
  */
-bool emberAfMessageSentCallback(EmberOutgoingMessageType type, uint16_t indexOrDestination, EmberApsFrame * apsFrame,
-                                uint16_t msgLen, uint8_t * message, EmberStatus status)
+bool __attribute__((weak)) emberAfMessageSentCallback(
+    EmberOutgoingMessageType type, uint16_t indexOrDestination,
+    EmberApsFrame * apsFrame, uint16_t msgLen, uint8_t * message,
+    EmberStatus status)
 {
     return false;
 }
@@ -298,7 +309,8 @@ bool emberAfMessageSentCallback(EmberOutgoingMessageType type, uint16_t indexOrD
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+EmberAfStatus __attribute__((weak)) emberAfPreAttributeChangeCallback(
+    EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
                                                 uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
                                                 uint8_t * value)
 {
@@ -320,8 +332,12 @@ EmberAfStatus emberAfPreAttributeChangeCallback(EndpointId endpoint, ClusterId c
  * @param size   Ver.: always
  * @param value   Ver.: always
  */
-void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value) {}
+void __attribute__((weak)) emberAfPostAttributeChangeCallback(
+    EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+    uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size,
+    uint8_t * value)
+{
+}
 
 /** @brief Read Attributes Response
  *
@@ -334,7 +350,8 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool __attribute__((weak)) emberAfReadAttributesResponseCallback(
+    ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -375,7 +392,8 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer
  * @param buffer   Ver.: always
  * @param maxReadLength   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+EmberAfStatus __attribute__((weak)) emberAfExternalAttributeReadCallback(
+    EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength)
 {
@@ -393,7 +411,8 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
  * Ver.: always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool __attribute__((weak)) emberAfWriteAttributesResponseCallback(
+    ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -444,7 +463,8 @@ bool emberAfWriteAttributesResponseCallback(ClusterId clusterId, uint8_t * buffe
  * @param manufacturerCode   Ver.: always
  * @param buffer   Ver.: always
  */
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+EmberAfStatus __attribute__((weak)) emberAfExternalAttributeWriteCallback(
+    EndpointId endpoint, ClusterId clusterId,
                                                     EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                     uint8_t * buffer)
 {
@@ -462,7 +482,8 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
  * always
  * @param bufLen The length in bytes of the list.  Ver.: always
  */
-bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+bool __attribute__((weak)) emberAfReportAttributesCallback(
+    ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
 {
     return false;
 }
@@ -476,7 +497,7 @@ bool emberAfReportAttributesCallback(ClusterId clusterId, uint8_t * buffer, uint
  * that device does not have access to real time.
  *
  */
-uint32_t emberAfGetCurrentTimeCallback()
+uint32_t __attribute__((weak)) emberAfGetCurrentTimeCallback()
 {
     return 0;
 }
@@ -498,7 +519,9 @@ uint32_t emberAfGetCurrentTimeCallback()
  * @param returnEndpointInfo A pointer to a data struct that will be written
  * with information about the endpoint.  Ver.: always
  */
-bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo)
+bool __attribute__((weak)) emberAfGetEndpointInfoCallback(
+    EndpointId endpoint, uint8_t * returnNetworkIndex,
+    EmberAfEndpointInfoStruct * returnEndpointInfo)
 {
     return false;
 }
@@ -510,7 +533,8 @@ bool emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetwork
  *
  * @param destination The node id of the destination  Ver.: always
  */
-uint8_t emberAfGetSourceRouteOverheadCallback(EmberNodeId destination)
+uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(
+    EmberNodeId destination)
 {
     return 0;
 }
@@ -521,7 +545,7 @@ uint8_t emberAfGetSourceRouteOverheadCallback(EmberNodeId destination)
  * process.
  *
  */
-void emberAfRegistrationAbortCallback() {}
+void __attribute__((weak)) emberAfRegistrationAbortCallback() {}
 
 /** @brief Interpan Send Message
  *
@@ -533,7 +557,8 @@ void emberAfRegistrationAbortCallback() {}
  * always
  * @param message The message data received or to send.  Ver.: always
  */
-EmberStatus emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
+EmberStatus __attribute__((weak)) emberAfInterpanSendMessageCallback(
+    EmberAfInterpanHeader * header, uint16_t messageLength, uint8_t * message)
 {
     return EMBER_LIBRARY_NOT_PRESENT;
 }
@@ -544,7 +569,7 @@ EmberStatus emberAfInterpanSendMessageCallback(EmberAfInterpanHeader * header, u
  * to a new parent.
  *
  */
-bool emberAfStartMoveCallback()
+bool __attribute__((weak)) emberAfStartMoveCallback()
 {
     return false;
 }


### PR DESCRIPTION
#### Problem

Stub functions generated from the template src/app/zap-templates/templates/app/callback-stub-src.zapt cannot be overriden and would need to be manually commented.

#### Summary of Changes

* Attribute functions in the template with weak.

Fixes #4480