### PR TITLE
Rename code to PASESession and CASESession

### DIFF
--- a/docs/dots/Rendezvous/RendezvousSessionGeneral.dot
+++ b/docs/dots/Rendezvous/RendezvousSessionGeneral.dot
@@ -20,7 +20,7 @@ digraph RendezvousSession
   subgraph cluster_transport {
     label=<<b>Transport</b>>
 
-    RendezvousSession [shape=record, label=<{RendezvousSession|<font point-size="11">AuthenticatedSessionEstablishmentDelegate</font>}>, URL="@ref chip::AuthenticatedSessionEstablishmentDelegate"]
+    RendezvousSession [shape=record, label=<{RendezvousSession|<font point-size="11">SessionEstablishmentDelegate</font>}>, URL="@ref chip::SessionEstablishmentDelegate"]
     TransportBle [label="Transport::BLE", URL="@ref chip::Transport::BLE"]
     TransportInet [label="Transport::?", style=dashed, color=gray]
   }

--- a/docs/dots/Rendezvous/RendezvousSessionInit.dot
+++ b/docs/dots/Rendezvous/RendezvousSessionInit.dot
@@ -22,17 +22,17 @@ digraph RendezvousSession
   subgraph rendezvousSession {
     node [fillcolor="white:gray", gradientangle=90]
 
-    RendezvousSession [shape=record, label=<{RendezvousSession|<font point-size="11">AuthenticatedSessionEstablishmentDelegate</font>}>, URL="@ref chip::AuthenticatedSessionEstablishmentDelegate"]
+    RendezvousSession [shape=record, label=<{RendezvousSession|<font point-size="11">SessionEstablishmentDelegate</font>}>, URL="@ref chip::SessionEstablishmentDelegate"]
   }
 
-  # This section represents methods which belongs to SecurePairingSession
+  # This section represents methods which belongs to PASESession
   subgraph cluster_securePairingSession {
-    label=<<b>SecurePairingSession</b>>
+    label=<<b>PASESession</b>>
     node [fillcolor="gray"]
 
-    WaitForPairing [URL="@ref chip::SecurePairingSession::WaitForPairing"]
-    Pair [URL="@ref chip::SecurePairingSession::Pair"]
-    DeriveSecureSession [URL="@ref chip::SecurePairingSession::DeriveSecureSession"]
+    WaitForPairing [URL="@ref chip::PASESession::WaitForPairing"]
+    Pair [URL="@ref chip::PASESession::Pair"]
+    DeriveSecureSession [URL="@ref chip::PASESession::DeriveSecureSession"]
   }
 
   # This section represents methods which belongs to RendezvousParameters
@@ -54,13 +54,13 @@ digraph RendezvousSession
     OnRendezvousError [URL="@ref chip::RendezvousSessionDelegate::OnRendezvousError"]
   }
 
-  # This section represents callbacks which belongs to AuthenticatedSessionEstablishmentDelegate
-  subgraph cluster_secureAuthenticatedSessionEstablishmentDelegate {
-    label=<<b>AuthenticatedSessionEstablishmentDelegate</b>>
+  # This section represents callbacks which belongs to SessionEstablishmentDelegate
+  subgraph cluster_secureSessionEstablishmentDelegate {
+    label=<<b>SessionEstablishmentDelegate</b>>
     node [fillcolor="white"]
 
-    OnPairingError [URL="@ref chip::AuthenticatedSessionEstablishmentDelegate::OnPairingError"]
-    OnPairingComplete [URL="@ref chip::AuthenticatedSessionEstablishmentDelegate::OnPairingComplete"]
+    OnSessionEstablishmentError [URL="@ref chip::SessionEstablishmentDelegate::OnSessionEstablishmentError"]
+    OnSessionEstablished [URL="@ref chip::SessionEstablishmentDelegate::OnSessionEstablished"]
   }
 
   #############################
@@ -78,6 +78,6 @@ digraph RendezvousSession
 
   HasConnectionObject -> WaitForPairing [label=NO]
 
-  OnPairingError -> OnRendezvousError
-  OnPairingComplete -> DeriveSecureSession -> OnRendezvousConnectionOpened
+  OnSessionEstablishmentError -> OnRendezvousError
+  OnSessionEstablished -> DeriveSecureSession -> OnRendezvousConnectionOpened
 }

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -22,7 +22,7 @@
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
 
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 
 // ================================================================================
 // Main Code

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -34,7 +34,7 @@
 
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/UDP.h>
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -35,7 +35,7 @@
 #include "InteractionModelEngine.h"
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/UDP.h>
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -239,7 +239,7 @@ void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader 
 CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SecurePairingSession pairingSession;
+    PASESession pairingSession;
 
     if (mSessionManager == nullptr || mState == ConnectionState::SecureConnected)
     {

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -31,7 +31,7 @@
 #include <core/CHIPCore.h>
 #include <support/Base64.h>
 #include <support/DLLUtil.h>
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/MessageHeader.h>
@@ -217,7 +217,7 @@ public:
 
     void SetAddress(const Inet::IPAddress & deviceAddr) { mDeviceAddr = deviceAddr; }
 
-    SecurePairingSessionSerializable & GetPairing() { return mPairing; }
+    PASESessionSerializable & GetPairing() { return mPairing; }
 
     void AddResponseHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onResponse);
     void AddReportHandler(EndpointId endpoint, ClusterId cluster, Callback::Callback<> * onReport);
@@ -258,7 +258,7 @@ private:
     bool mActive;
     ConnectionState mState;
 
-    SecurePairingSessionSerializable mPairing;
+    PASESessionSerializable mPairing;
 
     DeviceStatusDelegate * mStatusDelegate;
 
@@ -324,7 +324,7 @@ constexpr uint16_t kMaxInterfaceName = 32;
 
 typedef struct SerializableDevice
 {
-    SecurePairingSessionSerializable mOpsCreds;
+    PASESessionSerializable mOpsCreds;
     uint64_t mDeviceId; /* This field is serialized in LittleEndian byte order */
     uint8_t mDeviceAddr[INET6_ADDRSTRLEN];
     uint16_t mDevicePort; /* This field is serealized in LittelEndian byte order */

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -34,7 +34,7 @@
 #include <protocols/echo/Echo.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -34,7 +34,7 @@
 #include <protocols/echo/Echo.h>
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecurePairingSession.h>
+#include <transport/PASESession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -19,11 +19,12 @@ static_library("transport") {
   output_name = "libTransportLayer"
 
   sources = [
-    "AuthenticatedSessionEstablishmentDelegate.h",
-    "CertificateAuthenticatedSessionEstablishment.cpp",
-    "CertificateAuthenticatedSessionEstablishment.h",
+    "CASESession.cpp",
+    "CASESession.h",
     "NetworkProvisioning.cpp",
     "NetworkProvisioning.h",
+    "PASESession.cpp",
+    "PASESession.h",
     "PeerConnectionState.h",
     "PeerConnections.h",
     "RendezvousParameters.h",
@@ -32,12 +33,11 @@ static_library("transport") {
     "RendezvousSessionDelegate.h",
     "SecureMessageCodec.cpp",
     "SecureMessageCodec.h",
-    "SecurePairingSession.cpp",
-    "SecurePairingSession.h",
     "SecureSession.cpp",
     "SecureSession.h",
     "SecureSessionMgr.cpp",
     "SecureSessionMgr.h",
+    "SessionEstablishmentDelegate.h",
     "TransportMgr.cpp",
     "TransportMgr.h",
   ]

--- a/src/transport/CASESession.h
+++ b/src/transport/CASESession.h
@@ -29,9 +29,9 @@
 #include <protocols/secure_channel/Constants.h>
 #include <support/Base64.h>
 #include <system/SystemPacketBuffer.h>
-#include <transport/AuthenticatedSessionEstablishmentDelegate.h>
 #include <transport/PeerConnectionState.h>
 #include <transport/SecureSession.h>
+#include <transport/SessionEstablishmentDelegate.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -39,16 +39,16 @@ namespace chip {
 
 using namespace Crypto;
 
-class DLL_EXPORT CertificateAuthenticatedSessionEstablishment
+class DLL_EXPORT CASESession
 {
 public:
-    CertificateAuthenticatedSessionEstablishment();
-    CertificateAuthenticatedSessionEstablishment(CertificateAuthenticatedSessionEstablishment &&)      = default;
-    CertificateAuthenticatedSessionEstablishment(const CertificateAuthenticatedSessionEstablishment &) = default;
-    CertificateAuthenticatedSessionEstablishment & operator=(const CertificateAuthenticatedSessionEstablishment &) = default;
-    CertificateAuthenticatedSessionEstablishment & operator=(CertificateAuthenticatedSessionEstablishment &&) = default;
+    CASESession();
+    CASESession(CASESession &&)      = default;
+    CASESession(const CASESession &) = default;
+    CASESession & operator=(const CASESession &) = default;
+    CASESession & operator=(CASESession &&) = default;
 
-    virtual ~CertificateAuthenticatedSessionEstablishment();
+    virtual ~CASESession();
 
     /**
      * @brief
@@ -60,7 +60,7 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR WaitForSessionEstablishment(NodeId myNodeId, uint16_t myKeyId, AuthenticatedSessionEstablishmentDelegate * delegate);
+    CHIP_ERROR WaitForSessionEstablishment(NodeId myNodeId, uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -75,7 +75,7 @@ public:
      * @return CHIP_ERROR      The result of initialization
      */
     CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, NodeId myNodeId, NodeId peerNodeId, uint16_t myKeyId,
-                                AuthenticatedSessionEstablishmentDelegate * delegate);
+                                SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -151,7 +151,7 @@ private:
 
     void Clear();
 
-    AuthenticatedSessionEstablishmentDelegate * mDelegate = nullptr;
+    SessionEstablishmentDelegate * mDelegate = nullptr;
 
     Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::CASE_SigmaErr;
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -97,8 +97,9 @@ RendezvousSession::~RendezvousSession()
     mDelegate = nullptr;
 }
 
-CHIP_ERROR RendezvousSession::SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
-                                                 System::PacketBufferHandle msgIn)
+CHIP_ERROR RendezvousSession::SendSessionEstablishmentMessage(const PacketHeader & header,
+                                                              const Transport::PeerAddress & peerAddress,
+                                                              System::PacketBufferHandle msgIn)
 {
     if (mCurrentState != State::kSecurePairing)
     {
@@ -115,7 +116,7 @@ CHIP_ERROR RendezvousSession::SendPairingMessage(const PacketHeader & header, co
     }
     else
     {
-        ChipLogError(Ble, "SendPairingMessage dropped since no transport mgr for IP rendezvous");
+        ChipLogError(Ble, "SendSessionEstablishmentMessage dropped since no transport mgr for IP rendezvous");
         return CHIP_ERROR_INVALID_ADDRESS;
     }
 }
@@ -131,12 +132,12 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
     return mSecureSessionMgr->SendMessage(*mPairingSessionHandle, payloadHeader, std::move(msgBuf));
 }
 
-void RendezvousSession::OnPairingError(CHIP_ERROR err)
+void RendezvousSession::OnSessionEstablishmentError(CHIP_ERROR err)
 {
     OnRendezvousError(err);
 }
 
-void RendezvousSession::OnPairingComplete()
+void RendezvousSession::OnSessionEstablished()
 {
     CHIP_ERROR err =
         mSecureSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
@@ -191,7 +192,7 @@ void RendezvousSession::OnRendezvousConnectionOpened()
     CHIP_ERROR err = Pair(mParams.GetLocalNodeId(), mParams.GetSetupPINCode());
     if (err != CHIP_NO_ERROR)
     {
-        OnPairingError(err);
+        OnSessionEstablishmentError(err);
     }
 }
 

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -26,9 +26,9 @@
 #include <protocols/Protocols.h>
 #include <support/BufBound.h>
 #include <transport/NetworkProvisioning.h>
+#include <transport/PASESession.h>
 #include <transport/RendezvousParameters.h>
 #include <transport/RendezvousSessionDelegate.h>
-#include <transport/SecurePairingSession.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/PeerAddress.h>
@@ -63,7 +63,7 @@ class SecureSessionHandle;
  *
  * @dotfile dots/Rendezvous/RendezvousSessionInit.dot
  */
-class RendezvousSession : public AuthenticatedSessionEstablishmentDelegate,
+class RendezvousSession : public SessionEstablishmentDelegate,
                           public RendezvousSessionDelegate,
                           public RendezvousDeviceCredentialsDelegate,
                           public NetworkProvisioningDelegate,
@@ -96,18 +96,18 @@ public:
      * @brief
      *  Return the associated pairing session.
      *
-     * @return SecurePairingSession The associated pairing session
+     * @return PASESession The associated pairing session
      */
-    SecurePairingSession & GetPairingSession() { return mPairingSession; }
+    PASESession & GetPairingSession() { return mPairingSession; }
 
     Optional<NodeId> GetLocalNodeId() const { return mParams.GetLocalNodeId(); }
     Optional<NodeId> GetRemoteNodeId() const { return mParams.GetRemoteNodeId(); }
 
-    //////////// AuthenticatedSessionEstablishmentDelegate Implementation ///////////////
-    CHIP_ERROR SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
-                                  System::PacketBufferHandle msgBuf) override;
-    void OnPairingError(CHIP_ERROR err) override;
-    void OnPairingComplete() override;
+    //////////// SessionEstablishmentDelegate Implementation ///////////////
+    CHIP_ERROR SendSessionEstablishmentMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                               System::PacketBufferHandle msgBuf) override;
+    void OnSessionEstablishmentError(CHIP_ERROR err) override;
+    void OnSessionEstablished() override;
 
     //////////// RendezvousSessionDelegate Implementation ///////////////
     void OnRendezvousConnectionOpened() override;
@@ -151,7 +151,7 @@ private:
     RendezvousSessionDelegate * mDelegate = nullptr; ///< Underlying transport events
     RendezvousParameters mParams;                    ///< Rendezvous configuration
 
-    SecurePairingSession mPairingSession;
+    PASESession mPairingSession;
     NetworkProvisioning mNetworkProvision;
     Transport::PeerAddress mPeerAddress; // Current peer address we are doing rendezvous with.
     TransportMgrBase * mTransportMgr;

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -34,9 +34,9 @@
 #include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
+#include <transport/PASESession.h>
 #include <transport/RendezvousSession.h>
 #include <transport/SecureMessageCodec.h>
-#include <transport/SecurePairingSession.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 
@@ -213,8 +213,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                                        SecurePairingSession * pairing, Transport::Base * transport)
+CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PASESession * pairing,
+                                        Transport::Base * transport)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -32,8 +32,8 @@
 #include <inet/IPEndPointBasis.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
+#include <transport/PASESession.h>
 #include <transport/PeerConnections.h>
-#include <transport/SecurePairingSession.h>
 #include <transport/SecureSession.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/Base.h>
@@ -205,7 +205,7 @@ public:
      *   establishes the security keys for secure communication with the
      *   peer node.
      */
-    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, SecurePairingSession * pairing,
+    CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PASESession * pairing,
                           Transport::Base * transport = nullptr);
 
     /**

--- a/src/transport/SessionEstablishmentDelegate.h
+++ b/src/transport/SessionEstablishmentDelegate.h
@@ -31,7 +31,7 @@
 
 namespace chip {
 
-class DLL_EXPORT AuthenticatedSessionEstablishmentDelegate
+class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
     /**
@@ -45,8 +45,8 @@ public:
      *
      * TODO: Rename function as per issue: https://github.com/project-chip/connectedhomeip/issues/4468
      */
-    virtual CHIP_ERROR SendPairingMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
-                                          System::PacketBufferHandle msgBuf)
+    virtual CHIP_ERROR SendSessionEstablishmentMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                                       System::PacketBufferHandle msgBuf)
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
@@ -59,7 +59,7 @@ public:
      *
      * TODO: Rename function as per issue: https://github.com/project-chip/connectedhomeip/issues/4468
      */
-    virtual void OnPairingError(CHIP_ERROR error) {}
+    virtual void OnSessionEstablishmentError(CHIP_ERROR error) {}
 
     /**
      * @brief
@@ -67,9 +67,9 @@ public:
      *
      * TODO: Rename function as per issue: https://github.com/project-chip/connectedhomeip/issues/4468
      */
-    virtual void OnPairingComplete() {}
+    virtual void OnSessionEstablished() {}
 
-    virtual ~AuthenticatedSessionEstablishmentDelegate() {}
+    virtual ~SessionEstablishmentDelegate() {}
 };
 
 } // namespace chip

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -22,8 +22,8 @@ chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
   test_sources = [
+    "TestPASESession.cpp",
     "TestPeerConnections.cpp",
-    "TestSecurePairingSession.cpp",
     "TestSecureSession.cpp",
     "TestSecureSessionMgr.cpp",
   ]


### PR DESCRIPTION
 #### Problem
SecurePairingSession implements PASE protocol, as defined in CHIP specifications. The class name is not conveying the purpose of code.

 #### Summary of Changes
Rename the code and files as follows
1. SecurePairingSession -> PASESession
2. CertificateAuthenticatedSessionEstablishment -> CASESession
3. AuthenticatedSessionEstablishmentDelegate -> SessionEstablishmentDelegate
4. Rename functions in AuthenticatedSessionEstablishmentDelegate class

 Fixes #4468 
