### PR TITLE
ExchangeManager: inline DispatchMessage function

### DIFF
--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -184,9 +184,6 @@ private:
 
     ExchangeContext * AllocContext(uint16_t ExchangeId, SecureSessionHandle session, bool Initiator, ExchangeDelegate * delegate);
 
-    void DispatchMessage(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                         System::PacketBufferHandle msgBuf);
-
     CHIP_ERROR RegisterUMH(uint32_t protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(uint32_t protocolId, int16_t msgType);
 


### PR DESCRIPTION
The ExchangeManager::DispatchMessage is only used by
ExchangeManager::OnMessageReceived. inline this function will make
following PRs cleaner.

This is only a refactor.