### PR TITLE
Enclose Linux specific code in lightning-app/linux/main.cpp with CHIP…

### DIFF
--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -177,6 +177,7 @@ int main(int argc, char * argv[])
     // Init ZCL Data Model and CHIP App Server
     InitServer();
 
+#ifdef CHIP_DEVICE_LAYER_TARGET_LINUX
     if (LinuxDeviceOptions::GetInstance().mWiFi)
     {
         chip::DeviceLayer::ConnectivityMgrImpl().StartWiFiManagement();
@@ -186,6 +187,7 @@ int main(int argc, char * argv[])
     {
         chip::DeviceLayer::ThreadStackMgrImpl().InitThreadStack();
     }
+#endif
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 


### PR DESCRIPTION
…_DEVICE_LAYER_TARGET_LINUX

 #### Problem

The `lightning-app` use code specific to the Linux device layer. It prevent it to be compiled with the darwin specific device layer.

 #### Summary of Changes
 * Enclose the Linux specific code with `CHIP_DEVICE_LAYER_TARGET_LINUX`
 Fixes #4472