### PR TITLE
Removed logs from the configuration manager getter methods.

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -132,14 +132,14 @@ int AppTask::Init()
     sLightLED.Set(LightMgr().IsLightOn());
     UpdateClusterState();
 
+    ConfigurationMgr().LogDeviceConfig();
+
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    uint32_t setupPinCode;
     std::string QRCode;
 
-    if (GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE) == CHIP_NO_ERROR)
+    if (GetQRCode(QRCode, chip::RendezvousInformationFlags::kBLE) == CHIP_NO_ERROR)
     {
-        EFR32_LOG("SetupPINCode: [%09u]", setupPinCode);
         LCDWriteQRCode((uint8_t *) QRCode.c_str());
     }
     else

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -112,6 +112,7 @@ int AppTask::Init()
 
     // Init ZCL Data Model and start server
     InitServer();
+    ConfigurationMgr().LogDeviceConfig();
     PrintQRCode(chip::RendezvousInformationFlags::kBLE);
 
 #ifdef CONFIG_CHIP_NFC_COMMISSIONING
@@ -436,10 +437,9 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 int AppTask::StartNFCTag()
 {
     // Get QR Code and emulate its content using NFC tag
-    uint32_t setupPinCode;
     std::string QRCode;
 
-    int result = GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE);
+    int result = GetQRCode(QRCode, chip::RendezvousInformationFlags::kBLE);
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -132,14 +132,14 @@ int AppTask::Init()
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
     UpdateClusterState();
 
+    ConfigurationMgr().LogDeviceConfig();
+
     // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    uint32_t setupPinCode;
     std::string QRCode;
 
-    if (GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE) == CHIP_NO_ERROR)
+    if (GetQRCode(QRCode, chip::RendezvousInformationFlags::kBLE) == CHIP_NO_ERROR)
     {
-        EFR32_LOG("SetupPINCode: [%09u]", setupPinCode);
         LCDWriteQRCode((uint8_t *) QRCode.c_str());
     }
     else

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -104,6 +104,7 @@ int AppTask::Init()
 
     // Init ZCL Data Model and start server
     InitServer();
+    ConfigurationMgr().LogDeviceConfig();
     PrintQRCode(chip::RendezvousInformationFlags::kBLE);
 
 #ifdef CONFIG_CHIP_NFC_COMMISSIONING
@@ -438,10 +439,9 @@ void AppTask::StartTimer(uint32_t aTimeoutInMs)
 int AppTask::StartNFCTag()
 {
     // Get QR Code and emulate its content using NFC tag
-    uint32_t setupPinCode;
     std::string QRCode;
 
-    int result = GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE);
+    int result = GetQRCode(QRCode, chip::RendezvousInformationFlags::kBLE);
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());

--- a/examples/lock-app/qpg6100/src/AppTask.cpp
+++ b/examples/lock-app/qpg6100/src/AppTask.cpp
@@ -104,6 +104,7 @@ int AppTask::Init()
     InitServer();
     UpdateClusterState();
 
+    ConfigurationMgr().LogDeviceConfig();
     PrintQRCode(chip::RendezvousInformationFlags::kBLE);
 
     return err;

--- a/src/app/server/QRCodeUtil.cpp
+++ b/src/app/server/QRCodeUtil.cpp
@@ -31,16 +31,14 @@ constexpr char specialCharsUnreservedInRfc3986[] = "-._~";
 
 void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags)
 {
-    uint32_t setupPinCode;
     std::string QRCode;
 
-    if (GetQRCode(setupPinCode, QRCode, rendezvousFlags) == CHIP_NO_ERROR)
+    if (GetQRCode(QRCode, rendezvousFlags) == CHIP_NO_ERROR)
     {
         chip::Platform::ScopedMemoryBuffer<char> qrCodeBuffer;
         const size_t qrCodeBufferMaxSize = 3 * QRCode.size() + 1;
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
-        ChipLogProgress(AppServer, "SetupPINCode: [%" PRIu32 "]", setupPinCode);
         ChipLogProgress(AppServer, "SetupQRCode:  [%s]", QRCode.c_str());
         if (EncodeQRCodeToUrl(QRCode.c_str(), QRCode.size(), &qrCodeBuffer[0], qrCodeBufferMaxSize) == CHIP_NO_ERROR)
         {
@@ -54,7 +52,7 @@ void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags)
     }
 }
 
-CHIP_ERROR GetQRCode(uint32_t & setupPinCode, std::string & QRCode, chip::RendezvousInformationFlags rendezvousFlags)
+CHIP_ERROR GetQRCode(std::string & QRCode, chip::RendezvousInformationFlags rendezvousFlags)
 {
     using namespace ::chip::DeviceLayer;
 
@@ -67,7 +65,6 @@ CHIP_ERROR GetQRCode(uint32_t & setupPinCode, std::string & QRCode, chip::Rendez
     err = ConfigurationMgr().GetSetupPinCode(payload.setUpPINCode);
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogProgress(AppServer, "ConfigurationMgr().GetSetupPinCode() failed: %s", chip::ErrorStr(err)));
-    setupPinCode = payload.setUpPINCode;
 
     err = ConfigurationMgr().GetSetupDiscriminator(payload.discriminator);
     VerifyOrExit(err == CHIP_NO_ERROR,

--- a/src/app/server/QRCodeUtil.h
+++ b/src/app/server/QRCodeUtil.h
@@ -20,7 +20,7 @@
 #include <setup_payload/SetupPayload.h>
 
 void PrintQRCode(chip::RendezvousInformationFlags rendezvousFlags);
-CHIP_ERROR GetQRCode(uint32_t & setupPinCode, std::string & QRCode, chip::RendezvousInformationFlags rendezvousFlags);
+CHIP_ERROR GetQRCode(std::string & QRCode, chip::RendezvousInformationFlags rendezvousFlags);
 
 /**
  * Initialize DataModelHandler and start CHIP datamodel server, the server

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -132,6 +132,8 @@ public:
 
     CHIP_ERROR ComputeProvisioningHash(uint8_t * hashBuf, size_t hashBufSize);
 
+    void LogDeviceConfig();
+
 private:
     // ===== Members for internal use by the following friends.
 
@@ -538,5 +540,11 @@ inline void ConfigurationManager::UseManufacturerCredentialsAsOperational(bool v
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+
+inline void ConfigurationManager::LogDeviceConfig()
+{
+    static_cast<ImplClass *>(this)->_LogDeviceConfig();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ConfigureChipStack()
 
 #if CHIP_PROGRESS_LOGGING
 
-    Impl()->LogDeviceConfig();
+    Impl()->_LogDeviceConfig();
 
 #if CHIP_DEVICE_CONFIG_LOG_PROVISIONING_HASH
     {
@@ -193,7 +193,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSerialNumber(char * b
         VerifyOrExit(sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER) <= bufSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
         memcpy(buf, CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER, sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER));
         serialNumLen = sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER) - 1;
-        ChipLogProgress(DeviceLayer, "Serial Number not found; using default: %s", CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER);
         err = CHIP_NO_ERROR;
     }
 #endif // CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER
@@ -324,7 +323,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetManufacturerDeviceCer
         certLen = TestDeviceCertLength;
         VerifyOrExit(buf != NULL, err = CHIP_NO_ERROR);
         VerifyOrExit(TestDeviceCertLength <= bufSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
-        ChipLogProgress(DeviceLayer, "Device certificate not found; using default");
         memcpy(buf, TestDeviceCert, TestDeviceCertLength);
         err = CHIP_NO_ERROR;
     }
@@ -358,7 +356,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetManufacturerDeviceInt
         certsLen = TestDeviceIntermediateCACertLength;
         VerifyOrExit(buf != NULL, err = CHIP_NO_ERROR);
         VerifyOrExit(TestDeviceIntermediateCACertLength <= bufSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
-        ChipLogProgress(DeviceLayer, "Device certificate not found; using default");
         memcpy(buf, TestDeviceIntermediateCACert, TestDeviceIntermediateCACertLength);
         err = CHIP_NO_ERROR;
     }
@@ -393,7 +390,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetManufacturerDevicePri
         keyLen = TestDevicePrivateKeyLength;
         VerifyOrExit(buf != NULL, err = CHIP_NO_ERROR);
         VerifyOrExit(TestDevicePrivateKeyLength <= bufSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
-        ChipLogProgress(DeviceLayer, "Device private key not found; using default");
         memcpy(buf, TestDevicePrivateKey, TestDevicePrivateKeyLength);
         err = CHIP_NO_ERROR;
     }
@@ -558,7 +554,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupPinCode(uint32_t
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         setupPinCode = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE;
-        ChipLogProgress(DeviceLayer, "Setup PIN code not found; using default: %09u", CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE);
         err = CHIP_NO_ERROR;
     }
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
@@ -585,8 +580,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupDiscriminator(ui
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         val = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR;
-        ChipLogProgress(DeviceLayer, "Setup PIN discriminator not found; using default: %03x",
-                        CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR);
         err = CHIP_NO_ERROR;
     }
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR
@@ -1025,10 +1018,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_RunUnitTests()
 }
 #endif
 
-#if CHIP_PROGRESS_LOGGING
-
 template <class ImplClass>
-void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
+void GenericConfigurationManagerImpl<ImplClass>::_LogDeviceConfig()
 {
     CHIP_ERROR err;
 
@@ -1073,6 +1064,24 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
     }
 
     {
+        uint32_t setupPINCode;
+        if (Impl()->_GetSetupPinCode(setupPINCode) != CHIP_NO_ERROR)
+        {
+            setupPINCode = 0;
+        }
+        ChipLogProgress(DeviceLayer, "  Setup Pin Code: %" PRIu32 "", setupPINCode);
+    }
+
+    {
+        uint16_t setupDiscriminator;
+        if (Impl()->_GetSetupDiscriminator(setupDiscriminator) != CHIP_NO_ERROR)
+        {
+            setupDiscriminator = 0;
+        }
+        ChipLogProgress(DeviceLayer, "  Setup Discriminator: %" PRIu16 " (0x%" PRIX16 ")", setupDiscriminator, setupDiscriminator);
+    }
+
+    {
         uint16_t year;
         uint8_t month, dayOfMonth;
         err = Impl()->_GetManufacturingDate(year, month, dayOfMonth);
@@ -1099,8 +1108,6 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
     ChipLogProgress(DeviceLayer, "  Pairing Code: %s", (FabricState.PairingCode != NULL) ? FabricState.PairingCode : "(none)");
 #endif // CHIP_CONFIG_ENABLE_FABRIC_STATE
 }
-
-#endif // CHIP_PROGRESS_LOGGING
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.
 template class GenericConfigurationManagerImpl<ConfigurationManagerImpl>;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSerialNumber(char * b
         VerifyOrExit(sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER) <= bufSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
         memcpy(buf, CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER, sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER));
         serialNumLen = sizeof(CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER) - 1;
-        err = CHIP_NO_ERROR;
+        err          = CHIP_NO_ERROR;
     }
 #endif // CHIP_DEVICE_CONFIG_USE_TEST_SERIAL_NUMBER
     SuccessOrExit(err);
@@ -554,7 +554,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetSetupPinCode(uint32_t
     if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         setupPinCode = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE;
-        err = CHIP_NO_ERROR;
+        err          = CHIP_NO_ERROR;
     }
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
     SuccessOrExit(err);

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -114,6 +114,7 @@ public:
     bool _OperationalDeviceCredentialsProvisioned();
     void _UseManufacturerCredentialsAsOperational(bool val);
 #endif
+    void _LogDeviceConfig();
 
 protected:
     enum
@@ -127,7 +128,6 @@ protected:
 
     uint8_t mFlags;
 
-    void LogDeviceConfig();
     CHIP_ERROR PersistProvisioningData(ProvisioningDataSet & provData);
 
 private:


### PR DESCRIPTION
 #### Problem
Getter methods of the Configuration Manager contain logs, what results in printing the same logs multiple times on the console.

 #### Summary of Changes
* Removed logs from Configuration Manager getter methods
* Added printing information about setup pin code and setup discriminator to the LogDeviceConfig() method
* Removed if CHIP_PROGRESS_LOGGING condition before LogDeviceConfig() implementation, as it should be checked before calling it (and is already used there)
* Created interface to the LogDeviceConfig() to allow using it in samples
* Removed returning setupPinCode from the QRCodeUtil::GetQRCode() method.
* Removed printing setup pin code from the PrintQRCode method().
* Aligned nrfconnect, EFR32 and QPG6100 samples, because of the QRCodeUtil API changes.