### PR TITLE
Align NFC URI format in Android CHIP Tool and nrfconnect firmware to the iOS.

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -47,6 +47,8 @@
 #include <logging/log.h>
 #include <zephyr.h>
 
+#include <algorithm>
+
 LOG_MODULE_DECLARE(app);
 
 namespace {
@@ -441,6 +443,9 @@ int AppTask::StartNFCTag()
 
     int result = GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE);
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
+
+    // TODO: Issue #4504 - Remove replacing spaces with _ after problem described in #415 will be fixed.
+    std::replace(QRCode.begin(), QRCode.end(), ' ', '_');
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());
     VerifyOrExit(result >= 0, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -42,6 +42,8 @@
 #include <setup_payload/SetupPayload.h>
 #include <zephyr.h>
 
+#include <algorithm>
+
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000
 #define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000
 #define APP_EVENT_QUEUE_SIZE 10
@@ -443,6 +445,9 @@ int AppTask::StartNFCTag()
 
     int result = GetQRCode(setupPinCode, QRCode, chip::RendezvousInformationFlags::kBLE);
     VerifyOrExit(!result, ChipLogError(AppServer, "Getting QR code payload failed"));
+
+    // TODO: Issue #4504 - Remove replacing spaces with _ after problem described in #415 will be fixed.
+    std::replace(QRCode.begin(), QRCode.end(), ' ', '_');
 
     result = sNFC.StartTagEmulation(QRCode.c_str(), QRCode.size());
     VerifyOrExit(result >= 0, ChipLogError(AppServer, "Starting NFC Tag emulation failed"));

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -145,7 +145,8 @@ class CHIPToolActivity :
     val uri = records[0].toUri()
     if (!uri?.scheme.equals("ch", true)) return
 
-    val setupPayload = SetupPayloadParser().parseQrCode(uri.toString().toUpperCase())
+    // TODO: Issue #4504 - Remove replacing _ with spaces after problem described in #415 will be fixed.
+    val setupPayload = SetupPayloadParser().parseQrCode(uri.toString().toUpperCase().replace('_', ' '))
     val deviceInfo = CHIPDeviceInfo(
         setupPayload.version,
         setupPayload.vendorId,


### PR DESCRIPTION
 #### Problem
There is a discussion on the CHIP-Specifications/connectedhomeip-spec#415 about need of replacing spaces with _ in the NFC URI, but it is not fixed yet. Currently iOS CHIP Tool is expecting _ characters, while other Android and nrfconnect platforms are still using spaces.

 #### Summary of Changes
* Added replacing _ with spaces in NFC payload for the Android CHIP Tool
* Added replacing spaces with _ in NFC payload for nrfconnect samples

 Fixes #4497