### PR TITLE
Synchronize pw_log, pw_rpc response and SDK logs

### DIFF
--- a/examples/common/pigweed/RpcService.cpp
+++ b/examples/common/pigweed/RpcService.cpp
@@ -1,0 +1,134 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "RpcService.h"
+
+#include <array>
+#include <span>
+#include <string_view>
+
+#include "pw_hdlc/rpc_channel.h"
+#include "pw_hdlc/rpc_packets.h"
+#include "pw_log/log.h"
+#include "pw_rpc/channel.h"
+#include "pw_status/status.h"
+#include "pw_stream/sys_io_stream.h"
+#include "pw_sys_io/sys_io.h"
+
+#include "logging/CHIPLogging.h"
+
+#include <array>
+
+namespace chip {
+namespace rpc {
+namespace {
+
+using std::byte;
+
+constexpr size_t kMaxTransmissionUnit = 1500;
+
+// Used to write HDLC data to pw::sys_io.
+pw::stream::SysIoWriter writer;
+
+// May be nullptr
+::chip::rpc::Mutex * uart_mutex;
+
+template <size_t buffer_size>
+class ChipRpcChannelOutputBuffer : public pw::rpc::ChannelOutput
+{
+public:
+    constexpr ChipRpcChannelOutputBuffer(pw::stream::Writer & writer, uint8_t address, const char * channel_name) :
+        pw::rpc::ChannelOutput(channel_name), mWriter(writer), mAddress(address)
+    {}
+
+    std::span<std::byte> AcquireBuffer() override
+    {
+        if (uart_mutex)
+        {
+            uart_mutex->Lock();
+        }
+        return mBuffer;
+    }
+
+    pw::Status SendAndReleaseBuffer(std::span<const std::byte> buffer) override
+    {
+        PW_DASSERT(buffer.data() == mBuffer.data());
+        if (buffer.empty())
+        {
+            if (uart_mutex)
+            {
+                uart_mutex->Unlock();
+            }
+            return pw::OkStatus();
+        }
+        pw::Status ret = pw::hdlc::WriteUIFrame(mAddress, buffer, mWriter);
+        if (uart_mutex)
+        {
+            uart_mutex->Unlock();
+        }
+        return ret;
+    }
+
+private:
+    pw::stream::Writer & mWriter;
+    std::array<std::byte, buffer_size> mBuffer;
+    const uint8_t mAddress;
+};
+
+// Set up the output channel for the pw_rpc server to use to use.
+ChipRpcChannelOutputBuffer<kMaxTransmissionUnit> hdlc_channel_output(writer, pw::hdlc::kDefaultRpcAddress, "HDLC channel");
+
+pw::rpc::Channel channels[] = { pw::rpc::Channel::Create<1>(&hdlc_channel_output) };
+
+// pw_rpc server with the HDLC channel.
+pw::rpc::Server server(channels);
+
+} // namespace
+
+void Start(void (*RegisterServices)(pw::rpc::Server &), ::chip::rpc::Mutex * uart_mutex_)
+{
+    PW_DASSERT(uart_mutex_ != nullptr);
+    PW_DASSERT(RegisterServices != nullptr);
+    uart_mutex = uart_mutex_;
+
+    // Send log messages to HDLC address 1. This prevents logs from interfering
+    // with pw_rpc communications.
+    pw::log_basic::SetOutput([](std::string_view log) {
+        if (uart_mutex)
+        {
+            uart_mutex->Lock();
+        }
+        pw::hdlc::WriteUIFrame(1, std::as_bytes(std::span(log)), writer);
+        if (uart_mutex)
+        {
+            uart_mutex->Unlock();
+        }
+    });
+
+    // Set up the server and start processing data.
+    RegisterServices(server);
+
+    // Declare a buffer for decoding incoming HDLC frames.
+    std::array<std::byte, kMaxTransmissionUnit> input_buffer;
+
+    Logging::Log(Logging::kLogModule_NotSpecified, Logging::kLogCategory_Detail, "Starting pw_rpc server");
+    pw::hdlc::ReadAndProcessPackets(server, hdlc_channel_output, input_buffer);
+}
+
+} // namespace rpc
+} // namespace chip

--- a/examples/common/pigweed/RpcService.h
+++ b/examples/common/pigweed/RpcService.h
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "pw_rpc/server.h"
+
+namespace chip {
+namespace rpc {
+
+class Mutex
+{
+public:
+    virtual void Lock()   = 0;
+    virtual void Unlock() = 0;
+};
+
+void Start(void (*RegisterServices)(pw::rpc::Server &), ::chip::rpc::Mutex * uart_mutex_);
+
+} // namespace rpc
+} // namespace chip

--- a/examples/common/pigweed/system_rpc_server.cc
+++ b/examples/common/pigweed/system_rpc_server.cc
@@ -12,6 +12,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// THIS FILE IS DEPRECATED, keep only until examples/pigweed-app depends on
+// third_party/pigweed/repo/pw_hdlc/rpc_example/hdlc_rpc_server.cc
+
 #include <cstddef>
 
 #include "pw_hdlc/rpc_channel.h"

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -89,12 +89,16 @@ pw_proto_library(pigweed_lighting_protolib
 
 target_sources(app PRIVATE
   main/Rpc.cpp
+  ../../common/pigweed/RpcService.cpp
   ${NRFCONNECT_COMMON}/util/PigweedLogger.cpp
 )
 
 target_include_directories(app PRIVATE
   ${ZEPHYR_BASE}/subsys // required to get access to `log_output_std.h`
-)
+  ${PIGWEED_ROOT}/pw_sys_io/public
+  ${CHIP_ROOT}/src/lib/support
+  ${CHIP_ROOT}/src/system
+  ../../common)
 
 target_link_libraries(app PRIVATE
   pigweed_lighting_protolib.nanopb_rpc

--- a/examples/platform/nrfconnect/util/PigweedLogger.cpp
+++ b/examples/platform/nrfconnect/util/PigweedLogger.cpp
@@ -146,4 +146,14 @@ LOG_BACKEND_DEFINE(pigweedLogBackend, pigweedLogApi, /* autostart */ true);
 #endif // CONFIG_LOG
 
 } // namespace
+
+k_sem * GetSemaphore()
+{
+#if CONFIG_LOG
+    return &sLoggerLock;
+#else
+    return nullptr;
+#endif
+}
+
 } // namespace PigweedLogger

--- a/examples/platform/nrfconnect/util/include/PigweedLogger.h
+++ b/examples/platform/nrfconnect/util/include/PigweedLogger.h
@@ -1,0 +1,26 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <kernel.h>
+
+namespace PigweedLogger {
+
+k_sem * GetSemaphore();
+
+} // namespace PigweedLogger


### PR DESCRIPTION
 #### Problem

Pigweed logs, RPC responses and SDK logs all compete for the
underlying transport (e.g. UART). Synchronization and locking is
needed.

 #### Summary of Changes

This change introduces examples/common/pigweed/RpcService.{cpp,h}
that uses a synchronized logging and rpc response mechanism. In addition, its interface is open to adding arbitrary RPC services to be served by the same RPC server.

For nrfconnect, the existing SDK logging over pw_log (actually, pw_hdlc) is also added among the synchronization targets.

Fixes: #4489