### PR TITLE
[ExchangeManager] Pass SecureSession messages and events to old SecureSession delegates

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -65,7 +65,8 @@ ExchangeManager::ExchangeManager() : mReliableMessageMgr(mContextPool)
     mState = State::kState_NotInitialized;
 }
 
-CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr, SecureSessionMgrDelegate * legacySecureSessionEventReceiver)
+CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
+                                 SecureSessionMgrDelegate * legacySecureSessionEventReceiver)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -70,7 +70,8 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr, SecureSessionMgrDelegate * legacySecureSessionEventReceiver = nullptr);
+    CHIP_ERROR Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
+                    SecureSessionMgrDelegate * legacySecureSessionEventReceiver = nullptr);
 
     /**
      *  Shutdown the ExchangeManager. This terminates this instance


### PR DESCRIPTION
 #### Problem

#5011 Need a solution to pass messages and events to old secure session delegates.

For now, we have two secure session delegates in CHIP, one is the DeviceController (in src/controller) and the other is AppServer (in src/app/server), they are not migrated to Message Layer yet, and we need a method to make it work after we enable the exchange manager but before fully deprecate them.

#### Changes

Before fully migrated to messaging layer, there are lots of components depending on SecureSessionMgrDelegate events. Allow these components continuing receives these events to keep it compatible. Once we have fully migrated to the messaging layer, we can safely use mechanism provided by messaging layer to replace there events.

This PR will make it possible for supporting both interaction model (over exchange context) and current ZCL messages at the same time on device and controller.