### PR TITLE
Fix issue with building chip-build docker image.

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -70,7 +70,7 @@ RUN set -x \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
     && add-apt-repository universe \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y python python2 \
-    && curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py \
+    && curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py \
     && python2 get-pip.py \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line


### PR DESCRIPTION
There is an error when docker tries to execute 
https://bootstrap.pypa.io/get-pip.py script by using python2.7

Starting from pip version 21.0 (released in January 2021), 
support for python 2 has been dropped (https://pypi.org/project/pip/).

To solve this problem, link used to download get-pip.py script has to be replaced with the other one,
which points to python2.7 compatible version.

 #### Problem
Building **integration/docker/images/chip-build** docker image failed after pip v21.0 has been released.
```
+ curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1883k  100 1883k    0     0  1317k      0  0:00:01  0:00:01 --:--:-- 1316k
+ python2 get-pip.py
Traceback (most recent call last):
  File "get-pip.py", line 24226, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpn0P0xD/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```


 #### Summary of Changes
Replace link used to download get-pip.py script.