### PR TITLE
Fix RPC builds after recent Pigweed rollup

### DIFF
--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -130,6 +130,7 @@ install-chip : $(OUTPUT_DIR)
 	  echo "pw_log_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic\"" >> $(OUTPUT_DIR)/args.gn     ;\
 	  echo "pw_assert_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log\"" >> $(OUTPUT_DIR)/args.gn ;\
 	  echo "pw_sys_io_BACKEND = \"//third_party/connectedhomeip/examples/platform/esp32/pw_sys_io:pw_sys_io_esp32\"" >> $(OUTPUT_DIR)/args.gn      ;\
+	  echo "pw_rpc_system_server_BACKEND = \"//third_party/connectedhomeip/examples/common/pigweed:system_rpc_server\"" >> $(OUTPUT_DIR)/args.gn      ;\
 	  echo "dir_pw_third_party_nanopb = \"//third_party/connectedhomeip/third_party/nanopb/repo\"" >>$(OUTPUT_DIR)/args.gn         ;\
 	fi
 	echo "Written file $(OUTPUT_DIR)/args.gn"

--- a/config/esp32/lib/pw_rpc/BUILD.gn
+++ b/config/esp32/lib/pw_rpc/BUILD.gn
@@ -19,16 +19,16 @@ import("$dir_pw_build/target_types.gni")
 static_library("pw_rpc") {
   output_name = "libPwRpc"
 
-  public_configs = [ "${dir_pigweed}/pw_hdlc_lite:default_config" ]
-  sources = [ "${dir_pigweed}/pw_hdlc_lite/rpc_example/hdlc_rpc_server.cc" ]
+  public_configs = [ "${dir_pigweed}/pw_hdlc:default_config" ]
+  sources = [ "${dir_pigweed}/pw_hdlc/rpc_example/hdlc_rpc_server.cc" ]
   deps = [
     "$dir_pw_rpc:server",
     "$dir_pw_rpc/nanopb:echo_service",
-    "$dir_pw_rpc/system_server:sys_io",
+    "$dir_pw_rpc/system_server",
     "${chip_root}/examples/platform/esp32/pw_sys_io:pw_sys_io_esp32",
-    "${dir_pigweed}/pw_hdlc_lite:pw_rpc",
+    "${dir_pigweed}/pw_hdlc:pw_rpc",
     dir_pw_assert,
-    dir_pw_hdlc_lite,
+    dir_pw_hdlc,
     dir_pw_log,
   ]
 

--- a/config/nrfconnect/chip-gn/BUILD.gn
+++ b/config/nrfconnect/chip-gn/BUILD.gn
@@ -38,7 +38,7 @@ group("nrfconnect") {
   # Building PW_RPC lib with GN may go obsolete after getting full CMake
   # support in Pigweed.
   if (chip_build_pw_rpc_lib) {
-    deps += [ "//lib/pw_rpc" ]
+    deps += [ "lib/pw_rpc" ]
   }
 }
 

--- a/config/nrfconnect/chip-gn/lib/pw_rpc/pw_rpc.gni
+++ b/config/nrfconnect/chip-gn/lib/pw_rpc/pw_rpc.gni
@@ -19,10 +19,7 @@ pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/nrfconnect/pw_sys_io:pw_sys_io_nrfconnect"
-pw_rpc_system_server_BACKEND = "$dir_pw_rpc/system_server:sys_io"
+pw_rpc_system_server_BACKEND =
+    "${chip_root}/examples/common/pigweed:system_rpc_server"
 
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
-pw_protobuf_GENERATORS = [
-  "pwpb",
-  "nanopb_rpc",
-]

--- a/examples/common/pigweed/BUILD.gn
+++ b/examples/common/pigweed/BUILD.gn
@@ -12,27 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("$dir_pw_build/target_types.gni")
 
-static_library("pw_rpc") {
-  output_name = "libPwRpc"
-
-  public_configs = [ "${dir_pigweed}/pw_hdlc:default_config" ]
-  sources = [ "${dir_pigweed}/pw_hdlc/rpc_example/hdlc_rpc_server.cc" ]
+pw_source_set("system_rpc_server") {
   deps = [
-    "$dir_pw_rpc:server",
-    "$dir_pw_rpc/nanopb:echo_service",
-    "$dir_pw_rpc/system_server",
-    "${chip_root}/examples/platform/nrfconnect/pw_sys_io:pw_sys_io_nrfconnect",
-    "${dir_pigweed}/pw_hdlc:pw_rpc",
-    dir_pw_assert,
-    dir_pw_hdlc,
+    "$dir_pw_hdlc:pw_rpc",
+    "$dir_pw_hdlc:rpc_channel_output",
+    "$dir_pw_rpc/system_server:facade",
+    "$dir_pw_stream:sys_io_stream",
     dir_pw_log,
   ]
-
-  output_dir = "${root_out_dir}/lib"
-
-  complete_static_lib = true
+  sources = [ "system_rpc_server.cc" ]
 }

--- a/examples/common/pigweed/system_rpc_server.cc
+++ b/examples/common/pigweed/system_rpc_server.cc
@@ -1,0 +1,76 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+#include <cstddef>
+
+#include "pw_hdlc/rpc_channel.h"
+#include "pw_hdlc/rpc_packets.h"
+#include "pw_log/log.h"
+#include "pw_rpc_system_server/rpc_server.h"
+#include "pw_stream/sys_io_stream.h"
+
+namespace pw::rpc::system_server {
+namespace {
+
+constexpr size_t kMaxTransmissionUnit = 256;
+
+// Used to write HDLC data to pw::sys_io.
+stream::SysIoWriter writer;
+stream::SysIoReader reader;
+
+// Set up the output channel for the pw_rpc server to use.
+hdlc::RpcChannelOutputBuffer<kMaxTransmissionUnit> hdlc_channel_output(writer, pw::hdlc::kDefaultRpcAddress, "HDLC channel");
+Channel channels[] = { pw::rpc::Channel::Create<1>(&hdlc_channel_output) };
+rpc::Server server(channels);
+
+} // namespace
+
+void Init()
+{
+    // Send log messages to HDLC address 1. This prevents logs from interfering
+    // with pw_rpc communications.
+    pw::log_basic::SetOutput([](std::string_view log) { pw::hdlc::WriteUIFrame(1, std::as_bytes(std::span(log)), writer); });
+}
+
+rpc::Server & Server()
+{
+    return server;
+}
+
+Status Start()
+{
+    // Declare a buffer for decoding incoming HDLC frames.
+    std::array<std::byte, kMaxTransmissionUnit> input_buffer;
+    hdlc::Decoder decoder(input_buffer);
+
+    while (true)
+    {
+        std::byte byte;
+        Status ret_val = pw::sys_io::ReadByte(&byte);
+        if (!ret_val.ok())
+        {
+            return ret_val;
+        }
+        if (auto result = decoder.Process(byte); result.ok())
+        {
+            hdlc::Frame & frame = result.value();
+            if (frame.address() == hdlc::kDefaultRpcAddress)
+            {
+                server.ProcessPacket(frame.data(), hdlc_channel_output);
+            }
+        }
+    }
+}
+
+} // namespace pw::rpc::system_server

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -29,10 +29,10 @@ project(chip-nrf52840-lighting-example)
 
 zephyr_compile_options(-Werror)
 
-target_include_directories(app PRIVATE 
-                           main/include 
-                           ${LIGHTING_COMMON} 
-                           ${NRFCONNECT_COMMON}/util/include 
+target_include_directories(app PRIVATE
+                           main/include
+                           ${LIGHTING_COMMON}
+                           ${NRFCONNECT_COMMON}/util/include
                            ${NRFCONNECT_COMMON}/app/include)
 
 target_sources(app PRIVATE
@@ -98,7 +98,7 @@ target_include_directories(app PRIVATE
 
 target_link_libraries(app PRIVATE
   pigweed_lighting_protolib.nanopb_rpc
-  pw_hdlc_lite
+  pw_hdlc
   pw_log
   pw_rpc.server
 )

--- a/examples/lighting-app/nrfconnect/main/Rpc.cpp
+++ b/examples/lighting-app/nrfconnect/main/Rpc.cpp
@@ -20,8 +20,8 @@
 #include "AppTask.h"
 
 #include "main/pigweed_lighting.rpc.pb.h"
-#include "pw_hdlc_lite/rpc_channel.h"
-#include "pw_hdlc_lite/rpc_packets.h"
+#include "pw_hdlc/rpc_channel.h"
+#include "pw_hdlc/rpc_packets.h"
 #include "pw_rpc/server.h"
 #include "pw_stream/sys_io_stream.h"
 #include "pw_sys_io/sys_io.h"
@@ -42,7 +42,7 @@ public:
     pw::Status ButtonEvent(ServerContext & ctx, const chip_rpc_Button & request, chip_rpc_Empty & response)
     {
         GetAppTask().ButtonEventHandler(request.action << request.idx /* button_state */, 1 << request.idx /* has_changed */);
-        return pw::Status::OK;
+        return pw::OkStatus();
     }
 };
 
@@ -61,8 +61,7 @@ struct k_thread rpc_thread_data;
 pw::stream::SysIoWriter writer;
 
 // Set up the output channel for the pw_rpc server to use.
-pw::hdlc_lite::RpcChannelOutputBuffer<kMaxTransmissionUnit> hdlc_channel_output(writer, pw::hdlc_lite::kDefaultRpcAddress,
-                                                                                "HDLC channel");
+pw::hdlc::RpcChannelOutputBuffer<kMaxTransmissionUnit> hdlc_channel_output(writer, pw::hdlc::kDefaultRpcAddress, "HDLC channel");
 
 pw::rpc::Channel channels[] = { pw::rpc::Channel::Create<1>(&hdlc_channel_output) };
 
@@ -85,7 +84,7 @@ void Start()
     std::array<std::byte, kMaxTransmissionUnit> input_buffer;
 
     LOG_INF("Starting pw_rpc server");
-    pw::hdlc_lite::ReadAndProcessPackets(server, hdlc_channel_output, input_buffer);
+    pw::hdlc::ReadAndProcessPackets(server, hdlc_channel_output, input_buffer);
 }
 
 } // namespace

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -21,7 +21,7 @@ following features are available:
 
 ---
 
--   [Pigweed RPC Example](#chip-pigweed-rpc-example)
+-   [CHIP ESP32 Pigweed Example Application](#chip-esp32-pigweed-example-application)
     -   [Building the Example Application](#building-the-example-application)
         -   [To build the application, follow these steps:](#to-build-the-application-follow-these-steps)
     -   [Testing the Example Application](#testing-the-example-application)
@@ -101,7 +101,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 Run the following command to start an interactive Python shell, where the Echo
 RPC commands can be invoked:
 
-        python -m pw_hdlc_lite.rpc_console --device /dev/tty.SLAB_USBtoUART -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/pw_rpc_protos/echo.proto -o /tmp/pw_rpc.out
+        python -m pw_hdlc.rpc_console --device /dev/tty.SLAB_USBtoUART -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/pw_rpc_protos/echo.proto -o /tmp/pw_rpc.out
 
 To send an Echo RPC message, type the following command, where the actual
 message is the text in quotation marks after the `msg=` phrase:

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -317,7 +317,7 @@ to read more about flashing on the nRF52840 Dongle.
 Run the following command to start an interactive Python shell, where the Echo
 RPC commands can be invoked:
 
-        python -m pw_hdlc_lite.rpc_console --device /dev/ttyACM0 -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/pw_rpc_protos/echo.proto -o /tmp/pw_rpc.out
+        python -m pw_hdlc.rpc_console --device /dev/ttyACM0 -b 115200 $CHIP_ROOT/third_party/pigweed/repo/pw_rpc/pw_rpc_protos/echo.proto -o /tmp/pw_rpc.out
 
 To send an Echo RPC message, type the following command, where the actual
 message is the text in quotation marks after the `msg=` phrase:

--- a/examples/platform/esp32/pw_sys_io/sys_io_esp32.cc
+++ b/examples/platform/esp32/pw_sys_io/sys_io_esp32.cc
@@ -79,16 +79,16 @@ namespace pw::sys_io {
 Status ReadByte(std::byte * dest)
 {
     if (!dest)
-        return Status::INVALID_ARGUMENT;
+        return Status::InvalidArgument();
 
     int ret = console_getchar(reinterpret_cast<uint8_t *>(dest));
-    return ret < 0 ? Status::FAILED_PRECONDITION : Status::OK;
+    return ret < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 Status WriteByte(std::byte b)
 {
     int ret = console_putchar(reinterpret_cast<const char *>(&b));
-    return ret < 0 ? Status::FAILED_PRECONDITION : Status::OK;
+    return ret < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 // Writes a string using pw::sys_io, and add newline characters at the end.

--- a/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
+++ b/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
@@ -44,17 +44,17 @@ namespace pw::sys_io {
 Status ReadByte(std::byte * dest)
 {
     if (!dest)
-        return Status::INVALID_ARGUMENT;
+        return Status::InvalidArgument();
 
     const int c = console_getchar();
     *dest       = static_cast<std::byte>(c);
 
-    return c < 0 ? Status::FAILED_PRECONDITION : Status::OK;
+    return c < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 Status WriteByte(std::byte b)
 {
-    return console_putchar(static_cast<char>(b)) < 0 ? Status::FAILED_PRECONDITION : Status::OK;
+    return console_putchar(static_cast<char>(b)) < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 // Writes a string using pw::sys_io, and add newline characters at the end.

--- a/examples/platform/nrfconnect/util/PigweedLogger.cpp
+++ b/examples/platform/nrfconnect/util/PigweedLogger.cpp
@@ -30,7 +30,7 @@
 #include <logging/log_output.h>
 #include <zephyr.h>
 
-#include <pw_hdlc_lite/encoder.h>
+#include <pw_hdlc/encoder.h>
 #include <pw_stream/sys_io_stream.h>
 #include <pw_sys_io_nrfconnect/init.h>
 
@@ -61,7 +61,7 @@ bool sIsPanicMode;
 
 void flush()
 {
-    pw::hdlc_lite::WriteUIFrame(kLogHdlcAddress, std::as_bytes(std::span(sWriteBuffer, sWriteBufferPos)), sWriter);
+    pw::hdlc::WriteUIFrame(kLogHdlcAddress, std::as_bytes(std::span(sWriteBuffer, sWriteBufferPos)), sWriter);
     sWriteBufferPos = 0;
 }
 

--- a/integrations/mobly/build/lib/chip_mobly/pigweed_device.py
+++ b/integrations/mobly/build/lib/chip_mobly/pigweed_device.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import serial # type: ignore
 import importlib
 
-from pw_hdlc_lite.rpc import HdlcRpcClient
+from pw_hdlc.rpc import HdlcRpcClient
 
 # Point the script to the .proto file with our RPC services.
 PROTO = Path(os.environ["PW_ROOT"], "pw_rpc/pw_rpc_protos/echo.proto")

--- a/integrations/mobly/chip_mobly/pigweed_device.py
+++ b/integrations/mobly/chip_mobly/pigweed_device.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import serial # type: ignore
 import importlib
 
-from pw_hdlc_lite.rpc import HdlcRpcClient
+from pw_hdlc.rpc import HdlcRpcClient
 
 # Point the script to the .proto file with our RPC services.
 PROTO = Path(os.environ["PW_ROOT"], "pw_rpc/pw_rpc_protos/echo.proto")

--- a/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
@@ -54,17 +54,17 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     }
     switch (status_and_size.status().code())
     {
-    case pw::Status::OK:
+    case pw::OkStatus():
         return CHIP_NO_ERROR;
-    case pw::Status::NOT_FOUND:
+    case pw::Status::NotFound():
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-    case pw::Status::DATA_LOSS:
+    case pw::Status::DataLoss():
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
-    case pw::Status::RESOURCE_EXHAUSTED:
+    case pw::Status::ResourceExhausted():
         return CHIP_ERROR_BUFFER_TOO_SMALL;
-    case pw::Status::FAILED_PRECONDITION:
+    case pw::Status::FailedPrecondition():
         return CHIP_ERROR_WELL_UNINITIALIZED;
-    case pw::Status::INVALID_ARGUMENT:
+    case pw::Status::InvalidArgument():
         return CHIP_ERROR_INVALID_ARGUMENT;
     default:
         break;
@@ -78,16 +78,16 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     auto status = mKvs.Put(key, std::span<const std::byte>(reinterpret_cast<const std::byte *>(value), value_size));
     switch (status.code())
     {
-    case pw::Status::OK:
+    case pw::OkStatus():
         return CHIP_NO_ERROR;
-    case pw::Status::DATA_LOSS:
+    case pw::Status::DataLoss():
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
-    case pw::Status::RESOURCE_EXHAUSTED:
-    case pw::Status::ALREADY_EXISTS:
+    case pw::Status::ResourceExhausted():
+    case pw::Status::AlreadyExists():
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    case pw::Status::FAILED_PRECONDITION:
+    case pw::Status::FailedPrecondition():
         return CHIP_ERROR_WELL_UNINITIALIZED;
-    case pw::Status::INVALID_ARGUMENT:
+    case pw::Status::InvalidArgument():
         return CHIP_ERROR_INVALID_ARGUMENT;
     default:
         break;
@@ -101,17 +101,17 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
     auto status = mKvs.Delete(key);
     switch (status.code())
     {
-    case pw::Status::OK:
+    case pw::OkStatus():
         return CHIP_NO_ERROR;
-    case pw::Status::NOT_FOUND:
+    case pw::Status::NotFound():
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-    case pw::Status::DATA_LOSS:
+    case pw::Status::DataLoss():
         return CHIP_ERROR_INTEGRITY_CHECK_FAILED;
-    case pw::Status::RESOURCE_EXHAUSTED:
+    case pw::Status::ResourceExhausted():
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    case pw::Status::FAILED_PRECONDITION:
+    case pw::Status::FailedPrecondition():
         return CHIP_ERROR_WELL_UNINITIALIZED;
-    case pw::Status::INVALID_ARGUMENT:
+    case pw::Status::InvalidArgument():
         return CHIP_ERROR_INVALID_ARGUMENT;
     default:
         break;
@@ -125,11 +125,11 @@ CHIP_ERROR KeyValueStoreManagerImpl::ErasePartition()
     auto status = mKvsPartition.Erase();
     switch (status.code())
     {
-    case pw::Status::OK:
+    case pw::OkStatus():
         return CHIP_NO_ERROR;
-    case pw::Status::DEADLINE_EXCEEDED:
+    case pw::Status::DeadlineExceeded():
         return CHIP_ERROR_TIMEOUT;
-    case pw::Status::PERMISSION_DENIED:
+    case pw::Status::PermissionDenied():
         return CHIP_ERROR_ACCESS_DENIED;
     default:
         break;

--- a/src/platform/EFR32/KeyValueStoreManagerImpl.h
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.h
@@ -86,8 +86,8 @@ private:
         Efr32FlashMemory() : pw::kvs::FlashMemory(FLASH_PAGE_SIZE, FLASH_SIZE / FLASH_PAGE_SIZE, sizeof(uint32_t), FLASH_BASE) {}
 
         // Enabling flash handled by platform
-        pw::Status Enable() override { return pw::Status::OK; }
-        pw::Status Disable() override { return pw::Status::OK; }
+        pw::Status Enable() override { return pw::OkStatus(); }
+        pw::Status Disable() override { return pw::OkStatus(); }
         bool IsEnabled() const override { return true; }
 
         pw::Status Erase(Address flash_address, size_t num_sectors) override
@@ -102,13 +102,13 @@ private:
                     return status;
                 }
             }
-            return pw::Status::OK;
+            return pw::OkStatus();
         }
 
         pw::StatusWithSize Read(Address address, std::span<std::byte> output) override
         {
             memcpy(output.data(), reinterpret_cast<void *>(address), output.size());
-            return pw::StatusWithSize::Ok(output.size());
+            return pw::StatusWithSize(output.size());
         }
 
         pw::StatusWithSize Write(Address destination_flash_address, std::span<const std::byte> data) override
@@ -125,18 +125,18 @@ private:
             switch (msc_status)
             {
             case mscReturnOk:
-                return pw::Status::OK;
+                return pw::OkStatus();
             case mscReturnUnaligned:
             case mscReturnInvalidAddr:
-                return pw::Status::INVALID_ARGUMENT;
+                return pw::Status::InvalidArgument();
             case mscReturnLocked:
-                return pw::Status::PERMISSION_DENIED;
+                return pw::Status::PermissionDenied();
             case mscReturnTimeOut:
-                return pw::Status::DEADLINE_EXCEEDED;
+                return pw::Status::DeadlineExceeded();
             default:
                 break;
             }
-            return pw::Status::INTERNAL;
+            return pw::Status::Internal();
         }
     };
 


### PR DESCRIPTION
 #### Problem
A recent rollup in third_party/pigweed/repo broke builds of examples/pigweed-app and the RPC-ful builds of examples/lighting-app

 #### Summary of Changes
- Updates pw::Status format in CHIP repo
- Renames hdlc_lite to hdlc
- Re-adds system_rpc_server.cc (temporarily, will get rid soon)

Fixes: #4412