### PR TITLE
Log the longer setup code in the esp32 all-clusters-app

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -406,7 +406,20 @@ std::string createSetupPayload()
 
         if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
         {
-            ESP_LOGI(TAG, "Manual(decimal) setup code: %s", outCode.c_str());
+            ESP_LOGI(TAG, "Short Manual(decimal) setup code: %s", outCode.c_str());
+        }
+        else
+        {
+            ESP_LOGE(TAG, "Failed to get decimal setup code");
+        }
+
+        payload.requiresCustomFlow = 1;
+        generator                  = ManualSetupPayloadGenerator(payload);
+
+        if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR)
+        {
+            // intentional extra space here to align the log with the short code
+            ESP_LOGI(TAG, "Long Manual(decimal) setup code:  %s", outCode.c_str());
         }
         else
         {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The all-clusters-app logs the QRCode payload as well as the short code for setup. It is missing the optional long form setup code. 
We should log the long form as well as it is useful for debugging. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 Slight modification in the all-clusters-app to print out all setup code forms.
 
 Now prints both the short and long code. 
 ```
I (1397) all-clusters-app: Short Manual(decimal) setup code: 03950719949
I (1407) all-clusters-app: Long Manual(decimal) setup code:  039507199509050652797
```

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
