### PR TITLE
Convenience class for BufBound backed by a PacketBuffer.

### DIFF
--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -74,28 +74,23 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
                                                                                                                                    \
-    PacketBufferHandle payload = PacketBufferHandle::New(kMaxBufferSize);                                                          \
-    if (payload.IsNull())                                                                                                          \
+    PacketBufBound buf(kMaxBufferSize);                                                                                            \
+    if (buf.IsNull())                                                                                                              \
     {                                                                                                                              \
         ChipLogError(Zcl, "Could not allocate packet buffer while trying to encode %s command", kName);                            \
-        return payload;                                                                                                            \
+        return PacketBufferHandle();                                                                                               \
     }                                                                                                                              \
                                                                                                                                    \
-    BufBound buf = BufBound(payload->Start(), kMaxBufferSize);                                                                     \
     if (doEncodeApsFrame(buf, clusterId, kSourceEndpoint, destinationEndpoint, 0, 0, 0, 0, false))                                 \
     {
 
 #define COMMAND_FOOTER()                                                                                                           \
     }                                                                                                                              \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
-    if (result == 0)                                                                                                               \
+    if (!buf.Fit())                                                                                                                \
     {                                                                                                                              \
         ChipLogError(Zcl, "Command %s can't fit in the allocated buffer", kName);                                                  \
-        return PacketBufferHandle();                                                                                               \
     }                                                                                                                              \
-                                                                                                                                   \
-    payload->SetDataLength(result);                                                                                                \
-    return payload;
+    return buf.Finalize();
 
 /*----------------------------------------------------------------------------*\
 | Cluster Name                                                        |   ID   |

--- a/src/app/zap-templates/templates/chip/encoder-src.zapt
+++ b/src/app/zap-templates/templates/chip/encoder-src.zapt
@@ -60,28 +60,24 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
                                                                                                                                    \
-    PacketBufferHandle payload = PacketBufferHandle::New(kMaxBufferSize);                                               \
-    if (payload.IsNull())                                                                                                          \
+    PacketBufBound buf(kMaxBufferSize);                                                                                            \
+    if (buf.IsNull())                                                                                                              \
     {                                                                                                                              \
         ChipLogError(Zcl, "Could not allocate packet buffer while trying to encode %s command", kName);                            \
-        return payload;                                                                                                            \
+        return PacketBufferHandle();                                                                                               \
     }                                                                                                                              \
                                                                                                                                    \
-    BufBound buf = BufBound(payload->Start(), kMaxBufferSize);                                                                     \
     if (doEncodeApsFrame(buf, clusterId, kSourceEndpoint, destinationEndpoint, 0, 0, 0, 0, false))                                 \
     {
 
 #define COMMAND_FOOTER()                                                                                                           \
     }                                                                                                                              \
-    uint16_t result = buf.Fit() && CanCastTo<uint16_t>(buf.Needed()) ? static_cast<uint16_t>(buf.Needed()) : 0;                    \
-    if (result == 0)                                                                                                               \
+    if (!buf.Fit())                                                                                                                \
     {                                                                                                                              \
         ChipLogError(Zcl, "Command %s can't fit in the allocated buffer", kName);                                                  \
-        return PacketBufferHandle();                                                                                               \
     }                                                                                                                              \
-                                                                                                                                   \
-    payload->SetDataLength(result);                                                                                                \
-    return payload;
+    return buf.Finalize();
+
 
 {{> clusters_header}}
 

--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -37,7 +37,7 @@ namespace chip {
  */
 class BufBound
 {
-protected:
+private:
     uint8_t * mBuf;
     size_t mSize;
     size_t mNeeded;
@@ -155,6 +155,14 @@ public:
      * @brief Size of the buffer
      */
     size_t Size() const { return mSize; }
+
+protected:
+    void Reset(uint8_t * buf, size_t len)
+    {
+        mBuf    = buf;
+        mSize   = len;
+        mNeeded = 0;
+    }
 };
 
 } // namespace chip

--- a/src/lib/support/BufBound.h
+++ b/src/lib/support/BufBound.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ namespace chip {
  */
 class BufBound
 {
-private:
+protected:
     uint8_t * mBuf;
     size_t mSize;
     size_t mNeeded;

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -2,7 +2,6 @@
 
 #include <nlunit-test.h>
 
-#include <support/BufBound.h>
 #include <support/CodeUtils.h>
 #include <support/UnitTestRegistration.h>
 
@@ -20,15 +19,15 @@ void TestHelperWrittenAndParsedMatch(nlTestSuite * inSuite, void * inContext, Ms
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    size_t msgSize                    = testMsg.MessageSize();
-    System::PacketBufferHandle msgBuf = System::PacketBufferHandle::New(static_cast<uint16_t>(msgSize));
-    NL_TEST_ASSERT(inSuite, !msgBuf.IsNull());
+    size_t msgSize = testMsg.MessageSize();
+    System::PacketBufBound bbuf(msgSize);
+    NL_TEST_ASSERT(inSuite, !bbuf.IsNull());
 
-    BufBound bbuf(msgBuf->Start(), msgBuf->AvailableDataLength());
     testMsg.WriteToBuffer(bbuf);
     NL_TEST_ASSERT(inSuite, bbuf.Fit());
-    msgBuf->SetDataLength(static_cast<uint16_t>(bbuf.Needed()));
 
+    System::PacketBufferHandle msgBuf = bbuf.Finalize();
+    NL_TEST_ASSERT(inSuite, !msgBuf.IsNull());
     System::PacketBufferHandle rcvBuf = System::PacketBufferHandle::NewWithData(msgBuf->Start(), msgSize);
     NL_TEST_ASSERT(inSuite, !rcvBuf.IsNull());
 

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -591,26 +591,23 @@ PacketBufBound::PacketBufBound(size_t aAvailableSize, uint16_t aReservedSize) : 
     mPacket = PacketBufferHandle::New(aAvailableSize, aReservedSize);
     if (!mPacket.IsNull())
     {
-        mBuf  = mPacket->Start();
-        mSize = aAvailableSize;
+        Reset(mPacket->Start(), aAvailableSize);
     }
 }
 
 PacketBufferHandle PacketBufBound::Finalize()
 {
-    if (!mPacket.IsNull() && (mNeeded <= mSize))
+    if (!mPacket.IsNull() && Fit())
     {
         // Since mPacket was successfully allocated to hold the maximum length,
         // we know that the actual length fits in a uint16_t.
-        mPacket->SetDataLength(static_cast<uint16_t>(mNeeded));
+        mPacket->SetDataLength(static_cast<uint16_t>(Needed()));
     }
     else
     {
         mPacket = nullptr;
     }
-    mBuf    = nullptr;
-    mSize   = 0;
-    mNeeded = 0;
+    Reset(nullptr, 0);
     return std::move(mPacket);
 }
 

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -1,7 +1,7 @@
 /*
  *
  *    Copyright (c) 2020-2021 Project CHIP Authors
- *    Copyright (c) 2016-2021 Nest Labs, Inc.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -1,7 +1,7 @@
 /*
  *
  *    Copyright (c) 2020-2021 Project CHIP Authors
- *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    Copyright (c) 2016-2021 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -585,6 +585,34 @@ void PacketBufferHandle::RightSizeForMemoryAlloc()
 }
 
 #endif
+
+PacketBufBound::PacketBufBound(size_t aAvailableSize, uint16_t aReservedSize) : BufBound(nullptr, 0)
+{
+    mPacket = PacketBufferHandle::New(aAvailableSize, aReservedSize);
+    if (!mPacket.IsNull())
+    {
+        mBuf  = mPacket->Start();
+        mSize = aAvailableSize;
+    }
+}
+
+PacketBufferHandle PacketBufBound::Finalize()
+{
+    if (!mPacket.IsNull() && (mNeeded <= mSize))
+    {
+        // Since mPacket was successfully allocated to hold the maximum length,
+        // we know that the actual length fits in a uint16_t.
+        mPacket->SetDataLength(static_cast<uint16_t>(mNeeded));
+    }
+    else
+    {
+        mPacket = nullptr;
+    }
+    mBuf    = nullptr;
+    mSize   = 0;
+    mNeeded = 0;
+    return std::move(mPacket);
+}
 
 } // namespace System
 } // namespace chip

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -645,8 +645,8 @@ public:
      *  If no memory is available, or if the size requested is too large, then \c IsNull() will be true.
      *  Otherwise, it is guaranteed that the available space is no less than \a aAvailableSize.
      *
-     *  @param[in]  aAvailableSize  Minimim number of octets to allocate after the cursor.
-     *  @param[in]  aReservedSize   Minimum number of octets to reserve behind the cursor.
+     *  @param[in]  aAvailableSize  Minimim octets to allocate after the cursor; see \c PacketBufferHandle::New().
+     *  @param[in]  aReservedSize   Minimum octets to reserve behind the cursor; see \c PacketBufferHandle::New().
      */
     PacketBufBound(size_t aAvailableSize, uint16_t aReservedSize = CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -1,7 +1,7 @@
 /*
  *
  *    Copyright (c) 2020-2021 Project CHIP Authors
- *    Copyright (c) 2016-2021 Nest Labs, Inc.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -447,7 +447,7 @@ public:
     PacketBuffer * operator->() const { return mBuffer; }
 
     /**
-     * Test whether this PacketBufferHandle is empty, or owns a PacketBuffer.
+     * Test whether this PacketBufferHandle is empty, or conversely owns a PacketBuffer.
      *
      * @return \c true if this PacketBufferHandle is empty; return \c false if it owns a PacketBuffer.
      */
@@ -543,14 +543,20 @@ public:
     /**
      * Allocates a packet buffer.
      *
+     *  A packet buffer is conceptually divided into two parts:
+     *  @li  Space reserved for network protocol headers. The size of this space normally defaults to a value determined
+     *       by the network layer configuration, but can be given explicity by \c aReservedSize for special cases.
+     *  @li  Space for application data. The minimum size of this space is given by \c aAvailableSize, and then \c Start()
+     *       provides a pointer to the start of this space.
+     *
      *  Fails and returns \c nullptr if no memory is available, or if the size requested is too large.
      *  When the sum of \a aAvailableSize and \a aReservedSize is no greater than \c kMaxPacketBufferSizeWithoutReserve,
      *  that is guaranteed not to be too large.
      *
      *  On success, it is guaranteed that \c AvailableDataSize() is no less than \a aAvailableSize.
      *
-     *  @param[in]  aAvailableSize  Minimim number of octets to allocate after the cursor.
-     *  @param[in]  aReservedSize   Minimum number of octets to reserve behind the cursor.
+     *  @param[in]  aAvailableSize  Minimim number of octets to for application data (at `Start()`).
+     *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers (before `Start()`).
      *
      *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
      */
@@ -561,8 +567,8 @@ public:
      *
      *  @param[in]  aData           Initial buffer contents.
      *  @param[in]  aDataSize       Size of initial buffer contents.
-     *  @param[in]  aAdditionalSize Size of additional buffer space after the initial contents.
-     *  @param[in]  aReservedSize   Number of octets to reserve behind the cursor.
+     *  @param[in]  aAdditionalSize Size of additional application data space after the initial contents.
+     *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers.
      *
      *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
      */
@@ -635,6 +641,17 @@ inline PacketBufferHandle PacketBuffer::Last()
 
 /**
  * BufBound backed by packet buffer.
+ *
+ * Typical use:
+ *  @code
+ *      PacketBufBound buf(maximumLength);
+ *      if (buf.IsNull()) { return CHIP_ERROR_NO_MEMORY; }
+ *      buf.Put(...);
+ *      ...
+ *      PacketBufferHandle handle = buf.Finalize();
+ *      if (buf.IsNull()) { return CHIP_ERROR_BUFFER_TOO_SMALL; }
+ *      // valid data
+ *  @endcode
  */
 class PacketBufBound : public BufBound
 {
@@ -643,27 +660,32 @@ public:
      * Constructs a BufBound that writes into a newly allocated packet buffer.
      *
      *  If no memory is available, or if the size requested is too large, then \c IsNull() will be true.
-     *  Otherwise, it is guaranteed that the available space is no less than \a aAvailableSize.
+     *  Otherwise, it is guaranteed that the BufBound length is \a aAvailableSize. (The underlying packet
+     *  buffer may be larger.)
      *
-     *  @param[in]  aAvailableSize  Minimim octets to allocate after the cursor; see \c PacketBufferHandle::New().
-     *  @param[in]  aReservedSize   Minimum octets to reserve behind the cursor; see \c PacketBufferHandle::New().
+     *  @param[in]  aAvailableSize  Length bound of the BufBound.
+     *  @param[in]  aReservedSize   Reserved packet buffer space for protocol headers; see \c PacketBufferHandle::New().
      */
     PacketBufBound(size_t aAvailableSize, uint16_t aReservedSize = CHIP_SYSTEM_CONFIG_HEADER_RESERVE_SIZE);
 
     /**
-     * Test whether this PacketBufBound has a backing packet buffer.
+     * Test whether this PacketBufBound is null, or conversely owns a PacketBuffer.
      *
-     * @return \c true if construction failed or if \c Finalize() has been called.
+     * @retval true     The PacketBufBound is null; it does not own a PacketBuffer. This implies either that
+     *                  construction failed, or that \c Finalize() has previously been called to release the buffer.
+     * @retval false    The PacketBufBound owns a PacketBuffer, which can be written using BufBound \c Put() methods,
+     *                  and (assuming no overflow) obtained by calling \c Finalize().
      */
     bool IsNull() const { return mPacket.IsNull(); }
 
     /**
      * Obtain the backing packet buffer, if it is valid.
      *
-     *  Given that construction succeeded, \c Finalize() has not already been called,
-     *  and no Put overflowed the available space, the caller takes ownership of a
-     *  buffer containing the desired data. Otherwise, the returned handle tests null,
-     *  and any underlying storage has been released.
+     *  If construction succeeded, \c Finalize() has not already been called, and \c BufBound::Fit() is true, the caller
+     *  takes ownership of a buffer containing the desired data. Otherwise, the returned handle tests null, and any
+     *  underlying storage has been released.
+     *
+     *  @return     A packet buffer handle.
      */
     PacketBufferHandle Finalize();
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1,7 +1,7 @@
 /*
  *
  *    Copyright (c) 2020-2021 Project CHIP Authors
- *    Copyright (c) 2016-2021 Nest Labs, Inc.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -529,8 +529,6 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const PacketHeader & header, con
     const uint8_t * buf = msg->Start();
     size_t buf_len      = msg->DataLength();
 
-    System::PacketBufferHandle resp;
-
     ChipLogDetail(Ble, "Received spake2p msg1");
 
     VerifyOrExit(buf != nullptr, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
@@ -557,22 +555,19 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const PacketHeader & header, con
     VerifyOrExit(CanCastTo<uint16_t>(Y_len + verifier_len), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
     data_len = static_cast<uint16_t>(Y_len + verifier_len);
 
-    resp = System::PacketBufferHandle::New(data_len);
-    VerifyOrExit(!resp.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-
     {
-        BufBound bbuf(resp->Start(), data_len);
+        System::PacketBufBound bbuf(data_len);
+        VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
         bbuf.Put(&Y[0], Y_len);
         bbuf.Put(verifier, verifier_len);
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
+
+        mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2p3;
+
+        // Call delegate to send the Msg2 to peer
+        err = AttachHeaderAndSend(Protocols::SecureChannel::MsgType::PASE_Spake2p2, bbuf.Finalize());
+        SuccessOrExit(err);
     }
-
-    resp->SetDataLength(data_len);
-    mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2p3;
-
-    // Call delegate to send the Msg2 to peer
-    err = AttachHeaderAndSend(Protocols::SecureChannel::MsgType::PASE_Spake2p2, std::move(resp));
-    SuccessOrExit(err);
 
     ChipLogDetail(Ble, "Sent spake2p msg2");
 
@@ -616,20 +611,17 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(const PacketHeader & header, con
         mConnectionState.SetPeerNodeId(header.GetSourceNodeId().Value());
     }
 
-    resp = System::PacketBufferHandle::New(verifier_len);
-    VerifyOrExit(!resp.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
-
     {
-        BufBound bbuf(resp->Start(), verifier_len);
+        System::PacketBufBound bbuf(verifier_len);
+        VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
+
         bbuf.Put(verifier, verifier_len);
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
+
+        // Call delegate to send the Msg3 to peer
+        err = AttachHeaderAndSend(Protocols::SecureChannel::MsgType::PASE_Spake2p3, bbuf.Finalize());
+        SuccessOrExit(err);
     }
-
-    resp->SetDataLength(verifier_len);
-
-    // Call delegate to send the Msg3 to peer
-    err = AttachHeaderAndSend(Protocols::SecureChannel::MsgType::PASE_Spake2p3, std::move(resp));
-    SuccessOrExit(err);
 
     ChipLogDetail(Ble, "Sent spake2p msg3");
 


### PR DESCRIPTION
#### Problem

Several places use similar code to safely write to a packet buffer.
Encapsulating this encourages this safety method by making it easier,
and reduces opportunity for mistakes in the steps involved.

#### Summary of Changes

- Added a `PacketBufBound` class that can never yield a truncated buffer.
- Converted existing uses of the `BufBound`+`PacketBuffer` combination.
