### PR TITLE
Fix K32W platform build

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -403,6 +403,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
           "OpenThread/OpenThreadUtils.cpp",
         ]
       }
+
+      public_deps += [ "${chip_root}/src/crypto" ]
     } else if (chip_device_platform == "linux") {
       sources += [
         "Linux/BLEManagerImpl.cpp",

--- a/src/platform/K32W/BLEManagerImpl.cpp
+++ b/src/platform/K32W/BLEManagerImpl.cpp
@@ -1094,7 +1094,7 @@ void BLEManagerImpl::HandleRXCharWrite(blekw_msg_t * msg)
     uint8_t * data                         = att_wr_data->data;
 
     // Copy the data to a PacketBuffer.
-    buf = PacketBuffer::NewWithAvailableSize(writeLen);
+    buf = System::PacketBufferHandle::New(writeLen);
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
     VerifyOrExit(buf->AvailableDataLength() >= writeLen, err = CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(buf->Start(), data, writeLen);
@@ -1112,7 +1112,7 @@ void BLEManagerImpl::HandleRXCharWrite(blekw_msg_t * msg)
         ChipDeviceEvent event;
         event.Type                        = DeviceEventType::kCHIPoBLEWriteReceived;
         event.CHIPoBLEWriteReceived.ConId = att_wr_data->device_id;
-        event.CHIPoBLEWriteReceived.Data  = buf.Release_ForNow();
+        event.CHIPoBLEWriteReceived.Data  = std::move(buf).UnsafeRelease();
         PlatformMgr().PostEvent(&event);
     }
 exit:


### PR DESCRIPTION
This fixes the following errors with the K32W build:

  ERROR at //src/platform/K32W/BLEManagerImpl.cpp:29:11: Include not allowed.
  #include <crypto/CHIPCryptoPAL.h>
	    ^---------------------
  It is not in any dependency of
    //src/platform:platform
  The include file is in the target(s):
    //src/crypto:crypto
  which should somehow be reachable.

and

  ../../src/platform/K32W/BLEManagerImpl.cpp: In member function 'void chip::DeviceLayer::Internal::BLEManagerImpl::HandleRXCharWrite(chip::DeviceLayer::Internal::BLEManagerImpl::blekw_msg_t*)':
  ../../src/platform/K32W/BLEManagerImpl.cpp:1097:11: error: 'PacketBuffer' has not been declared
   1097 |     buf = PacketBuffer::NewWithAvailableSize(writeLen);
	|           ^~~~~~~~~~~~
  ../../src/platform/K32W/BLEManagerImpl.cpp:1115:49: error: 'class chip::System::PacketBufferHandle' has no member named 'Release_ForNow'
   1115 |         event.CHIPoBLEWriteReceived.Data  = buf.Release_ForNow();
	|