### PR TITLE
[.github/workflows] Added pigweed-app related builds to workflows.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -46,13 +46,20 @@ jobs:
               with:
                   languages: "cpp, python"
                   queries: +security-and-quality
-            - name: Build example Echo App
-              run: scripts/examples/esp_echo_app.sh
+            - name: Build example All Clusters App
+              run: scripts/examples/esp_example.sh all-clusters-app
             - name: Copy aside build products
               run: |
                   mkdir -p example_binaries/$BUILD_TYPE-build
                   cp examples/all-clusters-app/esp32/build/chip-all-clusters-app.elf \
                      example_binaries/$BUILD_TYPE-build/chip-all-clusters-app.elf
+            - name: Build example Pigweed App
+              run: scripts/examples/esp_example.sh pigweed-app
+            - name: Copy aside build products
+              run: |
+                  mkdir -p example_binaries/$BUILD_TYPE-build
+                  cp examples/pigweed-app/esp32/build/chip-pigweed-app.elf \
+                     example_binaries/$BUILD_TYPE-build/chip-pigweed-app.elf
             - name: Binary artifact suffix
               id: outsuffix
               uses: haya14busa/action-cond@v1.0.0

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -45,12 +45,14 @@ jobs:
             #   with:
             #       languages: "cpp, python"
             #       queries: +security-and-quality
-            - name: Build example nRF Connect SDK Lock App
-              run: scripts/examples/nrfconnect_example.sh lock-app
-            - name: Build example nRF Connect SDK Lighting App
-              run: scripts/examples/nrfconnect_example.sh lighting-app
-            - name: Build example nRF Connect SDK Shell
-              run: scripts/examples/nrfconnect_example.sh shell
+            - name: Build example nRF Connect SDK Lock App on nRF52840 DK
+              run: scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840
+            - name: Build example nRF Connect SDK Lighting App on nRF52840 DK
+              run: scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840
+            - name: Build example nRF Connect SDK Shell on nRF52840 DK
+              run: scripts/examples/nrfconnect_example.sh shell nrf52840dk_nrf52840
+            - name: Build example nRF Connect SDK Pigweed on nRF52840 DK
+              run: scripts/examples/nrfconnect_example.sh pigweed-app nrf52840dk_nrf52840
             - name: Run unit tests for Zephyr native_posix_64 platform
               run:
                   scripts/tests/nrfconnect_native_posix_tests.sh native_posix_64

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -37,8 +37,8 @@ jobs:
               uses: actions/checkout@v2
               with:
                   submodules: true
-            - name: Build example Echo App
-              run: scripts/examples/esp_echo_app.sh
+            - name: Build example All Clusters App
+              run: scripts/examples/esp_example.sh all-clusters-app
             - name: Build ESP32 QEMU and Run Tests
               run: scripts/tests/esp32_qemu_tests.sh /tmp/test_logs
             - name: Uploading Logs

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -37,7 +37,7 @@ jobs:
               with:
                   submodules: true
             - name: Build
-              run: scripts/examples/esp_echo_app.sh
+              run: scripts/examples/esp_example.sh all-clusters-app
 
             - name: Upload artifact
               run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -181,9 +181,9 @@
             "problemMatcher": ["$gcc"]
         },
         {
-            "label": "Build nRF Connect Lock Example",
+            "label": "Build nRF Connect Lock Example (nRF52840)",
             "type": "shell",
-            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh lock-app",
+            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840",
             "group": "build",
             "problemMatcher": {
                 "base": "$gcc",
@@ -194,9 +194,9 @@
             }
         },
         {
-            "label": "Build nRF Connect Lighting Example",
+            "label": "Build nRF Connect Lighting Example (nRF52840)",
             "type": "shell",
-            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh lighting-app",
+            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840",
             "group": "build",
             "problemMatcher": {
                 "base": "$gcc",
@@ -207,9 +207,9 @@
             }
         },
         {
-            "label": "Build nRF Connect Shell Example",
+            "label": "Build nRF Connect Shell Example (nRF52840)",
             "type": "shell",
-            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh shell",
+            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh shell nrf52840dk_nrf52840",
             "group": "build",
             "problemMatcher": {
                 "base": "$gcc",
@@ -220,9 +220,9 @@
             }
         },
         {
-            "label": "Build nRF Connect Pigweed Example",
+            "label": "Build nRF Connect Pigweed Example (nRF52840)",
             "type": "shell",
-            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh pigweed-app",
+            "command": "source scripts/activate.sh && scripts/examples/nrfconnect_example.sh pigweed-app nrf52840dk_nrf52840",
             "group": "build",
             "problemMatcher": {
                 "base": "$gcc",

--- a/examples/pigweed-app/esp32/Makefile
+++ b/examples/pigweed-app/esp32/Makefile
@@ -19,7 +19,7 @@
 # project subdirectory.
 #
 
-PROJECT_NAME := pw-rpc-app
+PROJECT_NAME := chip-pigweed-app
 
 EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32/components \
 

--- a/examples/pigweed-app/esp32/main/main.cpp
+++ b/examples/pigweed-app/esp32/main/main.cpp
@@ -19,7 +19,7 @@
 #include "pw_sys_io/sys_io.h"
 #include "pw_sys_io_esp32/init.h"
 
-const char * TAG = "pw-rpc-app";
+const char * TAG = "chip-pigweed-app";
 
 namespace hdlc_example {
 extern void Start();

--- a/scripts/examples/nrfconnect_example.sh
+++ b/scripts/examples/nrfconnect_example.sh
@@ -16,12 +16,15 @@
 #    limitations under the License.
 #
 
-# Run bootstrap to set up e.g. Pigweed correctly
+# Run bootstrap and activate to set up e.g. Pigweed correctly
 source "$(dirname "$0")/../../scripts/bootstrap.sh"
+source "$(dirname "$0")/../../scripts/activate.sh"
 
 cd "$(dirname "$0")/../../examples"
 
 APP="$1"
+BOARD="$2"
+shift 2
 
 if [[ ! -f "$APP/nrfconnect/CMakeLists.txt" ]]; then
     echo "Usage: $0 <application>" >&2
@@ -30,8 +33,13 @@ if [[ ! -f "$APP/nrfconnect/CMakeLists.txt" ]]; then
     exit 1
 fi
 
+if [ -z "$BOARD" ]; then
+    echo "No mandatory BOARD argument supplied!"
+    exit 1
+fi
+
 set -x
 [[ -n $ZEPHYR_BASE ]] && source "$ZEPHYR_BASE/zephyr-env.sh"
 env
 
-west build -b nrf52840dk_nrf52840 -d "$APP/nrfconnect/build" "$APP/nrfconnect"
+west build -b "$BOARD" -d "$APP/nrfconnect/build" "$APP/nrfconnect" -- "$@"


### PR DESCRIPTION
 #### Problem
There is no build validation in CI for pigweed-app, as this app related builds are not ran in the github workflows.

 #### Summary of Changes
* Modified nrfconnect_example.sh to take board name as an mandatory argument and also allow passing list of additional arguments (e.g. attaching overlays).
* Added pigweed-app build and lighting-app with rpc.overlay build to the nrfconnect github workflows.
* Renamed esp_echo_app.sh to the esp_example.sh and modified it to take application name as an argument.
* Added pigweed-app build to the esp32 github workflow.
* Renamed Echo App build step to the All Clusters App in the esp32 and qemu github workflows, as in fact that app is being build.

 Fixes #4562
