### PR TITLE
Add UI to dynamically change number of onOff endpoints/cluster and adopt CHIPFramework API to control different lights/endpoints

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.h
@@ -20,7 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OnOffViewController : UIViewController <CHIPDeviceControllerDelegate, UIPickerViewDelegate, UIPickerViewDataSource, UITextFieldDelegate>
+@interface OnOffViewController
+    : UIViewController <CHIPDeviceControllerDelegate, UIPickerViewDelegate, UIPickerViewDataSource, UITextFieldDelegate>
 
 @end
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.h
@@ -20,7 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OnOffViewController : UIViewController <CHIPDeviceControllerDelegate>
+@interface OnOffViewController : UIViewController <CHIPDeviceControllerDelegate, UIPickerViewDelegate, UIPickerViewDataSource, UITextFieldDelegate>
 
 @end
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -23,14 +23,14 @@
 NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 @interface OnOffViewController ()
-@property (nonatomic, strong) UITextField *numLightsTextField;
+@property (nonatomic, strong) UITextField * numLightsTextField;
 
-@property (readwrite) NSArray<CHIPOnOff *> *onOffClusters;
+@property (readwrite) NSArray<CHIPOnOff *> * onOffClusters;
 @property (readwrite) CHIPOnOff * onOffEndpoint2;
 
 @property (nonatomic, strong) UILabel * resultLabel;
-@property (nonatomic, strong) UILabel *titleLabel;
-@property (nonatomic, strong) UIStackView *stackView;
+@property (nonatomic, strong) UILabel * titleLabel;
+@property (nonatomic, strong) UIStackView * stackView;
 
 @property (readwrite) CHIPDeviceController * chipController;
 @property (readwrite) CHIPDevice * chipDevice;
@@ -40,8 +40,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 @implementation OnOffViewController {
     dispatch_queue_t _callbackQueue;
-    NSArray *_numLightsOptions;
-
+    NSArray * _numLightsOptions;
 }
 
 // MARK: UIViewController methods
@@ -55,15 +54,12 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
     [self initializeChipController];
     [self setupUIElements];
-
-
 }
 
 - (void)dismissKeyboard
 {
     [_numLightsTextField resignFirstResponder];
 }
-
 
 // MARK: UI Setup
 
@@ -74,7 +70,6 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     // Title
     _titleLabel = [CHIPUIViewUtils addTitle:@"On Off Cluster" toView:self.view];
     [self setupStackView];
-
 }
 
 - (void)setupStackView
@@ -96,25 +91,29 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
     // Num lights to show
     [self setupNumberOfLightClustersFromDefaults];
-    UILabel *numLightsLabel = [UILabel new];
+    UILabel * numLightsLabel = [UILabel new];
     numLightsLabel.text = @"# of light endpoints:";
     _numLightsTextField = [UITextField new];
-    _numLightsOptions = @[@"1", @"2", @"3", @"4", @"5", @"6", @"7", @"8", @"9", @"10"];
-    _numLightsTextField.text = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster) ?: [_numLightsOptions objectAtIndex:0];
-    UIPickerView *numLightsPicker = [[UIPickerView alloc] initWithFrame:CGRectMake(0, 100, 0, 0)];
+    _numLightsOptions = @[ @"1", @"2", @"3", @"4", @"5", @"6", @"7", @"8", @"9", @"10" ];
+    _numLightsTextField.text
+        = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster) ?: [_numLightsOptions objectAtIndex:0];
+    UIPickerView * numLightsPicker = [[UIPickerView alloc] initWithFrame:CGRectMake(0, 100, 0, 0)];
     _numLightsTextField.inputView = numLightsPicker;
-    [numLightsPicker setDataSource: self];
-    [numLightsPicker setDelegate: self];
+    [numLightsPicker setDataSource:self];
+    [numLightsPicker setDelegate:self];
     _numLightsTextField.delegate = self;
-    UIView *numLightsView = [CHIPUIViewUtils viewWithLabel:numLightsLabel textField:_numLightsTextField];
+    UIView * numLightsView = [CHIPUIViewUtils viewWithLabel:numLightsLabel textField:_numLightsTextField];
     numLightsLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
 
-    UIToolbar* keyboardDoneButtonView = [[UIToolbar alloc] init];
+    UIToolbar * keyboardDoneButtonView = [[UIToolbar alloc] init];
     [keyboardDoneButtonView sizeToFit];
-    UIBarButtonItem* doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
-                                                                    style:UIBarButtonItemStylePlain target:self
+    UIBarButtonItem * doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
+                                                                    style:UIBarButtonItemStylePlain
+                                                                   target:self
                                                                    action:@selector(pickerDoneClicked:)];
-    UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:self action:nil];
+    UIBarButtonItem * flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
+                                                                               target:self
+                                                                               action:nil];
     [keyboardDoneButtonView setItems:[NSArray arrayWithObjects:flexible, doneButton, nil]];
     _numLightsTextField.inputAccessoryView = keyboardDoneButtonView;
 
@@ -178,10 +177,10 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-    NSLog(@"%@",[_numLightsOptions objectAtIndex:row]);
-    _numLightsTextField.text = [NSString stringWithFormat:@"%@",[_numLightsOptions objectAtIndex:row]];;
+    NSLog(@"%@", [_numLightsOptions objectAtIndex:row]);
+    _numLightsTextField.text = [NSString stringWithFormat:@"%@", [_numLightsOptions objectAtIndex:row]];
+    ;
 }
-
 
 - (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
 {
@@ -204,7 +203,8 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     return 200;
 }
 
-- (IBAction)pickerDoneClicked:(id)sender {
+- (IBAction)pickerDoneClicked:(id)sender
+{
     CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster, _numLightsTextField.text);
     [_numLightsTextField resignFirstResponder];
     [self setupStackView];
@@ -233,7 +233,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (int)numLightClustersToShow
 {
-    NSString *numClusters = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster);
+    NSString * numClusters = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster);
     int numberOfLights = 1;
 
     if (numClusters) {
@@ -249,9 +249,9 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (void)setupNumberOfLightClusters:(int)numLights
 {
-    NSMutableArray<CHIPOnOff *> *clusters = [NSMutableArray new];
-    for (int i = 0; i < numLights; i ++) {
-        CHIPOnOff *cluster = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:(i + 1) queue:_callbackQueue];
+    NSMutableArray<CHIPOnOff *> * clusters = [NSMutableArray new];
+    for (int i = 0; i < numLights; i++) {
+        CHIPOnOff * cluster = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:(i + 1) queue:_callbackQueue];
         [clusters addObject:cluster];
     }
     _onOffClusters = clusters;
@@ -270,12 +270,11 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     NSLog(@"Light %@ on button pressed.", @(lightNumber));
 
     if (lightNumber <= [_onOffClusters count]) {
-        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        CHIPOnOff * onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff on:completionHandler];
     } else {
         NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
     }
-
 }
 
 - (IBAction)offButtonTapped:(id)sender
@@ -289,7 +288,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     NSLog(@"Light %@ off button pressed.", @(lightNumber));
 
     if (lightNumber <= [_onOffClusters count]) {
-        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        CHIPOnOff * onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff off:completionHandler];
     } else {
         NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
@@ -307,7 +306,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     NSLog(@"Light %@ toggle button pressed.", @(lightNumber));
 
     if (lightNumber <= [_onOffClusters count]) {
-        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        CHIPOnOff * onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff toggle:completionHandler];
     } else {
         NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -20,13 +20,17 @@
 #import "DefaultsUtils.h"
 #import <CHIP/CHIP.h>
 
+NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
+
 @interface OnOffViewController ()
-@property (weak, nonatomic) IBOutlet UIButton * onButton;
-@property (weak, nonatomic) IBOutlet UIButton * offButton;
-@property (weak, nonatomic) IBOutlet UIButton * toggleButton;
-@property (readwrite) CHIPOnOff * onOff;
+@property (nonatomic, strong) UITextField *numLightsTextField;
+
+@property (readwrite) NSArray<CHIPOnOff *> *onOffClusters;
+@property (readwrite) CHIPOnOff * onOffEndpoint2;
 
 @property (nonatomic, strong) UILabel * resultLabel;
+@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong) UIStackView *stackView;
 
 @property (readwrite) CHIPDeviceController * chipController;
 @property (readwrite) CHIPDevice * chipDevice;
@@ -34,22 +38,30 @@
 @property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
 @end
 
-@implementation OnOffViewController
+@implementation OnOffViewController {
+    dispatch_queue_t _callbackQueue;
+    NSArray *_numLightsOptions;
+    
+}
 
 // MARK: UIViewController methods
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    [self.view addGestureRecognizer:tap];
+    
     [self setupUIElements];
 
     _persistentStorage = [[CHIPToolPersistentStorageDelegate alloc] init];
 
     // initialize the device controller
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.onoffvc.callback", DISPATCH_QUEUE_SERIAL);
+    _callbackQueue = dispatch_queue_create("com.zigbee.chip.onoffvc.callback", DISPATCH_QUEUE_SERIAL);
     self.chipController = [CHIPDeviceController sharedController];
-    [self.chipController setDelegate:self queue:callbackQueue];
-    [self.chipController setPersistentStorageDelegate:_persistentStorage queue:callbackQueue];
+    [self.chipController setDelegate:self queue:_callbackQueue];
+    [self.chipController setPersistentStorageDelegate:_persistentStorage queue:_callbackQueue];
 
     uint64_t deviceID = CHIPGetNextAvailableDeviceID();
     if (deviceID > 1) {
@@ -57,9 +69,14 @@
         deviceID--;
         NSError * error;
         self.chipDevice = [self.chipController getPairedDevice:deviceID error:&error];
-        self.onOff = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:1 queue:callbackQueue];
     }
 }
+
+- (void)dismissKeyboard
+{
+    [_numLightsTextField resignFirstResponder];
+}
+
 
 // MARK: UI Setup
 
@@ -68,23 +85,58 @@
     self.view.backgroundColor = UIColor.whiteColor;
 
     // Title
-    UILabel * titleLabel = [CHIPUIViewUtils addTitle:@"On Off Cluster" toView:self.view];
+    _titleLabel = [CHIPUIViewUtils addTitle:@"On Off Cluster" toView:self.view];
+    [self setupStackView];
+    
+}
 
+- (void)setupStackView
+{
     // stack view
     UIStackView * stackView = [UIStackView new];
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.distribution = UIStackViewDistributionEqualSpacing;
     stackView.alignment = UIStackViewAlignmentLeading;
     stackView.spacing = 30;
+    [_stackView removeFromSuperview];
+    _stackView = stackView;
     [self.view addSubview:stackView];
 
     stackView.translatesAutoresizingMaskIntoConstraints = false;
-    [stackView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:30].active = YES;
+    [stackView.topAnchor constraintEqualToAnchor:_titleLabel.bottomAnchor constant:30].active = YES;
     [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
+    
+    // Num lights to show[
+    [self setupNumberOfLightsFromDefaults];
+    UILabel *numLightsLabel = [UILabel new];
+    numLightsLabel.text = @"# of light endpoints:";
+    _numLightsTextField = [UITextField new];
+    _numLightsOptions = @[@"1", @"2", @"3", @"4", @"5", @"6", @"7", @"8", @"9", @"10"];
+    _numLightsTextField.text = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster) ?: [_numLightsOptions objectAtIndex:0];
+    UIPickerView *numLightsPicker = [[UIPickerView alloc] initWithFrame:CGRectMake(0, 100, 0, 0)];
+    _numLightsTextField.inputView = numLightsPicker;
+    [numLightsPicker setDataSource: self];
+    [numLightsPicker setDelegate: self];
+    _numLightsTextField.delegate = self;
+    UIView *numLightsView = [CHIPUIViewUtils viewWithLabel:numLightsLabel textField:_numLightsTextField];
+    numLightsLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+    
+    UIToolbar* keyboardDoneButtonView = [[UIToolbar alloc] init];
+    [keyboardDoneButtonView sizeToFit];
+    UIBarButtonItem* doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
+                                                                    style:UIBarButtonItemStylePlain target:self
+                                                                   action:@selector(pickerDoneClicked:)];
+    UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:self action:nil];
+    [keyboardDoneButtonView setItems:[NSArray arrayWithObjects:flexible, doneButton, nil]];
+    _numLightsTextField.inputAccessoryView = keyboardDoneButtonView;
+    
+    [stackView addArrangedSubview:numLightsView];
+    numLightsView.translatesAutoresizingMaskIntoConstraints = false;
+    [numLightsView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = true;
 
     // Create buttons
-    [self addButtons:3 toStackView:stackView];
+    [self addButtons:[_onOffClusters count] toStackView:stackView];
 
     // Result message
     _resultLabel = [UILabel new];
@@ -105,7 +157,7 @@
     for (int i = 1; i <= numButtons; i++) {
         // Create buttons
         UILabel * labelLight = [UILabel new];
-        labelLight.text = [NSString stringWithFormat:@"Light %@: ", @(i)];
+        labelLight.text = [NSString stringWithFormat:@"Light (endpoint %@): ", @(i)];
         UIButton * onButton = [UIButton new];
         onButton.tag = i;
         [onButton setTitle:@"On" forState:UIControlStateNormal];
@@ -135,6 +187,69 @@
     _resultLabel.text = result;
 }
 
+// MARK: UIPickerView
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
+{
+    NSLog(@"%@",[_numLightsOptions objectAtIndex:row]);
+    _numLightsTextField.text = [NSString stringWithFormat:@"%@",[_numLightsOptions objectAtIndex:row]];;
+}
+
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
+{
+    return [_numLightsOptions count];
+}
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView
+{
+    return 1;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
+{
+    return [_numLightsOptions objectAtIndex:row];
+}
+
+// tell the picker the width of each row for a given component
+- (CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component
+{
+    return 200;
+}
+
+- (IBAction)pickerDoneClicked:(id)sender {
+    CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster, _numLightsTextField.text);
+    [_numLightsTextField resignFirstResponder];
+    [self setupStackView];
+}
+
+// MARK: Cluster Setup
+
+- (int)numLightsToShow
+{
+    NSString *numClusters = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster);
+    int numberOfLights = 1;
+    if (numClusters) {
+        numberOfLights = [numClusters intValue];
+    }
+    return numberOfLights;
+}
+
+- (void)setupNumberOfLightsFromDefaults
+{
+    [self setupNumberOfLights:[self numLightsToShow]];
+}
+
+- (void)setupNumberOfLights:(int)numLights
+{
+    NSMutableArray<CHIPOnOff *> *clusters = [NSMutableArray new];
+    for (int i = 0; i < numLights; i ++) {
+        CHIPOnOff *cluster = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:(i + 1) queue:_callbackQueue];
+        [clusters addObject:cluster];
+    }
+    _onOffClusters = clusters;
+}
+
 // MARK: UIButton actions
 
 - (IBAction)onButtonTapped:(id)sender
@@ -146,8 +261,14 @@
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ on button pressed.", @(lightNumber));
-    // TODO: Do something based on which light is selected
-    [self.onOff on:completionHandler];
+    
+    if (lightNumber <= [_onOffClusters count]) {
+        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        [onOff on:completionHandler];
+    } else {
+        NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
+    }
+    
 }
 
 - (IBAction)offButtonTapped:(id)sender
@@ -159,8 +280,13 @@
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ off button pressed.", @(lightNumber));
-    // TODO: Do something based on which light is selected
-    [self.onOff off:completionHandler];
+    
+    if (lightNumber <= [_onOffClusters count]) {
+        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        [onOff off:completionHandler];
+    } else {
+        NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
+    }
 }
 
 - (IBAction)toggleButtonTapped:(id)sender
@@ -172,8 +298,13 @@
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ toggle button pressed.", @(lightNumber));
-    // TODO: Do something based on which light is selected
-    [self.onOff toggle:completionHandler];
+    
+    if (lightNumber <= [_onOffClusters count]) {
+        CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
+        [onOff toggle:completionHandler];
+    } else {
+        NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
+    }
 }
 
 // MARK: CHIPDeviceControllerDelegate

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -41,7 +41,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 @implementation OnOffViewController {
     dispatch_queue_t _callbackQueue;
     NSArray *_numLightsOptions;
-    
+
 }
 
 // MARK: UIViewController methods
@@ -49,14 +49,14 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
-    
+
     [self initializeChipController];
     [self setupUIElements];
 
-    
+
 }
 
 - (void)dismissKeyboard
@@ -74,7 +74,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     // Title
     _titleLabel = [CHIPUIViewUtils addTitle:@"On Off Cluster" toView:self.view];
     [self setupStackView];
-    
+
 }
 
 - (void)setupStackView
@@ -93,7 +93,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     [stackView.topAnchor constraintEqualToAnchor:_titleLabel.bottomAnchor constant:30].active = YES;
     [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
-    
+
     // Num lights to show
     [self setupNumberOfLightClustersFromDefaults];
     UILabel *numLightsLabel = [UILabel new];
@@ -108,7 +108,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     _numLightsTextField.delegate = self;
     UIView *numLightsView = [CHIPUIViewUtils viewWithLabel:numLightsLabel textField:_numLightsTextField];
     numLightsLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
-    
+
     UIToolbar* keyboardDoneButtonView = [[UIToolbar alloc] init];
     [keyboardDoneButtonView sizeToFit];
     UIBarButtonItem* doneButton = [[UIBarButtonItem alloc] initWithTitle:@"Done"
@@ -117,7 +117,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:self action:nil];
     [keyboardDoneButtonView setItems:[NSArray arrayWithObjects:flexible, doneButton, nil]];
     _numLightsTextField.inputAccessoryView = keyboardDoneButtonView;
-    
+
     [stackView addArrangedSubview:numLightsView];
     numLightsView.translatesAutoresizingMaskIntoConstraints = false;
     [numLightsView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = true;
@@ -235,7 +235,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 {
     NSString *numClusters = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kCHIPNumLightOnOffCluster);
     int numberOfLights = 1;
-    
+
     if (numClusters) {
         numberOfLights = [numClusters intValue];
     }
@@ -268,14 +268,14 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ on button pressed.", @(lightNumber));
-    
+
     if (lightNumber <= [_onOffClusters count]) {
         CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff on:completionHandler];
     } else {
         NSLog(@"No cluster initated at endpoint %@.", @(lightNumber));
     }
-    
+
 }
 
 - (IBAction)offButtonTapped:(id)sender
@@ -287,7 +287,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ off button pressed.", @(lightNumber));
-    
+
     if (lightNumber <= [_onOffClusters count]) {
         CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff off:completionHandler];
@@ -305,7 +305,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     UIButton * button = (UIButton *) sender;
     NSInteger lightNumber = button.tag;
     NSLog(@"Light %@ toggle button pressed.", @(lightNumber));
-    
+
     if (lightNumber <= [_onOffClusters count]) {
         CHIPOnOff *onOff = [_onOffClusters objectAtIndex:(lightNumber - 1)];
         [onOff toggle:completionHandler];


### PR DESCRIPTION
- Adds UI to change how many light endpoints developer wants to control
- Hooks up the different light endpoints to the various clusters

 #### Problem
While there is currently basic UI to control lights, developer has to go in code to modify number of lights to be controlled. Only one light could be controlled regardless as as CHIPFramework had changed

 #### Summary of Changes
- Add UI to dynamically change how many lights user wants to control. This number of lights is persisted in defaults.
- Depending on how many endpoints/lights are requested, create different clusters pointing to correct endpoint.
- Tested for regressions

 Fixes #4566 

https://user-images.githubusercontent.com/61782012/106274901-4d069d80-6235-11eb-863b-bbcb91fe8189.mov
![IMG_0840](https://user-images.githubusercontent.com/61782012/106275149-acfd4400-6235-11eb-80a6-3e731a50f3a3.jpg)
![IMG_0843](https://user-images.githubusercontent.com/61782012/106275159-b1296180-6235-11eb-8df6-593881489c28.jpg)
![IMG_0841](https://user-images.githubusercontent.com/61782012/106275168-b4245200-6235-11eb-969c-4ad8dad9de54.jpg)

