### PR TITLE
Clear PASESession state while initializing it

### DIFF
--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -175,6 +175,9 @@ CHIP_ERROR PASESession::Init(Optional<NodeId> myNodeId, uint16_t myKeyId, uint32
 
     VerifyOrExit(delegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
+    // Reset any state maintained by PASESession object (in case it's being reused for pairing)
+    Clear();
+
     err = mCommissioningHash.Begin();
     SuccessOrExit(err);
 


### PR DESCRIPTION
 #### Problem
Reusing PASESession object for pairing causes a crash.

```
0x4008ebe5: abort at ../tools/esp-idf/components/esp32/panic.c:174

0x4015fdb2: esp_sha_read_digest_state at ../tools/esp-idf/components/mbedtls/port/esp32/sha.c:272

0x4015d932: mbedtls_sha256_finish_ret at ../tools/esp-idf/components/mbedtls/port/esp_sha256.c:395

0x4013d111: chip::Crypto::Hash_SHA256_stream::Finish(unsigned char*) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/crypto/CHIPCryptoPALmbedTLS.cpp:237

0x4013cbfc: chip::Crypto::Spake2p_P256_SHA256_HKDF_HMAC::HashFinalize(unsigned char*) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/crypto/CHIPCryptoPAL.cpp:425

0x4013c8de: chip::Crypto::Spake2p::GenerateKeys() at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/crypto/CHIPCryptoPAL.cpp:328

0x4013cac9: chip::Crypto::Spake2p::ComputeRoundTwo(unsigned char const*, unsigned int, unsigned char*, unsigned int*) ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/crypto/CHIPCryptoPAL.cpp:310

0x401367ae: chip::PASESession::HandleMsg1_and_SendMsg2(chip::PacketHeader const&, chip::System::PacketBufferHandle const&) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/transport/PASESession.cpp:556

0x40136bab: chip::PASESession::HandlePeerMessage(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/transport/PASESession.cpp:803

0x4013742e: chip::RendezvousSession::HandlePairingMessage(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle) at ./connectedhomeip/examples/all-clusters-app/esp32/build/chip/../../../../../config/esp32/third_party/connectedhomeip/src/transport/RendezvousSession.cpp:326
```

 #### Summary of Changes
The `PASESession` object contains state corresponding to `spake2p` handshake. Some of the state, e.g. `mCommissioningHash`, was getting reused when the PASESession object was reused for pairing. This caused crash in the crypto code.

This change clears the `PASESession` object state while it is being initialized.
