### PR TITLE
Open BLE advertisement only for the duration of pairing

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -61,6 +61,13 @@ bool isRendezvousBypassed()
     return rendezvousMode == RendezvousInformationFlags::kNone;
 }
 
+class ServerRendezvousAdvertisementDelegate : public RendezvousAdvertisementDelegate
+{
+public:
+    CHIP_ERROR StartAdvertisement() const override { return chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true); }
+    CHIP_ERROR StopAdvertisement() const override { return chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false); }
+};
+
 class ServerCallback : public SecureSessionMgrDelegate
 {
 public:
@@ -177,6 +184,7 @@ SecureSessionMgr gSessions;
 ServerCallback gCallbacks;
 SecurePairingUsingTestSecret gTestPairing;
 RendezvousServer gRendezvousServer;
+ServerRendezvousAdvertisementDelegate gRendezvousAdvDelegate;
 
 } // namespace
 
@@ -234,7 +242,8 @@ void InitServer(AppDelegate * delegate)
 #if CONFIG_NETWORK_LAYER_BLE
         params.SetSetupPINCode(pinCode)
             .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer())
-            .SetPeerAddress(Transport::PeerAddress::BLE());
+            .SetPeerAddress(Transport::PeerAddress::BLE())
+            .SetAdvertisementDelegate(&gRendezvousAdvDelegate);
 #else
         params.SetSetupPINCode(pinCode);
 #endif // CONFIG_NETWORK_LAYER_BLE

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -557,6 +557,8 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mDeviceBeingPaired == kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
 
+    params.SetAdvertisementDelegate(&mRendezvousAdvDelegate);
+
     // TODO: We need to specify the peer address for BLE transport in bindings.
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kBle ||
         params.GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -218,6 +218,27 @@ private:
 
 /**
  * @brief
+ *   The commissioner applications doesn't advertise itself as an available device for rendezvous
+ *   process. This delegate class provides no-op functions for the advertisement delegate.
+ */
+class DeviceCommissionerRendezvousAdvertisementDelegate : public RendezvousAdvertisementDelegate
+{
+public:
+    /**
+     * @brief
+     *   Starts advertisement of the device for rendezvous availability.
+     */
+    CHIP_ERROR StartAdvertisement() const override { return CHIP_NO_ERROR; }
+
+    /**
+     * @brief
+     *   Stops advertisement of the device for rendezvous availability.
+     */
+    CHIP_ERROR StopAdvertisement() const override { return CHIP_NO_ERROR; }
+};
+
+/**
+ * @brief
  *   The commissioner applications can use this class to pair new/unpaired CHIP devices. The application is
  *   required to provide write access to the persistent storage, where the paired device information
  *   will be stored.
@@ -313,6 +334,8 @@ private:
        the pairing for a device is removed. The DeviceCommissioner uses this to decide when to
        persist the device list */
     bool mPairedDevicesUpdated;
+
+    DeviceCommissionerRendezvousAdvertisementDelegate mRendezvousAdvDelegate;
 
     void PersistDeviceList();
 };

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -30,6 +30,24 @@ namespace chip {
 // The largest supported value for Rendezvous discriminators
 const uint16_t kMaxRendezvousDiscriminatorValue = 0xFFF;
 
+class DLL_EXPORT RendezvousAdvertisementDelegate
+{
+public:
+    /**
+     * @brief
+     *   Starts advertisement of the device for rendezvous availability.
+     */
+    virtual CHIP_ERROR StartAdvertisement() const { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * @brief
+     *   Stops advertisement of the device for rendezvous availability.
+     */
+    virtual CHIP_ERROR StopAdvertisement() const { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    virtual ~RendezvousAdvertisementDelegate() {}
+};
+
 class RendezvousParameters
 {
 public:
@@ -77,6 +95,14 @@ public:
         return *this;
     }
 
+    const RendezvousAdvertisementDelegate * GetAdvertisementDelegate() const { return mAdvDelegate; }
+
+    RendezvousParameters & SetAdvertisementDelegate(RendezvousAdvertisementDelegate * delegate)
+    {
+        mAdvDelegate = delegate;
+        return *this;
+    }
+
 #if CONFIG_NETWORK_LAYER_BLE
     bool HasBleLayer() const { return mBleLayer != nullptr; }
     Ble::BleLayer * GetBleLayer() const { return mBleLayer; }
@@ -103,6 +129,9 @@ private:
     Optional<NodeId> mRemoteNodeId;       ///< the remote node id
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
+
+    RendezvousAdvertisementDelegate mDefaultAdvDelegate;
+    RendezvousAdvertisementDelegate * mAdvDelegate = &mDefaultAdvDelegate;
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer               = nullptr;

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -58,6 +58,12 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params, Transpor
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kBle)
 #if CONFIG_NETWORK_LAYER_BLE
     {
+        if (!mParams.IsController())
+        {
+            // Enable BLE advertisement
+            ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
+        }
+
         Transport::BLE * transport = chip::Platform::New<Transport::BLE>();
         mTransport                 = transport;
 
@@ -267,6 +273,14 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
     {
         ReleasePairingSessionHandle();
     }
+
+#if CONFIG_NETWORK_LAYER_BLE
+    if (!mParams.IsController() && mParams.GetPeerAddress().GetTransportType() == Transport::Type::kBle && newState == State::kInit)
+    {
+        // Enable BLE advertisement
+        chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
+    }
+#endif
 }
 
 void RendezvousSession::OnRendezvousMessageReceived(const PacketHeader & packetHeader, const PeerAddress & peerAddress,

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -18,7 +18,6 @@
 
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
-#include <platform/ConnectivityManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
@@ -30,6 +29,10 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/PeerAddress.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/ConnectivityManager.h>
+#endif
 
 #if CONFIG_NETWORK_LAYER_BLE
 #include <transport/BLE.h>
@@ -59,12 +62,13 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params, Transpor
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kBle)
 #if CONFIG_NETWORK_LAYER_BLE
     {
+#if CONFIG_DEVICE_LAYER
         if (!mParams.IsController())
         {
             // Enable BLE advertisement
             ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
         }
-
+#endif
         Transport::BLE * transport = chip::Platform::New<Transport::BLE>();
         mTransport                 = transport;
 
@@ -275,7 +279,7 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
         ReleasePairingSessionHandle();
     }
 
-#if CONFIG_NETWORK_LAYER_BLE
+#if CONFIG_NETWORK_LAYER_BLE && CONFIG_DEVICE_LAYER
     if (!mParams.IsController() && mParams.GetPeerAddress().GetTransportType() == Transport::Type::kBle && newState == State::kInit)
     {
         // Enable BLE advertisement

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -18,6 +18,7 @@
 
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
+#include <platform/ConnectivityManager.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>


### PR DESCRIPTION
 #### Problem
The device keeps advertisement on BLE even after the pairing process is complete.

 #### Summary of Changes
Restrict BLE advertisement for the duration of pairing. The advertisement will start when the rendezvous session is opened on the device, and closed after a successful or unsuccessful pairing.
