### PR TITLE
Build break: Revert "Clear PASESession state while initializing it"

### DIFF
--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -175,9 +175,6 @@ CHIP_ERROR PASESession::Init(Optional<NodeId> myNodeId, uint16_t myKeyId, uint32
 
     VerifyOrExit(delegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    // Reset any state maintained by PASESession object (in case it's being reused for pairing)
-    Clear();
-
     err = mCommissioningHash.Begin();
     SuccessOrExit(err);
 


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#4567

Appears that this broke the Zephyr build, verifying.