### PR TITLE
Fix sporadic CI failure in crypto test for nrf platform

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -461,6 +461,7 @@ public:
      * @param context     The spake2p session will bootstrap from this hash context.
      *                    If the provided context pointer is null, the spake2p session will bootstrap
      *                    from a blank hash context.
+     *                    Note: calling this function will nullptr doesn't free the object state.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -61,13 +61,15 @@ void PASESession::Clear()
 {
     // This function zeroes out and resets the memory used by the object.
     // It's done so that no security related information will be leaked.
-    // Note: we don't need to explicitly clear the state of mSpake2p object.
-    //       Clearing the following buffers/state takes care of it.
     memset(&mPoint[0], 0, sizeof(mPoint));
     memset(&mWS[0][0], 0, sizeof(mWS));
     memset(&mKe[0], 0, sizeof(mKe));
     mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
+
+    // Note: we don't need to explicitly clear the state of mSpake2p object.
+    //       Clearing the following state takes care of it.
     mCommissioningHash.Clear();
+
     mIterationCount = 0;
     mSaltLength     = 0;
     if (mSalt != nullptr)

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -65,7 +65,6 @@ void PASESession::Clear()
     memset(&mWS[0][0], 0, sizeof(mWS));
     memset(&mKe[0], 0, sizeof(mKe));
     mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
-    mSpake2p.Init(nullptr);
     mCommissioningHash.Clear();
     mIterationCount = 0;
     mSaltLength     = 0;

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -61,6 +61,8 @@ void PASESession::Clear()
 {
     // This function zeroes out and resets the memory used by the object.
     // It's done so that no security related information will be leaked.
+    // Note: we don't need to explicitly clear the state of mSpake2p object.
+    //       Clearing the following buffers/state takes care of it.
     memset(&mPoint[0], 0, sizeof(mPoint));
     memset(&mWS[0][0], 0, sizeof(mWS));
     memset(&mKe[0], 0, sizeof(mKe));


### PR DESCRIPTION
 #### Problem
CI is intermittently failing in crypto tests while running `nrf` platform tests.

Failure logs are 

```
1: [ Test-CHIP-SecureChannel ]
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:53: assertion failed: "channel.Init(keypair, keypair2.Pubkey(), nullptr, 0, (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR"
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:57: assertion failed: "channel.Init(keypair, keypair2.Pubkey(), nullptr, 0, (const uint8_t *) info, sizeof(info)) == CHIP_ERROR_INCORRECT_STATE"
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:64: assertion failed: "channel2.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR"
1: [ Test-CHIP-SecureChannel : Init    ] : FAILED
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:90: assertion failed: "channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:95: assertion failed: "channel.Encrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:96: assertion failed: "channel.Encrypt(plain_text, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:97: assertion failed: "channel.Encrypt(plain_text, sizeof(plain_text), nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:101: assertion failed: "channel.Encrypt(plain_text, sizeof(plain_text), output, packetHeader, mac) == CHIP_NO_ERROR"
1: [ Test-CHIP-SecureChannel : Encrypt ] : FAILED
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:121: assertion failed: "channel.Init(keypair, keypair2.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:124: assertion failed: "channel.Encrypt(plain_text, sizeof(plain_text), encrypted, packetHeader, mac) == CHIP_NO_ERROR"
1: mbedTLS error: BIGNUM - Memory allocation failed
1: 
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:132: assertion failed: "channel2.Init(keypair2, keypair.Pubkey(), (const uint8_t *) salt, sizeof(salt), (const uint8_t *) info, sizeof(info)) == CHIP_NO_ERROR"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:137: assertion failed: "channel2.Decrypt(nullptr, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:138: assertion failed: "channel2.Decrypt(encrypted, 0, nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:139: assertion failed: "channel2.Decrypt(encrypted, sizeof(encrypted), nullptr, packetHeader, mac) == CHIP_ERROR_INVALID_ARGUMENT"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:143: assertion failed: "channel2.Decrypt(encrypted, sizeof(plain_text), output, packetHeader, mac) == CHIP_NO_ERROR"
1: ../../../../../../src/transport/tests/TestSecureSession.cpp:145: assertion failed: "memcmp(plain_text, output, sizeof(plain_text)) == 0"
1: [ Test-CHIP-SecureChannel : Decrypt ] : FAILED
1: Failed Tests:   3 / 3
1: Failed Asserts: 16 / 26
```

 #### Summary of Changes
`PASESession.Clear()` was calling `mSpake2p.Init(nullptr);`, but it doesn't clear the state of the Spake2p object. It initialized the SHA256 context, which was eventually leaked. The test runs were calling this repeatedly that drained the buffer pool from mbedTLS library. 
