### PR TITLE
minor documentation fix

### DIFF
--- a/examples/lock-app/k32w/README.md
+++ b/examples/lock-app/k32w/README.md
@@ -107,16 +107,16 @@ bolt is extended (i.e. door locked); when not lit, the bolt is retracted (door
 unlocked). The LED will flash whenever the simulated bolt is in motion from one
 position to another.
 
-**Button SW2** can be used to reset the device to a default state. Pressing and
-holding Button SW2 for 6 seconds initiates a factory reset. After an initial
+**Button SW2** can be used to change the state of the simulated bolt. This can
+be used to mimic a user manually operating the lock. The button behaves as a
+toggle, swapping the state every time it is pressed.
+
+**Button SW3** can be used to reset the device to a default state. Pressing and
+holding Button SW3 for 6 seconds initiates a factory reset. After an initial
 period of 3 seconds, LED2 D2 and D3 will flash in unison to signal the pending
 reset. Holding the button past 6 seconds will cause the device to reset its
 persistent configuration and initiate a reboot. The reset action can be
 cancelled by releasing the button at any point before the 6 second limit.
-
-**Button SW3** can be used to change the state of the simulated bolt. This can
-be used to mimic a user manually operating the lock. The button behaves as a
-toggle, swapping the state every time it is pressed.
 
 **Button SW4** can be used for joining a predefined Thread network advertised by
 a Border Router. Default parameters for a Thread network are hard-coded and are

--- a/third_party/k32w_sdk/mr2_fixes/patch_k32w_mr2_sdk.sh
+++ b/third_party/k32w_sdk/mr2_fixes/patch_k32w_mr2_sdk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! -v K32W061_SDK_ROOT ]]; then
+if [[ ! -d K32W061_SDK_ROOT ]]; then
     echo "K32W061_SDK_ROOT is not set"
     exit 1
 fi

--- a/third_party/k32w_sdk/mr2_fixes/patch_k32w_mr2_sdk.sh
+++ b/third_party/k32w_sdk/mr2_fixes/patch_k32w_mr2_sdk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! -d K32W061_SDK_ROOT ]]; then
+if [[ ! -d $K32W061_SDK_ROOT ]]; then
     echo "K32W061_SDK_ROOT is not set"
     exit 1
 fi


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 1. Documentation update for k32w specific elock example
 2. k32 SDK patching script had an error on macos
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 1. Fixed documentation to properly identify buttons with the expected behaviour
2. Make the k32w SDK patching script compatible to both linux and macos

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
