### PR TITLE
Update chip-tool listening port to be 'CHIP_PORT + 1' instead of CHIP…

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -119,8 +119,10 @@ exit:
 
 uint16_t PersistentStorage::GetListenPort()
 {
-    CHIP_ERROR err          = CHIP_NO_ERROR;
-    uint16_t chipListenPort = CHIP_PORT;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // By default chip-tool listens on CHIP_PORT + 1. This is done in order to avoid
+    // having 2 servers listening on CHIP_PORT when one runs an accessory server locally.
+    uint16_t chipListenPort = CHIP_PORT + 1;
 
     char value[6];
     uint16_t size = static_cast<uint16_t>(sizeof(value));


### PR DESCRIPTION
…_PORT

 #### Problem

`chip-tool` is sometimes used to connect to a local accessory server running on the same machine. In this case the accessory server and chip-tool conflicts because both listens to port `11097` (`CHIP_TOOL`).

It is easy to workaround this by adding a `ListenPort=11098` to `/tmp/chip_tool_config.ini` but it requires an extra step that is not necessary.

 #### Summary of changes
 * Listen on port `CHIP_PORT + 1` by default instead of `CHIP_PORT`