### PR TITLE
Send current IP address during network provisioning

### DIFF
--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -113,6 +113,14 @@ private:
      */
     CHIP_ERROR SendIPAddress(const Inet::IPAddress & addr);
 
+    /**
+     * @brief
+     *  The device can use this function to send its current IP address to
+     *  commissioner. This would generally be called during network
+     *  provisioning of the device, when the device already has an IP address.
+     */
+    CHIP_ERROR SendCurrentIPv4Address();
+
     static size_t EncodedStringSize(const char * str);
     static CHIP_ERROR EncodeString(const char * str, BufBound & bbuf);
     static CHIP_ERROR DecodeString(const uint8_t * input, size_t input_len, BufBound & bbuf, size_t & consumed);


### PR DESCRIPTION
 #### Problem
For multi-admin scenarios, the device address needs to be detected by the additional commissioners. In the current flow, the device sends its IP address to the commissioner as part of the network provisioning flow. Eventually, it'll be changed to DNS-SD.

In current flow, the network provisioning state machine doesn't send the IP address to the commissioner, if it was already connected to the network. The state machine needs to be updated, so that it can detect it has a valid IP, and send it to the commissioner.

 #### Summary of Changes
When network provisioning command is received from the commissioner, the device will
1. check if it is already connected to the network
2. find the interface that's up, is not loopback, and is not an access point (in case it was configured)
3. get the IP address of the interface, and send it to the commissioner.

#### Note
This is a temporary solution. Once Network Provisioning cluster and DNS-SD is implemented/integrated, the `NetworkProvisioning.cpp/.h` class implementation will be removed. This change is contained within this class, so it'll be removed along with it.