### PR TITLE
Release transport once rendezvous process is complete

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -76,7 +76,7 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params, Transpor
     }
 
     mNetworkProvision.Init(this);
-    // TODO: We should assmue mTransportMgr not null for IP rendezvous.
+    // TODO: We should assume mTransportMgr not null for IP rendezvous.
     if (mTransportMgr != nullptr)
     {
         mTransportMgr->SetRendezvousSession(this);
@@ -258,22 +258,37 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
     }
     mCurrentState = newState;
 
-    if (newState == State::kRendezvousComplete && mDelegate != nullptr)
+    switch (mCurrentState)
     {
-        mDelegate->OnRendezvousComplete();
-    }
+    case State::kRendezvousComplete:
+        if (mDelegate != nullptr)
+        {
+            mDelegate->OnRendezvousComplete();
+        }
+        break;
 
-    // Release the previous session handle if new state is init, or pairing just started
-    if (newState == State::kInit || newState == State::kSecurePairing)
-    {
+    case State::kSecurePairing:
+        // Release the previous session handle
         ReleasePairingSessionHandle();
-    }
+        break;
 
-    if (newState == State::kInit)
-    {
-        // Disable BLE advertisement
+    case State::kInit:
+        // Release the previous session handle
+        ReleasePairingSessionHandle();
+
+        // Disable rendezvous advertisement
         mParams.GetAdvertisementDelegate()->StopAdvertisement();
-    }
+        if (mTransport)
+        {
+            // Free the transport
+            chip::Platform::Delete(mTransport);
+            mTransport = nullptr;
+        }
+        break;
+
+    default:
+        break;
+    };
 }
 
 void RendezvousSession::OnRendezvousMessageReceived(const PacketHeader & packetHeader, const PeerAddress & peerAddress,


### PR DESCRIPTION
 #### Problem
Commissioner holds on to the transport (e.g BLE) even after the rendezvous process is finished. This prevents the BLE to be reused for future connections (e.g. for pairing additional commissioners), while the current commissioner app is still active.

 #### Summary of Changes
Release the transport when the rendezvous state machine enters `kInit` state. Also, reworked the code structure to clean up other state handling.
