### PR TITLE
Enable pairing window only when needed

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -261,6 +261,7 @@ public:
         if (i == 0)
         {
             ConnectivityMgr().ClearWiFiStationProvision();
+            OpenDefaultPairingWindow();
         }
     }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -35,3 +35,8 @@ using DemoTransportMgr = chip::TransportMgr<chip::Transport::UDP>;
  * @param [in] delegate   An optional AppDelegate
  */
 void InitServer(AppDelegate * delegate = nullptr);
+
+/**
+ * Open the pairing window using default configured parameters.
+ */
+CHIP_ERROR OpenDefaultPairingWindow();


### PR DESCRIPTION
 #### Problem
The example device (e.g. m5stack based demo device) opens the pairing window (i.e. advertises on BLE, and accepts rendezvous messages) on every reboot, even though the device might already be provisioned. This flow is not correct. The pairing window should only be open when

1. The device is not currently paired
2. In case of multi-admin it was instructed by an existing admin to allow pairing 

 #### Summary of Changes
The current PR restricts the pairing window to cases when the device is not currently paired. The new function `OpenPairingWindow` can be used for multi-admin scenarios, when implemented.

Also, the pairing window will be opened if the device was reset from screen.
