### PR TITLE
Update ZCL reporting code to be compatible with a client ZAP application

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -248,6 +248,40 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2504,6 +2504,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/bridge-app/bridge-common/gen/callback-stub.cpp
+++ b/examples/bridge-app/bridge-common/gen/callback-stub.cpp
@@ -168,6 +168,40 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/bridge-app/bridge-common/gen/callback.h
+++ b/examples/bridge-app/bridge-common/gen/callback.h
@@ -414,6 +414,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -163,6 +163,40 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -391,6 +391,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -154,6 +154,40 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -241,6 +241,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -168,6 +168,40 @@ bool emberAfDefaultResponseCallback(ClusterId clusterId, CommandId commandId, Em
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -308,6 +308,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -1078,13 +1078,3 @@ uint8_t emAfPluginReportingConditionallyAddReportingEntry(EmberAfPluginReporting
     }
     return 0;
 }
-
-bool emberAfConfigureReportingResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}
-
-bool emberAfReadReportingConfigurationResponseCallback(ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
-{
-    return false;
-}

--- a/src/app/reporting/reporting.h
+++ b/src/app/reporting/reporting.h
@@ -112,34 +112,6 @@ bool emberAfReadReportingConfigurationCommandCallback(const EmberAfClusterComman
  */
 EmberStatus emberAfClearReportTableCallback(void);
 
-/** @brief Configure Reporting Response
- *
- * This function is called by the application framework when a Configure
- * Reporting Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute status records.  Ver.:
- * always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-
-/** @brief Read Reporting Configuration Response
- *
- * This function is called by the application framework when a Read Reporting
- * Configuration Response command is received from an external device.  The
- * application should return true if the message was processed or false if it
- * was not.
- *
- * @param clusterId The cluster identifier of this response.  Ver.: always
- * @param buffer Buffer containing the list of attribute reporting configuration
- * records.  Ver.: always
- * @param bufLen The length in bytes of the list.  Ver.: always
- */
-bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
-
 /** @brief Reporting Attribute Change
  *
  * This function is called by the framework when an attribute managed by the

--- a/src/app/server/DataModelHandler.h
+++ b/src/app/server/DataModelHandler.h
@@ -23,16 +23,22 @@
 #pragma once
 
 #include <system/SystemPacketBuffer.h>
-#include <transport/SecureSessionMgr.h>
 #include <transport/raw/MessageHeader.h>
+
+/**
+ * Initialize the data model internal code to be ready to send and receive
+ * data model messages.
+ *
+ */
+void InitDataModelHandler();
 
 /**
  * Handle a message that should be processed via our data model processing
  * codepath.
  *
+ * @param [in] nodeId The source node id of the message
  * @param [in] buffer The buffer holding the message.  This function guarantees
  *                    that it will free the buffer before returning.
+ *
  */
-void HandleDataModelMessage(const chip::PacketHeader & header, chip::System::PacketBufferHandle buffer,
-                            chip::SecureSessionMgr * mgr);
-void InitDataModelHandler();
+void HandleDataModelMessage(chip::NodeId nodeId, chip::System::PacketBufferHandle buffer);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -88,7 +88,7 @@ public:
 
         ChipLogProgress(AppServer, "Packet received from %s: %zu bytes", src_addr, static_cast<size_t>(data_len));
 
-        HandleDataModelMessage(header, std::move(buffer), mgr);
+        HandleDataModelMessage(header.GetSourceNodeId().Value(), std::move(buffer));
 
     exit:;
     }

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -153,6 +153,42 @@ bool __attribute__((weak)) emberAfDefaultResponseCallback(
     return false;
 }
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfConfigureReportingResponseCallback(
+    ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool __attribute__((weak)) emberAfReadReportingConfigurationResponseCallback(
+    ClusterId clusterId, uint8_t * buffer, uint16_t bufLen)
+{
+    return false;
+}
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -233,6 +233,34 @@ bool emberAfAttributeWriteAccessCallback(chip::EndpointId endpoint, chip::Cluste
  */
 bool emberAfDefaultResponseCallback(chip::ClusterId clusterId, chip::CommandId commandId, EmberAfStatus status);
 
+/** @brief Configure Reporting Response
+ *
+ * This function is called by the application framework when a Configure
+ * Reporting Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute status records.  Ver.:
+ * always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfConfigureReportingResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
+/** @brief Read Reporting Configuration Response
+ *
+ * This function is called by the application framework when a Read Reporting
+ * Configuration Response command is received from an external device.  The
+ * application should return true if the message was processed or false if it
+ * was not.
+ *
+ * @param clusterId The cluster identifier of this response.  Ver.: always
+ * @param buffer Buffer containing the list of attribute reporting configuration
+ * records.  Ver.: always
+ * @param bufLen The length in bytes of the list.  Ver.: always
+ */
+bool emberAfReadReportingConfigurationResponseCallback(chip::ClusterId clusterId, uint8_t * buffer, uint16_t bufLen);
+
 /** @brief Discover Attributes Response
  *
  * This function is called by the application framework when a Discover


### PR DESCRIPTION
 #### Problem

In #3608, many reporting specific callbacks has been moved from `gen/callback-stub.cpp` to `src/app/reporting/`. The PR has been a bit overzealous since all the `*ReportingResponseCallback` declarations and definitions has been moved while those still needs to be part of the `gen/` content if one wants to override them.
Also, the server specific stack status callbacks are called for both the client and the server, while those only needs to be called by the reporter.

Those issues prevents to write a client application that consumes a `.zap` configuration file.

 #### Summary of changes
  * Move back `*ReportingResponseCallback` to the `gen/` folder
  * Update the `#ifdef` in `src/app/server/DataModelHandler.cpp` to only call the stack status callbacks for the server side
  * Update `HandleDataModelMessage` signature by only passing a `NodeId` for the first argument and remove the last one which is unused.