### PR TITLE
Add UI to manage biding/unbiding

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B243A6692513A73600E56FEA /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B243A6682513A73600E56FEA /* RootViewController.m */; };
 		B2946A4224C99D53005C87D0 /* WifiViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2946A4124C99D53005C87D0 /* WifiViewController.m */; };
 		B2946A9B24C9A7BF005C87D0 /* DefaultsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B2946A9A24C9A7BF005C87D0 /* DefaultsUtils.m */; };
+		B2B0209225C9C1AC00A4C220 /* BindingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B0209125C9C1AC00A4C220 /* BindingsViewController.m */; };
 		B2F51E99252DCDC000911FA5 /* TemperatureSensorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B2F51E98252DCDC000911FA5 /* TemperatureSensorViewController.m */; };
 		B2F53AEB245B0D140010745E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B2F53AE9245B0D140010745E /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -75,6 +76,8 @@
 		B2946A4124C99D53005C87D0 /* WifiViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WifiViewController.m; sourceTree = "<group>"; };
 		B2946A9924C9A7BF005C87D0 /* DefaultsUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DefaultsUtils.h; sourceTree = "<group>"; };
 		B2946A9A24C9A7BF005C87D0 /* DefaultsUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DefaultsUtils.m; sourceTree = "<group>"; };
+		B2B0209025C9C1AC00A4C220 /* BindingsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BindingsViewController.h; sourceTree = "<group>"; };
+		B2B0209125C9C1AC00A4C220 /* BindingsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BindingsViewController.m; sourceTree = "<group>"; };
 		B2F51E97252DCDC000911FA5 /* TemperatureSensorViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemperatureSensorViewController.h; sourceTree = "<group>"; };
 		B2F51E98252DCDC000911FA5 /* TemperatureSensorViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TemperatureSensorViewController.m; sourceTree = "<group>"; };
 		B2F53AEA245B0D140010745E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = UI/Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -195,6 +198,7 @@
 				B243A6672513A73600E56FEA /* RootViewController.h */,
 				B243A6682513A73600E56FEA /* RootViewController.m */,
 				B2F51E93252DCC9E00911FA5 /* Temperature Sensor */,
+				B2B0208F25C9C18500A4C220 /* Bindings */,
 				B2946A3F24C99D21005C87D0 /* Wifi */,
 				0C79937824858B3B0047A373 /* QRCode */,
 				0C79937924858B4F0047A373 /* Echo client */,
@@ -219,6 +223,15 @@
 				B2946A4124C99D53005C87D0 /* WifiViewController.m */,
 			);
 			path = Wifi;
+			sourceTree = "<group>";
+		};
+		B2B0208F25C9C18500A4C220 /* Bindings */ = {
+			isa = PBXGroup;
+			children = (
+				B2B0209025C9C1AC00A4C220 /* BindingsViewController.h */,
+				B2B0209125C9C1AC00A4C220 /* BindingsViewController.m */,
+			);
+			path = Bindings;
 			sourceTree = "<group>";
 		};
 		B2F51E93252DCC9E00911FA5 /* Temperature Sensor */ = {
@@ -334,6 +347,7 @@
 				B232D8BA2514BD0800792CB4 /* CHIPUIViewUtils.m in Sources */,
 				B2946A9B24C9A7BF005C87D0 /* DefaultsUtils.m in Sources */,
 				991DC091247747F500C13860 /* EchoViewController.m in Sources */,
+				B2B0209225C9C1AC00A4C220 /* BindingsViewController.m in Sources */,
 				B204A621244E1D0600C7C0E1 /* AppDelegate.m in Sources */,
 				B2F51E99252DCDC000911FA5 /* TemperatureSensorViewController.m in Sources */,
 				B243A6692513A73600E56FEA /* RootViewController.m in Sources */,

--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
@@ -140,6 +140,30 @@
     return containingView;
 }
 
++ (UIStackView *)stackViewWithButtons:(NSArray<UIButton *> *)buttons
+{
+    UIStackView * stackViewButtons = [UIStackView new];
+    stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
+    stackViewButtons.distribution = UIStackViewDistributionFillEqually;
+    stackViewButtons.alignment = UIStackViewAlignmentTrailing;
+    stackViewButtons.spacing = 10;
+
+    for (int i = 0; i < buttons.count; i++) {
+        UIButton * buttonForStack = [buttons objectAtIndex:i];
+        buttonForStack.backgroundColor = UIColor.systemBlueColor;
+        buttonForStack.titleLabel.font = [UIFont systemFontOfSize:17];
+        buttonForStack.titleLabel.textColor = [UIColor whiteColor];
+        buttonForStack.layer.cornerRadius = 5;
+        buttonForStack.clipsToBounds = YES;
+        buttonForStack.translatesAutoresizingMaskIntoConstraints = false;
+        [buttonForStack.widthAnchor constraintEqualToConstant:70].active = YES;
+        [stackViewButtons addArrangedSubview:buttonForStack];
+    }
+    return stackViewButtons;
+}
+
+
+
 + (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons
 {
     // Button stack view

--- a/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/UI Helpers/CHIPUIViewUtils.m
@@ -162,8 +162,6 @@
     return stackViewButtons;
 }
 
-
-
 + (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons
 {
     // Button stack view

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.h
@@ -14,22 +14,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CHIPUIViewUtils : NSObject
-+ (UIView *)viewWithUITextField:(UITextField *)textField button:(UIButton *)button;
-+ (UIStackView *)stackViewWithLabel:(UILabel *)label result:(UILabel *)result;
-+ (UIView *)viewWithLabel:(UILabel *)label textField:(UITextField *)textField;
-+ (UIView *)viewWithLabel:(UILabel *)label toggle:(UISwitch *)toggle;
+@interface BindingsViewController : UIViewController
 
-+ (UIStackView *)stackViewWithLabel:(UILabel *)label buttons:(NSArray<UIButton *> *)buttons;
-+ (UIStackView *)stackViewWithButtons:(NSArray<UIButton *> *)buttons;
-
-+ (UILabel *)addTitle:(NSString *)title toView:(UIView *)view;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -19,10 +19,10 @@
 #import "CHIPUIViewUtils.h"
 
 @interface BindingsViewController ()
-@property (nonatomic, strong) UITextField *nodeIDTextField;
-@property (nonatomic, strong) UITextField *groupIDTextField;
-@property (nonatomic, strong) UITextField *endpointIDTextField;
-@property (nonatomic, strong) UITextField *clusterIDTextField;
+@property (nonatomic, strong) UITextField * nodeIDTextField;
+@property (nonatomic, strong) UITextField * groupIDTextField;
+@property (nonatomic, strong) UITextField * endpointIDTextField;
+@property (nonatomic, strong) UITextField * clusterIDTextField;
 @end
 
 @implementation BindingsViewController
@@ -35,7 +35,6 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 }
-
 
 - (void)dismissKeyboard
 {
@@ -102,13 +101,13 @@
     [clusterIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 
     // Buttons
-    UIButton *bindButton = [UIButton new];
+    UIButton * bindButton = [UIButton new];
     [bindButton setTitle:@"Bind" forState:UIControlStateNormal];
-    UIButton *unbindButton = [UIButton new];
+    UIButton * unbindButton = [UIButton new];
     [unbindButton setTitle:@"Unbind" forState:UIControlStateNormal];
     [bindButton addTarget:self action:@selector(bind:) forControlEvents:UIControlEventTouchUpInside];
     [unbindButton addTarget:self action:@selector(unbind:) forControlEvents:UIControlEventTouchUpInside];
-    UIStackView *stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[bindButton, unbindButton]];
+    UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[ bindButton, unbindButton ]];
 
     [stackView addArrangedSubview:stackViewButtons];
     [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
@@ -128,7 +127,6 @@
 {
     [self _clearTextFields];
     // TODO: Call binding API
-
 }
 
 - (IBAction)unbind:(id)sender

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -1,0 +1,140 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "BindingsViewController.h"
+#import "CHIPUIViewUtils.h"
+
+@interface BindingsViewController ()
+@property (nonatomic, strong) UITextField *nodeIDTextField;
+@property (nonatomic, strong) UITextField *groupIDTextField;
+@property (nonatomic, strong) UITextField *endpointIDTextField;
+@property (nonatomic, strong) UITextField *clusterIDTextField;
+@end
+
+@implementation BindingsViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    [self setupUI];
+
+    UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    [self.view addGestureRecognizer:tap];
+}
+
+
+- (void)dismissKeyboard
+{
+    [_nodeIDTextField resignFirstResponder];
+    [_endpointIDTextField resignFirstResponder];
+    [_groupIDTextField resignFirstResponder];
+    [_clusterIDTextField resignFirstResponder];
+}
+
+// MARK: UI helpers
+
+- (void)setupUI
+{
+    self.view.backgroundColor = UIColor.whiteColor;
+
+    // Title
+    UILabel * titleLabel = [CHIPUIViewUtils addTitle:@"Bindings" toView:self.view];
+
+    // stack view
+    UIStackView * stackView = [UIStackView new];
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.spacing = 30;
+    [self.view addSubview:stackView];
+
+    stackView.translatesAutoresizingMaskIntoConstraints = false;
+    [stackView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:30].active = YES;
+    [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
+    [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
+
+    // nodeID entry
+    UILabel * nodeIDLabel = [UILabel new];
+    nodeIDLabel.text = @"Node ID";
+    _nodeIDTextField = [UITextField new];
+    UIView * nodeIDView = [CHIPUIViewUtils viewWithLabel:nodeIDLabel textField:_nodeIDTextField];
+    [stackView addArrangedSubview:nodeIDView];
+    nodeIDView.translatesAutoresizingMaskIntoConstraints = false;
+    [nodeIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // groupID entry
+    UILabel * groupIDLabel = [UILabel new];
+    groupIDLabel.text = @"Group ID";
+    _groupIDTextField = [UITextField new];
+    UIView * groupIDView = [CHIPUIViewUtils viewWithLabel:groupIDLabel textField:_groupIDTextField];
+    [stackView addArrangedSubview:groupIDView];
+    [groupIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+    
+    // endpointID entry
+    UILabel * endpointIDLabel = [UILabel new];
+    endpointIDLabel.text = @"Endpoint ID";
+    _endpointIDTextField = [UITextField new];
+    UIView * endpointIDView = [CHIPUIViewUtils viewWithLabel:endpointIDLabel textField:_endpointIDTextField];
+    [stackView addArrangedSubview:endpointIDView];
+    endpointIDView.translatesAutoresizingMaskIntoConstraints = false;
+    [endpointIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // clusterID entry
+    UILabel * clusterIDLabel = [UILabel new];
+    clusterIDLabel.text = @"Cluster ID";
+    _clusterIDTextField = [UITextField new];
+    UIView * clusterIDView = [CHIPUIViewUtils viewWithLabel:clusterIDLabel textField:_clusterIDTextField];
+    [stackView addArrangedSubview:clusterIDView];
+    [clusterIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Buttons
+    UIButton *bindButton = [UIButton new];
+    [bindButton setTitle:@"Bind" forState:UIControlStateNormal];
+    UIButton *unbindButton = [UIButton new];
+    [unbindButton setTitle:@"Unbind" forState:UIControlStateNormal];
+    [bindButton addTarget:self action:@selector(bind:) forControlEvents:UIControlEventTouchUpInside];
+    [unbindButton addTarget:self action:@selector(unbind:) forControlEvents:UIControlEventTouchUpInside];
+    UIStackView *stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[bindButton, unbindButton]];
+    
+    [stackView addArrangedSubview:stackViewButtons];
+    [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+}
+
+- (void)_clearTextFields
+{
+    _nodeIDTextField.text = @"";
+    _endpointIDTextField.text = @"";
+    _groupIDTextField.text = @"";
+    _clusterIDTextField.text = @"";
+}
+
+// MARK: Button methods
+
+- (IBAction)bind:(id)sender
+{
+    [self _clearTextFields];
+    // TODO: Call binding API
+    
+}
+
+- (IBAction)unbind:(id)sender
+{
+    [self _clearTextFields];
+    // TODO: Call unbinding API
+}
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -83,7 +83,7 @@
     UIView * groupIDView = [CHIPUIViewUtils viewWithLabel:groupIDLabel textField:_groupIDTextField];
     [stackView addArrangedSubview:groupIDView];
     [groupIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
-    
+
     // endpointID entry
     UILabel * endpointIDLabel = [UILabel new];
     endpointIDLabel.text = @"Endpoint ID";
@@ -109,7 +109,7 @@
     [bindButton addTarget:self action:@selector(bind:) forControlEvents:UIControlEventTouchUpInside];
     [unbindButton addTarget:self action:@selector(unbind:) forControlEvents:UIControlEventTouchUpInside];
     UIStackView *stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[bindButton, unbindButton]];
-    
+
     [stackView addArrangedSubview:stackViewButtons];
     [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 }
@@ -128,7 +128,7 @@
 {
     [self _clearTextFields];
     // TODO: Call binding API
-    
+
 }
 
 - (IBAction)unbind:(id)sender

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -16,12 +16,12 @@
  */
 
 #import "RootViewController.h"
+#import "BindingsViewController.h"
 #import "EchoViewController.h"
 #import "OnOffViewController.h"
 #import "QRCodeViewController.h"
 #import "TemperatureSensorViewController.h"
 #import "WifiViewController.h"
-#import "BindingsViewController.h"
 
 @implementation RootViewController
 
@@ -38,7 +38,9 @@
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     [self.view addSubview:self.tableView];
-    self.options = @[ @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration" ];
+    self.options = @[
+        @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration"
+    ];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -21,6 +21,7 @@
 #import "QRCodeViewController.h"
 #import "TemperatureSensorViewController.h"
 #import "WifiViewController.h"
+#import "BindingsViewController.h"
 
 @implementation RootViewController
 
@@ -37,7 +38,7 @@
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     [self.view addSubview:self.tableView];
-    self.options = @[ @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Wifi Configuration" ];
+    self.options = @[ @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration" ];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
@@ -75,11 +76,20 @@
         [self pushTemperatureSensor];
         break;
     case 4:
+        [self pushBindings];
+        break;
+    case 5:
         [self pushNetworkConfiguration];
         break;
     default:
         break;
     }
+}
+
+- (void)pushBindings
+{
+    BindingsViewController * controller = [BindingsViewController new];
+    [self.navigationController pushViewController:controller animated:YES];
 }
 
 - (void)pushTemperatureSensor

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
@@ -106,7 +106,7 @@
     [_clearButton addTarget:self action:@selector(clearCredientials:) forControlEvents:UIControlEventTouchUpInside];
     [_saveButton addTarget:self action:@selector(saveCredientials:) forControlEvents:UIControlEventTouchUpInside];
 
-    UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[_clearButton, _saveButton]];
+    UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[ _clearButton, _saveButton ]];
     [stackView addArrangedSubview:stackViewButtons];
     [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
@@ -105,7 +105,7 @@
     [_saveButton setTitle:@"Save" forState:UIControlStateNormal];
     [_clearButton addTarget:self action:@selector(clearCredientials:) forControlEvents:UIControlEventTouchUpInside];
     [_saveButton addTarget:self action:@selector(saveCredientials:) forControlEvents:UIControlEventTouchUpInside];
-    
+
     UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[_clearButton, _saveButton]];
     [stackView addArrangedSubview:stackViewButtons];
     [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Wifi/WifiViewController.m
@@ -99,37 +99,16 @@
     [passwordView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 
     // Button stack view
-    UIStackView * stackViewButtons = [UIStackView new];
-    stackViewButtons.axis = UILayoutConstraintAxisHorizontal;
-    stackViewButtons.distribution = UIStackViewDistributionEqualCentering;
-    stackViewButtons.alignment = UIStackViewAlignmentTrailing;
-    stackViewButtons.spacing = 10;
-    [self.view addSubview:stackViewButtons];
-
-    stackViewButtons.translatesAutoresizingMaskIntoConstraints = false;
-    [stackViewButtons.topAnchor constraintEqualToAnchor:stackView.bottomAnchor constant:30].active = YES;
-    [stackViewButtons.bottomAnchor constraintLessThanOrEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:-30].active
-        = YES;
-    [stackViewButtons.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
-    NSArray<NSString *> * buttonTitles = @[ @"Clear", @"Save" ];
     _clearButton = [UIButton new];
+    [_clearButton setTitle:@"Clear" forState:UIControlStateNormal];
     _saveButton = [UIButton new];
+    [_saveButton setTitle:@"Save" forState:UIControlStateNormal];
     [_clearButton addTarget:self action:@selector(clearCredientials:) forControlEvents:UIControlEventTouchUpInside];
     [_saveButton addTarget:self action:@selector(saveCredientials:) forControlEvents:UIControlEventTouchUpInside];
-    NSArray<UIButton *> * buttonsBelow = @[ _clearButton, _saveButton ];
-    for (int i = 0; i < buttonTitles.count; i++) {
-        UIButton * buttonForStack = [buttonsBelow objectAtIndex:i];
-        NSString * title = [buttonTitles objectAtIndex:i];
-        [buttonForStack setTitle:title forState:UIControlStateNormal];
-        buttonForStack.backgroundColor = UIColor.systemBlueColor;
-        buttonForStack.titleLabel.font = [UIFont systemFontOfSize:17];
-        buttonForStack.titleLabel.textColor = [UIColor whiteColor];
-        buttonForStack.layer.cornerRadius = 5;
-        buttonForStack.clipsToBounds = YES;
-        buttonForStack.translatesAutoresizingMaskIntoConstraints = false;
-        [buttonForStack.widthAnchor constraintEqualToConstant:70].active = YES;
-        [stackViewButtons addArrangedSubview:buttonForStack];
-    }
+    
+    UIStackView * stackViewButtons = [CHIPUIViewUtils stackViewWithButtons:@[_clearButton, _saveButton]];
+    [stackView addArrangedSubview:stackViewButtons];
+    [stackViewButtons.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
 }
 
 - (void)fillNetworkConfigWithDefaults


### PR DESCRIPTION
 #### Problem
Need to provide UI to use CHIPBinding API

 #### Summary of Changes
- Added a new pane in the iOS app to control binding unbinding. This is just a UI fix, it does not call any APIs so far
- Refactors code to add new UI helpers for a horizontal stack view to make adding new buttons more easy.


 Fixes #4607 

![IMG_0844](https://user-images.githubusercontent.com/61782012/106643459-0c3abb80-658a-11eb-98a9-604839fcd4fc.jpg)

