### PR TITLE
Add Silabs ZCL8 XML implementation

### DIFF
--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -19,7 +19,7 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../../third_party/zap/repo/zcl-builtin/silabs/zcl.json",
+      "path": "../../../../src/app/zap-templates/zcl/data-model/silabs/zcl.json",
       "version": "ZCL Test Data",
       "type": "zcl-properties"
     },

--- a/src/app/zap-templates/README.md
+++ b/src/app/zap-templates/README.md
@@ -19,8 +19,8 @@ Generate files in headless mode
 
 ```
 cd ./third_party/zap/repo/
-node src-script/zap-generate.js -z ./zcl-builtin/silabs/zcl.json -g ../../../src/app/zap-templates/app-templates.json -i <path to *.zap file> -o <Path to /gen/ folder>
-node src-script/zap-generate.js -z ./zcl-builtin/silabs/zcl.json -g ../../../src/app/zap-templates/chip-templates.json -i <path to *.zap file> -o ../../../
+node src-script/zap-generate.js -z ../../../../src/app/zap-templates/zcl/zcl.json -g ../../../src/app/zap-templates/app-templates.json -i <path to *.zap file> -o <Path to /gen/ folder>
+node src-script/zap-generate.js -z ../../../../src/app/zap-templates/zcl/zcl.json -g ../../../src/app/zap-templates/chip-templates.json -i <path to *.zap file> -o ../../../
 ```
 
 For more information please see the documentation under `docs/` in

--- a/src/app/zap-templates/templates/app/af-gen-event.zapt
+++ b/src/app/zap-templates/templates/app/af-gen-event.zapt
@@ -1,0 +1,85 @@
+{{> header}}
+
+// #TODO : This template wasn't tested in any way with CHIP
+// Might need a zap submodule update and / or other fixes to make it work.
+// ISSUE : #3637
+
+
+#pragma once
+
+#define EMBER_AF_GENERATED_UC_EVENTS_DEF \
+{{#user_endpoint_types}}
+	{{#user_clusters}}
+		{{#if (is_enabled enabled)}}
+			{{#template_options category="tick_events"}}
+				{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+				sl_zigbee_event_t {{optionCode}}Event{{endpoint_type_identifier ../../endpointTypeId}}; \
+				{{/if}}
+			{{/template_options}}
+		{{/if}}
+	{{/user_clusters}}
+{{/user_endpoint_types}}
+{{#all_user_clusters}}
+	{{#template_options category="generic_events"}}
+		{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+			sl_zigbee_event_t {{optionCode}}EndpointEvents[{{user_endpoint_count_by_cluster ../id ../side}}]; \
+		{{/if}}
+	{{/template_options}}
+{{/all_user_clusters}}
+
+
+#define EMBER_AF_GENERATED_UC_EVENTS_INIT \
+{{#all_user_clusters}}
+	{{#if (is_enabled enabled)}}
+		{{#template_options category="tick_events"}}
+			{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+			extern void {{optionCode}}(uint8_t enpoint); \
+			{{/if}}
+		{{/template_options}}
+	{{/if}}
+{{/all_user_clusters}}
+{{#user_endpoint_types}}
+	{{#user_clusters}}
+		{{#if (is_enabled enabled)}}
+			{{#template_options category="tick_events"}}
+				{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+				sl_zigbee_endpoint_event_init(&{{optionCode}}Event{{endpoint_type_identifier ../../endpointTypeId}}, {{optionCode}}, {{endpoint_type_identifier ../../endpointTypeId}}); \
+				{{/if}}
+			{{/template_options}}
+		{{/if}}
+	{{/user_clusters}}
+{{/user_endpoint_types}}
+{{#all_user_clusters}}
+	{{#if (is_enabled enabled)}}
+		{{#template_options category="generic_events"}}
+			{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+			extern void {{optionCode}}EndpointEventHandler(uint8_t enpoint); \
+			{{/if}}
+		{{/template_options}}
+	{{/if}}
+{{/all_user_clusters}}
+{{#user_endpoint_types}}
+	{{#user_clusters}}
+		{{#if (is_enabled enabled)}}
+			{{#template_options category="generic_events"}}
+				{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+				sl_zigbee_endpoint_event_init(&{{optionCode}}EndpointEvents[{{endpoint_type_identifier ../../endpointTypeId}}], {{optionCode}}EndpointEventHandler, {{endpoint_type_identifier ../../endpointTypeId}}); \
+				{{/if}}
+			{{/template_options}}
+		{{/if}}
+	{{/user_clusters}}
+{{/user_endpoint_types}}
+
+// sl_zigbee_event_context_t structs used to populate the sli_zigbee_app_event_context table
+#define EMBER_AF_GENERATED_UC_EVENT_CONTEXT \
+{{#user_endpoint_types}}
+	{{#user_clusters}}
+		{{#if (is_enabled enabled)}}
+			{{#template_options category="tick_events"}}
+				{{#if (is_lowercase_equal (concatenate ../name ../side) optionLabel)~}}
+				{ {{endpoint_type_identifier ../../endpointTypeId}}, {{asHex ../code}}, {{#if (is_client ../side)}}true{{else}}false{{/if}}, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP, &{{optionCode}}Event{{endpoint_type_identifier ../../endpointTypeId}} },     \
+				{{/if}}
+			{{/template_options}}
+		{{/if}}
+	{{/user_clusters}}
+{{/user_endpoint_types}}

--- a/src/app/zap-templates/templates/app/gen-tokens.zapt
+++ b/src/app/zap-templates/templates/app/gen-tokens.zapt
@@ -1,0 +1,146 @@
+{{> header}}
+
+// #TODO : This template wasn't tested in any way with CHIP
+// Might need a zap submodule update and / or other fixes to make it work.
+// ISSUE : #3637
+
+
+#pragma once
+
+{{#endpoint_config}}
+{{#tokens_context}}
+
+{{#each singletons}}
+// Creator for attribute: {{name}}, singleton
+#define CREATOR_{{define}}_SINGLETON {{asHex ../token_id 4}}
+#define NVM3KEY_{{define}}_SINGLETON (NVM3KEY_DOMAIN_ZIGBEE | {{asHex ../token_id 4}})
+{{token_next ..}}
+{{/each}}
+{{#each endpoints}}
+{{#each nonSingletons}}
+// Creator for attribute: {{name}}, endpoint: {{../id}}
+#define CREATOR_{{define}}_{{../id}} {{asHex ../../token_id 4}}
+#define NVM3KEY_{{define}}_{{../id}} (NVM3KEY_DOMAIN_ZIGBEE | {{asHex ../../token_id 4}})
+{{token_next ../..}}
+{{/each}}
+{{/each}}
+
+// Types for the tokens
+#ifdef DEFINETYPES
+{{#each singletons}}
+{{#if maxLength}}
+typedef uint8_t tokType_{{tokenType}}[{{maxLength}}];
+{{else}}
+typedef {{as_underlying_type type}} tokType_{{tokenType}};
+{{/if}}
+{{/each}}
+{{#each nonSingletons}}
+{{#if maxLength}}
+typedef uint8_t tokType_{{tokenType}}[{{maxLength}}];
+{{else}}
+typedef {{as_underlying_type type}} tokType_{{tokenType}};
+{{/if}}
+{{/each}}
+#endif // DEFINETYPES
+
+
+#ifdef DEFINETOKENS
+{{#each singletons}}
+{{#if longDefault}}
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{tokenType}}, { {{longDefault}} })
+{{else}}
+{{#if defaultValue}}
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{tokenType}}, {{defaultValue}})
+{{else}}
+DEFINE_BASIC_TOKEN({{define}}_SINGLETON, tokType_{{tokenType}}, 0)
+{{/if}}
+{{/if}}
+{{/each}}
+{{#each endpoints}}
+{{#each nonSingletons}}
+{{#if longDefault}}
+DEFINE_BASIC_TOKEN({{define}}_{{../id}}, tokType_{{tokenType}}, { {{longDefault}} })
+{{else}}
+{{#if defaultValue}}
+DEFINE_BASIC_TOKEN({{define}}_{{../id}}, tokType_{{tokenType}}, {{defaultValue}})
+{{else}}
+DEFINE_BASIC_TOKEN({{define}}_{{../id}}, tokType_{{tokenType}}, 0)
+{{/if}}
+{{/if}}
+{{/each}}
+{{/each}}
+#endif // DEFINETOKENS
+
+
+// Macro snippet that loads all the attributes from tokens
+#define GENERATED_TOKEN_LOADER(endpoint) do {\
+{{#if hasAttributes}}
+  uint8_t ptr[{{maxSize}}]; \
+{{/if}}
+{{#if hasNonSingletons}}
+  uint8_t curNetwork = emberGetCurrentNetwork(); \
+  uint8_t epNetwork; \
+{{/if}}
+{{#each singletons}}
+  halCommonGetToken((tokType_{{tokenType}} *)ptr, TOKEN_{{define}}_SINGLETON); \
+{{#if serverSide}}
+  emberAfWriteServerAttribute(1, ZCL_{{as_delimited_macro cluster.name}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+{{/if}}
+  {{#unless serverSide}}
+  emberAfWriteClientAttribute(1, ZCL_{{as_delimited_macro cluster.name}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+{{/unless}}
+{{/each}}
+{{#each endpoints}}
+{{#if hasNonSingletons}}
+  epNetwork = emberAfNetworkIndexFromEndpoint({{id}}); \
+  if({{id}} == (endpoint) || (EMBER_BROADCAST_ENDPOINT == (endpoint) && epNetwork == curNetwork)) { \
+{{#each nonSingletons}}
+    halCommonGetToken((tokType_{{tokenType}} *)ptr, TOKEN_{{define}}_{{../id}}); \
+{{#if serverSide}}
+    emberAfWriteServerAttribute(1, ZCL_{{as_delimited_macro cluster.name}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+{{/if}}
+{{#unless serverSide}}
+    emberAfWriteClientAttribute(1, ZCL_{{as_delimited_macro cluster.name}}_CLUSTER_ID, ZCL_{{define}}_ATTRIBUTE_ID, (uint8_t*)ptr, ZCL_{{as_delimited_macro type}}_ATTRIBUTE_TYPE); \
+{{/unless}}
+{{/each}}
+  } \
+{{/if}}
+{{/each}}
+} while(false)
+
+
+// Macro snippet that saves the attribute to token
+#define GENERATED_TOKEN_SAVER do {                                                                                               \
+    uint8_t allZeroData[{{maxSize}}];                                                                                                     \
+    MEMSET(allZeroData, 0, {{maxSize}});                                                                                                  \
+    if ( data == NULL ) { data = allZeroData; }                                                                                  \
+{{#each clusters}}
+{{#if hasSingletons}}
+    if ( {{hexCode}} == clusterId ) {                                                                                                 \
+{{#each singletons}}
+      if ( {{hexCode}} == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && !emberAfAttributeIsClient(metadata) ) {   \
+        halCommonSetToken(TOKEN_{{define}}_SINGLETON, data); }                                                                 \
+{{/each}}
+    } \
+{{/if}}
+{{/each}}
+{{#each endpoints}}
+{{#if hasNonSingletons}}
+    if ( {{id}} == endpoint ) { \
+{{#each clusters}}
+{{#if hasNonSingletons}}
+      if ( {{hexCode}} == clusterId ) { \
+{{#each nonSingletons}}
+        if ( {{hexCode}} == metadata->attributeId && 0x0000 == emberAfGetMfgCode(metadata) && {{#if serverSide}}!{{/if}}emberAfAttributeIsClient(metadata) ) \
+          halCommonSetToken(TOKEN_{{define}}_{{../../id}}, data); \
+{{/each}}
+      } \
+{{/if}}
+{{/each}}
+    } \
+{{/if}}
+{{/each}}
+} while(false)
+
+{{/tokens_context}}
+{{/endpoint_config}}

--- a/src/app/zap-templates/zcl/data-model/silabs/LICENSE.txt
+++ b/src/app/zap-templates/zcl/data-model/silabs/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/app/zap-templates/zcl/data-model/silabs/README.md
+++ b/src/app/zap-templates/zcl/data-model/silabs/README.md
@@ -1,10 +1,13 @@
 # ZCL Meta Repository
 
-This repository contains the test meta-files that describe the ZCL application layer.
+This repository contains the test meta-files that describe the ZCL application
+layer.
 
-**IMPORTANT**: these files are NOT the root repository of the ZCL XML files. It is ONLY a test snapshot so that the
-zap application has ability to run in a standalone mode.
+**IMPORTANT**: these files are NOT the root repository of the ZCL XML files. It
+is ONLY a test snapshot so that the zap application has ability to run in a
+standalone mode.
 
 ## License
 
-The contents of this repository are licensed using the [Apache 2.0 license](LICENSE.txt)
+The contents of this repository are licensed using the
+[Apache 2.0 license](LICENSE.txt)

--- a/src/app/zap-templates/zcl/data-model/silabs/README.md
+++ b/src/app/zap-templates/zcl/data-model/silabs/README.md
@@ -1,0 +1,10 @@
+# ZCL Meta Repository
+
+This repository contains the test meta-files that describe the ZCL application layer.
+
+**IMPORTANT**: these files are NOT the root repository of the ZCL XML files. It is ONLY a test snapshot so that the
+zap application has ability to run in a standalone mode.
+
+## License
+
+The contents of this repository are licensed using the [Apache 2.0 license](LICENSE.txt)

--- a/src/app/zap-templates/zcl/data-model/silabs/ami-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ami-devices.xml
@@ -1,0 +1,822 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>SE-rangeextender</name>
+    <domain>SE</domain>
+    <typeName>SE Range Extender</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-ESP</name>
+    <domain>SE</domain>
+    <typeName>SE Energy Service Interface</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0500</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Messaging</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-Meter</name>
+    <domain>SE</domain>
+    <typeName>SE Metering Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-Meter-Mirror</name>
+    <domain>SE</domain>
+    <typeName>SE Metering Mirror Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-IPD</name>
+    <domain>SE</domain>
+    <typeName>SE In-Premises Display</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0502</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-PCT</name>
+    <domain>SE</domain>
+    <typeName>SE Programmable Communicating Thermostat (PCT)</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0503</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-LC</name>
+    <domain>SE</domain>
+    <typeName>SE Load Control Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0504</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-SA</name>
+    <domain>SE</domain>
+    <typeName>SE Smart Appliance</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0505</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE-pt</name>
+    <domain>SE</domain>
+    <typeName>SE Prepayment Terminal</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0506</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Generic Tunnel</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-rangeextender</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Range Extender</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-ESP</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Energy Service Interface</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0500</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Messaging</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Device Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-Meter</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Metering Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-Meter-Mirror</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Metering Mirror Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-In-Home-Display</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 In-Home Display</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0502</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-PCT</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Programmable Communicating Thermostat (PCT)</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0503</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-LC</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Load Control Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0504</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-SA</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Smart Appliance</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0505</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-pt</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Prepayment Terminal</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0506</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-physical</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Physical Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0507</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.2-rcd</name>
+    <domain>SE</domain>
+    <typeName>SE 1.2 Remote Communications Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0508</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-rangeextender</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Range Extender</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-ESP</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Energy Service Interface</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0500</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Messaging</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Device Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-Meter</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Metering Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-Meter-Mirror</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Metering Mirror Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-In-Home-Display</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 In-Home Display</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0502</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-PCT</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Programmable Communicating Thermostat (PCT)</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0503</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-LC</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Load Control Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0504</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Demand Response and Load Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-SA</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Smart Appliance</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0505</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-pt</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Prepayment Terminal</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0506</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Price</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Time</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Prepayment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Calendar</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Management</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">MDU Pairing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Energy Management</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-physical</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Physical Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0507</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>SE1.4-rcd</name>
+    <domain>SE</domain>
+    <typeName>SE 1.4 Remote Communications Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0109</profileId>
+    <deviceId editable="false">0x0508</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Key Establishment</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Events</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Tunneling</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Keep-Alive</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Sub-GHz</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ami.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ami.xml
@@ -1,0 +1,5810 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="SE" spec="se-1.4-17-05019-001" dependsOn="zcl-1.0-07-5123-04" certifiable="false">
+    <!-- Whenever you upgrade to a new spec, make sure you move current spec into older spec section, so that version specific info will still be valid. -->
+    <older spec="se-1.2b-15-0131-02" dependsOn="zcl-1.0-07-5123-04" certifiable="false"/>
+    <older spec="se-1.2a-07-5356-19" dependsOn="zcl-1.0-07-5123-04" certifiable="true"/>
+    <older spec="se-1.1b-07-5356-18" dependsOn="zcl-1.0-07-5123-04" certifiable="true"/>
+    <older spec="se-1.1a-07-5356-17" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="se-1.1-07-5356-16" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="se-1.0-07-5356-15" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <!-- Price Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="BlockPeriodDurationType" type="BITMAP8">
+    <field name="Timebase" mask="0x0F"/>
+    <field name="Control" mask="0xF0"/>
+  </bitmap>
+  <enum name="BlockPeriodDurationTypeTimebase" type="ENUM8">
+    <item name="Minutes" value="0x00"/>
+    <item name="Days" value="0x01"/>
+    <item name="Weeks" value="0x02"/>
+    <item name="Months" value="0x03"/>
+  </enum>
+  <enum name="BlockPeriodDurationTypeControl" type="ENUM8">
+    <item name="StartOfTimebase" value="0x00"/>
+    <item name="EndOfTimebase" value="0x10"/>
+    <item name="NotSpecified" value="0x20"/>
+  </enum>
+  <enum name="CommodityType" type="ENUM8">
+    <item name="ElectricMetering" value="0x00"/>
+    <item name="GasMetering" value="0x01"/>
+    <item name="WaterMetering" value="0x02"/>
+    <item name="ThermalMetering" value="0x03"/>
+    <item name="PressureMetering" value="0x04"/>
+    <item name="HeatMetering" value="0x05"/>
+    <item name="CoolingMetering" value="0x06"/>
+    <item name="ElectricVehicleChargingMetering" value="0x07"/>
+    <item name="PvGenerationMetering" value="0x08"/>
+    <item name="WindTurbineGenerationMetering" value="0x09"/>
+    <item name="WaterTurbineGenerationMetering" value="0x0A"/>
+    <item name="MicroGenerationMetering" value="0x0B"/>
+    <item name="SolarHotWaterGenerationMetering" value="0x0C"/>
+    <item name="ElectricMeteringElement1" value="0x0D"/>
+    <item name="ElectricMeteringElement2" value="0x0E"/>
+    <item name="ElectricMeteringElement3" value="0x0F"/>
+  </enum>
+  <bitmap name="ConversionFactorTrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="CalorificValueUnit" type="ENUM8">
+    <item name="MegajoulePerCubicMeter" value="0x01"/>
+    <item name="MegajoulePerKilogram" value="0x02"/>
+  </enum>
+  <bitmap name="CalorificValueTrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="TierBlockMode" type="ENUM8">
+    <item name="ActiveBlock" value="0x00"/>
+    <item name="ActiveBlockPriceTier" value="0x01"/>
+    <item name="ActiveBlockPriceTierThreshold" value="0x02"/>
+    <item name="NotUsed" value="0xFF"/>
+  </enum>
+  <enum name="AmiUnitOfMeasure" type="ENUM8">
+    <item name="KiloWattHours" value="0x00"/>
+    <item name="CubicMeterPerHour" value="0x01"/>
+    <item name="CubicFeetPerHour" value="0x02"/>
+    <item name="CentumCubicFeetPerHour" value="0x03"/>
+    <item name="usGallonsPerHour" value="0x04"/>
+    <item name="ImperialGallonsPerHour" value="0x05"/>
+    <item name="btUsOrBtuPerHour" value="0x06"/>
+    <item name="LitersOrLitersPerHour" value="0x07"/>
+    <item name="KpaGauge" value="0x08"/>
+    <item name="KpaAbsolute" value="0x09"/>
+    <item name="mcfOrMcfPerSecond" value="0x0A"/>
+    <item name="Unitless" value="0x0B"/>
+    <item name="mjOrMjPerSecond" value="0x0C"/>
+    <item name="kVarOrKVarHours" value="0x0D"/>
+    <item name="KiloWattHoursBcd" value="0x80"/>
+    <item name="CubicMeterPerHourBcd" value="0x81"/>
+    <item name="CubicFeetPerHourBcd" value="0x82"/>
+    <item name="CentumCubicFeetPerHourBcd" value="0x83"/>
+    <item name="usGallonsPerHourBcd" value="0x84"/>
+    <item name="ImperialGallonsPerHourBcd" value="0x85"/>
+    <item name="btUsOrBtuPerHourBcd" value="0x86"/>
+    <item name="LitersOrLitersPerHourBcd" value="0x87"/>
+    <item name="KpaGuageBcd" value="0x88"/>
+    <item name="KpaAbsoluteBcd" value="0x89"/>
+    <item name="mcfOrMcfPerSecondBcd" value="0x8A"/>
+    <item name="UnitlessBcd" value="0x8B"/>
+    <item name="mjOrMjPerSecondBcd" value="0x8C"/>
+    <item name="kVarOrKVarHoursBcd" value="0x8D"/>
+  </enum>
+  <bitmap name="PriceTrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="TariffResolutionPeriod" type="ENUM8">
+    <item name="NotDefined" value="0x00"/>
+    <item name="BlockPeriod" value="0x01"/>
+    <item name="OneDay" value="0x02"/>
+  </enum>
+  <enum name="CO2Unit" type="ENUM8">
+    <item name="KilogramPerKilowattHour" value="0x01"/>
+    <item name="KilogramPerGallonOfGasoline" value="0x02"/>
+    <item name="KilogramPerThermOfNaturalGas" value="0x03"/>
+  </enum>
+  <bitmap name="CO2TrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="CreditPaymentStatus" type="ENUM8">
+    <item name="Pending" value="0x00"/>
+    <item name="ReceivedPaid" value="0x01"/>
+    <item name="Overdue" value="0x02"/>
+    <item name="2PaymentsOverdue" value="0x03"/>
+    <item name="3PaymentsOverdue" value="0x04"/>
+  </enum>
+  <enum name="PaymentDiscountDuration" type="ENUM8">
+    <item name="CurrentBillingPeriod" value="0x00"/>
+    <item name="CurrentConsolidatedBill" value="0x01"/>
+    <item name="OneMonth" value="0x02"/>
+    <item name="OneQuarter" value="0x03"/>
+    <item name="OneYear" value="0x04"/>
+  </enum>
+  <bitmap name="PriceTrailingDigitAndPriceTier" type="BITMAP8">
+    <field name="PriceTier" mask="0x0F"/>
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="PriceTier" type="ENUM8">
+    <item name="NoTierRelated" value="0x00"/>
+    <item name="Tier1PriceLabel" value="0x01"/>
+    <item name="Tier2PriceLabel" value="0x02"/>
+    <item name="Tier3PriceLabel" value="0x03"/>
+    <item name="Tier4PriceLabel" value="0x04"/>
+    <item name="Tier5PriceLabel" value="0x05"/>
+    <item name="Tier6PriceLabel" value="0x06"/>
+    <item name="Tier7PriceLabel" value="0x07"/>
+    <item name="Tier8PriceLabel" value="0x08"/>
+    <item name="Tier9PriceLabel" value="0x09"/>
+    <item name="Tier10PriceLabel" value="0x0A"/>
+    <item name="Tier11PriceLabel" value="0x0B"/>
+    <item name="Tier12PriceLabel" value="0x0C"/>
+    <item name="Tier13PriceLabel" value="0x0D"/>
+    <item name="Tier14PriceLabel" value="0x0E"/>
+    <!-- if ExtendedPriceTierField is 0x00 then this value
+         indicates that Tier15PriceLabel is to be used -->
+    <item name="ReferToExtendedPriceTierField" value="0x0F"/>
+    <item name="Tier15PriceLabel" value="0x0F"/>
+  </enum>
+  <bitmap name="PriceNumberOfPriceTiersAndRegisterTier" type="BITMAP8">
+    <field name="RegisterTier" mask="0x0F"/>
+    <field name="NumberOfPriceTiers" mask="0xF0"/>
+  </bitmap>
+  <enum name="RegisterTier" type="ENUM8">
+    <item name="NoTierRelated" value="0x00"/>
+    <item name="CurrentTier1SummationDeliveredAttribute" value="0x01"/>
+    <item name="CurrentTier2SummationDeliveredAttribute" value="0x02"/>
+    <item name="CurrentTier3SummationDeliveredAttribute" value="0x03"/>
+    <item name="CurrentTier4SummationDeliveredAttribute" value="0x04"/>
+    <item name="CurrentTier5SummationDeliveredAttribute" value="0x05"/>
+    <item name="CurrentTier6SummationDeliveredAttribute" value="0x06"/>
+    <item name="CurrentTier7SummationDeliveredAttribute" value="0x07"/>
+    <item name="CurrentTier8SummationDeliveredAttribute" value="0x08"/>
+    <item name="CurrentTier9SummationDeliveredAttribute" value="0x09"/>
+    <item name="CurrentTier10SummationDeliveredAttribute" value="0x0A"/>
+    <item name="CurrentTier11SummationDeliveredAttribute" value="0x0B"/>
+    <item name="CurrentTier12SummationDeliveredAttribute" value="0x0C"/>
+    <item name="CurrentTier13SummationDeliveredAttribute" value="0x0D"/>
+    <item name="CurrentTier14SummationDeliveredAttribute" value="0x0E"/>
+    <!-- if ExtendedRegisterTierField is 0x00 then this value
+         indicates that Tier15PriceLabel is to be used -->
+    <item name="ReferToExtendedRegisterTierField" value="0x0F"/>
+    <item name="CurrentTier15SummationDeliveredAttribute" value="0x0F"/>
+  </enum>
+  <enum name="AlternateCostUnit" type="ENUM8">
+    <item name="KgOfCo2PerUnitOfMeasure" value="0x02"/>
+  </enum>
+  <bitmap name="AlternateCostTrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <bitmap name="PriceControlMask" type="BITMAP8">
+    <field name="PriceAcknowledgementRequired" mask="0x01"/>
+    <field name="TotalTiersExceeds15" mask="0x02"/>
+  </bitmap>
+  <enum name="PriceControlAcknowledgement" type="ENUM8">
+    <item name="notRequired" value="0x00"/>
+    <item name="required" value="0x01"/>
+  </enum>
+  <enum name="GenerationTier" type="ENUM8">
+    <item name="CurrentTier1SummationReceivedAttribute" value="0x01"/>
+    <item name="CurrentTier2SummationReceivedAttribute" value="0x02"/>
+    <item name="CurrentTier3SummationReceivedAttribute" value="0x03"/>
+    <item name="CurrentTier4SummationReceivedAttribute" value="0x04"/>
+    <item name="CurrentTier5SummationReceivedAttribute" value="0x05"/>
+    <item name="CurrentTier6SummationReceivedAttribute" value="0x06"/>
+    <item name="CurrentTier7SummationReceivedAttribute" value="0x07"/>
+    <item name="CurrentTier8SummationReceivedAttribute" value="0x08"/>
+    <item name="CurrentTier9SummationReceivedAttribute" value="0x09"/>
+    <item name="CurrentTier10SummationReceivedAttribute" value="0x0A"/>
+    <item name="CurrentTier11SummationReceivedAttribute" value="0x0B"/>
+    <item name="CurrentTier12SummationReceivedAttribute" value="0x0C"/>
+    <item name="CurrentTier13SummationReceivedAttribute" value="0x0D"/>
+    <item name="CurrentTier14SummationReceivedAttribute" value="0x0E"/>
+    <item name="CurrentTier15SummationReceivedAttribute" value="0x0F"/>
+    <item name="CurrentTier16SummationReceivedAttribute" value="0x10"/>
+    <item name="CurrentTier17SummationReceivedAttribute" value="0x11"/>
+    <item name="CurrentTier18SummationReceivedAttribute" value="0x12"/>
+    <item name="CurrentTier19SummationReceivedAttribute" value="0x13"/>
+    <item name="CurrentTier20SummationReceivedAttribute" value="0x14"/>
+    <item name="CurrentTier21SummationReceivedAttribute" value="0x15"/>
+    <item name="CurrentTier22SummationReceivedAttribute" value="0x16"/>
+    <item name="CurrentTier23SummationReceivedAttribute" value="0x17"/>
+    <item name="CurrentTier24SummationReceivedAttribute" value="0x18"/>
+    <item name="CurrentTier25SummationReceivedAttribute" value="0x19"/>
+    <item name="CurrentTier26SummationReceivedAttribute" value="0x1A"/>
+    <item name="CurrentTier27SummationReceivedAttribute" value="0x1B"/>
+    <item name="CurrentTier28SummationReceivedAttribute" value="0x1C"/>
+    <item name="CurrentTier29SummationReceivedAttribute" value="0x1D"/>
+    <item name="CurrentTier30SummationReceivedAttribute" value="0x1E"/>
+    <item name="CurrentTier31SummationReceivedAttribute" value="0x1F"/>
+    <item name="CurrentTier32SummationReceivedAttribute" value="0x20"/>
+    <item name="CurrentTier33SummationReceivedAttribute" value="0x21"/>
+    <item name="CurrentTier34SummationReceivedAttribute" value="0x22"/>
+    <item name="CurrentTier35SummationReceivedAttribute" value="0x23"/>
+    <item name="CurrentTier36SummationReceivedAttribute" value="0x24"/>
+    <item name="CurrentTier37SummationReceivedAttribute" value="0x25"/>
+    <item name="CurrentTier38SummationReceivedAttribute" value="0x26"/>
+    <item name="CurrentTier39SummationReceivedAttribute" value="0x27"/>
+    <item name="CurrentTier40SummationReceivedAttribute" value="0x28"/>
+    <item name="CurrentTier41SummationReceivedAttribute" value="0x29"/>
+    <item name="CurrentTier42SummationReceivedAttribute" value="0x2A"/>
+    <item name="CurrentTier43SummationReceivedAttribute" value="0x2B"/>
+    <item name="CurrentTier44SummationReceivedAttribute" value="0x2C"/>
+    <item name="CurrentTier45SummationReceivedAttribute" value="0x2D"/>
+    <item name="CurrentTier46SummationReceivedAttribute" value="0x2E"/>
+    <item name="CurrentTier47SummationReceivedAttribute" value="0x2F"/>
+    <item name="CurrentTier48SummationReceivedAttribute" value="0x30"/>
+  </enum>
+  <enum name="ExtendedNumberOfPriceTiers" type="ENUM8">
+    <item name="ReferToNumberOfPriceTiersField" value="0x00"/>
+    <item name="NumberOfPriceTiers16" value="0x01"/>
+    <item name="NumberOfPriceTiers17" value="0x02"/>
+    <item name="NumberOfPriceTiers18" value="0x03"/>
+    <item name="NumberOfPriceTiers19" value="0x04"/>
+    <item name="NumberOfPriceTiers20" value="0x05"/>
+    <item name="NumberOfPriceTiers21" value="0x06"/>
+    <item name="NumberOfPriceTiers22" value="0x07"/>
+    <item name="NumberOfPriceTiers23" value="0x08"/>
+    <item name="NumberOfPriceTiers24" value="0x09"/>
+    <item name="NumberOfPriceTiers25" value="0x0A"/>
+    <item name="NumberOfPriceTiers26" value="0x0B"/>
+    <item name="NumberOfPriceTiers27" value="0x0C"/>
+    <item name="NumberOfPriceTiers28" value="0x0D"/>
+    <item name="NumberOfPriceTiers29" value="0x0E"/>
+    <item name="NumberOfPriceTiers30" value="0x0F"/>
+    <item name="NumberOfPriceTiers31" value="0x10"/>
+    <item name="NumberOfPriceTiers32" value="0x11"/>
+    <item name="NumberOfPriceTiers33" value="0x12"/>
+    <item name="NumberOfPriceTiers34" value="0x13"/>
+    <item name="NumberOfPriceTiers35" value="0x14"/>
+    <item name="NumberOfPriceTiers36" value="0x15"/>
+    <item name="NumberOfPriceTiers37" value="0x16"/>
+    <item name="NumberOfPriceTiers38" value="0x17"/>
+    <item name="NumberOfPriceTiers39" value="0x18"/>
+    <item name="NumberOfPriceTiers40" value="0x19"/>
+    <item name="NumberOfPriceTiers41" value="0x1A"/>
+    <item name="NumberOfPriceTiers42" value="0x1B"/>
+    <item name="NumberOfPriceTiers43" value="0x1C"/>
+    <item name="NumberOfPriceTiers44" value="0x1D"/>
+    <item name="NumberOfPriceTiers45" value="0x1E"/>
+    <item name="NumberOfPriceTiers46" value="0x1F"/>
+    <item name="NumberOfPriceTiers47" value="0x20"/>
+    <item name="NumberOfPriceTiers48" value="0x21"/>
+  </enum>
+  <enum name="ExtendedPriceTier" type="ENUM8">
+    <item name="ReferToPriceTierField" value="0x00"/>
+    <item name="Tier16PriceLabel" value="0x01"/>
+    <item name="Tier17PriceLabel" value="0x02"/>
+    <item name="Tier18PriceLabel" value="0x03"/>
+    <item name="Tier19PriceLabel" value="0x04"/>
+    <item name="Tier20PriceLabel" value="0x05"/>
+    <item name="Tier21PriceLabel" value="0x06"/>
+    <item name="Tier22PriceLabel" value="0x07"/>
+    <item name="Tier23PriceLabel" value="0x08"/>
+    <item name="Tier24PriceLabel" value="0x09"/>
+    <item name="Tier25PriceLabel" value="0x0A"/>
+    <item name="Tier26PriceLabel" value="0x0B"/>
+    <item name="Tier27PriceLabel" value="0x0C"/>
+    <item name="Tier28PriceLabel" value="0x0D"/>
+    <item name="Tier29PriceLabel" value="0x0E"/>
+    <item name="Tier30PriceLabel" value="0x0F"/>
+    <item name="Tier31PriceLabel" value="0x10"/>
+    <item name="Tier32PriceLabel" value="0x11"/>
+    <item name="Tier33PriceLabel" value="0x12"/>
+    <item name="Tier34PriceLabel" value="0x13"/>
+    <item name="Tier35PriceLabel" value="0x14"/>
+    <item name="Tier36PriceLabel" value="0x15"/>
+    <item name="Tier37PriceLabel" value="0x16"/>
+    <item name="Tier38PriceLabel" value="0x17"/>
+    <item name="Tier39PriceLabel" value="0x18"/>
+    <item name="Tier40PriceLabel" value="0x19"/>
+    <item name="Tier41PriceLabel" value="0x1A"/>
+    <item name="Tier42PriceLabel" value="0x1B"/>
+    <item name="Tier43PriceLabel" value="0x1C"/>
+    <item name="Tier44PriceLabel" value="0x1D"/>
+    <item name="Tier45PriceLabel" value="0x1E"/>
+    <item name="Tier46PriceLabel" value="0x1F"/>
+    <item name="Tier47PriceLabel" value="0x20"/>
+    <item name="Tier48PriceLabel" value="0x21"/>
+  </enum>
+  <enum name="ExtendedRegisterTier" type="ENUM8">
+    <item name="ReferToRegisterTierField" value="0x00"/>
+    <item name="CurrentTier16SummationDeliveredAttribute" value="0x01"/>
+    <item name="CurrentTier17SummationDeliveredAttribute" value="0x02"/>
+    <item name="CurrentTier18SummationDeliveredAttribute" value="0x03"/>
+    <item name="CurrentTier19SummationDeliveredAttribute" value="0x04"/>
+    <item name="CurrentTier20SummationDeliveredAttribute" value="0x05"/>
+    <item name="CurrentTier21SummationDeliveredAttribute" value="0x06"/>
+    <item name="CurrentTier22SummationDeliveredAttribute" value="0x07"/>
+    <item name="CurrentTier23SummationDeliveredAttribute" value="0x08"/>
+    <item name="CurrentTier24SummationDeliveredAttribute" value="0x09"/>
+    <item name="CurrentTier25SummationDeliveredAttribute" value="0x0A"/>
+    <item name="CurrentTier26SummationDeliveredAttribute" value="0x0B"/>
+    <item name="CurrentTier27SummationDeliveredAttribute" value="0x0C"/>
+    <item name="CurrentTier28SummationDeliveredAttribute" value="0x0D"/>
+    <item name="CurrentTier29SummationDeliveredAttribute" value="0x0E"/>
+    <item name="CurrentTier30SummationDeliveredAttribute" value="0x0F"/>
+    <item name="CurrentTier31SummationDeliveredAttribute" value="0x10"/>
+    <item name="CurrentTier32SummationDeliveredAttribute" value="0x11"/>
+    <item name="CurrentTier33SummationDeliveredAttribute" value="0x12"/>
+    <item name="CurrentTier34SummationDeliveredAttribute" value="0x13"/>
+    <item name="CurrentTier35SummationDeliveredAttribute" value="0x14"/>
+    <item name="CurrentTier36SummationDeliveredAttribute" value="0x15"/>
+    <item name="CurrentTier37SummationDeliveredAttribute" value="0x16"/>
+    <item name="CurrentTier38SummationDeliveredAttribute" value="0x17"/>
+    <item name="CurrentTier39SummationDeliveredAttribute" value="0x18"/>
+    <item name="CurrentTier40SummationDeliveredAttribute" value="0x19"/>
+    <item name="CurrentTier41SummationDeliveredAttribute" value="0x1A"/>
+    <item name="CurrentTier42SummationDeliveredAttribute" value="0x1B"/>
+    <item name="CurrentTier43SummationDeliveredAttribute" value="0x1C"/>
+    <item name="CurrentTier44SummationDeliveredAttribute" value="0x1D"/>
+    <item name="CurrentTier45SummationDeliveredAttribute" value="0x1E"/>
+    <item name="CurrentTier46SummationDeliveredAttribute" value="0x1F"/>
+    <item name="CurrentTier47SummationDeliveredAttribute" value="0x20"/>
+    <item name="CurrentTier48SummationDeliveredAttribute" value="0x21"/>
+  </enum>
+  <bitmap name="BlockPeriodControl" type="BITMAP8">
+    <field name="PriceAcknowledgementRequirement" mask="0x01"/>
+    <field name="RepeatingBlock" mask="0x02"/>
+  </bitmap>
+  <bitmap name="TariffTypeChargingScheme" type="BITMAP8">
+    <field name="TariffType" mask="0x0F"/>
+    <field name="TariffChargingScheme" mask="0xF0"/>
+  </bitmap>
+  <enum name="TariffType" type="ENUM8">
+    <item name="DeliveredTariff" value="0x00"/>
+    <item name="ReceivedTariff" value="0x01"/>
+    <item name="DeliveredAndReceivedTariff" value="0x02"/>
+  </enum>
+  <enum name="TariffChargingScheme" type="ENUM8">
+    <item name="TouTariff" value="0x00"/>
+    <item name="BlockTariff" value="0x10"/>
+    <item name="BlockTouTariffWithCommonThresholds" value="0x20"/>
+    <item name="BlockTouTariffWithIndividualThresholdsPerTier" value="0x30"/>
+  </enum>
+  <bitmap name="PriceMatrixSubPayloadControl" type="BITMAP8">
+    <field name="TouBased" mask="0x01"/>
+  </bitmap>
+  <struct name="PriceMatrixSubPayload">
+    <item name="tierBlockId" type="INT8U"/>
+    <item name="price" type="INT32U"/>
+  </struct>
+  <bitmap name="BlockThresholdSubPayloadControl" type="BITMAP8">
+    <field name="ApplyToAllTouTiersOrWhenBlockOnlyCharging" mask="0x01"/>
+  </bitmap>
+  <struct name="BlockThresholdSubPayload">
+    <item name="tierNumberOfBlockThresholds" type="INT8U"/>
+    <item name="blockThreshold" type="INT48U"/>
+  </struct>
+  <struct name="TierLabelsPayload">
+    <item name="tierId" type="INT8U"/>
+    <item name="tierLabel" type="OCTET_STRING"/>
+  </struct>
+  <bitmap name="BillingPeriodDuration" type="BITMAP24">
+    <field name="Duration" mask="0x3FFFFF"/>
+    <field name="Units" mask="0xC00000"/>
+  </bitmap>
+  <enum name="BillingPeriodDurationUnits" type="INT24U">
+    <!-- ENUM24 is not a valid ZCL data type, so use INT24U instead. -->
+    <item name="Minutes" value="0x000000"/>
+    <item name="Days" value="0x400000"/>
+    <item name="Weeks" value="0x800000"/>
+    <item name="Months" value="0xC00000"/>
+  </enum>
+  <bitmap name="BillingPeriodDurationType" type="BITMAP8">
+    <field name="Timebase" mask="0x0F"/>
+    <field name="Control" mask="0xF0"/>
+  </bitmap>
+  <bitmap name="BillTrailingDigit" type="BITMAP8">
+    <field name="TrailingDigit" mask="0xF0"/>
+  </bitmap>
+  <enum name="CppPriceTier" type="ENUM8">
+    <item name="CPP1" value="0x00"/>
+    <item name="CPP2" value="0x01"/>
+  </enum>
+  <enum name="PublishCppEventCppAuth" type="ENUM8">
+    <item name="Pending" value="0x00"/>
+    <item name="Accepted" value="0x01"/>
+    <item name="Rejected" value="0x02"/>
+    <item name="Forced" value="0x03"/>
+  </enum>
+  <bitmap name="CurrencyChangeControl" type="BITMAP32">
+    <field name="ClearBillingInfo" mask="0x01"/>
+    <field name="ConvertBillingInfoUsingNewCurrency" mask="0x02"/>
+    <field name="ClearOldConsumptionData" mask="0x04"/>
+    <field name="ConvertOldConsumptionDataUsingNewCurrency" mask="0x08"/>
+  </bitmap>
+  <bitmap name="BlockThresholdMask" type="BITMAP16">
+    <field name="Tier1" mask="0x0002"/>
+    <field name="Tier2" mask="0x0004"/>
+    <field name="Tier3" mask="0x0008"/>
+    <field name="Tier4" mask="0x0010"/>
+    <field name="Tier5" mask="0x0020"/>
+    <field name="Tier6" mask="0x0040"/>
+    <field name="Tier7" mask="0x0080"/>
+    <field name="Tier8" mask="0x0100"/>
+    <field name="Tier9" mask="0x0200"/>
+    <field name="Tier10" mask="0x0400"/>
+    <field name="Tier11" mask="0x0800"/>
+    <field name="Tier12" mask="0x1000"/>
+    <field name="Tier13" mask="0x2000"/>
+    <field name="Tier14" mask="0x4000"/>
+    <field name="Tier15" mask="0x8000"/>
+  </bitmap>
+  <enum name="CppEventResponseCppAuth" type="ENUM8">
+    <item name="Accepted" value="0x01"/>
+    <item name="Rejected" value="0x02"/>
+  </enum>
+  <bitmap name="AmiCommandOptions" type="BITMAP8">
+    <field name="requestRxOnWhenIdle" mask="0x01"/>
+  </bitmap>
+  <!-- Price Cluster -->
+  <cluster>
+    <name>Price</name>
+    <domain>SE</domain>
+    <description>The Price Cluster provides the mechanism for communicating Gas, Energy, or Water pricing information within the premises.</description>
+    <code>0x0700</code>
+    <define>PRICE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Price Cluster Server - Attributes -->
+    <!-- Price Cluster Server - Tier Label (Delivered) Attribute Set -->
+    <attribute side="server" code="0x0000" define="TIER1_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 1" optional="true">tier 1 price label</attribute>
+    <attribute side="server" code="0x0001" define="TIER2_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 2" optional="true">tier 2 price label</attribute>
+    <attribute side="server" code="0x0002" define="TIER3_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 3" optional="true">tier 3 price label</attribute>
+    <attribute side="server" code="0x0003" define="TIER4_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 4" optional="true">tier 4 price label</attribute>
+    <attribute side="server" code="0x0004" define="TIER5_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 5" optional="true">tier 5 price label</attribute>
+    <attribute side="server" code="0x0005" define="TIER6_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 6" optional="true">tier 6 price label</attribute>
+    <attribute side="server" code="0x0006" define="TIER7_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 7" optional="true">tier 7 price label</attribute>
+    <attribute side="server" code="0x0007" define="TIER8_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 8" optional="true">tier 8 price label</attribute>
+    <attribute side="server" code="0x0008" define="TIER9_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 9" optional="true">tier 9 price label</attribute>
+    <attribute side="server" code="0x0009" define="TIER10_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 10" optional="true">tier 10 price label</attribute>
+    <attribute side="server" code="0x000A" define="TIER11_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 11" optional="true">tier 11 price label</attribute>
+    <attribute side="server" code="0x000B" define="TIER12_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 12" optional="true">tier 12 price label</attribute>
+    <attribute side="server" code="0x000C" define="TIER13_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 13" optional="true">tier 13 price label</attribute>
+    <attribute side="server" code="0x000D" define="TIER14_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 14" optional="true">tier 14 price label</attribute>
+    <attribute side="server" code="0x000E" define="TIER15_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 15" optional="true">tier 15 price label</attribute>
+    <attribute side="server" code="0x000F" define="TIER16_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 16" optional="true" introducedIn="se-1.2a-07-5356-19">tier 16 price label</attribute>
+    <attribute side="server" code="0x0010" define="TIER17_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 17" optional="true" introducedIn="se-1.2a-07-5356-19">tier 17 price label</attribute>
+    <attribute side="server" code="0x0011" define="TIER18_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 18" optional="true" introducedIn="se-1.2a-07-5356-19">tier 18 price label</attribute>
+    <attribute side="server" code="0x0012" define="TIER19_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 19" optional="true" introducedIn="se-1.2a-07-5356-19">tier 19 price label</attribute>
+    <attribute side="server" code="0x0013" define="TIER20_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 20" optional="true" introducedIn="se-1.2a-07-5356-19">tier 20 price label</attribute>
+    <attribute side="server" code="0x0014" define="TIER21_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 21" optional="true" introducedIn="se-1.2a-07-5356-19">tier 21 price label</attribute>
+    <attribute side="server" code="0x0015" define="TIER22_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 22" optional="true" introducedIn="se-1.2a-07-5356-19">tier 22 price label</attribute>
+    <attribute side="server" code="0x0016" define="TIER23_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 23" optional="true" introducedIn="se-1.2a-07-5356-19">tier 23 price label</attribute>
+    <attribute side="server" code="0x0017" define="TIER24_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 24" optional="true" introducedIn="se-1.2a-07-5356-19">tier 24 price label</attribute>
+    <attribute side="server" code="0x0018" define="TIER25_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 25" optional="true" introducedIn="se-1.2a-07-5356-19">tier 25 price label</attribute>
+    <attribute side="server" code="0x0019" define="TIER26_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 26" optional="true" introducedIn="se-1.2a-07-5356-19">tier 26 price label</attribute>
+    <attribute side="server" code="0x001A" define="TIER27_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 27" optional="true" introducedIn="se-1.2a-07-5356-19">tier 27 price label</attribute>
+    <attribute side="server" code="0x001B" define="TIER28_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 28" optional="true" introducedIn="se-1.2a-07-5356-19">tier 28 price label</attribute>
+    <attribute side="server" code="0x001C" define="TIER29_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 29" optional="true" introducedIn="se-1.2a-07-5356-19">tier 29 price label</attribute>
+    <attribute side="server" code="0x001D" define="TIER30_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 30" optional="true" introducedIn="se-1.2a-07-5356-19">tier 30 price label</attribute>
+    <attribute side="server" code="0x001E" define="TIER31_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 31" optional="true" introducedIn="se-1.2a-07-5356-19">tier 31 price label</attribute>
+    <attribute side="server" code="0x001F" define="TIER32_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 32" optional="true" introducedIn="se-1.2a-07-5356-19">tier 32 price label</attribute>
+    <attribute side="server" code="0x0020" define="TIER33_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 33" optional="true" introducedIn="se-1.2a-07-5356-19">tier 33 price label</attribute>
+    <attribute side="server" code="0x0021" define="TIER34_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 34" optional="true" introducedIn="se-1.2a-07-5356-19">tier 34 price label</attribute>
+    <attribute side="server" code="0x0022" define="TIER35_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 35" optional="true" introducedIn="se-1.2a-07-5356-19">tier 35 price label</attribute>
+    <attribute side="server" code="0x0023" define="TIER36_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 36" optional="true" introducedIn="se-1.2a-07-5356-19">tier 36 price label</attribute>
+    <attribute side="server" code="0x0024" define="TIER37_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 37" optional="true" introducedIn="se-1.2a-07-5356-19">tier 37 price label</attribute>
+    <attribute side="server" code="0x0025" define="TIER38_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 38" optional="true" introducedIn="se-1.2a-07-5356-19">tier 38 price label</attribute>
+    <attribute side="server" code="0x0026" define="TIER39_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 39" optional="true" introducedIn="se-1.2a-07-5356-19">tier 39 price label</attribute>
+    <attribute side="server" code="0x0027" define="TIER40_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 40" optional="true" introducedIn="se-1.2a-07-5356-19">tier 40 price label</attribute>
+    <attribute side="server" code="0x0028" define="TIER41_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 41" optional="true" introducedIn="se-1.2a-07-5356-19">tier 41 price label</attribute>
+    <attribute side="server" code="0x0029" define="TIER42_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 42" optional="true" introducedIn="se-1.2a-07-5356-19">tier 42 price label</attribute>
+    <attribute side="server" code="0x002A" define="TIER43_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 43" optional="true" introducedIn="se-1.2a-07-5356-19">tier 43 price label</attribute>
+    <attribute side="server" code="0x002B" define="TIER44_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 44" optional="true" introducedIn="se-1.2a-07-5356-19">tier 44 price label</attribute>
+    <attribute side="server" code="0x002C" define="TIER45_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 45" optional="true" introducedIn="se-1.2a-07-5356-19">tier 45 price label</attribute>
+    <attribute side="server" code="0x002D" define="TIER46_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 46" optional="true" introducedIn="se-1.2a-07-5356-19">tier 46 price label</attribute>
+    <attribute side="server" code="0x002E" define="TIER47_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 47" optional="true" introducedIn="se-1.2a-07-5356-19">tier 47 price label</attribute>
+    <attribute side="server" code="0x002F" define="TIER48_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 48" optional="true" introducedIn="se-1.2a-07-5356-19">tier 48 price label</attribute>
+    <!-- Price Cluster Server - Block Threshold (Delivered) Attribute Set -->
+    <attribute side="server" code="0x0100" define="BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 1 threshold</attribute>
+    <attribute side="server" code="0x0101" define="BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 2 threshold</attribute>
+    <attribute side="server" code="0x0102" define="BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 3 threshold</attribute>
+    <attribute side="server" code="0x0103" define="BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 4 threshold</attribute>
+    <attribute side="server" code="0x0104" define="BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 5 threshold</attribute>
+    <attribute side="server" code="0x0105" define="BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 6 threshold</attribute>
+    <attribute side="server" code="0x0106" define="BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 7 threshold</attribute>
+    <attribute side="server" code="0x0107" define="BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 8 threshold</attribute>
+    <attribute side="server" code="0x0108" define="BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 9 threshold</attribute>
+    <attribute side="server" code="0x0109" define="BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 10 threshold</attribute>
+    <attribute side="server" code="0x010A" define="BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 11 threshold</attribute>
+    <attribute side="server" code="0x010B" define="BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 12 threshold</attribute>
+    <attribute side="server" code="0x010C" define="BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 13 threshold</attribute>
+    <attribute side="server" code="0x010D" define="BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 14 threshold</attribute>
+    <attribute side="server" code="0x010E" define="BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">block 15 threshold</attribute>
+    <attribute side="server" code="0x010F" define="BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">block threshold count</attribute>
+    <attribute side="server" code="0x0110" define="TIER1_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 1 threshold</attribute>
+    <attribute side="server" code="0x0111" define="TIER1_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 2 threshold</attribute>
+    <attribute side="server" code="0x0112" define="TIER1_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 3 threshold</attribute>
+    <attribute side="server" code="0x0113" define="TIER1_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 4 threshold</attribute>
+    <attribute side="server" code="0x0114" define="TIER1_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 5 threshold</attribute>
+    <attribute side="server" code="0x0115" define="TIER1_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 6 threshold</attribute>
+    <attribute side="server" code="0x0116" define="TIER1_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 7 threshold</attribute>
+    <attribute side="server" code="0x0117" define="TIER1_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 8 threshold</attribute>
+    <attribute side="server" code="0x0118" define="TIER1_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 9 threshold</attribute>
+    <attribute side="server" code="0x0119" define="TIER1_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 10 threshold</attribute>
+    <attribute side="server" code="0x011A" define="TIER1_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 11 threshold</attribute>
+    <attribute side="server" code="0x011B" define="TIER1_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 12 threshold</attribute>
+    <attribute side="server" code="0x011C" define="TIER1_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 13 threshold</attribute>
+    <attribute side="server" code="0x011D" define="TIER1_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 14 threshold</attribute>
+    <attribute side="server" code="0x011E" define="TIER1_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block 15 threshold</attribute>
+    <attribute side="server" code="0x011F" define="TIER1_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 1 block threshold count</attribute>
+    <attribute side="server" code="0x0120" define="TIER2_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 1 threshold</attribute>
+    <attribute side="server" code="0x0121" define="TIER2_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 2 threshold</attribute>
+    <attribute side="server" code="0x0122" define="TIER2_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 3 threshold</attribute>
+    <attribute side="server" code="0x0123" define="TIER2_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 4 threshold</attribute>
+    <attribute side="server" code="0x0124" define="TIER2_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 5 threshold</attribute>
+    <attribute side="server" code="0x0125" define="TIER2_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 6 threshold</attribute>
+    <attribute side="server" code="0x0126" define="TIER2_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 7 threshold</attribute>
+    <attribute side="server" code="0x0127" define="TIER2_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 8 threshold</attribute>
+    <attribute side="server" code="0x0128" define="TIER2_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 9 threshold</attribute>
+    <attribute side="server" code="0x0129" define="TIER2_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 10 threshold</attribute>
+    <attribute side="server" code="0x012A" define="TIER2_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 11 threshold</attribute>
+    <attribute side="server" code="0x012B" define="TIER2_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 12 threshold</attribute>
+    <attribute side="server" code="0x012C" define="TIER2_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 13 threshold</attribute>
+    <attribute side="server" code="0x012D" define="TIER2_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 14 threshold</attribute>
+    <attribute side="server" code="0x012E" define="TIER2_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block 15 threshold</attribute>
+    <attribute side="server" code="0x012F" define="TIER2_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 2 block threshold count</attribute>
+    <attribute side="server" code="0x0130" define="TIER3_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 1 threshold</attribute>
+    <attribute side="server" code="0x0131" define="TIER3_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 2 threshold</attribute>
+    <attribute side="server" code="0x0132" define="TIER3_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 3 threshold</attribute>
+    <attribute side="server" code="0x0133" define="TIER3_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 4 threshold</attribute>
+    <attribute side="server" code="0x0134" define="TIER3_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 5 threshold</attribute>
+    <attribute side="server" code="0x0135" define="TIER3_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 6 threshold</attribute>
+    <attribute side="server" code="0x0136" define="TIER3_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 7 threshold</attribute>
+    <attribute side="server" code="0x0137" define="TIER3_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 8 threshold</attribute>
+    <attribute side="server" code="0x0138" define="TIER3_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 9 threshold</attribute>
+    <attribute side="server" code="0x0139" define="TIER3_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 10 threshold</attribute>
+    <attribute side="server" code="0x013A" define="TIER3_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 11 threshold</attribute>
+    <attribute side="server" code="0x013B" define="TIER3_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 12 threshold</attribute>
+    <attribute side="server" code="0x013C" define="TIER3_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 13 threshold</attribute>
+    <attribute side="server" code="0x013D" define="TIER3_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 14 threshold</attribute>
+    <attribute side="server" code="0x013E" define="TIER3_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block 15 threshold</attribute>
+    <attribute side="server" code="0x013F" define="TIER3_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 3 block threshold count</attribute>
+    <attribute side="server" code="0x0140" define="TIER4_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 1 threshold</attribute>
+    <attribute side="server" code="0x0141" define="TIER4_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 2 threshold</attribute>
+    <attribute side="server" code="0x0142" define="TIER4_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 3 threshold</attribute>
+    <attribute side="server" code="0x0143" define="TIER4_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 4 threshold</attribute>
+    <attribute side="server" code="0x0144" define="TIER4_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 5 threshold</attribute>
+    <attribute side="server" code="0x0145" define="TIER4_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 6 threshold</attribute>
+    <attribute side="server" code="0x0146" define="TIER4_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 7 threshold</attribute>
+    <attribute side="server" code="0x0147" define="TIER4_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 8 threshold</attribute>
+    <attribute side="server" code="0x0148" define="TIER4_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 9 threshold</attribute>
+    <attribute side="server" code="0x0149" define="TIER4_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 10 threshold</attribute>
+    <attribute side="server" code="0x014A" define="TIER4_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 11 threshold</attribute>
+    <attribute side="server" code="0x014B" define="TIER4_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 12 threshold</attribute>
+    <attribute side="server" code="0x014C" define="TIER4_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 13 threshold</attribute>
+    <attribute side="server" code="0x014D" define="TIER4_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 14 threshold</attribute>
+    <attribute side="server" code="0x014E" define="TIER4_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block 15 threshold</attribute>
+    <attribute side="server" code="0x014F" define="TIER4_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 4 block threshold count</attribute>
+    <attribute side="server" code="0x0150" define="TIER5_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 1 threshold</attribute>
+    <attribute side="server" code="0x0151" define="TIER5_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 2 threshold</attribute>
+    <attribute side="server" code="0x0152" define="TIER5_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 3 threshold</attribute>
+    <attribute side="server" code="0x0153" define="TIER5_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 4 threshold</attribute>
+    <attribute side="server" code="0x0154" define="TIER5_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 5 threshold</attribute>
+    <attribute side="server" code="0x0155" define="TIER5_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 6 threshold</attribute>
+    <attribute side="server" code="0x0156" define="TIER5_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 7 threshold</attribute>
+    <attribute side="server" code="0x0157" define="TIER5_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 8 threshold</attribute>
+    <attribute side="server" code="0x0158" define="TIER5_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 9 threshold</attribute>
+    <attribute side="server" code="0x0159" define="TIER5_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 10 threshold</attribute>
+    <attribute side="server" code="0x015A" define="TIER5_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 11 threshold</attribute>
+    <attribute side="server" code="0x015B" define="TIER5_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 12 threshold</attribute>
+    <attribute side="server" code="0x015C" define="TIER5_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 13 threshold</attribute>
+    <attribute side="server" code="0x015D" define="TIER5_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 14 threshold</attribute>
+    <attribute side="server" code="0x015E" define="TIER5_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block 15 threshold</attribute>
+    <attribute side="server" code="0x015F" define="TIER5_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 5 block threshold count</attribute>
+    <attribute side="server" code="0x0160" define="TIER6_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 1 threshold</attribute>
+    <attribute side="server" code="0x0161" define="TIER6_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 2 threshold</attribute>
+    <attribute side="server" code="0x0162" define="TIER6_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 3 threshold</attribute>
+    <attribute side="server" code="0x0163" define="TIER6_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 4 threshold</attribute>
+    <attribute side="server" code="0x0164" define="TIER6_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 5 threshold</attribute>
+    <attribute side="server" code="0x0165" define="TIER6_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 6 threshold</attribute>
+    <attribute side="server" code="0x0166" define="TIER6_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 7 threshold</attribute>
+    <attribute side="server" code="0x0167" define="TIER6_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 8 threshold</attribute>
+    <attribute side="server" code="0x0168" define="TIER6_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 9 threshold</attribute>
+    <attribute side="server" code="0x0169" define="TIER6_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 10 threshold</attribute>
+    <attribute side="server" code="0x016A" define="TIER6_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 11 threshold</attribute>
+    <attribute side="server" code="0x016B" define="TIER6_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 12 threshold</attribute>
+    <attribute side="server" code="0x016C" define="TIER6_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 13 threshold</attribute>
+    <attribute side="server" code="0x016D" define="TIER6_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 14 threshold</attribute>
+    <attribute side="server" code="0x016E" define="TIER6_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block 15 threshold</attribute>
+    <attribute side="server" code="0x016F" define="TIER6_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 6 block threshold count</attribute>
+    <attribute side="server" code="0x0170" define="TIER7_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 1 threshold</attribute>
+    <attribute side="server" code="0x0171" define="TIER7_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 2 threshold</attribute>
+    <attribute side="server" code="0x0172" define="TIER7_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 3 threshold</attribute>
+    <attribute side="server" code="0x0173" define="TIER7_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 4 threshold</attribute>
+    <attribute side="server" code="0x0174" define="TIER7_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 5 threshold</attribute>
+    <attribute side="server" code="0x0175" define="TIER7_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 6 threshold</attribute>
+    <attribute side="server" code="0x0176" define="TIER7_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 7 threshold</attribute>
+    <attribute side="server" code="0x0177" define="TIER7_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 8 threshold</attribute>
+    <attribute side="server" code="0x0178" define="TIER7_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 9 threshold</attribute>
+    <attribute side="server" code="0x0179" define="TIER7_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 10 threshold</attribute>
+    <attribute side="server" code="0x017A" define="TIER7_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 11 threshold</attribute>
+    <attribute side="server" code="0x017B" define="TIER7_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 12 threshold</attribute>
+    <attribute side="server" code="0x017C" define="TIER7_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 13 threshold</attribute>
+    <attribute side="server" code="0x017D" define="TIER7_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 14 threshold</attribute>
+    <attribute side="server" code="0x017E" define="TIER7_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block 15 threshold</attribute>
+    <attribute side="server" code="0x017F" define="TIER7_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 7 block threshold count</attribute>
+    <attribute side="server" code="0x0180" define="TIER8_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 1 threshold</attribute>
+    <attribute side="server" code="0x0181" define="TIER8_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 2 threshold</attribute>
+    <attribute side="server" code="0x0182" define="TIER8_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 3 threshold</attribute>
+    <attribute side="server" code="0x0183" define="TIER8_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 4 threshold</attribute>
+    <attribute side="server" code="0x0184" define="TIER8_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 5 threshold</attribute>
+    <attribute side="server" code="0x0185" define="TIER8_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 6 threshold</attribute>
+    <attribute side="server" code="0x0186" define="TIER8_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 7 threshold</attribute>
+    <attribute side="server" code="0x0187" define="TIER8_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 8 threshold</attribute>
+    <attribute side="server" code="0x0188" define="TIER8_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 9 threshold</attribute>
+    <attribute side="server" code="0x0189" define="TIER8_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 10 threshold</attribute>
+    <attribute side="server" code="0x018A" define="TIER8_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 11 threshold</attribute>
+    <attribute side="server" code="0x018B" define="TIER8_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 12 threshold</attribute>
+    <attribute side="server" code="0x018C" define="TIER8_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 13 threshold</attribute>
+    <attribute side="server" code="0x018D" define="TIER8_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 14 threshold</attribute>
+    <attribute side="server" code="0x018E" define="TIER8_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block 15 threshold</attribute>
+    <attribute side="server" code="0x018F" define="TIER8_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 8 block threshold count</attribute>
+    <attribute side="server" code="0x0190" define="TIER9_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 1 threshold</attribute>
+    <attribute side="server" code="0x0191" define="TIER9_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 2 threshold</attribute>
+    <attribute side="server" code="0x0192" define="TIER9_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 3 threshold</attribute>
+    <attribute side="server" code="0x0193" define="TIER9_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 4 threshold</attribute>
+    <attribute side="server" code="0x0194" define="TIER9_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 5 threshold</attribute>
+    <attribute side="server" code="0x0195" define="TIER9_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 6 threshold</attribute>
+    <attribute side="server" code="0x0196" define="TIER9_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 7 threshold</attribute>
+    <attribute side="server" code="0x0197" define="TIER9_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 8 threshold</attribute>
+    <attribute side="server" code="0x0198" define="TIER9_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 9 threshold</attribute>
+    <attribute side="server" code="0x0199" define="TIER9_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 10 threshold</attribute>
+    <attribute side="server" code="0x019A" define="TIER9_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 11 threshold</attribute>
+    <attribute side="server" code="0x019B" define="TIER9_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 12 threshold</attribute>
+    <attribute side="server" code="0x019C" define="TIER9_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 13 threshold</attribute>
+    <attribute side="server" code="0x019D" define="TIER9_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 14 threshold</attribute>
+    <attribute side="server" code="0x019E" define="TIER9_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block 15 threshold</attribute>
+    <attribute side="server" code="0x019F" define="TIER9_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 9 block threshold count</attribute>
+    <attribute side="server" code="0x01A0" define="TIER10_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 1 threshold</attribute>
+    <attribute side="server" code="0x01A1" define="TIER10_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 2 threshold</attribute>
+    <attribute side="server" code="0x01A2" define="TIER10_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 3 threshold</attribute>
+    <attribute side="server" code="0x01A3" define="TIER10_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 4 threshold</attribute>
+    <attribute side="server" code="0x01A4" define="TIER10_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 5 threshold</attribute>
+    <attribute side="server" code="0x01A5" define="TIER10_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 6 threshold</attribute>
+    <attribute side="server" code="0x01A6" define="TIER10_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 7 threshold</attribute>
+    <attribute side="server" code="0x01A7" define="TIER10_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 8 threshold</attribute>
+    <attribute side="server" code="0x01A8" define="TIER10_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 9 threshold</attribute>
+    <attribute side="server" code="0x01A9" define="TIER10_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 10 threshold</attribute>
+    <attribute side="server" code="0x01AA" define="TIER10_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 11 threshold</attribute>
+    <attribute side="server" code="0x01AB" define="TIER10_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 12 threshold</attribute>
+    <attribute side="server" code="0x01AC" define="TIER10_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 13 threshold</attribute>
+    <attribute side="server" code="0x01AD" define="TIER10_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 14 threshold</attribute>
+    <attribute side="server" code="0x01AE" define="TIER10_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block 15 threshold</attribute>
+    <attribute side="server" code="0x01AF" define="TIER10_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 10 block threshold count</attribute>
+    <attribute side="server" code="0x01B0" define="TIER11_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 1 threshold</attribute>
+    <attribute side="server" code="0x01B1" define="TIER11_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 2 threshold</attribute>
+    <attribute side="server" code="0x01B2" define="TIER11_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 3 threshold</attribute>
+    <attribute side="server" code="0x01B3" define="TIER11_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 4 threshold</attribute>
+    <attribute side="server" code="0x01B4" define="TIER11_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 5 threshold</attribute>
+    <attribute side="server" code="0x01B5" define="TIER11_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 6 threshold</attribute>
+    <attribute side="server" code="0x01B6" define="TIER11_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 7 threshold</attribute>
+    <attribute side="server" code="0x01B7" define="TIER11_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 8 threshold</attribute>
+    <attribute side="server" code="0x01B8" define="TIER11_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 9 threshold</attribute>
+    <attribute side="server" code="0x01B9" define="TIER11_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 10 threshold</attribute>
+    <attribute side="server" code="0x01BA" define="TIER11_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 11 threshold</attribute>
+    <attribute side="server" code="0x01BB" define="TIER11_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 12 threshold</attribute>
+    <attribute side="server" code="0x01BC" define="TIER11_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 13 threshold</attribute>
+    <attribute side="server" code="0x01BD" define="TIER11_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 14 threshold</attribute>
+    <attribute side="server" code="0x01BE" define="TIER11_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block 15 threshold</attribute>
+    <attribute side="server" code="0x01BF" define="TIER11_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 11 block threshold count</attribute>
+    <attribute side="server" code="0x01C0" define="TIER12_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 1 threshold</attribute>
+    <attribute side="server" code="0x01C1" define="TIER12_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 2 threshold</attribute>
+    <attribute side="server" code="0x01C2" define="TIER12_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 3 threshold</attribute>
+    <attribute side="server" code="0x01C3" define="TIER12_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 4 threshold</attribute>
+    <attribute side="server" code="0x01C4" define="TIER12_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 5 threshold</attribute>
+    <attribute side="server" code="0x01C5" define="TIER12_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 6 threshold</attribute>
+    <attribute side="server" code="0x01C6" define="TIER12_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 7 threshold</attribute>
+    <attribute side="server" code="0x01C7" define="TIER12_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 8 threshold</attribute>
+    <attribute side="server" code="0x01C8" define="TIER12_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 9 threshold</attribute>
+    <attribute side="server" code="0x01C9" define="TIER12_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 10 threshold</attribute>
+    <attribute side="server" code="0x01CA" define="TIER12_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 11 threshold</attribute>
+    <attribute side="server" code="0x01CB" define="TIER12_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 12 threshold</attribute>
+    <attribute side="server" code="0x01CC" define="TIER12_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 13 threshold</attribute>
+    <attribute side="server" code="0x01CD" define="TIER12_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 14 threshold</attribute>
+    <attribute side="server" code="0x01CE" define="TIER12_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block 15 threshold</attribute>
+    <attribute side="server" code="0x01CF" define="TIER12_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 12 block threshold count</attribute>
+    <attribute side="server" code="0x01D0" define="TIER13_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 1 threshold</attribute>
+    <attribute side="server" code="0x01D1" define="TIER13_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 2 threshold</attribute>
+    <attribute side="server" code="0x01D2" define="TIER13_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 3 threshold</attribute>
+    <attribute side="server" code="0x01D3" define="TIER13_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 4 threshold</attribute>
+    <attribute side="server" code="0x01D4" define="TIER13_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 5 threshold</attribute>
+    <attribute side="server" code="0x01D5" define="TIER13_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 6 threshold</attribute>
+    <attribute side="server" code="0x01D6" define="TIER13_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 7 threshold</attribute>
+    <attribute side="server" code="0x01D7" define="TIER13_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 8 threshold</attribute>
+    <attribute side="server" code="0x01D8" define="TIER13_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 9 threshold</attribute>
+    <attribute side="server" code="0x01D9" define="TIER13_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 10 threshold</attribute>
+    <attribute side="server" code="0x01DA" define="TIER13_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 11 threshold</attribute>
+    <attribute side="server" code="0x01DB" define="TIER13_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 12 threshold</attribute>
+    <attribute side="server" code="0x01DC" define="TIER13_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 13 threshold</attribute>
+    <attribute side="server" code="0x01DD" define="TIER13_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 14 threshold</attribute>
+    <attribute side="server" code="0x01DE" define="TIER13_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block 15 threshold</attribute>
+    <attribute side="server" code="0x01DF" define="TIER13_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 13 block threshold count</attribute>
+    <attribute side="server" code="0x01E0" define="TIER14_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 1 threshold</attribute>
+    <attribute side="server" code="0x01E1" define="TIER14_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 2 threshold</attribute>
+    <attribute side="server" code="0x01E2" define="TIER14_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 3 threshold</attribute>
+    <attribute side="server" code="0x01E3" define="TIER14_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 4 threshold</attribute>
+    <attribute side="server" code="0x01E4" define="TIER14_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 5 threshold</attribute>
+    <attribute side="server" code="0x01E5" define="TIER14_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 6 threshold</attribute>
+    <attribute side="server" code="0x01E6" define="TIER14_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 7 threshold</attribute>
+    <attribute side="server" code="0x01E7" define="TIER14_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 8 threshold</attribute>
+    <attribute side="server" code="0x01E8" define="TIER14_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 9 threshold</attribute>
+    <attribute side="server" code="0x01E9" define="TIER14_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 10 threshold</attribute>
+    <attribute side="server" code="0x01EA" define="TIER14_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 11 threshold</attribute>
+    <attribute side="server" code="0x01EB" define="TIER14_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 12 threshold</attribute>
+    <attribute side="server" code="0x01EC" define="TIER14_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 13 threshold</attribute>
+    <attribute side="server" code="0x01ED" define="TIER14_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 14 threshold</attribute>
+    <attribute side="server" code="0x01EE" define="TIER14_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block 15 threshold</attribute>
+    <attribute side="server" code="0x01EF" define="TIER14_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 14 block threshold count</attribute>
+    <attribute side="server" code="0x01F0" define="TIER15_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 1 threshold</attribute>
+    <attribute side="server" code="0x01F1" define="TIER15_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 2 threshold</attribute>
+    <attribute side="server" code="0x01F2" define="TIER15_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 3 threshold</attribute>
+    <attribute side="server" code="0x01F3" define="TIER15_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 4 threshold</attribute>
+    <attribute side="server" code="0x01F4" define="TIER15_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 5 threshold</attribute>
+    <attribute side="server" code="0x01F5" define="TIER15_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 6 threshold</attribute>
+    <attribute side="server" code="0x01F6" define="TIER15_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 7 threshold</attribute>
+    <attribute side="server" code="0x01F7" define="TIER15_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 8 threshold</attribute>
+    <attribute side="server" code="0x01F8" define="TIER15_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 9 threshold</attribute>
+    <attribute side="server" code="0x01F9" define="TIER15_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 10 threshold</attribute>
+    <attribute side="server" code="0x01FA" define="TIER15_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 11 threshold</attribute>
+    <attribute side="server" code="0x01FB" define="TIER15_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 12 threshold</attribute>
+    <attribute side="server" code="0x01FC" define="TIER15_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 13 threshold</attribute>
+    <attribute side="server" code="0x01FD" define="TIER15_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 14 threshold</attribute>
+    <attribute side="server" code="0x01FE" define="TIER15_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block 15 threshold</attribute>
+    <attribute side="server" code="0x01FF" define="TIER15_BLOCK_THRESHOLD_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">tier 15 block threshold count</attribute>
+    <!-- Price Cluster Server - Block Period (Delivered) Attribute Set -->
+    <attribute side="server" code="0x0200" define="START_OF_BLOCK_PERIOD" type="UTC_TIME" writable="false" optional="true">start of block period</attribute>
+    <attribute side="server" code="0x0201" define="BLOCK_PERIOD_DURATION_MINUTES" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">block period duration (minutes)</attribute>
+    <attribute side="server" code="0x0202" define="THRESHOLD_MULTIPLIER" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">threshold multiplier</attribute>
+    <attribute side="server" code="0x0203" define="THRESHOLD_DIVISOR" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">threshold divisor</attribute>
+    <attribute side="server" code="0x0204" define="BLOCK_PERIOD_DURATION_TYPE" type="BITMAP8" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">block period duration type</attribute>
+    <!-- Price Cluster Server - Commodity Attribute Set -->
+    <attribute side="server" code="0x0300" define="COMMODITY_TYPE_SERVER" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true">commodity type</attribute>
+    <attribute side="server" code="0x0301" define="STANDING_CHARGE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">standing charge</attribute>
+    <attribute side="server" code="0x0302" define="CONVERSION_FACTOR" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x10000000" optional="true" introducedIn="se-1.1a-07-5356-17">conversion factor</attribute>
+    <attribute side="server" code="0x0303" define="CONVERSION_FACTOR_TRAILING_DIGIT" type="BITMAP8" writable="false" default="0x70" optional="true" introducedIn="se-1.1a-07-5356-17">conversion factor trailing digit</attribute>
+    <attribute side="server" code="0x0304" define="CALORIFIC_VALUE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x02625A00" optional="true" introducedIn="se-1.1a-07-5356-17">calorific value</attribute>
+    <attribute side="server" code="0x0305" define="CALORIFIC_VALUE_UNIT" type="ENUM8" writable="false" default="0x01" optional="true" introducedIn="se-1.1a-07-5356-17">calorific value unit</attribute>
+    <attribute side="server" code="0x0306" define="CALORIFIC_VALUE_TRAILING_DIGIT" type="BITMAP8" writable="false" default="0x60" optional="true" introducedIn="se-1.1a-07-5356-17">calorific value trailing digit</attribute>
+    <!-- Price Cluster Server - Block Price Information (Delivered) Attribute Set -->
+    <attribute side="server" code="0x0400" define="NO_TIER_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 1 price</attribute>
+    <attribute side="server" code="0x0401" define="NO_TIER_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 2 price</attribute>
+    <attribute side="server" code="0x0402" define="NO_TIER_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 3 price</attribute>
+    <attribute side="server" code="0x0403" define="NO_TIER_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 4 price</attribute>
+    <attribute side="server" code="0x0404" define="NO_TIER_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 5 price</attribute>
+    <attribute side="server" code="0x0405" define="NO_TIER_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 6 price</attribute>
+    <attribute side="server" code="0x0406" define="NO_TIER_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 7 price</attribute>
+    <attribute side="server" code="0x0407" define="NO_TIER_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 8 price</attribute>
+    <attribute side="server" code="0x0408" define="NO_TIER_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 9 price</attribute>
+    <attribute side="server" code="0x0409" define="NO_TIER_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 10 price</attribute>
+    <attribute side="server" code="0x040A" define="NO_TIER_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 11 price</attribute>
+    <attribute side="server" code="0x040B" define="NO_TIER_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 12 price</attribute>
+    <attribute side="server" code="0x040C" define="NO_TIER_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 13 price</attribute>
+    <attribute side="server" code="0x040D" define="NO_TIER_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 14 price</attribute>
+    <attribute side="server" code="0x040E" define="NO_TIER_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 15 price</attribute>
+    <attribute side="server" code="0x040F" define="NO_TIER_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">no tier block 16 price</attribute>
+    <attribute side="server" code="0x0410" define="TIER1_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 1 price</attribute>
+    <attribute side="server" code="0x0411" define="TIER1_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 2 price</attribute>
+    <attribute side="server" code="0x0412" define="TIER1_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 3 price</attribute>
+    <attribute side="server" code="0x0413" define="TIER1_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 4 price</attribute>
+    <attribute side="server" code="0x0414" define="TIER1_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 5 price</attribute>
+    <attribute side="server" code="0x0415" define="TIER1_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 6 price</attribute>
+    <attribute side="server" code="0x0416" define="TIER1_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 7 price</attribute>
+    <attribute side="server" code="0x0417" define="TIER1_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 8 price</attribute>
+    <attribute side="server" code="0x0418" define="TIER1_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 9 price</attribute>
+    <attribute side="server" code="0x0419" define="TIER1_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 10 price</attribute>
+    <attribute side="server" code="0x041A" define="TIER1_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 11 price</attribute>
+    <attribute side="server" code="0x041B" define="TIER1_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 12 price</attribute>
+    <attribute side="server" code="0x041C" define="TIER1_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 13 price</attribute>
+    <attribute side="server" code="0x041D" define="TIER1_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 14 price</attribute>
+    <attribute side="server" code="0x041E" define="TIER1_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 15 price</attribute>
+    <attribute side="server" code="0x041F" define="TIER1_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 1 block 16 price</attribute>
+    <attribute side="server" code="0x0420" define="TIER2_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 1 price</attribute>
+    <attribute side="server" code="0x0421" define="TIER2_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 2 price</attribute>
+    <attribute side="server" code="0x0422" define="TIER2_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 3 price</attribute>
+    <attribute side="server" code="0x0423" define="TIER2_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 4 price</attribute>
+    <attribute side="server" code="0x0424" define="TIER2_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 5 price</attribute>
+    <attribute side="server" code="0x0425" define="TIER2_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 6 price</attribute>
+    <attribute side="server" code="0x0426" define="TIER2_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 7 price</attribute>
+    <attribute side="server" code="0x0427" define="TIER2_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 8 price</attribute>
+    <attribute side="server" code="0x0428" define="TIER2_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 9 price</attribute>
+    <attribute side="server" code="0x0429" define="TIER2_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 10 price</attribute>
+    <attribute side="server" code="0x042A" define="TIER2_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 11 price</attribute>
+    <attribute side="server" code="0x042B" define="TIER2_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 12 price</attribute>
+    <attribute side="server" code="0x042C" define="TIER2_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 13 price</attribute>
+    <attribute side="server" code="0x042D" define="TIER2_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 14 price</attribute>
+    <attribute side="server" code="0x042E" define="TIER2_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 15 price</attribute>
+    <attribute side="server" code="0x042F" define="TIER2_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 2 block 16 price</attribute>
+    <attribute side="server" code="0x0430" define="TIER3_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 1 price</attribute>
+    <attribute side="server" code="0x0431" define="TIER3_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 2 price</attribute>
+    <attribute side="server" code="0x0432" define="TIER3_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 3 price</attribute>
+    <attribute side="server" code="0x0433" define="TIER3_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 4 price</attribute>
+    <attribute side="server" code="0x0434" define="TIER3_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 5 price</attribute>
+    <attribute side="server" code="0x0435" define="TIER3_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 6 price</attribute>
+    <attribute side="server" code="0x0436" define="TIER3_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 7 price</attribute>
+    <attribute side="server" code="0x0437" define="TIER3_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 8 price</attribute>
+    <attribute side="server" code="0x0438" define="TIER3_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 9 price</attribute>
+    <attribute side="server" code="0x0439" define="TIER3_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 10 price</attribute>
+    <attribute side="server" code="0x043A" define="TIER3_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 11 price</attribute>
+    <attribute side="server" code="0x043B" define="TIER3_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 12 price</attribute>
+    <attribute side="server" code="0x043C" define="TIER3_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 13 price</attribute>
+    <attribute side="server" code="0x043D" define="TIER3_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 14 price</attribute>
+    <attribute side="server" code="0x043E" define="TIER3_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 15 price</attribute>
+    <attribute side="server" code="0x043F" define="TIER3_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 3 block 16 price</attribute>
+    <attribute side="server" code="0x0440" define="TIER4_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 1 price</attribute>
+    <attribute side="server" code="0x0441" define="TIER4_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 2 price</attribute>
+    <attribute side="server" code="0x0442" define="TIER4_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 3 price</attribute>
+    <attribute side="server" code="0x0443" define="TIER4_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 4 price</attribute>
+    <attribute side="server" code="0x0444" define="TIER4_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 5 price</attribute>
+    <attribute side="server" code="0x0445" define="TIER4_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 6 price</attribute>
+    <attribute side="server" code="0x0446" define="TIER4_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 7 price</attribute>
+    <attribute side="server" code="0x0447" define="TIER4_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 8 price</attribute>
+    <attribute side="server" code="0x0448" define="TIER4_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 9 price</attribute>
+    <attribute side="server" code="0x0449" define="TIER4_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 10 price</attribute>
+    <attribute side="server" code="0x044A" define="TIER4_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 11 price</attribute>
+    <attribute side="server" code="0x044B" define="TIER4_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 12 price</attribute>
+    <attribute side="server" code="0x044C" define="TIER4_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 13 price</attribute>
+    <attribute side="server" code="0x044D" define="TIER4_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 14 price</attribute>
+    <attribute side="server" code="0x044E" define="TIER4_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 15 price</attribute>
+    <attribute side="server" code="0x044F" define="TIER4_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 4 block 16 price</attribute>
+    <attribute side="server" code="0x0450" define="TIER5_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 1 price</attribute>
+    <attribute side="server" code="0x0451" define="TIER5_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 2 price</attribute>
+    <attribute side="server" code="0x0452" define="TIER5_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 3 price</attribute>
+    <attribute side="server" code="0x0453" define="TIER5_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 4 price</attribute>
+    <attribute side="server" code="0x0454" define="TIER5_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 5 price</attribute>
+    <attribute side="server" code="0x0455" define="TIER5_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 6 price</attribute>
+    <attribute side="server" code="0x0456" define="TIER5_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 7 price</attribute>
+    <attribute side="server" code="0x0457" define="TIER5_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 8 price</attribute>
+    <attribute side="server" code="0x0458" define="TIER5_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 9 price</attribute>
+    <attribute side="server" code="0x0459" define="TIER5_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 10 price</attribute>
+    <attribute side="server" code="0x045A" define="TIER5_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 11 price</attribute>
+    <attribute side="server" code="0x045B" define="TIER5_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 12 price</attribute>
+    <attribute side="server" code="0x045C" define="TIER5_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 13 price</attribute>
+    <attribute side="server" code="0x045D" define="TIER5_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 14 price</attribute>
+    <attribute side="server" code="0x045E" define="TIER5_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 15 price</attribute>
+    <attribute side="server" code="0x045F" define="TIER5_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 5 block 16 price</attribute>
+    <attribute side="server" code="0x0460" define="TIER6_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 1 price</attribute>
+    <attribute side="server" code="0x0461" define="TIER6_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 2 price</attribute>
+    <attribute side="server" code="0x0462" define="TIER6_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 3 price</attribute>
+    <attribute side="server" code="0x0463" define="TIER6_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 4 price</attribute>
+    <attribute side="server" code="0x0464" define="TIER6_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 5 price</attribute>
+    <attribute side="server" code="0x0465" define="TIER6_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 6 price</attribute>
+    <attribute side="server" code="0x0466" define="TIER6_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 7 price</attribute>
+    <attribute side="server" code="0x0467" define="TIER6_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 8 price</attribute>
+    <attribute side="server" code="0x0468" define="TIER6_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 9 price</attribute>
+    <attribute side="server" code="0x0469" define="TIER6_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 10 price</attribute>
+    <attribute side="server" code="0x046A" define="TIER6_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 11 price</attribute>
+    <attribute side="server" code="0x046B" define="TIER6_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 12 price</attribute>
+    <attribute side="server" code="0x046C" define="TIER6_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 13 price</attribute>
+    <attribute side="server" code="0x046D" define="TIER6_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 14 price</attribute>
+    <attribute side="server" code="0x046E" define="TIER6_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 15 price</attribute>
+    <attribute side="server" code="0x046F" define="TIER6_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 6 block 16 price</attribute>
+    <attribute side="server" code="0x0470" define="TIER7_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 1 price</attribute>
+    <attribute side="server" code="0x0471" define="TIER7_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 2 price</attribute>
+    <attribute side="server" code="0x0472" define="TIER7_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 3 price</attribute>
+    <attribute side="server" code="0x0473" define="TIER7_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 4 price</attribute>
+    <attribute side="server" code="0x0474" define="TIER7_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 5 price</attribute>
+    <attribute side="server" code="0x0475" define="TIER7_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 6 price</attribute>
+    <attribute side="server" code="0x0476" define="TIER7_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 7 price</attribute>
+    <attribute side="server" code="0x0477" define="TIER7_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 8 price</attribute>
+    <attribute side="server" code="0x0478" define="TIER7_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 9 price</attribute>
+    <attribute side="server" code="0x0479" define="TIER7_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 10 price</attribute>
+    <attribute side="server" code="0x047A" define="TIER7_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 11 price</attribute>
+    <attribute side="server" code="0x047B" define="TIER7_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 12 price</attribute>
+    <attribute side="server" code="0x047C" define="TIER7_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 13 price</attribute>
+    <attribute side="server" code="0x047D" define="TIER7_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 14 price</attribute>
+    <attribute side="server" code="0x047E" define="TIER7_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 15 price</attribute>
+    <attribute side="server" code="0x047F" define="TIER7_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 7 block 16 price</attribute>
+    <attribute side="server" code="0x0480" define="TIER8_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 1 price</attribute>
+    <attribute side="server" code="0x0481" define="TIER8_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 2 price</attribute>
+    <attribute side="server" code="0x0482" define="TIER8_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 3 price</attribute>
+    <attribute side="server" code="0x0483" define="TIER8_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 4 price</attribute>
+    <attribute side="server" code="0x0484" define="TIER8_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 5 price</attribute>
+    <attribute side="server" code="0x0485" define="TIER8_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 6 price</attribute>
+    <attribute side="server" code="0x0486" define="TIER8_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 7 price</attribute>
+    <attribute side="server" code="0x0487" define="TIER8_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 8 price</attribute>
+    <attribute side="server" code="0x0488" define="TIER8_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 9 price</attribute>
+    <attribute side="server" code="0x0489" define="TIER8_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 10 price</attribute>
+    <attribute side="server" code="0x048A" define="TIER8_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 11 price</attribute>
+    <attribute side="server" code="0x048B" define="TIER8_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 12 price</attribute>
+    <attribute side="server" code="0x048C" define="TIER8_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 13 price</attribute>
+    <attribute side="server" code="0x048D" define="TIER8_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 14 price</attribute>
+    <attribute side="server" code="0x048E" define="TIER8_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 15 price</attribute>
+    <attribute side="server" code="0x048F" define="TIER8_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 8 block 16 price</attribute>
+    <attribute side="server" code="0x0490" define="TIER9_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 1 price</attribute>
+    <attribute side="server" code="0x0491" define="TIER9_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 2 price</attribute>
+    <attribute side="server" code="0x0492" define="TIER9_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 3 price</attribute>
+    <attribute side="server" code="0x0493" define="TIER9_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 4 price</attribute>
+    <attribute side="server" code="0x0494" define="TIER9_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 5 price</attribute>
+    <attribute side="server" code="0x0495" define="TIER9_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 6 price</attribute>
+    <attribute side="server" code="0x0496" define="TIER9_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 7 price</attribute>
+    <attribute side="server" code="0x0497" define="TIER9_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 8 price</attribute>
+    <attribute side="server" code="0x0498" define="TIER9_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 9 price</attribute>
+    <attribute side="server" code="0x0499" define="TIER9_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 10 price</attribute>
+    <attribute side="server" code="0x049A" define="TIER9_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 11 price</attribute>
+    <attribute side="server" code="0x049B" define="TIER9_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 12 price</attribute>
+    <attribute side="server" code="0x049C" define="TIER9_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 13 price</attribute>
+    <attribute side="server" code="0x049D" define="TIER9_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 14 price</attribute>
+    <attribute side="server" code="0x049E" define="TIER9_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 15 price</attribute>
+    <attribute side="server" code="0x049F" define="TIER9_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 9 block 16 price</attribute>
+    <attribute side="server" code="0x04A0" define="TIER10_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 1 price</attribute>
+    <attribute side="server" code="0x04A1" define="TIER10_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 2 price</attribute>
+    <attribute side="server" code="0x04A2" define="TIER10_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 3 price</attribute>
+    <attribute side="server" code="0x04A3" define="TIER10_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 4 price</attribute>
+    <attribute side="server" code="0x04A4" define="TIER10_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 5 price</attribute>
+    <attribute side="server" code="0x04A5" define="TIER10_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 6 price</attribute>
+    <attribute side="server" code="0x04A6" define="TIER10_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 7 price</attribute>
+    <attribute side="server" code="0x04A7" define="TIER10_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 8 price</attribute>
+    <attribute side="server" code="0x04A8" define="TIER10_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 9 price</attribute>
+    <attribute side="server" code="0x04A9" define="TIER10_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 10 price</attribute>
+    <attribute side="server" code="0x04AA" define="TIER10_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 11 price</attribute>
+    <attribute side="server" code="0x04AB" define="TIER10_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 12 price</attribute>
+    <attribute side="server" code="0x04AC" define="TIER10_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 13 price</attribute>
+    <attribute side="server" code="0x04AD" define="TIER10_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 14 price</attribute>
+    <attribute side="server" code="0x04AE" define="TIER10_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 15 price</attribute>
+    <attribute side="server" code="0x04AF" define="TIER10_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 10 block 16 price</attribute>
+    <attribute side="server" code="0x04B0" define="TIER11_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 1 price</attribute>
+    <attribute side="server" code="0x04B1" define="TIER11_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 2 price</attribute>
+    <attribute side="server" code="0x04B2" define="TIER11_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 3 price</attribute>
+    <attribute side="server" code="0x04B3" define="TIER11_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 4 price</attribute>
+    <attribute side="server" code="0x04B4" define="TIER11_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 5 price</attribute>
+    <attribute side="server" code="0x04B5" define="TIER11_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 6 price</attribute>
+    <attribute side="server" code="0x04B6" define="TIER11_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 7 price</attribute>
+    <attribute side="server" code="0x04B7" define="TIER11_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 8 price</attribute>
+    <attribute side="server" code="0x04B8" define="TIER11_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 9 price</attribute>
+    <attribute side="server" code="0x04B9" define="TIER11_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 10 price</attribute>
+    <attribute side="server" code="0x04BA" define="TIER11_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 11 price</attribute>
+    <attribute side="server" code="0x04BB" define="TIER11_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 12 price</attribute>
+    <attribute side="server" code="0x04BC" define="TIER11_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 13 price</attribute>
+    <attribute side="server" code="0x04BD" define="TIER11_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 14 price</attribute>
+    <attribute side="server" code="0x04BE" define="TIER11_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 15 price</attribute>
+    <attribute side="server" code="0x04BF" define="TIER11_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 11 block 16 price</attribute>
+    <attribute side="server" code="0x04C0" define="TIER12_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 1 price</attribute>
+    <attribute side="server" code="0x04C1" define="TIER12_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 2 price</attribute>
+    <attribute side="server" code="0x04C2" define="TIER12_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 3 price</attribute>
+    <attribute side="server" code="0x04C3" define="TIER12_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 4 price</attribute>
+    <attribute side="server" code="0x04C4" define="TIER12_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 5 price</attribute>
+    <attribute side="server" code="0x04C5" define="TIER12_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 6 price</attribute>
+    <attribute side="server" code="0x04C6" define="TIER12_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 7 price</attribute>
+    <attribute side="server" code="0x04C7" define="TIER12_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 8 price</attribute>
+    <attribute side="server" code="0x04C8" define="TIER12_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 9 price</attribute>
+    <attribute side="server" code="0x04C9" define="TIER12_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 10 price</attribute>
+    <attribute side="server" code="0x04CA" define="TIER12_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 11 price</attribute>
+    <attribute side="server" code="0x04CB" define="TIER12_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 12 price</attribute>
+    <attribute side="server" code="0x04CC" define="TIER12_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 13 price</attribute>
+    <attribute side="server" code="0x04CD" define="TIER12_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 14 price</attribute>
+    <attribute side="server" code="0x04CE" define="TIER12_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 15 price</attribute>
+    <attribute side="server" code="0x04CF" define="TIER12_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 12 block 16 price</attribute>
+    <attribute side="server" code="0x04D0" define="TIER13_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 1 price</attribute>
+    <attribute side="server" code="0x04D1" define="TIER13_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 2 price</attribute>
+    <attribute side="server" code="0x04D2" define="TIER13_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 3 price</attribute>
+    <attribute side="server" code="0x04D3" define="TIER13_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 4 price</attribute>
+    <attribute side="server" code="0x04D4" define="TIER13_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 5 price</attribute>
+    <attribute side="server" code="0x04D5" define="TIER13_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 6 price</attribute>
+    <attribute side="server" code="0x04D6" define="TIER13_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 7 price</attribute>
+    <attribute side="server" code="0x04D7" define="TIER13_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 8 price</attribute>
+    <attribute side="server" code="0x04D8" define="TIER13_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 9 price</attribute>
+    <attribute side="server" code="0x04D9" define="TIER13_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 10 price</attribute>
+    <attribute side="server" code="0x04DA" define="TIER13_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 11 price</attribute>
+    <attribute side="server" code="0x04DB" define="TIER13_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 12 price</attribute>
+    <attribute side="server" code="0x04DC" define="TIER13_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 13 price</attribute>
+    <attribute side="server" code="0x04DD" define="TIER13_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 14 price</attribute>
+    <attribute side="server" code="0x04DE" define="TIER13_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 15 price</attribute>
+    <attribute side="server" code="0x04DF" define="TIER13_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 13 block 16 price</attribute>
+    <attribute side="server" code="0x04E0" define="TIER14_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 1 price</attribute>
+    <attribute side="server" code="0x04E1" define="TIER14_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 2 price</attribute>
+    <attribute side="server" code="0x04E2" define="TIER14_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 3 price</attribute>
+    <attribute side="server" code="0x04E3" define="TIER14_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 4 price</attribute>
+    <attribute side="server" code="0x04E4" define="TIER14_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 5 price</attribute>
+    <attribute side="server" code="0x04E5" define="TIER14_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 6 price</attribute>
+    <attribute side="server" code="0x04E6" define="TIER14_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 7 price</attribute>
+    <attribute side="server" code="0x04E7" define="TIER14_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 8 price</attribute>
+    <attribute side="server" code="0x04E8" define="TIER14_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 9 price</attribute>
+    <attribute side="server" code="0x04E9" define="TIER14_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 10 price</attribute>
+    <attribute side="server" code="0x04EA" define="TIER14_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 11 price</attribute>
+    <attribute side="server" code="0x04EB" define="TIER14_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 12 price</attribute>
+    <attribute side="server" code="0x04EC" define="TIER14_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 13 price</attribute>
+    <attribute side="server" code="0x04ED" define="TIER14_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 14 price</attribute>
+    <attribute side="server" code="0x04EE" define="TIER14_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 15 price</attribute>
+    <attribute side="server" code="0x04EF" define="TIER14_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 14 block 16 price</attribute>
+    <attribute side="server" code="0x04F0" define="TIER15_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 1 price</attribute>
+    <attribute side="server" code="0x04F1" define="TIER15_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 2 price</attribute>
+    <attribute side="server" code="0x04F2" define="TIER15_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 3 price</attribute>
+    <attribute side="server" code="0x04F3" define="TIER15_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 4 price</attribute>
+    <attribute side="server" code="0x04F4" define="TIER15_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 5 price</attribute>
+    <attribute side="server" code="0x04F5" define="TIER15_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 6 price</attribute>
+    <attribute side="server" code="0x04F6" define="TIER15_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 7 price</attribute>
+    <attribute side="server" code="0x04F7" define="TIER15_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 8 price</attribute>
+    <attribute side="server" code="0x04F8" define="TIER15_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 9 price</attribute>
+    <attribute side="server" code="0x04F9" define="TIER15_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 10 price</attribute>
+    <attribute side="server" code="0x04FA" define="TIER15_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 11 price</attribute>
+    <attribute side="server" code="0x04FB" define="TIER15_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 12 price</attribute>
+    <attribute side="server" code="0x04FC" define="TIER15_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 13 price</attribute>
+    <attribute side="server" code="0x04FD" define="TIER15_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 14 price</attribute>
+    <attribute side="server" code="0x04FE" define="TIER15_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 15 price</attribute>
+    <attribute side="server" code="0x04FF" define="TIER15_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">tier 15 block 16 price</attribute>
+    <!-- Price Cluster Server - Extended Price Information (Delivered) Attribute Set -->
+    <attribute side="server" code="0x050F" define="PRICE_TIER16" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 16</attribute>
+    <attribute side="server" code="0x0510" define="PRICE_TIER17" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 17</attribute>
+    <attribute side="server" code="0x0511" define="PRICE_TIER18" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 18</attribute>
+    <attribute side="server" code="0x0512" define="PRICE_TIER19" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 19</attribute>
+    <attribute side="server" code="0x0513" define="PRICE_TIER20" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 20</attribute>
+    <attribute side="server" code="0x0514" define="PRICE_TIER21" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 21</attribute>
+    <attribute side="server" code="0x0515" define="PRICE_TIER22" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 22</attribute>
+    <attribute side="server" code="0x0516" define="PRICE_TIER23" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 23</attribute>
+    <attribute side="server" code="0x0517" define="PRICE_TIER24" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 24</attribute>
+    <attribute side="server" code="0x0518" define="PRICE_TIER25" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 25</attribute>
+    <attribute side="server" code="0x0519" define="PRICE_TIER26" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 26</attribute>
+    <attribute side="server" code="0x051A" define="PRICE_TIER27" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 27</attribute>
+    <attribute side="server" code="0x051B" define="PRICE_TIER28" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 28</attribute>
+    <attribute side="server" code="0x051C" define="PRICE_TIER29" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 29</attribute>
+    <attribute side="server" code="0x051D" define="PRICE_TIER30" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 30</attribute>
+    <attribute side="server" code="0x051E" define="PRICE_TIER31" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 31</attribute>
+    <attribute side="server" code="0x051F" define="PRICE_TIER32" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 32</attribute>
+    <attribute side="server" code="0x0520" define="PRICE_TIER33" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 33</attribute>
+    <attribute side="server" code="0x0521" define="PRICE_TIER34" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 34</attribute>
+    <attribute side="server" code="0x0522" define="PRICE_TIER35" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 35</attribute>
+    <attribute side="server" code="0x0523" define="PRICE_TIER36" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 36</attribute>
+    <attribute side="server" code="0x0524" define="PRICE_TIER37" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 37</attribute>
+    <attribute side="server" code="0x0525" define="PRICE_TIER38" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 38</attribute>
+    <attribute side="server" code="0x0526" define="PRICE_TIER39" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 39</attribute>
+    <attribute side="server" code="0x0527" define="PRICE_TIER40" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 40</attribute>
+    <attribute side="server" code="0x0528" define="PRICE_TIER41" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 41</attribute>
+    <attribute side="server" code="0x0529" define="PRICE_TIER42" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 42</attribute>
+    <attribute side="server" code="0x052A" define="PRICE_TIER43" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 43</attribute>
+    <attribute side="server" code="0x052B" define="PRICE_TIER44" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 44</attribute>
+    <attribute side="server" code="0x052C" define="PRICE_TIER45" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 45</attribute>
+    <attribute side="server" code="0x052D" define="PRICE_TIER46" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 46</attribute>
+    <attribute side="server" code="0x052E" define="PRICE_TIER47" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 47</attribute>
+    <attribute side="server" code="0x052F" define="PRICE_TIER48" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">price tier 48</attribute>
+    <attribute side="server" code="0x05FE" define="CPP1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">CPP1 Price</attribute>
+    <attribute side="server" code="0x05FF" define="CPP2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">CPP2 Price</attribute>
+    <!-- Price Cluster Server - Tariff Information (Delivered) Attribute Set -->
+    <attribute side="server" code="0x0610" define="TARIFF_LABEL" type="OCTET_STRING" length="24" writable="false" default="0" optional="true" introducedIn="se-1.2a-07-5356-19">tariff label</attribute>
+    <attribute side="server" code="0x0611" define="NUMBER_OF_PRICE_TIERS_IN_USE" type="INT8U" min="0x00" max="0x0F" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">number of price tiers in use</attribute>
+    <attribute side="server" code="0x0612" define="NUMBER_OF_BLOCK_THRESHOLDS_IN_USE" type="INT8U" min="0x00" max="0x0F" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">number of block thresholds in use</attribute>
+    <attribute side="server" code="0x0613" define="TIER_BLOCK_MODE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true" introducedIn="se-1.2a-07-5356-19">tier block mode</attribute>
+    <attribute side="server" code="0x0615" define="TARIFF_UNIT_OF_MEASURE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">unit of measure</attribute>
+    <attribute side="server" code="0x0616" define="TARIFF_CURRENCY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">currency</attribute>
+    <attribute side="server" code="0x0617" define="TARIFF_PRICE_TRAILING_DIGIT" type="BITMAP8" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">price trailing digit</attribute>
+    <attribute side="server" code="0x0619" define="TARIFF_RESOLUTION_PERIOD" type="ENUM8" writable="false" default="0" optional="true" introducedIn="se-1.2a-07-5356-19">tariff resolution period</attribute>
+    <attribute side="server" code="0x0620" define="TARIFF_CO2" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x000000B9" optional="true" introducedIn="se-1.2a-07-5356-19">CO2</attribute>
+    <attribute side="server" code="0x0621" define="TARIFF_CO2_UNIT" type="ENUM8" writable="false" default="0x01" optional="true" introducedIn="se-1.2a-07-5356-19">CO2 unit</attribute>
+    <attribute side="server" code="0x0622" define="TARIFF_CO2_TRAILING_DIGIT" type="BITMAP8" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">CO2 trailing digit</attribute>
+    <!-- Price Cluster Server - Billing Information (Delivered)  Attribute Set -->
+    <attribute side="server" code="0x0700" define="CURRENT_BILLING_PERIOD_START" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1b-07-5356-18">current billing period start</attribute>
+    <attribute side="server" code="0x0701" define="CURRENT_BILLING_PERIOD_DURATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.1b-07-5356-18">current billing period duration</attribute>
+    <attribute side="server" code="0x0702" define="LAST_BILLING_PERIOD_START" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">last billing period start</attribute>
+    <attribute side="server" code="0x0703" define="LAST_BILLING_PERIOD_DURATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">last billing period duration</attribute>
+    <attribute side="server" code="0x0704" define="LAST_BILLING_PERIOD_CONSOLIDATED_BILL" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">last billing period consolidated bill</attribute>
+    <!-- Price Cluster Server - Credit Payment Attribute Set -->
+    <attribute side="server" code="0x0800" define="CREDIT_PAYMENT_DUE_DATE" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment due date</attribute>
+    <attribute side="server" code="0x0801" define="CREDIT_PAYMENT_STATUS" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment status</attribute>
+    <attribute side="server" code="0x0802" define="CREDIT_PAYMENT_OVER_DUE_AMOUNT" type="INT32S" min="-2147483647" max="2147483647" writable="false" default="0" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment over due amount</attribute>
+    <attribute side="server" code="0x080A" define="PAYMENT_DISCOUNT" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">payment discount</attribute>
+    <attribute side="server" code="0x080B" define="PAYMENT_DISCOUNT_PERIOD" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">payment discount period</attribute>
+    <attribute side="server" code="0x0810" define="CREDIT_PAYMENT_1" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment 1</attribute>
+    <attribute side="server" code="0x0811" define="CREDIT_PAYMENT_DATE_1" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment date 1</attribute>
+    <attribute side="server" code="0x0812" define="CREDIT_PAYMENT_REF_1" type="OCTET_STRING" length="20" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment ref 1</attribute>
+    <attribute side="server" code="0x0820" define="CREDIT_PAYMENT_2" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment 2</attribute>
+    <attribute side="server" code="0x0821" define="CREDIT_PAYMENT_DATE_2" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment date 2</attribute>
+    <attribute side="server" code="0x0822" define="CREDIT_PAYMENT_REF_2" type="OCTET_STRING" length="20" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment ref 2</attribute>
+    <attribute side="server" code="0x0830" define="CREDIT_PAYMENT_3" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment 3</attribute>
+    <attribute side="server" code="0x0831" define="CREDIT_PAYMENT_DATE_3" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment date 3</attribute>
+    <attribute side="server" code="0x0832" define="CREDIT_PAYMENT_REF_3" type="OCTET_STRING" length="20" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment ref 3</attribute>
+    <attribute side="server" code="0x0840" define="CREDIT_PAYMENT_4" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment 4</attribute>
+    <attribute side="server" code="0x0841" define="CREDIT_PAYMENT_DATE_4" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment date 4</attribute>
+    <attribute side="server" code="0x0842" define="CREDIT_PAYMENT_REF_4" type="OCTET_STRING" length="20" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment ref 4</attribute>
+    <attribute side="server" code="0x0850" define="CREDIT_PAYMENT_5" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment 5</attribute>
+    <attribute side="server" code="0x0851" define="CREDIT_PAYMENT_DATE_5" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment date 5</attribute>
+    <attribute side="server" code="0x0852" define="CREDIT_PAYMENT_REF_5" type="OCTET_STRING" length="20" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit payment ref 5</attribute>
+    <!-- Price Cluster Server - Received Tier Label  Attribute Set -->
+    <attribute side="server" code="0x8000" define="RX_TIER1_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 1" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 price label</attribute>
+    <attribute side="server" code="0x8001" define="RX_TIER2_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 2" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 price label</attribute>
+    <attribute side="server" code="0x8002" define="RX_TIER3_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 3" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 price label</attribute>
+    <attribute side="server" code="0x8003" define="RX_TIER4_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 4" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 price label</attribute>
+    <attribute side="server" code="0x8004" define="RX_TIER5_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 5" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 price label</attribute>
+    <attribute side="server" code="0x8005" define="RX_TIER6_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 6" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 price label</attribute>
+    <attribute side="server" code="0x8006" define="RX_TIER7_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 7" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 price label</attribute>
+    <attribute side="server" code="0x8007" define="RX_TIER8_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 8" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 price label</attribute>
+    <attribute side="server" code="0x8008" define="RX_TIER9_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 9" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 price label</attribute>
+    <attribute side="server" code="0x8009" define="RX_TIER10_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 10" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 price label</attribute>
+    <attribute side="server" code="0x800A" define="RX_TIER11_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 11" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 price label</attribute>
+    <attribute side="server" code="0x800B" define="RX_TIER12_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 12" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 price label</attribute>
+    <attribute side="server" code="0x800C" define="RX_TIER13_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 13" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 price label</attribute>
+    <attribute side="server" code="0x800D" define="RX_TIER14_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 14" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 price label</attribute>
+    <attribute side="server" code="0x800E" define="RX_TIER15_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 15" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 price label</attribute>
+    <attribute side="server" code="0x800F" define="RX_TIER16_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 16" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 16 price label</attribute>
+    <attribute side="server" code="0x8010" define="RX_TIER17_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 17" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 17 price label</attribute>
+    <attribute side="server" code="0x8011" define="RX_TIER18_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 18" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 18 price label</attribute>
+    <attribute side="server" code="0x8012" define="RX_TIER19_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 19" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 19 price label</attribute>
+    <attribute side="server" code="0x8013" define="RX_TIER20_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 20" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 20 price label</attribute>
+    <attribute side="server" code="0x8014" define="RX_TIER21_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 21" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 21 price label</attribute>
+    <attribute side="server" code="0x8015" define="RX_TIER22_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 22" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 22 price label</attribute>
+    <attribute side="server" code="0x8016" define="RX_TIER23_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 23" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 23 price label</attribute>
+    <attribute side="server" code="0x8017" define="RX_TIER24_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 24" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 24 price label</attribute>
+    <attribute side="server" code="0x8018" define="RX_TIER25_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 25" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 25 price label</attribute>
+    <attribute side="server" code="0x8019" define="RX_TIER26_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 26" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 26 price label</attribute>
+    <attribute side="server" code="0x801A" define="RX_TIER27_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 27" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 27 price label</attribute>
+    <attribute side="server" code="0x801B" define="RX_TIER28_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 28" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 28 price label</attribute>
+    <attribute side="server" code="0x801C" define="RX_TIER29_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 29" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 29 price label</attribute>
+    <attribute side="server" code="0x801D" define="RX_TIER30_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 30" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 30 price label</attribute>
+    <attribute side="server" code="0x801E" define="RX_TIER31_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 31" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 31 price label</attribute>
+    <attribute side="server" code="0x801F" define="RX_TIER32_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 32" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 32 price label</attribute>
+    <attribute side="server" code="0x8020" define="RX_TIER33_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 33" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 33 price label</attribute>
+    <attribute side="server" code="0x8021" define="RX_TIER34_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 34" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 34 price label</attribute>
+    <attribute side="server" code="0x8022" define="RX_TIER35_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 35" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 35 price label</attribute>
+    <attribute side="server" code="0x8023" define="RX_TIER36_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 36" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 36 price label</attribute>
+    <attribute side="server" code="0x8024" define="RX_TIER37_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 37" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 37 price label</attribute>
+    <attribute side="server" code="0x8025" define="RX_TIER38_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 38" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 38 price label</attribute>
+    <attribute side="server" code="0x8026" define="RX_TIER39_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 39" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 39 price label</attribute>
+    <attribute side="server" code="0x8027" define="RX_TIER40_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 40" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 40 price label</attribute>
+    <attribute side="server" code="0x8028" define="RX_TIER41_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 41" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 41 price label</attribute>
+    <attribute side="server" code="0x8029" define="RX_TIER42_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 42" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 42 price label</attribute>
+    <attribute side="server" code="0x802A" define="RX_TIER43_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 43" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 43 price label</attribute>
+    <attribute side="server" code="0x802B" define="RX_TIER44_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 44" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 44 price label</attribute>
+    <attribute side="server" code="0x802C" define="RX_TIER45_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 45" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 45 price label</attribute>
+    <attribute side="server" code="0x802D" define="RX_TIER46_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 46" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 46 price label</attribute>
+    <attribute side="server" code="0x802E" define="RX_TIER47_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 47" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 47 price label</attribute>
+    <attribute side="server" code="0x802F" define="RX_TIER48_PRICE_LABEL" type="OCTET_STRING" length="12" writable="true" default="Tier 48" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 48 price label</attribute>
+    <!-- Price Cluster Server - Received Block Threshold Attribute Set -->
+    <attribute side="server" code="0x8100" define="RX_BLOCK1_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 1 threshold</attribute>
+    <attribute side="server" code="0x8101" define="RX_BLOCK2_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 2 threshold</attribute>
+    <attribute side="server" code="0x8102" define="RX_BLOCK3_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 3 threshold</attribute>
+    <attribute side="server" code="0x8103" define="RX_BLOCK4_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 4 threshold</attribute>
+    <attribute side="server" code="0x8104" define="RX_BLOCK5_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 5 threshold</attribute>
+    <attribute side="server" code="0x8105" define="RX_BLOCK6_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 6 threshold</attribute>
+    <attribute side="server" code="0x8106" define="RX_BLOCK7_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 7 threshold</attribute>
+    <attribute side="server" code="0x8107" define="RX_BLOCK8_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 8 threshold</attribute>
+    <attribute side="server" code="0x8108" define="RX_BLOCK9_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 9 threshold</attribute>
+    <attribute side="server" code="0x8109" define="RX_BLOCK10_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 10 threshold</attribute>
+    <attribute side="server" code="0x810A" define="RX_BLOCK11_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 11 threshold</attribute>
+    <attribute side="server" code="0x810B" define="RX_BLOCK12_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 12 threshold</attribute>
+    <attribute side="server" code="0x810C" define="RX_BLOCK13_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 13 threshold</attribute>
+    <attribute side="server" code="0x810D" define="RX_BLOCK14_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 14 threshold</attribute>
+    <attribute side="server" code="0x810E" define="RX_BLOCK15_THRESHOLD" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block 15 threshold</attribute>
+    <!-- Price Cluster Server - Received Block Period Attribute Set -->
+    <attribute side="server" code="0x8200" define="RX_START_OF_BLOCK_PERIOD" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx start of block period</attribute>
+    <attribute side="server" code="0x8201" define="RX_BLOCK_PERIOD_DURATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx block period duration</attribute>
+    <attribute side="server" code="0x8202" define="RX_THRESHOLD_MULTIPLIER" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx threshold multiplier</attribute>
+    <attribute side="server" code="0x8203" define="RX_THRESHOLD_DIVISOR" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx threshold divisor</attribute>
+    <!-- Price Cluster Server - Received Block Price Information Attribute Set -->
+    <attribute side="server" code="0x8400" define="RX_NO_TIER_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 1 price</attribute>
+    <attribute side="server" code="0x8401" define="RX_NO_TIER_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 2 price</attribute>
+    <attribute side="server" code="0x8402" define="RX_NO_TIER_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 3 price</attribute>
+    <attribute side="server" code="0x8403" define="RX_NO_TIER_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 4 price</attribute>
+    <attribute side="server" code="0x8404" define="RX_NO_TIER_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 5 price</attribute>
+    <attribute side="server" code="0x8405" define="RX_NO_TIER_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 6 price</attribute>
+    <attribute side="server" code="0x8406" define="RX_NO_TIER_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 7 price</attribute>
+    <attribute side="server" code="0x8407" define="RX_NO_TIER_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 8 price</attribute>
+    <attribute side="server" code="0x8408" define="RX_NO_TIER_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 9 price</attribute>
+    <attribute side="server" code="0x8409" define="RX_NO_TIER_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 10 price</attribute>
+    <attribute side="server" code="0x840A" define="RX_NO_TIER_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 11 price</attribute>
+    <attribute side="server" code="0x840B" define="RX_NO_TIER_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 12 price</attribute>
+    <attribute side="server" code="0x840C" define="RX_NO_TIER_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 13 price</attribute>
+    <attribute side="server" code="0x840D" define="RX_NO_TIER_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 14 price</attribute>
+    <attribute side="server" code="0x840E" define="RX_NO_TIER_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 15 price</attribute>
+    <attribute side="server" code="0x840F" define="RX_NO_TIER_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx no tier block 16 price</attribute>
+    <attribute side="server" code="0x8410" define="RX_TIER1_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 1 price</attribute>
+    <attribute side="server" code="0x8411" define="RX_TIER1_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 2 price</attribute>
+    <attribute side="server" code="0x8412" define="RX_TIER1_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 3 price</attribute>
+    <attribute side="server" code="0x8413" define="RX_TIER1_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 4 price</attribute>
+    <attribute side="server" code="0x8414" define="RX_TIER1_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 5 price</attribute>
+    <attribute side="server" code="0x8415" define="RX_TIER1_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 6 price</attribute>
+    <attribute side="server" code="0x8416" define="RX_TIER1_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 7 price</attribute>
+    <attribute side="server" code="0x8417" define="RX_TIER1_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 8 price</attribute>
+    <attribute side="server" code="0x8418" define="RX_TIER1_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 9 price</attribute>
+    <attribute side="server" code="0x8419" define="RX_TIER1_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 10 price</attribute>
+    <attribute side="server" code="0x841A" define="RX_TIER1_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 11 price</attribute>
+    <attribute side="server" code="0x841B" define="RX_TIER1_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 12 price</attribute>
+    <attribute side="server" code="0x841C" define="RX_TIER1_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 13 price</attribute>
+    <attribute side="server" code="0x841D" define="RX_TIER1_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 14 price</attribute>
+    <attribute side="server" code="0x841E" define="RX_TIER1_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 15 price</attribute>
+    <attribute side="server" code="0x841F" define="RX_TIER1_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 1 block 16 price</attribute>
+    <attribute side="server" code="0x8420" define="RX_TIER2_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 1 price</attribute>
+    <attribute side="server" code="0x8421" define="RX_TIER2_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 2 price</attribute>
+    <attribute side="server" code="0x8422" define="RX_TIER2_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 3 price</attribute>
+    <attribute side="server" code="0x8423" define="RX_TIER2_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 4 price</attribute>
+    <attribute side="server" code="0x8424" define="RX_TIER2_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 5 price</attribute>
+    <attribute side="server" code="0x8425" define="RX_TIER2_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 6 price</attribute>
+    <attribute side="server" code="0x8426" define="RX_TIER2_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 7 price</attribute>
+    <attribute side="server" code="0x8427" define="RX_TIER2_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 8 price</attribute>
+    <attribute side="server" code="0x8428" define="RX_TIER2_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 9 price</attribute>
+    <attribute side="server" code="0x8429" define="RX_TIER2_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 10 price</attribute>
+    <attribute side="server" code="0x842A" define="RX_TIER2_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 11 price</attribute>
+    <attribute side="server" code="0x842B" define="RX_TIER2_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 12 price</attribute>
+    <attribute side="server" code="0x842C" define="RX_TIER2_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 13 price</attribute>
+    <attribute side="server" code="0x842D" define="RX_TIER2_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 14 price</attribute>
+    <attribute side="server" code="0x842E" define="RX_TIER2_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 15 price</attribute>
+    <attribute side="server" code="0x842F" define="RX_TIER2_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 2 block 16 price</attribute>
+    <attribute side="server" code="0x8430" define="RX_TIER3_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 1 price</attribute>
+    <attribute side="server" code="0x8431" define="RX_TIER3_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 2 price</attribute>
+    <attribute side="server" code="0x8432" define="RX_TIER3_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 3 price</attribute>
+    <attribute side="server" code="0x8433" define="RX_TIER3_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 4 price</attribute>
+    <attribute side="server" code="0x8434" define="RX_TIER3_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 5 price</attribute>
+    <attribute side="server" code="0x8435" define="RX_TIER3_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 6 price</attribute>
+    <attribute side="server" code="0x8436" define="RX_TIER3_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 7 price</attribute>
+    <attribute side="server" code="0x8437" define="RX_TIER3_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 8 price</attribute>
+    <attribute side="server" code="0x8438" define="RX_TIER3_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 9 price</attribute>
+    <attribute side="server" code="0x8439" define="RX_TIER3_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 10 price</attribute>
+    <attribute side="server" code="0x843A" define="RX_TIER3_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 11 price</attribute>
+    <attribute side="server" code="0x843B" define="RX_TIER3_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 12 price</attribute>
+    <attribute side="server" code="0x843C" define="RX_TIER3_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 13 price</attribute>
+    <attribute side="server" code="0x843D" define="RX_TIER3_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 14 price</attribute>
+    <attribute side="server" code="0x843E" define="RX_TIER3_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 15 price</attribute>
+    <attribute side="server" code="0x843F" define="RX_TIER3_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 3 block 16 price</attribute>
+    <attribute side="server" code="0x8440" define="RX_TIER4_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 1 price</attribute>
+    <attribute side="server" code="0x8441" define="RX_TIER4_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 2 price</attribute>
+    <attribute side="server" code="0x8442" define="RX_TIER4_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 3 price</attribute>
+    <attribute side="server" code="0x8443" define="RX_TIER4_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 4 price</attribute>
+    <attribute side="server" code="0x8444" define="RX_TIER4_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 5 price</attribute>
+    <attribute side="server" code="0x8445" define="RX_TIER4_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 6 price</attribute>
+    <attribute side="server" code="0x8446" define="RX_TIER4_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 7 price</attribute>
+    <attribute side="server" code="0x8447" define="RX_TIER4_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 8 price</attribute>
+    <attribute side="server" code="0x8448" define="RX_TIER4_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 9 price</attribute>
+    <attribute side="server" code="0x8449" define="RX_TIER4_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 10 price</attribute>
+    <attribute side="server" code="0x844A" define="RX_TIER4_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 11 price</attribute>
+    <attribute side="server" code="0x844B" define="RX_TIER4_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 12 price</attribute>
+    <attribute side="server" code="0x844C" define="RX_TIER4_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 13 price</attribute>
+    <attribute side="server" code="0x844D" define="RX_TIER4_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 14 price</attribute>
+    <attribute side="server" code="0x844E" define="RX_TIER4_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 15 price</attribute>
+    <attribute side="server" code="0x844F" define="RX_TIER4_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 4 block 16 price</attribute>
+    <attribute side="server" code="0x8450" define="RX_TIER5_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 1 price</attribute>
+    <attribute side="server" code="0x8451" define="RX_TIER5_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 2 price</attribute>
+    <attribute side="server" code="0x8452" define="RX_TIER5_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 3 price</attribute>
+    <attribute side="server" code="0x8453" define="RX_TIER5_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 4 price</attribute>
+    <attribute side="server" code="0x8454" define="RX_TIER5_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 5 price</attribute>
+    <attribute side="server" code="0x8455" define="RX_TIER5_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 6 price</attribute>
+    <attribute side="server" code="0x8456" define="RX_TIER5_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 7 price</attribute>
+    <attribute side="server" code="0x8457" define="RX_TIER5_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 8 price</attribute>
+    <attribute side="server" code="0x8458" define="RX_TIER5_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 9 price</attribute>
+    <attribute side="server" code="0x8459" define="RX_TIER5_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 10 price</attribute>
+    <attribute side="server" code="0x845A" define="RX_TIER5_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 11 price</attribute>
+    <attribute side="server" code="0x845B" define="RX_TIER5_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 12 price</attribute>
+    <attribute side="server" code="0x845C" define="RX_TIER5_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 13 price</attribute>
+    <attribute side="server" code="0x845D" define="RX_TIER5_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 14 price</attribute>
+    <attribute side="server" code="0x845E" define="RX_TIER5_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 15 price</attribute>
+    <attribute side="server" code="0x845F" define="RX_TIER5_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 5 block 16 price</attribute>
+    <attribute side="server" code="0x8460" define="RX_TIER6_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 1 price</attribute>
+    <attribute side="server" code="0x8461" define="RX_TIER6_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 2 price</attribute>
+    <attribute side="server" code="0x8462" define="RX_TIER6_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 3 price</attribute>
+    <attribute side="server" code="0x8463" define="RX_TIER6_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 4 price</attribute>
+    <attribute side="server" code="0x8464" define="RX_TIER6_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 5 price</attribute>
+    <attribute side="server" code="0x8465" define="RX_TIER6_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 6 price</attribute>
+    <attribute side="server" code="0x8466" define="RX_TIER6_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 7 price</attribute>
+    <attribute side="server" code="0x8467" define="RX_TIER6_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 8 price</attribute>
+    <attribute side="server" code="0x8468" define="RX_TIER6_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 9 price</attribute>
+    <attribute side="server" code="0x8469" define="RX_TIER6_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 10 price</attribute>
+    <attribute side="server" code="0x846A" define="RX_TIER6_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 11 price</attribute>
+    <attribute side="server" code="0x846B" define="RX_TIER6_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 12 price</attribute>
+    <attribute side="server" code="0x846C" define="RX_TIER6_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 13 price</attribute>
+    <attribute side="server" code="0x846D" define="RX_TIER6_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 14 price</attribute>
+    <attribute side="server" code="0x846E" define="RX_TIER6_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 15 price</attribute>
+    <attribute side="server" code="0x846F" define="RX_TIER6_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 6 block 16 price</attribute>
+    <attribute side="server" code="0x8470" define="RX_TIER7_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 1 price</attribute>
+    <attribute side="server" code="0x8471" define="RX_TIER7_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 2 price</attribute>
+    <attribute side="server" code="0x8472" define="RX_TIER7_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 3 price</attribute>
+    <attribute side="server" code="0x8473" define="RX_TIER7_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 4 price</attribute>
+    <attribute side="server" code="0x8474" define="RX_TIER7_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 5 price</attribute>
+    <attribute side="server" code="0x8475" define="RX_TIER7_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 6 price</attribute>
+    <attribute side="server" code="0x8476" define="RX_TIER7_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 7 price</attribute>
+    <attribute side="server" code="0x8477" define="RX_TIER7_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 8 price</attribute>
+    <attribute side="server" code="0x8478" define="RX_TIER7_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 9 price</attribute>
+    <attribute side="server" code="0x8479" define="RX_TIER7_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 10 price</attribute>
+    <attribute side="server" code="0x847A" define="RX_TIER7_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 11 price</attribute>
+    <attribute side="server" code="0x847B" define="RX_TIER7_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 12 price</attribute>
+    <attribute side="server" code="0x847C" define="RX_TIER7_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 13 price</attribute>
+    <attribute side="server" code="0x847D" define="RX_TIER7_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 14 price</attribute>
+    <attribute side="server" code="0x847E" define="RX_TIER7_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 15 price</attribute>
+    <attribute side="server" code="0x847F" define="RX_TIER7_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 7 block 16 price</attribute>
+    <attribute side="server" code="0x8480" define="RX_TIER8_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 1 price</attribute>
+    <attribute side="server" code="0x8481" define="RX_TIER8_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 2 price</attribute>
+    <attribute side="server" code="0x8482" define="RX_TIER8_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 3 price</attribute>
+    <attribute side="server" code="0x8483" define="RX_TIER8_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 4 price</attribute>
+    <attribute side="server" code="0x8484" define="RX_TIER8_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 5 price</attribute>
+    <attribute side="server" code="0x8485" define="RX_TIER8_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 6 price</attribute>
+    <attribute side="server" code="0x8486" define="RX_TIER8_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 7 price</attribute>
+    <attribute side="server" code="0x8487" define="RX_TIER8_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 8 price</attribute>
+    <attribute side="server" code="0x8488" define="RX_TIER8_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 9 price</attribute>
+    <attribute side="server" code="0x8489" define="RX_TIER8_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 10 price</attribute>
+    <attribute side="server" code="0x848A" define="RX_TIER8_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 11 price</attribute>
+    <attribute side="server" code="0x848B" define="RX_TIER8_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 12 price</attribute>
+    <attribute side="server" code="0x848C" define="RX_TIER8_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 13 price</attribute>
+    <attribute side="server" code="0x848D" define="RX_TIER8_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 14 price</attribute>
+    <attribute side="server" code="0x848E" define="RX_TIER8_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 15 price</attribute>
+    <attribute side="server" code="0x848F" define="RX_TIER8_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 8 block 16 price</attribute>
+    <attribute side="server" code="0x8490" define="RX_TIER9_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 1 price</attribute>
+    <attribute side="server" code="0x8491" define="RX_TIER9_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 2 price</attribute>
+    <attribute side="server" code="0x8492" define="RX_TIER9_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 3 price</attribute>
+    <attribute side="server" code="0x8493" define="RX_TIER9_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 4 price</attribute>
+    <attribute side="server" code="0x8494" define="RX_TIER9_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 5 price</attribute>
+    <attribute side="server" code="0x8495" define="RX_TIER9_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 6 price</attribute>
+    <attribute side="server" code="0x8496" define="RX_TIER9_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 7 price</attribute>
+    <attribute side="server" code="0x8497" define="RX_TIER9_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 8 price</attribute>
+    <attribute side="server" code="0x8498" define="RX_TIER9_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 9 price</attribute>
+    <attribute side="server" code="0x8499" define="RX_TIER9_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 10 price</attribute>
+    <attribute side="server" code="0x849A" define="RX_TIER9_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 11 price</attribute>
+    <attribute side="server" code="0x849B" define="RX_TIER9_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 12 price</attribute>
+    <attribute side="server" code="0x849C" define="RX_TIER9_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 13 price</attribute>
+    <attribute side="server" code="0x849D" define="RX_TIER9_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 14 price</attribute>
+    <attribute side="server" code="0x849E" define="RX_TIER9_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 15 price</attribute>
+    <attribute side="server" code="0x849F" define="RX_TIER9_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 9 block 16 price</attribute>
+    <attribute side="server" code="0x84A0" define="RX_TIER10_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 1 price</attribute>
+    <attribute side="server" code="0x84A1" define="RX_TIER10_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 2 price</attribute>
+    <attribute side="server" code="0x84A2" define="RX_TIER10_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 3 price</attribute>
+    <attribute side="server" code="0x84A3" define="RX_TIER10_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 4 price</attribute>
+    <attribute side="server" code="0x84A4" define="RX_TIER10_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 5 price</attribute>
+    <attribute side="server" code="0x84A5" define="RX_TIER10_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 6 price</attribute>
+    <attribute side="server" code="0x84A6" define="RX_TIER10_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 7 price</attribute>
+    <attribute side="server" code="0x84A7" define="RX_TIER10_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 8 price</attribute>
+    <attribute side="server" code="0x84A8" define="RX_TIER10_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 9 price</attribute>
+    <attribute side="server" code="0x84A9" define="RX_TIER10_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 10 price</attribute>
+    <attribute side="server" code="0x84AA" define="RX_TIER10_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 11 price</attribute>
+    <attribute side="server" code="0x84AB" define="RX_TIER10_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 12 price</attribute>
+    <attribute side="server" code="0x84AC" define="RX_TIER10_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 13 price</attribute>
+    <attribute side="server" code="0x84AD" define="RX_TIER10_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 14 price</attribute>
+    <attribute side="server" code="0x84AE" define="RX_TIER10_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 15 price</attribute>
+    <attribute side="server" code="0x84AF" define="RX_TIER10_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 10 block 16 price</attribute>
+    <attribute side="server" code="0x84B0" define="RX_TIER11_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 1 price</attribute>
+    <attribute side="server" code="0x84B1" define="RX_TIER11_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 2 price</attribute>
+    <attribute side="server" code="0x84B2" define="RX_TIER11_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 3 price</attribute>
+    <attribute side="server" code="0x84B3" define="RX_TIER11_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 4 price</attribute>
+    <attribute side="server" code="0x84B4" define="RX_TIER11_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 5 price</attribute>
+    <attribute side="server" code="0x84B5" define="RX_TIER11_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 6 price</attribute>
+    <attribute side="server" code="0x84B6" define="RX_TIER11_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 7 price</attribute>
+    <attribute side="server" code="0x84B7" define="RX_TIER11_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 8 price</attribute>
+    <attribute side="server" code="0x84B8" define="RX_TIER11_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 9 price</attribute>
+    <attribute side="server" code="0x84B9" define="RX_TIER11_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 10 price</attribute>
+    <attribute side="server" code="0x84BA" define="RX_TIER11_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 11 price</attribute>
+    <attribute side="server" code="0x84BB" define="RX_TIER11_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 12 price</attribute>
+    <attribute side="server" code="0x84BC" define="RX_TIER11_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 13 price</attribute>
+    <attribute side="server" code="0x84BD" define="RX_TIER11_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 14 price</attribute>
+    <attribute side="server" code="0x84BE" define="RX_TIER11_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 15 price</attribute>
+    <attribute side="server" code="0x84BF" define="RX_TIER11_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 11 block 16 price</attribute>
+    <attribute side="server" code="0x84C0" define="RX_TIER12_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 1 price</attribute>
+    <attribute side="server" code="0x84C1" define="RX_TIER12_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 2 price</attribute>
+    <attribute side="server" code="0x84C2" define="RX_TIER12_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 3 price</attribute>
+    <attribute side="server" code="0x84C3" define="RX_TIER12_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 4 price</attribute>
+    <attribute side="server" code="0x84C4" define="RX_TIER12_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 5 price</attribute>
+    <attribute side="server" code="0x84C5" define="RX_TIER12_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 6 price</attribute>
+    <attribute side="server" code="0x84C6" define="RX_TIER12_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 7 price</attribute>
+    <attribute side="server" code="0x84C7" define="RX_TIER12_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 8 price</attribute>
+    <attribute side="server" code="0x84C8" define="RX_TIER12_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 9 price</attribute>
+    <attribute side="server" code="0x84C9" define="RX_TIER12_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 10 price</attribute>
+    <attribute side="server" code="0x84CA" define="RX_TIER12_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 11 price</attribute>
+    <attribute side="server" code="0x84CB" define="RX_TIER12_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 12 price</attribute>
+    <attribute side="server" code="0x84CC" define="RX_TIER12_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 13 price</attribute>
+    <attribute side="server" code="0x84CD" define="RX_TIER12_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 14 price</attribute>
+    <attribute side="server" code="0x84CE" define="RX_TIER12_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 15 price</attribute>
+    <attribute side="server" code="0x84CF" define="RX_TIER12_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 12 block 16 price</attribute>
+    <attribute side="server" code="0x84D0" define="RX_TIER13_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 1 price</attribute>
+    <attribute side="server" code="0x84D1" define="RX_TIER13_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 2 price</attribute>
+    <attribute side="server" code="0x84D2" define="RX_TIER13_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 3 price</attribute>
+    <attribute side="server" code="0x84D3" define="RX_TIER13_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 4 price</attribute>
+    <attribute side="server" code="0x84D4" define="RX_TIER13_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 5 price</attribute>
+    <attribute side="server" code="0x84D5" define="RX_TIER13_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 6 price</attribute>
+    <attribute side="server" code="0x84D6" define="RX_TIER13_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 7 price</attribute>
+    <attribute side="server" code="0x84D7" define="RX_TIER13_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 8 price</attribute>
+    <attribute side="server" code="0x84D8" define="RX_TIER13_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 9 price</attribute>
+    <attribute side="server" code="0x84D9" define="RX_TIER13_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 10 price</attribute>
+    <attribute side="server" code="0x84DA" define="RX_TIER13_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 11 price</attribute>
+    <attribute side="server" code="0x84DB" define="RX_TIER13_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 12 price</attribute>
+    <attribute side="server" code="0x84DC" define="RX_TIER13_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 13 price</attribute>
+    <attribute side="server" code="0x84DD" define="RX_TIER13_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 14 price</attribute>
+    <attribute side="server" code="0x84DE" define="RX_TIER13_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 15 price</attribute>
+    <attribute side="server" code="0x84DF" define="RX_TIER13_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 13 block 16 price</attribute>
+    <attribute side="server" code="0x84E0" define="RX_TIER14_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 1 price</attribute>
+    <attribute side="server" code="0x84E1" define="RX_TIER14_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 2 price</attribute>
+    <attribute side="server" code="0x84E2" define="RX_TIER14_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 3 price</attribute>
+    <attribute side="server" code="0x84E3" define="RX_TIER14_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 4 price</attribute>
+    <attribute side="server" code="0x84E4" define="RX_TIER14_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 5 price</attribute>
+    <attribute side="server" code="0x84E5" define="RX_TIER14_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 6 price</attribute>
+    <attribute side="server" code="0x84E6" define="RX_TIER14_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 7 price</attribute>
+    <attribute side="server" code="0x84E7" define="RX_TIER14_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 8 price</attribute>
+    <attribute side="server" code="0x84E8" define="RX_TIER14_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 9 price</attribute>
+    <attribute side="server" code="0x84E9" define="RX_TIER14_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 10 price</attribute>
+    <attribute side="server" code="0x84EA" define="RX_TIER14_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 11 price</attribute>
+    <attribute side="server" code="0x84EB" define="RX_TIER14_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 12 price</attribute>
+    <attribute side="server" code="0x84EC" define="RX_TIER14_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 13 price</attribute>
+    <attribute side="server" code="0x84ED" define="RX_TIER14_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 14 price</attribute>
+    <attribute side="server" code="0x84EE" define="RX_TIER14_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 15 price</attribute>
+    <attribute side="server" code="0x84EF" define="RX_TIER14_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 14 block 16 price</attribute>
+    <attribute side="server" code="0x84F0" define="RX_TIER15_BLOCK1_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 1 price</attribute>
+    <attribute side="server" code="0x84F1" define="RX_TIER15_BLOCK2_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 2 price</attribute>
+    <attribute side="server" code="0x84F2" define="RX_TIER15_BLOCK3_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 3 price</attribute>
+    <attribute side="server" code="0x84F3" define="RX_TIER15_BLOCK4_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 4 price</attribute>
+    <attribute side="server" code="0x84F4" define="RX_TIER15_BLOCK5_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 5 price</attribute>
+    <attribute side="server" code="0x84F5" define="RX_TIER15_BLOCK6_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 6 price</attribute>
+    <attribute side="server" code="0x84F6" define="RX_TIER15_BLOCK7_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 7 price</attribute>
+    <attribute side="server" code="0x84F7" define="RX_TIER15_BLOCK8_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 8 price</attribute>
+    <attribute side="server" code="0x84F8" define="RX_TIER15_BLOCK9_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 9 price</attribute>
+    <attribute side="server" code="0x84F9" define="RX_TIER15_BLOCK10_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 10 price</attribute>
+    <attribute side="server" code="0x84FA" define="RX_TIER15_BLOCK11_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 11 price</attribute>
+    <attribute side="server" code="0x84FB" define="RX_TIER15_BLOCK12_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 12 price</attribute>
+    <attribute side="server" code="0x84FC" define="RX_TIER15_BLOCK13_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 13 price</attribute>
+    <attribute side="server" code="0x84FD" define="RX_TIER15_BLOCK14_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 14 price</attribute>
+    <attribute side="server" code="0x84FE" define="RX_TIER15_BLOCK15_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 15 price</attribute>
+    <attribute side="server" code="0x84FF" define="RX_TIER15_BLOCK16_PRICE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier 15 block 16 price</attribute>
+    <!-- Price Cluster Server - Received Extended Price Information Attribute Set -->
+    <attribute side="server" code="0x850F" define="RX_PRICE_TIER16" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 16</attribute>
+    <attribute side="server" code="0x8510" define="RX_PRICE_TIER17" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 17</attribute>
+    <attribute side="server" code="0x8511" define="RX_PRICE_TIER18" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 18</attribute>
+    <attribute side="server" code="0x8512" define="RX_PRICE_TIER19" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 19</attribute>
+    <attribute side="server" code="0x8513" define="RX_PRICE_TIER20" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 20</attribute>
+    <attribute side="server" code="0x8514" define="RX_PRICE_TIER21" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 21</attribute>
+    <attribute side="server" code="0x8515" define="RX_PRICE_TIER22" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 22</attribute>
+    <attribute side="server" code="0x8516" define="RX_PRICE_TIER23" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 23</attribute>
+    <attribute side="server" code="0x8517" define="RX_PRICE_TIER24" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 24</attribute>
+    <attribute side="server" code="0x8518" define="RX_PRICE_TIER25" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 25</attribute>
+    <attribute side="server" code="0x8519" define="RX_PRICE_TIER26" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 26</attribute>
+    <attribute side="server" code="0x851A" define="RX_PRICE_TIER27" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 27</attribute>
+    <attribute side="server" code="0x851B" define="RX_PRICE_TIER28" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 28</attribute>
+    <attribute side="server" code="0x851C" define="RX_PRICE_TIER29" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 29</attribute>
+    <attribute side="server" code="0x851D" define="RX_PRICE_TIER30" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 30</attribute>
+    <attribute side="server" code="0x851E" define="RX_PRICE_TIER31" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 31</attribute>
+    <attribute side="server" code="0x851F" define="RX_PRICE_TIER32" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 32</attribute>
+    <attribute side="server" code="0x8520" define="RX_PRICE_TIER33" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 33</attribute>
+    <attribute side="server" code="0x8521" define="RX_PRICE_TIER34" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 34</attribute>
+    <attribute side="server" code="0x8522" define="RX_PRICE_TIER35" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 35</attribute>
+    <attribute side="server" code="0x8523" define="RX_PRICE_TIER36" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 36</attribute>
+    <attribute side="server" code="0x8524" define="RX_PRICE_TIER37" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 37</attribute>
+    <attribute side="server" code="0x8525" define="RX_PRICE_TIER38" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 38</attribute>
+    <attribute side="server" code="0x8526" define="RX_PRICE_TIER39" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 39</attribute>
+    <attribute side="server" code="0x8527" define="RX_PRICE_TIER40" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 40</attribute>
+    <attribute side="server" code="0x8528" define="RX_PRICE_TIER41" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 41</attribute>
+    <attribute side="server" code="0x8529" define="RX_PRICE_TIER42" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 42</attribute>
+    <attribute side="server" code="0x852A" define="RX_PRICE_TIER43" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 43</attribute>
+    <attribute side="server" code="0x852B" define="RX_PRICE_TIER44" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 44</attribute>
+    <attribute side="server" code="0x852C" define="RX_PRICE_TIER45" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 45</attribute>
+    <attribute side="server" code="0x852D" define="RX_PRICE_TIER46" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 46</attribute>
+    <attribute side="server" code="0x852E" define="RX_PRICE_TIER47" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 47</attribute>
+    <attribute side="server" code="0x852F" define="RX_PRICE_TIER48" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx price tier 48</attribute>
+    <!-- Price Cluster Server - Received Tariff Information Attribute Set -->
+    <attribute side="server" code="0x8610" define="RX_TARIFF_LABEL" type="OCTET_STRING" length="24" writable="false" default="0" optional="true" introducedIn="se-1.2a-07-5356-19">rx tariff label</attribute>
+    <attribute side="server" code="0x8611" define="RX_NUMBER_OF_PRICE_TIERS_IN_USE" type="INT8U" min="0x00" max="0x0F" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">rx number of price tiers in use</attribute>
+    <attribute side="server" code="0x8612" define="RX_NUMBER_OF_BLOCK_THRESHOLDS_IN_USE" type="INT8U" min="0x00" max="0x0F" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">rx number of block thresholds in use</attribute>
+    <attribute side="server" code="0x8613" define="RX_TIER_BLOCK_MODE" type="INT8U" min="0x00" max="0x01" writable="false" default="0xFF" optional="true" introducedIn="se-1.2a-07-5356-19">rx tier block mode</attribute>
+    <attribute side="server" code="0x8615" define="RX_TARIFF_RESOLUTION_PERIOD" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">rx tariff resolution period</attribute>
+    <attribute side="server" code="0x8625" define="RX_CO2" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x000000B9" optional="true" introducedIn="se-1.2a-07-5356-19">rx CO2</attribute>
+    <attribute side="server" code="0x8626" define="RX_CO2_UNIT" type="ENUM8" writable="false" default="0x01" optional="true" introducedIn="se-1.2a-07-5356-19">rx CO2 unit</attribute>
+    <attribute side="server" code="0x8627" define="RX_CO2_TRAILING_DIGIT" type="BITMAP8" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">rx CO2 trailing digit</attribute>
+    <!-- Price Cluster Server - Received Billing Information Attribute Set -->
+    <attribute side="server" code="0x8700" define="RX_CURRENT_BILLING_PERIOD_START" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx current billing period start</attribute>
+    <attribute side="server" code="0x8701" define="RX_CURRENT_BILLING_PERIOD_DURATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx current billing period duration</attribute>
+    <attribute side="server" code="0x8702" define="RX_LAST_BILLING_PERIOD_START" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx last billing period start</attribute>
+    <attribute side="server" code="0x8703" define="RX_LAST_BILLING_PERIOD_DURATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx last billing period duration</attribute>
+    <attribute side="server" code="0x8704" define="RX_LAST_BILLING_PERIOD_CONSOLIDATED_BILL" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">rx last billing period consolidated bill</attribute>
+    <!-- Price Cluster Client - Attributes -->
+    <attribute side="client" code="0x0000" define="PRICE_INCREASE_RANDOMIZE_MINUTES" type="INT8U" min="0x00" max="0x3C" writable="true" default="0x05" optional="true">price increase randomize minutes</attribute>
+    <attribute side="client" code="0x0001" define="PRICE_DECREASE_RANDOMIZE_MINUTES" type="INT8U" min="0x00" max="0x3C" writable="true" default="0x0F" optional="true">price decrease randomize minutes</attribute>
+    <attribute side="client" code="0x0002" define="COMMODITY_TYPE_CLIENT" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true">commodity type</attribute>
+    <!-- Price Cluster Server - Commands -->
+    <command source="server" code="0x00" name="PublishPrice" optional="false" cli="zcl price pub-price">
+      <description>
+        The PublishPrice command is generated in response to receiving a Get Current Price command, in response to a Get Scheduled Prices command, and when an update to the pricing information is available from the commodity provider, either before or when a TOU price becomes active.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="rateLabel" type="OCTET_STRING"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="currentTime" type="UTC_TIME"/>
+      <arg name="unitOfMeasure" type="AmiUnitOfMeasure"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="priceTrailingDigitAndPriceTier" type="PriceTrailingDigitAndPriceTier"/>
+      <arg name="numberOfPriceTiersAndRegisterTier" type="PriceNumberOfPriceTiersAndRegisterTier"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceRatio" type="INT8U"/>
+      <arg name="generationPrice" type="INT32U"/>
+      <arg name="generationPriceRatio" type="INT8U"/>
+      <arg name="alternateCostDelivered" type="INT32U" introducedIn="se-1.0-07-5356-15" default="0xFFFFFFFF"/>
+      <arg name="alternateCostUnit" type="AlternateCostUnit" introducedIn="se-1.0-07-5356-15" default="0xFF"/>
+      <arg name="alternateCostTrailingDigit" type="AlternateCostTrailingDigit" introducedIn="se-1.0-07-5356-15" default="0xFF"/>
+      <arg name="numberOfBlockThresholds" type="INT8U" introducedIn="se-1.1-07-5356-16" default="0xFF"/>
+      <arg name="priceControl" type="PriceControlMask" introducedIn="se-1.1-07-5356-16" default="0x00"/>
+      <arg name="numberOfGenerationTiers" type="INT8U" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+      <arg name="generationTier" type="GenerationTier" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+      <arg name="extendedNumberOfPriceTiers" type="ExtendedNumberOfPriceTiers" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+      <arg name="extendedPriceTier" type="ExtendedPriceTier" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+      <arg name="extendedRegisterTier" type="ExtendedRegisterTier" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+    </command>
+    <command source="server" code="0x01" name="PublishBlockPeriod" optional="true" introducedIn="se-1.1-07-5356-16" cli="zcl price pub-block-period">
+      <description>
+        The PublishBlockPeriod command is generated in response to receiving a GetBlockPeriod(s) command or when an update to the block tariff schedule is available from the commodity provider.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="blockPeriodStartTime" type="UTC_TIME"/>
+      <arg name="blockPeriodDuration" type="INT24U"/>
+      <arg name="numberOfPriceTiersAndNumberOfBlockThresholds" type="BITMAP8" removedIn="se-1.2a-07-5356-19"/>
+      <arg name="blockPeriodControl" type="BlockPeriodControl"/>
+      <arg name="blockPeriodDurationType" type="BlockPeriodDurationType" introducedIn="se-1.2a-07-5356-19"/>
+      <arg name="tariffType" type="TariffType" introducedIn="se-1.2a-07-5356-19"/>
+      <arg name="tariffResolutionPeriod" type="TariffResolutionPeriod" introducedIn="se-1.2a-07-5356-19"/>
+    </command>
+    <command source="server" code="0x02" name="PublishConversionFactor" optional="true" introducedIn="se-1.1a-07-5356-17" cli="zcl price pub-x-factor">
+      <description>
+        The PublishConversionFactor command is sent in response to a GetConversionFactor command or if a new Conversion factor is available.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="conversionFactor" type="INT32U"/>
+      <arg name="conversionFactorTrailingDigit" type="ConversionFactorTrailingDigit"/>
+    </command>
+    <command source="server" code="0x03" name="PublishCalorificValue" optional="true" introducedIn="se-1.1a-07-5356-17" cli="zcl price pub-cal-val">
+      <description>
+        The PublishCalorificValue command is sent in response to a GetCalorificValue command or if a new calorific value is available.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="calorificValue" type="INT32U"/>
+      <arg name="calorificValueUnit" type="CalorificValueUnit"/>
+      <arg name="calorificValueTrailingDigit" type="CalorificValueTrailingDigit"/>
+    </command>
+    <command source="server" code="0x04" name="PublishTariffInformation" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-tariff-info">
+      <description>
+        The PublishTariffInformation command is sent in response to a GetTariffInformation command or if new tariff information is available (including price matrix and block thresholds).
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerTariffId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="tariffTypeChargingScheme" type="TariffTypeChargingScheme"/>
+      <arg name="tariffLabel" type="OCTET_STRING"/>
+      <arg name="numberOfPriceTiersInUse" type="INT8U"/>
+      <arg name="numberOfBlockThresholdsInUse" type="INT8U"/>
+      <arg name="unitOfMeasure" type="AmiUnitOfMeasure"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="priceTrailingDigit" type="PriceTrailingDigit"/>
+      <arg name="standingCharge" type="INT32U"/>
+      <arg name="tierBlockMode" type="TierBlockMode"/>
+      <arg name="blockThresholdMultiplier" type="INT24U"/>
+      <arg name="blockThresholdDivisor" type="INT24U"/>
+    </command>
+    <command source="server" code="0x05" name="PublishPriceMatrix" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-price-matrix">
+      <description>
+        PublishPriceMatrix command is used to publish the Block Price Information Set (up to 15 tiers x 15 blocks) and the Extended Price Information Set (up to 48 tiers).  The PublishPriceMatrix command is sent in response to a GetPriceMatrix command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="issuerTariffId" type="INT32U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="subPayloadControl" type="PriceMatrixSubPayloadControl"/>
+      <arg name="payload" type="PriceMatrixSubPayload" array="true"/>
+    </command>
+    <command source="server" code="0x06" name="PublishBlockThresholds" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-block-threshold">
+      <description>
+        The PublishBlockThreshold command is sent in response to a GetBlockThreshold command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="issuerTariffId" type="INT32U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="subPayloadControl" type="BlockThresholdSubPayloadControl"/>
+      <arg name="payload" type="BlockThresholdSubPayload" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="PublishCO2Value" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-co2-val">
+      <description>
+        The PublishCO2Value command is sent in response to a GetCO2Value command or if a new CO2 conversion factor is available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="tariffType" type="TariffType"/>
+      <arg name="cO2Value" type="INT32U"/>
+      <arg name="cO2ValueUnit" type="CO2Unit"/>
+      <arg name="cO2ValueTrailingDigit" type="CO2TrailingDigit"/>
+    </command>
+    <command source="server" code="0x08" name="PublishTierLabels" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-tier-labels">
+      <description>
+        The PublishTierLabels command is generated in response to receiving a GetTierLabels command or when there is a tier label change.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerTariffId" type="INT32U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="numberOfLabels" type="INT8U"/>
+      <arg name="tierLabelsPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x09" name="PublishBillingPeriod" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-billing-period">
+      <description>
+        The PublishBillingPeriod command is generated in response to receiving a GetBillingPeriod(s) command or when an update to the Billing schedule is available from the commodity Supplier.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="billingPeriodStartTime" type="UTC_TIME"/>
+      <arg name="billingPeriodDuration" type="BillingPeriodDuration"/>
+      <arg name="billingPeriodDurationType" type="BillingPeriodDurationType"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="server" code="0x0A" name="PublishConsolidatedBill" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-consolidated-bill">
+      <description>
+        The PublishConsolidatedBill command is used to make consolidated billing information of previous billing periods available to other end devices.  This command is issued in response to a GetConsolidatedBill command or if new billing information is available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="billingPeriodStartTime" type="UTC_TIME"/>
+      <arg name="billingPeriodDuration" type="BillingPeriodDuration"/>
+      <arg name="billingPeriodDurationType" type="BillingPeriodDurationType"/>
+      <arg name="tariffType" type="TariffType"/>
+      <arg name="consolidatedBill" type="INT32U"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="billTrailingDigit" type="BillTrailingDigit"/>
+    </command>
+    <command source="server" code="0x0B" name="PublishCppEvent" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-cpp-event">
+      <description>
+        The PublishCPPEvent command is sent from an ESI to its price clients to notify them of a Critical Peak Pricing event.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="tariffType" type="TariffType"/>
+      <arg name="cppPriceTier" type="CppPriceTier"/>
+      <arg name="cppAuth" type="PublishCppEventCppAuth"/>
+    </command>
+    <command source="server" code="0x0C" name="PublishCreditPayment" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-credit-payment">
+      <description>
+        The PublishCreditPayment command is used to update the credit payment information is available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="creditPaymentDueDate" type="UTC_TIME"/>
+      <arg name="creditPaymentOverDueAmount" type="INT32U"/>
+      <arg name="creditPaymentStatus" type="CreditPaymentStatus"/>
+      <arg name="creditPayment" type="INT32U"/>
+      <arg name="creditPaymentDate" type="UTC_TIME"/>
+      <arg name="creditPaymentRef" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x0D" name="PublishCurrencyConversion" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price pub-currency-conversion">
+      <description>
+        The PublishCurrencyConversion command is sent in response to a GetCurrencyConversion command or when a new currency becomes available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="oldCurrency" type="INT16U"/>
+      <arg name="newCurrency" type="INT16U"/>
+      <arg name="conversionFactor" type="INT32U"/>
+      <arg name="conversionFactorTrailingDigit" type="ConversionFactorTrailingDigit"/>
+      <arg name="currencyChangeControlFlags" type="CurrencyChangeControl"/>
+    </command>
+    <command source="server" code="0x0E" name="CancelTariff" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price cancel-tariff">
+      <description>
+        The CancelTariff command indicates that all data associated with a particular tariff instance should be discarded.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerTariffId" type="INT32U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <!-- Price Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetCurrentPrice" optional="false" cli="zcl price current">
+      <description>
+        The GetCurrentPrice command initiates a PublishPrice command for the current time.
+      </description>
+      <arg name="commandOptions" type="AmiCommandOptions"/>
+    </command>
+    <command source="client" code="0x01" name="GetScheduledPrices" optional="true" cli="zcl price scheduled">
+      <description>
+        The GetScheduledPrices command initiates a PublishPrice command for available price events.
+      </description>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="numberOfEvents" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="PriceAcknowledgement" optional="false" introducedIn="se-1.1-07-5356-16" cli="zcl price price-ack">
+      <description>
+        The PriceAcknowledgement command described provides the ability to acknowledge a previously sent PublishPrice command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="priceAckTime" type="UTC_TIME"/>
+      <arg name="control" type="PriceControlMask"/>
+    </command>
+    <command source="client" code="0x03" name="GetBlockPeriods" optional="true" introducedIn="se-1.1-07-5356-16" cli="zcl price get-block-periods">
+      <description>
+        The GetBlockPeriods command initiates a PublishBlockPeriod command for the currently scheduled block periods.
+      </description>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="numberOfEvents" type="INT8U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="client" code="0x04" name="GetConversionFactor" optional="true" introducedIn="se-1.1a-07-5356-17" cli="zcl price get-conversion-factor">
+      <description>
+        The GetConversionFactor command initiates a PublishConversionFactor command for the scheduled conversion factor updates.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="GetCalorificValue" optional="true" introducedIn="se-1.1a-07-5356-17" cli="zcl price get-cal-val">
+      <description>
+        The GetCalorificValue command initiates a PublishCalorificValue command for the scheduled conversion factor updates.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="GetTariffInformation" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-tariff-info">
+      <description>
+        The GetTariffInformation command initiates a PublishTariffInformation command for the scheduled tariff updates.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="client" code="0x07" name="GetPriceMatrix" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-price-matrix">
+      <description>
+        The GetPriceMatrix command initiates a PublishPriceMatrix command for the scheduled Price Matrix updates.
+      </description>
+      <arg name="issuerTariffId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x08" name="GetBlockThresholds" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-block-thresholds">
+      <description>
+        The GetBlockThresholds command initiates a PublishBlockThreshold command for the scheduled Block Threshold updates.
+      </description>
+      <arg name="issuerTariffId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x09" name="GetCO2Value" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-co2-value">
+      <description>
+        The GetCO2Value command initiates a PublishCO2Value command for the scheduled CO2 conversion factor updates.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="client" code="0x0A" name="GetTierLabels" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-tier-labels">
+      <description>
+        The GetTierLabels command allows a client to retrieve the tier labels associated with a given tariff; this command initiates a PublishTierLabels command from the server.
+      </description>
+      <arg name="issuerTariffId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0B" name="GetBillingPeriod" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-billing-period">
+      <description>
+        The GetBillingPeriod command initiates one or more PublishBillingPeriod commands for the currently scheduled billing periods.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="client" code="0x0C" name="GetConsolidatedBill" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-con-bill">
+      <description>
+        The GetConsolidatedBill command initiates one or more PublishConsolidatedBill commands with the requested billing information.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="tariffType" type="TariffType"/>
+    </command>
+    <command source="client" code="0x0D" name="CppEventResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price cpp-event-resp" disableDefaultResponse="true">
+      <description>
+        The CPPEventResponse command is sent from a Client (IHD) to the ESI to notify it of a Critical Peak Pricing event authorization.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="cppAuth" type="CppEventResponseCppAuth"/>
+    </command>
+    <command source="client" code="0x0E" name="GetCreditPayment" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-credit-payment">
+      <description>
+        The GetCreditPayment command initiates PublishCreditPayment commands for the requested credit payment information.
+      </description>
+      <arg name="latestEndTime" type="UTC_TIME"/>
+      <arg name="numberOfRecords" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0F" name="GetCurrencyConversionCommand" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-cur-conv-cmd">
+      <description>
+        The GetCurrencyConversionCommand command initiates a PublishCurrencyConversion command for the currency conversion factor updates. A server shall be capable of storing both the old and the new currencies.
+      </description>
+    </command>
+    <command source="client" code="0x10" name="GetTariffCancellation" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl price get-tariff-cancellation">
+      <description>
+        The GetTariffCancellation command initiates the return of the last CancelTariff command held on the associated server.
+      </description>
+    </command>
+  </cluster>
+  <!-- Demand Response and Load Control Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="AmiDeviceClass" type="BITMAP16">
+    <field name="hvacCompressorOrFurnace" mask="0x0001"/>
+    <field name="StripHeatBaseboardHeat" mask="0x0002"/>
+    <field name="WaterHeater" mask="0x0004"/>
+    <field name="PoolPumpSpaJacuzzi" mask="0x0008"/>
+    <field name="SmartAppliances" mask="0x0010"/>
+    <field name="IrrigationPump" mask="0x0020"/>
+    <field name="ManagedCAndILoads" mask="0x0040"/>
+    <field name="SimpleMiscLoads" mask="0x0080"/>
+    <field name="ExteriorLighting" mask="0x0100"/>
+    <field name="InteriorLighting" mask="0x0200"/>
+    <field name="ElectricVehicle" mask="0x0400"/>
+    <field name="GenerationSystems" mask="0x0800"/>
+  </bitmap>
+  <enum name="AmiCriticalityLevel" type="ENUM8">
+    <item name="Reserved" value="0x00"/>
+    <item name="Green" value="0x01"/>
+    <item name="1" value="0x02"/>
+    <item name="2" value="0x03"/>
+    <item name="3" value="0x04"/>
+    <item name="4" value="0x05"/>
+    <item name="5" value="0x06"/>
+    <item name="Emergency" value="0x07"/>
+    <item name="PlannedOutage" value="0x08"/>
+    <item name="ServiceDisconnect" value="0x09"/>
+    <item name="UtilityDefined1" value="0x0A"/>
+    <item name="UtilityDefined2" value="0x0B"/>
+    <item name="UtilityDefined3" value="0x0C"/>
+    <item name="UtilityDefined4" value="0x0D"/>
+    <item name="UtilityDefined5" value="0x0E"/>
+    <item name="UtilityDefined6" value="0x0F"/>
+  </enum>
+  <bitmap name="AmiEventControl" type="BITMAP8">
+    <field name="randomizedStartTime" mask="0x01"/>
+    <field name="randomizedEndTime" mask="0x02"/>
+  </bitmap>
+  <bitmap name="AmiCancelControl" type="BITMAP8">
+    <field name="terminateWithRandomization" mask="0x01"/>
+  </bitmap>
+  <enum name="AmiEventStatus" type="ENUM8">
+    <item name="LoadControlEventCommandRx" value="0x01"/>
+    <item name="EventStarted" value="0x02"/>
+    <item name="EventCompleted" value="0x03"/>
+    <item name="UserHasChooseToOptOut" value="0x04"/>
+    <item name="UserHasChooseToOptIn" value="0x05"/>
+    <item name="TheEventHasBeenCanceled" value="0x06"/>
+    <item name="TheEventHasBeenSuperseded" value="0x07"/>
+    <item name="EventPartiallyCompletedWithUserOptOut" value="0x08"/>
+    <item name="EventPartiallyCompletedDueToUserOptIn" value="0x09"/>
+    <item name="EventCompletedNoUserParticipationPreviousOptOut" value="0x0A"/>
+    <item name="InvalidOptOut" value="0xF6"/>
+    <item name="EventNotFound" value="0xF7"/>
+    <item name="RejectedInvalidCancelCommand" value="0xF8"/>
+    <item name="RejectedInvalidCancelCommandInvalidEffectiveTime" value="0xF9"/>
+    <item name="RejectedEventExpired" value="0xFB"/>
+    <item name="RejectedInvalidCancelUndefinedEvent" value="0xFD"/>
+    <item name="LoadControlEventCommandRejected" value="0xFE"/>
+  </enum>
+  <enum name="SignatureType" type="ENUM8">
+    <item name="Reserved" value="0x00"/>
+    <item name="ECDSA" value="0x01"/>
+  </enum>
+  <struct name="Signature" length="42"/>
+  <!-- Demand Response and Load Control Cluster -->
+  <cluster>
+    <name>Demand Response and Load Control</name>
+    <domain>SE</domain>
+    <description>This cluster provides an interface to the functionality of Smart Energy Demand Response and Load Control. Devices targeted by this cluster include thermostats and devices that support load control.</description>
+    <code>0x0701</code>
+    <define>DEMAND_RESPONSE_LOAD_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Demand Response and Load Control Cluster Server - Attributes -->
+    <!-- Demand Response and Load Control Cluster Client - Attributes -->
+    <attribute side="client" code="0x0000" define="UTILITY_ENROLLMENT_GROUP" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="false">utility enrollment group</attribute>
+    <attribute side="client" code="0x0001" define="START_RANDOMIZATION_MINUTES" type="INT8U" min="0x00" max="0x3C" writable="true" default="0x1E" optional="false">start randomization minutes</attribute>
+    <attribute side="client" code="0x0002" define="DURATION_RANDOMIZATION_MINUTES" type="INT8U" min="0x00" max="0x3C" writable="true" default="0x00" optional="false">duration randomization minutes</attribute>
+    <attribute side="client" code="0x0003" define="DEVICE_CLASS_VALUE" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false">device class value</attribute>
+    <!-- Demand Response and Load Control Cluster Server - Commands -->
+    <command source="server" code="0x00" name="LoadControlEvent" optional="false">
+      <description>
+        Command description for LoadControlEvent
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="deviceClass" type="AmiDeviceClass"/>
+      <arg name="utilityEnrollmentGroup" type="INT8U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="criticalityLevel" type="AmiCriticalityLevel"/>
+      <arg name="coolingTemperatureOffset" type="INT8U"/>
+      <arg name="heatingTemperatureOffset" type="INT8U"/>
+      <arg name="coolingTemperatureSetPoint" type="INT16S"/>
+      <arg name="heatingTemperatureSetPoint" type="INT16S"/>
+      <arg name="averageLoadAdjustmentPercentage" type="INT8S"/>
+      <arg name="dutyCycle" type="INT8U"/>
+      <arg name="eventControl" type="AmiEventControl"/>
+    </command>
+    <command source="server" code="0x01" name="CancelLoadControlEvent" optional="false" cli="zcl drlc cl">
+      <description>
+        Command description for CancelLoadControlEvent
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="deviceClass" type="AmiDeviceClass"/>
+      <arg name="utilityEnrollmentGroup" type="INT8U"/>
+      <arg name="cancelControl" type="AmiCancelControl"/>
+      <arg name="effectiveTime" type="UTC_TIME"/>
+    </command>
+    <command source="server" code="0x02" name="CancelAllLoadControlEvents" optional="false" cli="zcl drlc ca">
+      <description>
+        Command description for CancelAllLoadControlEvents
+      </description>
+      <arg name="cancelControl" type="AmiCancelControl"/>
+    </command>
+    <!-- Demand Response and Load Control Cluster Client - Commands -->
+    <command source="client" code="0x00" name="ReportEventStatus" optional="false">
+      <description>
+        Command description for ReportEventStatus
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="eventStatus" type="AmiEventStatus"/>
+      <arg name="eventStatusTime" type="UTC_TIME"/>
+      <arg name="criticalityLevelApplied" type="AmiCriticalityLevel"/>
+      <arg name="coolingTemperatureSetPointApplied" type="INT16U"/>
+      <arg name="heatingTemperatureSetPointApplied" type="INT16U"/>
+      <arg name="averageLoadAdjustmentPercentageApplied" type="INT8S"/>
+      <arg name="dutyCycleApplied" type="INT8U"/>
+      <arg name="eventControl" type="AmiEventControl"/>
+      <arg name="signatureType" type="SignatureType"/>
+      <arg name="signature" type="Signature"/>
+    </command>
+    <command source="client" code="0x01" name="GetScheduledEvents" optional="false" cli="zcl drlc gse">
+      <description>
+        Command description for GetScheduledEvents
+      </description>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="numberOfEvents" type="INT8U"/>
+      <arg name="issuerEventId" type="INT32U" introducedIn="se-1.2b-15-0131-02"/>
+    </command>
+  </cluster>
+  <!-- Metering Cluster - Structs, BITMAPs & ENUMs -->
+  <enum name="MeteringBlockEnumerations" type="ENUM8">
+    <item name="NoBlocksInUse" value="0x00"/>
+    <item name="Block1" value="0x01"/>
+    <item name="Block2" value="0x02"/>
+    <item name="Block3" value="0x03"/>
+    <item name="Block4" value="0x04"/>
+    <item name="Block5" value="0x05"/>
+    <item name="Block6" value="0x06"/>
+    <item name="Block7" value="0x07"/>
+    <item name="Block8" value="0x08"/>
+    <item name="Block9" value="0x09"/>
+    <item name="Block10" value="0x0A"/>
+    <item name="Block11" value="0x0B"/>
+    <item name="Block12" value="0x0C"/>
+    <item name="Block13" value="0x0D"/>
+    <item name="Block14" value="0x0E"/>
+    <item name="Block15" value="0x0F"/>
+    <item name="Block16" value="0x10"/>
+  </enum>
+  <enum name="Block" type="ENUM8">
+    <item name="NoBlocksInUse" value="0x00"/>
+    <item name="Block1" value="0x01"/>
+    <item name="Block2" value="0x02"/>
+    <item name="Block3" value="0x03"/>
+    <item name="Block4" value="0x04"/>
+    <item name="Block5" value="0x05"/>
+    <item name="Block6" value="0x06"/>
+    <item name="Block7" value="0x07"/>
+    <item name="Block8" value="0x08"/>
+    <item name="Block9" value="0x09"/>
+    <item name="Block10" value="0x0A"/>
+    <item name="Block11" value="0x0B"/>
+    <item name="Block12" value="0x0C"/>
+    <item name="Block13" value="0x0D"/>
+    <item name="Block14" value="0x0E"/>
+    <item name="Block15" value="0x0F"/>
+    <item name="Block16" value="0x10"/>
+  </enum>
+  <enum name="AmiIntervalPeriod" type="ENUM8">
+    <item name="Daily" value="0x00"/>
+    <item name="Minutes60" value="0x01"/>
+    <item name="Minutes30" value="0x02"/>
+    <item name="Minutes15" value="0x03"/>
+    <item name="Minutes10" value="0x04"/>
+    <item name="Minutes7p5" value="0x05"/>
+    <item name="Minutes5" value="0x06"/>
+    <item name="Minutes2p5" value="0x07"/>
+  </enum>
+  <enum name="MeteringSupplyStatus" type="ENUM8">
+    <item name="SupplyOff" value="0x00"/>
+    <item name="SupplyOffArmed" value="0x01"/>
+    <item name="SupplyOn" value="0x02"/>
+  </enum>
+  <enum name="MeteringTemperatureUnitOfMeasure" type="ENUM8">
+    <item name="Kelvin" value="0x00"/>
+    <item name="Celsius" value="0x01"/>
+    <item name="Fahrenheit" value="0x02"/>
+    <item name="KelvinBcd" value="0x80"/>
+    <item name="CelsiusBcd" value="0x81"/>
+    <item name="FahrenheitBcd" value="0x82"/>
+  </enum>
+  <bitmap name="AmiMeterStatus" type="BITMAP8">
+    <field name="checkMeter" mask="0x01"/>
+    <field name="lowBattery" mask="0x02"/>
+    <field name="tamperDetect" mask="0x04"/>
+    <field name="powerFailure" mask="0x08"/>
+    <field name="powerQuality" mask="0x10"/>
+    <field name="leakDetect" mask="0x20"/>
+    <field name="serviceDisconnectOpen" mask="0x40"/>
+    <field name="reserved" mask="0x80"/>
+  </bitmap>
+  <bitmap name="MeteringStatusElectricity" type="BITMAP8">
+    <field name="checkMeter" mask="0x01"/>
+    <field name="lowBattery" mask="0x02"/>
+    <field name="tamperDetect" mask="0x04"/>
+    <field name="powerFailure" mask="0x08"/>
+    <field name="powerQuality" mask="0x10"/>
+    <field name="leakDetect" mask="0x20"/>
+    <field name="serviceDisconnectOpen" mask="0x40"/>
+    <field name="reserved" mask="0x80"/>
+  </bitmap>
+  <bitmap name="MeteringStatusGas" type="BITMAP8">
+    <field name="checkMeter" mask="0x01"/>
+    <field name="lowBattery" mask="0x02"/>
+    <field name="tamperDetect" mask="0x04"/>
+    <field name="notDefined" mask="0x08"/>
+    <field name="lowPressure" mask="0x10"/>
+    <field name="leakDetect" mask="0x20"/>
+    <field name="serviceDisconnect" mask="0x40"/>
+    <field name="reverseFlow" mask="0x80"/>
+  </bitmap>
+  <bitmap name="MeteringStatusWater" type="BITMAP8">
+    <field name="checkMeter" mask="0x01"/>
+    <field name="lowBattery" mask="0x02"/>
+    <field name="tamperDetect" mask="0x04"/>
+    <field name="pipeEmpty" mask="0x08"/>
+    <field name="lowPressure" mask="0x10"/>
+    <field name="leakDetect" mask="0x20"/>
+    <field name="serviceDisconnect" mask="0x40"/>
+    <field name="reverseFlow" mask="0x80"/>
+  </bitmap>
+  <bitmap name="MeteringStatusHeatAndCooling" type="BITMAP8">
+    <field name="checkMeter" mask="0x01"/>
+    <field name="lowBattery" mask="0x02"/>
+    <field name="tamperDetect" mask="0x04"/>
+    <field name="temperatureSensor" mask="0x08"/>
+    <field name="burstDetect" mask="0x10"/>
+    <field name="leakDetect" mask="0x20"/>
+    <field name="serviceDisconnect" mask="0x40"/>
+    <field name="flowSensor" mask="0x80"/>
+  </bitmap>
+  <bitmap name="MeteringExtendedStatus" type="BITMAP64">
+    <field name="MeterCoverRemoved" mask="0x0000000000000001"/>
+    <field name="StrongMagneticFieldDetected" mask="0x0000000000000002"/>
+    <field name="BatteryFailure" mask="0x0000000000000004"/>
+    <field name="ProgramMemoryError" mask="0x0000000000000008"/>
+    <field name="RamError" mask="0x0000000000000010"/>
+    <field name="NvMemoryError" mask="0x0000000000000020"/>
+    <field name="MeasurementSystemError" mask="0x0000000000000040"/>
+    <field name="WatchdogError" mask="0x0000000000000080"/>
+    <field name="SupplyDisconnectFailure" mask="0x0000000000000100"/>
+    <field name="SupplyConnectFailure" mask="0x0000000000000200"/>
+    <field name="MeasurementSwChangedTampered" mask="0x0000000000000400"/>
+    <field name="ClockInvalid" mask="0x0000000000000800"/>
+    <field name="TemperatureExceeded" mask="0x0000000000001000"/>
+    <field name="MoistureDetected" mask="0x0000000000002000"/>
+    <field name="ElectricityMeterTerminalCoverRemoved" mask="0x0000000001000000"/>
+    <field name="ElectricityMeterIncorrectPolarity" mask="0x0000000002000000"/>
+    <field name="ElectricityMeterCurrentWithNoVoltage" mask="0x0000000004000000"/>
+    <field name="ElectricityMeterLimitThresholdExceeded" mask="0x0000000008000000"/>
+    <field name="ElectricityMeterUnderVoltage" mask="0x0000000010000000"/>
+    <field name="ElectricityMeterOverVoltage" mask="0x0000000020000000"/>
+    <field name="GasMeterBatteryCoverRemoved" mask="0x0000000001000000"/>
+    <field name="GasMeterTiltTamper" mask="0x0000000002000000"/>
+    <field name="GasMeterExcessFlow" mask="0x0000000004000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffDueToOverPower" mask="0x0000000040000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffDueToOverVoltage" mask="0x0000000080000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffDueToRemoteLoadControl" mask="0x00000000C0000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffByOtherRemoteCommand" mask="0x0000000100000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffDueToOverheatingShortCircuit" mask="0x0000000140000000"/>
+    <field name="ElectricityMeterServiceDisconnectionReasonOffDueToOverheatingOther" mask="0x0000000180000000"/>
+    <field name="ElectricityMeterBiDirectionalOperation" mask="0x0000000400000000"/>
+    <field name="ElectricityMeterActivePowerReceived" mask="0x0000000800000000"/>
+    <field name="ElectricityMeterModeOfOperation" mask="0x0000001000000000"/>
+  </bitmap>
+  <enum name="MeteringConsumptionStatus" type="ENUM8">
+    <item name="LowEnergyUsage" value="0x00"/>
+    <item name="MediumEnergyUsage" value="0x01"/>
+    <item name="HighEnergyUsage" value="0x02"/>
+  </enum>
+  <enum name="MeteringDeviceType" type="ENUM8">
+    <item name="ElectricMetering" value="0x00"/>
+    <item name="GasMetering" value="0x01"/>
+    <item name="WaterMetering" value="0x02"/>
+    <item name="ThermalMetering" value="0x03"/>
+    <item name="PressureMetering" value="0x04"/>
+    <item name="HeatMetering" value="0x05"/>
+    <item name="CoolingMetering" value="0x06"/>
+    <item name="ElectricVehicleChargingMetering" value="0x07"/>
+    <item name="PvGenerationMetering" value="0x08"/>
+    <item name="WindTurbineGenerationMetering" value="0x09"/>
+    <item name="WaterTurbineGenerationMetering" value="0x0A"/>
+    <item name="MicroGenerationMetering" value="0x0B"/>
+    <item name="SolarHotWaterGenerationMetering" value="0x0C"/>
+    <item name="ElectricMeteringElement1" value="0x0D"/>
+    <item name="ElectricMeteringElement2" value="0x0E"/>
+    <item name="ElectricMeteringElement3" value="0x0F"/>
+    <item name="MirroredElectricMetering" value="0x7F"/>
+    <item name="MirroredGasMetering" value="0x80"/>
+    <item name="MirroredWaterMetering" value="0x81"/>
+    <item name="MirroredThermalMetering" value="0x82"/>
+    <item name="MirroredPressureMetering" value="0x83"/>
+    <item name="MirroredHeatMetering" value="0x84"/>
+    <item name="MirroredCoolingMetering" value="0x85"/>
+    <item name="MirroredElectricVehicleChargingMetering" value="0x86"/>
+    <item name="MirroredPvGenerationMetering" value="0x87"/>
+    <item name="MirroredWindTurbineGenerationMetering" value="0x88"/>
+    <item name="MirroredWaterTurbineGenerationMetering" value="0x89"/>
+    <item name="MirroredMicroGenerationMetering" value="0x8A"/>
+    <item name="MirroredSolarHotWaterGenerationMetering" value="0x8B"/>
+    <item name="MirroredElectricMeteringElement1" value="0x8C"/>
+    <item name="MirroredElectricMeteringElement2" value="0x8D"/>
+    <item name="MirroredElectricMeteringElement3" value="0x8E"/>
+    <item name="UndefinedMirrorMeter" value="0xFE"/>
+  </enum>
+  <!-- TODO: remove this definition.  It's only here for backward compatibility.
+     Applications should use the MeteringDeviceType enum defined above. -->
+  <enum name="MeterDeviceType" type="ENUM8">
+    <item name="ElectricMeter" value="0x00"/>
+    <item name="GasMeter" value="0x01"/>
+    <item name="WaterMeter" value="0x02"/>
+    <item name="ThermalMeter" value="0x03"/>
+    <item name="PressureMeter" value="0x04"/>
+    <item name="HeatMeter" value="0x05"/>
+    <item name="CoolingMeter" value="0x06"/>
+    <item name="MirroredGasMeter" value="0x80"/>
+    <item name="MirroredWaterMeter" value="0x81"/>
+    <item name="MirroredThermalMeter" value="0x82"/>
+    <item name="MirroredPressureMeter" value="0x83"/>
+    <item name="MirroredHeatMeter" value="0x84"/>
+    <item name="MirroredCoolingMeter" value="0x85"/>
+    <item name="UndefinedMirrorMeter" value="0xFE"/>
+  </enum>
+  <enum name="SupplyStatus" type="ENUM8">
+    <item name="SupplyOff" value="0x00"/>
+    <item name="SupplyOffArmed" value="0x01"/>
+    <item name="SupplyOn" value="0x02"/>
+    <item name="SupplyUnchanged" value="0x03"/>
+  </enum>
+  <enum name="MeteringAlarmCode" type="ENUM8">
+    <!-- Generic Alarm Group -->
+    <item name="CheckMeter" value="0x00"/>
+    <item name="LowBattery" value="0x01"/>
+    <item name="TamperDetect" value="0x02"/>
+    <item name="PowerFailurePipeEmptyTemperatureSensor" value="0x03"/>
+    <item name="PowerQualityLowPressureBurstDetect" value="0x04"/>
+    <item name="LeakDetect" value="0x05"/>
+    <item name="ServiceDisconnect" value="0x06"/>
+    <item name="ReverseFlowFlowSensor" value="0x07"/>
+    <item name="MeterCoverRemoved" value="0x08"/>
+    <item name="MeterCoverClosed" value="0x09"/>
+    <item name="StrongMagneticField" value="0x0A"/>
+    <item name="NoStrongMagneticField" value="0x0B"/>
+    <item name="BatteryFailure" value="0x0C"/>
+    <item name="ProgramMemoryError" value="0x0D"/>
+    <item name="RAMError" value="0x0E"/>
+    <item name="NVMemoryError" value="0x0F"/>
+    <!-- Electricity Alarm Group -->
+    <item name="LowVoltageL1" value="0x10"/>
+    <item name="HighVoltageL1" value="0x11"/>
+    <item name="LowVoltageL2" value="0x12"/>
+    <item name="HighVoltageL2" value="0x13"/>
+    <item name="LowVoltageL3" value="0x14"/>
+    <item name="HighVoltageL3" value="0x15"/>
+    <item name="OverCurrentL1" value="0x16"/>
+    <item name="OverCurrentL2" value="0x17"/>
+    <item name="OverCurrentL3" value="0x18"/>
+    <item name="FrequencyTooLowL1" value="0x19"/>
+    <item name="FrequencyTooHighL1" value="0x1A"/>
+    <item name="FrequencyTooLowL2" value="0x1B"/>
+    <item name="FrequencyTooHighL2" value="0x1C"/>
+    <item name="FrequencyTooLowL3" value="0x1D"/>
+    <item name="FrequencyTooHighL3" value="0x1E"/>
+    <item name="GroundFault" value="0x1F"/>
+    <item name="ElectricTamperDetect" value="0x20"/>
+    <item name="IncorrectPolarity" value="0x21"/>
+    <item name="CurrentNoVoltage" value="0x22"/>
+    <item name="UnderVoltage" value="0x23"/>
+    <item name="OverVoltage" value="0x24"/>
+    <item name="NormalVoltage" value="0x25"/>
+    <item name="PFBelowThreshold" value="0x26"/>
+    <item name="PFAboveThreshold" value="0x27"/>
+    <item name="TerminalCoverRemoved" value="0x28"/>
+    <item name="TerminalCoverClosed" value="0x29"/>
+    <!-- Generic Flow/Pressure Alarm Group -->
+    <item name="BurstDetect" value="0x30"/>
+    <item name="PressureTooLow" value="0x31"/>
+    <item name="PressureTooHigh" value="0x32"/>
+    <item name="FlowSensorCommunicationError" value="0x33"/>
+    <item name="FlowSensorMeasurementFault" value="0x34"/>
+    <item name="FlowSensorReverseFlow" value="0x35"/>
+    <item name="FlowSensorAirDetect" value="0x36"/>
+    <item name="PipeEmpty" value="0x37"/>
+    <!-- Water Specific Alarm Group -->
+    <!-- Heat and Cooling Specific Alarm Group -->
+    <item name="InletTemperatureSensorFault" value="0x50"/>
+    <item name="OutletTemperatureSensorFault" value="0x51"/>
+    <!-- Gas Specific Alarm Group -->
+    <item name="TiltTamper" value="0x60"/>
+    <item name="BatteryCoverRemoved" value="0x61"/>
+    <item name="BatteryCoverClosed" value="0x62"/>
+    <item name="ExcessFlow" value="0x63"/>
+    <item name="TiltTamperEnded" value="0x64"/>
+    <!-- Extended Generic Alarm Group -->
+    <item name="MeasurementSystemError" value="0x70"/>
+    <item name="WatchdogError" value="0x71"/>
+    <item name="SupplyDisconnectFailure" value="0x72"/>
+    <item name="SupplyConnectFailure" value="0x73"/>
+    <item name="MeasurmentSoftwareChanged" value="0x74"/>
+    <item name="DstEnabled" value="0x75"/>
+    <item name="DstDisabled" value="0x76"/>
+    <item name="ClockAdjBackward" value="0x77"/>
+    <item name="ClockAdjForward" value="0x78"/>
+    <item name="ClockInvalid" value="0x79"/>
+    <item name="CommunicationErrorHan" value="0x7A"/>
+    <item name="CommunicationOkHAn" value="0x7B"/>
+    <item name="MeterFraudAttempt" value="0x7C"/>
+    <item name="PowerLoss" value="0x7D"/>
+    <item name="UnusualHanTraffic" value="0x7E"/>
+    <item name="UnexpectedClockChange" value="0x7F"/>
+    <item name="CommsUsingUnauthenticatedComponent" value="0x80"/>
+    <item name="ErrorRegClear" value="0x81"/>
+    <item name="AlarmRegClear" value="0x82"/>
+    <item name="UnexpectedHwReset" value="0x83"/>
+    <item name="UnexpectedProgramExecution" value="0x84"/>
+    <item name="EventLogCleared" value="0x85"/>
+    <item name="LimitThresholdExceeded" value="0x86"/>
+    <item name="LimitThresholdOk" value="0x87"/>
+    <item name="LimitThresholdChanged" value="0x88"/>
+    <item name="MaximumDemandExceeded" value="0x89"/>
+    <item name="ProfileCleared" value="0x8A"/>
+    <item name="SamplingBuffercleared" value="0x8B"/>
+    <item name="BatteryWarning" value="0x8C"/>
+    <item name="WrongSignature" value="0x8D"/>
+    <item name="NoSignature" value="0x8E"/>
+    <item name="UnauthorisedActionfromHan" value="0x8F"/>
+    <item name="FastPollingStart" value="0x90"/>
+    <item name="FastPollingEnd" value="0x91"/>
+    <item name="MeterReportingIntervalChanged" value="0x92"/>
+    <item name="DisconnectDuetoLoadLimit" value="0x93"/>
+    <item name="MeterSupplyStatusRegisterChanged" value="0x94"/>
+    <item name="MeterAlarmStatusRegisterChanged" value="0x95"/>
+    <item name="ExtendedMeterAlarmStatusRegisterChanged" value="0x96"/>
+    <!-- Manufacturer Specific Alarm Group -->
+    <item name="ManufacturerSpecificA" value="0xB0"/>
+    <item name="ManufacturerSpecificB" value="0xB1"/>
+    <item name="ManufacturerSpecificC" value="0xB2"/>
+    <item name="ManufacturerSpecificD" value="0xB3"/>
+    <item name="ManufacturerSpecificE" value="0xB4"/>
+    <item name="ManufacturerSpecificF" value="0xB5"/>
+    <item name="ManufacturerSpecificG" value="0xB6"/>
+    <item name="ManufacturerSpecificH" value="0xB7"/>
+    <item name="ManufacturerSpecificI" value="0xB8"/>
+  </enum>
+  <enum name="GenericAlarmGroups" type="ENUM8">
+    <item name="CheckMeter" value="0x00"/>
+    <item name="LowBattery" value="0x01"/>
+    <item name="TamperDetect" value="0x02"/>
+    <item name="LeakDetect" value="0x05"/>
+    <item name="ServiceDisconnect" value="0x06"/>
+    <item name="MeterCoverRemoved" value="0x08"/>
+    <item name="MeterCoverClosed" value="0x09"/>
+    <item name="StrongMagneticField" value="0x0A"/>
+    <item name="NoStrongMagneticField" value="0x0B"/>
+    <item name="BatteryFailure" value="0x0C"/>
+    <item name="ProgramMemoryError" value="0x0D"/>
+    <item name="RAMError" value="0x0E"/>
+    <item name="NVMemoryError" value="0x0F"/>
+  </enum>
+  <enum name="GenericAlarmGroupsElectricity" type="ENUM8">
+    <item name="PowerFailure" value="0x03"/>
+    <item name="PowerQuality" value="0x04"/>
+  </enum>
+  <enum name="GenericAlarmGroupsGas" type="ENUM8">
+    <item name="LowPressure" value="0x04"/>
+    <item name="ReverseFlow" value="0x07"/>
+  </enum>
+  <enum name="GenericAlarmGroupsWater" type="ENUM8">
+    <item name="WaterPipeEmpty" value="0x03"/>
+    <item name="WaterLowPressure" value="0x04"/>
+    <item name="WaterReverseFlow" value="0x07"/>
+  </enum>
+  <enum name="GenericAlarmGroupsHeatCooling" type="ENUM8">
+    <item name="TemperatureSensor" value="0x03"/>
+    <item name="BurstDetect" value="0x04"/>
+    <item name="FlowSensor" value="0x07"/>
+  </enum>
+  <enum name="ElectricityAlarmGroups" type="ENUM8">
+    <item name="LowVoltageL1" value="0x10"/>
+    <item name="HighVoltageL1" value="0x11"/>
+    <item name="LowVoltageL2" value="0x12"/>
+    <item name="HighVoltageL2" value="0x13"/>
+    <item name="LowVoltageL3" value="0x14"/>
+    <item name="HighVoltageL3" value="0x15"/>
+    <item name="OverCurrentL1" value="0x16"/>
+    <item name="OverCurrentL2" value="0x17"/>
+    <item name="OverCurrentL3" value="0x18"/>
+    <item name="FrequencyTooLowL1" value="0x19"/>
+    <item name="FrequencyTooHighL1" value="0x1A"/>
+    <item name="FrequencyTooLowL2" value="0x1B"/>
+    <item name="FrequencyTooHighL2" value="0x1C"/>
+    <item name="FrequencyTooLowL3" value="0x1D"/>
+    <item name="FrequencyTooHighL3" value="0x1E"/>
+    <item name="GroundFault" value="0x1F"/>
+    <item name="ElectricTamperDetect" value="0x20"/>
+    <item name="IncorrectPolarity" value="0x21"/>
+    <item name="CurrentNoVoltage" value="0x22"/>
+    <item name="UnderVoltage" value="0x23"/>
+    <item name="OverVoltage" value="0x24"/>
+    <item name="NormalVoltage" value="0x25"/>
+    <item name="PFBelowThreshold" value="0x26"/>
+    <item name="PFAboveThreshold" value="0x27"/>
+    <item name="TerminalCoverRemoved" value="0x28"/>
+    <item name="TerminalCoverClosed" value="0x29"/>
+  </enum>
+  <enum name="GenericFlowPressureAlarmGroups" type="ENUM8">
+    <item name="BurstDetect" value="0x30"/>
+    <item name="PressureTooLow" value="0x31"/>
+    <item name="PressureTooHigh" value="0x32"/>
+    <item name="FlowSensorCommunicationError" value="0x33"/>
+    <item name="FlowSensorMeasurementFault" value="0x34"/>
+    <item name="FlowSensorReverseFlow" value="0x35"/>
+    <item name="FlowSensorAirDetect" value="0x36"/>
+    <item name="PipeEmpty" value="0x37"/>
+  </enum>
+  <enum name="HeatAndCoolingSpecificAlarmGroups" type="ENUM8">
+    <item name="InletTemperatureSensorFault" value="0x50"/>
+    <item name="OutletTemperatureSensorFault" value="0x51"/>
+  </enum>
+  <enum name="GasSpecificAlarmGroups" type="ENUM8">
+    <item name="TiltTamper" value="0x60"/>
+    <item name="BatteryCoverRemoved" value="0x61"/>
+    <item name="BatteryCoverClosed" value="0x62"/>
+    <item name="ExcessFlow" value="0x63"/>
+    <item name="TiltTamperEnded" value="0x64"/>
+  </enum>
+  <enum name="ExtendedGenericAlarmGroups" type="ENUM8">
+    <item name="MeasurementSystemError" value="0x70"/>
+    <item name="WatchdogError" value="0x71"/>
+    <item name="SupplyDisconnectFailure" value="0x72"/>
+    <item name="SupplyConnectFailure" value="0x73"/>
+    <item name="MeasurmentSoftwareChanged" value="0x74"/>
+    <item name="DstEnabled" value="0x75"/>
+    <item name="DstDisabled" value="0x76"/>
+    <item name="ClockAdjBackward" value="0x77"/>
+    <item name="ClockAdjForward" value="0x78"/>
+    <item name="ClockInvalid" value="0x79"/>
+    <item name="CommunicationErrorHan" value="0x7A"/>
+    <item name="CommunicationOkHAn" value="0x7B"/>
+    <item name="MeterFraudAttempt" value="0x7C"/>
+    <item name="PowerLoss" value="0x7D"/>
+    <item name="UnusualHanTraffic" value="0x7E"/>
+    <item name="UnexpectedClockChange" value="0x7F"/>
+    <item name="CommsUsingUnauthenticatedComponent" value="0x80"/>
+    <item name="ErrorRegClear" value="0x81"/>
+    <item name="AlarmRegClear" value="0x82"/>
+    <item name="UnexpectedHwReset" value="0x83"/>
+    <item name="UnexpectedProgramExecution" value="0x84"/>
+    <item name="EventLogCleared" value="0x85"/>
+    <item name="LimitThresholdExceeded" value="0x86"/>
+    <item name="LimitThresholdOk" value="0x87"/>
+    <item name="LimitThresholdChanged" value="0x88"/>
+    <item name="MaximumDemandExceeded" value="0x89"/>
+    <item name="ProfileCleared" value="0x8A"/>
+    <item name="SamplingBuffercleared" value="0x8B"/>
+    <item name="BatteryWarning" value="0x8C"/>
+    <item name="WrongSignature" value="0x8D"/>
+    <item name="NoSignature" value="0x8E"/>
+    <item name="UnauthorisedActionfromHan" value="0x8F"/>
+    <item name="FastPollingStart" value="0x90"/>
+    <item name="FastPollingEnd" value="0x91"/>
+    <item name="MeterReportingIntervalChanged" value="0x92"/>
+    <item name="DisconnectDuetoLoadLimit" value="0x93"/>
+    <item name="MeterSupplyStatusRegisterChanged" value="0x94"/>
+    <item name="MeterAlarmStatusRegisterChanged" value="0x95"/>
+    <item name="ExtendedMeterAlarmStatusRegisterChanged" value="0x96"/>
+  </enum>
+  <enum name="ManufacturerSpecificAlarmGroups" type="ENUM8">
+    <item name="ManufacturerSpecificA" value="0xB0"/>
+    <item name="ManufacturerSpecificB" value="0xB1"/>
+    <item name="ManufacturerSpecificC" value="0xB2"/>
+    <item name="ManufacturerSpecificD" value="0xB3"/>
+    <item name="ManufacturerSpecificE" value="0xB4"/>
+    <item name="ManufacturerSpecificF" value="0xB5"/>
+    <item name="ManufacturerSpecificG" value="0xB6"/>
+    <item name="ManufacturerSpecificH" value="0xB7"/>
+    <item name="ManufacturerSpecificI" value="0xB8"/>
+  </enum>
+  <bitmap name="FunctionalNotificationFlags" type="BITMAP32">
+    <field name="NewOtaFirmware" mask="0x00000001"/>
+    <field name="CbkeUpdateRequest" mask="0x00000002"/>
+    <field name="TimeSync" mask="0x00000004"/>
+    <field name="StayAwakeRequestHan" mask="0x00000010"/>
+    <field name="StayAwakeRequestWan" mask="0x00000020"/>
+    <field name="PushHistoricalMeteringDataAttributeSet" mask="0x000001C0"/>
+    <field name="PushHistoricalPrepaymentDataAttributeSet" mask="0x00000E00"/>
+    <field name="PushAllStaticDataBasicCluster" mask="0x00001000"/>
+    <field name="PushAllStaticDataMeteringCluster" mask="0x00002000"/>
+    <field name="PushAllStaticDataPrepaymentCluster" mask="0x00004000"/>
+    <field name="NetworkKeyActive" mask="0x00008000"/>
+    <field name="DisplayMessage" mask="0x00010000"/>
+    <field name="CancelAllMessages" mask="0x00020000"/>
+    <field name="ChangeSupply" mask="0x00040000"/>
+    <field name="LocalChangeSupply" mask="0x00080000"/>
+    <field name="SetUncontrolledFlowThreshold" mask="0x00100000"/>
+    <field name="TunnelMessagePending" mask="0x00200000"/>
+    <field name="GetSnapshot" mask="0x00400000"/>
+    <field name="GetSampledData" mask="0x00800000"/>
+    <field name="NewSubGhzChannelMasksAvailable" mask="0x01000000"/>
+    <field name="EnergyScanPending" mask="0x02000000"/>
+    <field name="ChannelChangePending" mask="0x04000000"/>
+  </bitmap>
+  <enum name="PushHistoricalMeteringData" type="ENUM16">
+    <item name="Day" value="0x0040"/>
+    <item name="Week" value="0x0080"/>
+    <item name="Month" value="0x0180"/>
+    <item name="Year" value="0x01C0"/>
+  </enum>
+  <enum name="PushHistoricalPaymentData" type="ENUM16">
+    <item name="Day" value="0x0200"/>
+    <item name="Week" value="0x0400"/>
+    <item name="Month" value="0x0C00"/>
+    <item name="Year" value="0x0E00"/>
+  </enum>
+  <enum name="AmiGetProfileStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="UndefinedIntervalChannelRequested" value="0x01"/>
+    <item name="IntervalChannelNotSupported" value="0x02"/>
+    <item name="InvalidEndTime" value="0x03"/>
+    <item name="MorePeriodsRequestedThanCanBeReturned" value="0x04"/>
+    <item name="NoIntervalsAvailableForTheRequestedTime" value="0x05"/>
+  </enum>
+  <enum name="SnapshotScheduleConfirmation" type="ENUM8">
+    <item name="Accepted" value="0x00"/>
+    <item name="SnapshotTypeNotSupported" value="0x01"/>
+    <item name="SnapshotCauseNotSupported" value="0x02"/>
+    <item name="SnapshotScheduleNotCurrentlyAvailable" value="0x03"/>
+    <item name="SnapshotSchedulesNotSupportedByDevice" value="0x04"/>
+    <item name="InsufficientSpaceForSnapshotSchedule" value="0x05"/>
+  </enum>
+  <struct name="SnapshotResponsePayload">
+    <item name="snapshotScheduleId" type="INT8U"/>
+    <item name="snapshotScheduleConfirmation" type="SnapshotScheduleConfirmation"/>
+  </struct>
+  <enum name="SnapshotConfirmation" type="ENUM8">
+    <item name="Accepted" value="0x00"/>
+    <item name="SnapshotCauseNotSupported" value="0x01"/>
+  </enum>
+  <bitmap name="SnapshotCause" type="BITMAP32">
+    <field name="General" mask="0x00000001"/>
+    <field name="EndOfBillingPeriod" mask="0x00000002"/>
+    <field name="EndOfBlockPeriod" mask="0x00000004"/>
+    <field name="ChangeOfTariffInformation" mask="0x00000008"/>
+    <field name="ChangeOfPriceMatrix" mask="0x00000010"/>
+    <field name="ChangeOfBlockThresholds" mask="0x00000020"/>
+    <field name="ChangeOfCv" mask="0x00000040"/>
+    <field name="ChangeOfCf" mask="0x00000080"/>
+    <field name="ChangeOfCalendar" mask="0x00000100"/>
+    <field name="CriticalPeakPricing" mask="0x00000200"/>
+    <field name="ManuallyTriggeredFromClient" mask="0x00000400"/>
+    <field name="EndOfResolvePeriod" mask="0x00000800"/>
+    <field name="ChangeOfTenancy" mask="0x00001000"/>
+    <field name="ChangeOfSupplier" mask="0x00002000"/>
+    <field name="ChangeOfMode" mask="0x00004000"/>
+    <field name="DebtPayment" mask="0x00008000"/>
+    <field name="ScheduledSnapshot" mask="0x00010000"/>
+    <field name="OtaFirmwareDownload" mask="0x00020000"/>
+  </bitmap>
+  <enum name="SnapshotPayloadType" type="ENUM8">
+    <item name="TouInformationSetDeliveredRegisters" value="0x00"/>
+    <item name="TouInformationSetReceivedRegisters" value="0x01"/>
+    <item name="BlockTierInformationSetDelivered" value="0x02"/>
+    <item name="BlockTierInformationSetReceived" value="0x03"/>
+    <item name="TouInformationSetDeliveredRegistersNoBilling" value="0x04"/>
+    <item name="TouInformationSetReceivedRegisterNoBillings" value="0x05"/>
+    <item name="BlockTierInformationSetDeliveredNoBilling" value="0x06"/>
+    <item name="BlockTierInformationSetReceivedNoBilling" value="0x07"/>
+    <item name="DataUnavailable" value="0x80"/>
+  </enum>
+  <enum name="SampleType" type="ENUM8">
+    <item name="ConsumptionDelivered" value="0x00"/>
+  </enum>
+  <enum name="NotificationScheme" type="ENUM8">
+    <item name="NoNotificationSchemeDefined" value="0x00"/>
+    <item name="PredefinedNotificationSchemeA" value="0x01"/>
+    <item name="PredefinedNotificationSchemeB" value="0x02"/>
+  </enum>
+  <enum name="AmiIntervalChannel" type="ENUM8">
+    <item name="ConsumptionDelivered" value="0x00"/>
+    <item name="ConsumptionReceived" value="0x01"/>
+  </enum>
+  <struct name="SnapshotSchedulePayload">
+    <item name="snapshotScheduleId" type="INT8U"/>
+    <item name="snapshotStartTime" type="UTC_TIME"/>
+    <item name="snapshotSchedule" type="BITMAP24"/>
+    <item name="snapshotPayloadType" type="SnapshotPayloadType"/>
+    <item name="snapshotCause" type="SnapshotCause"/>
+  </struct>
+  <bitmap name="SupplyControlBits" type="BITMAP8">
+    <field name="AcknowledgeRequired" mask="0x01"/>
+  </bitmap>
+  <enum name="ProposedSupplyStatus" type="ENUM8">
+    <item name="Reserved" value="0x00"/>
+    <item name="SupplyOffArmed" value="0x01"/>
+    <item name="SupplyOn" value="0x02"/>
+  </enum>
+  <enum name="AttributeReportingStatus" type="ENUM8">
+    <item name="Pending" value="0x00"/>
+    <item name="AttributeReportingComplete" value="0x01"/>
+  </enum>
+  <!-- Metering Cluster -->
+  <cluster>
+    <name>Simple Metering</name>
+    <domain>SE</domain>
+    <description>The Metering Cluster provides a mechanism to retrieve usage information from Electric, Gas, Water, and potentially Thermal metering devices.</description>
+    <code>0x0702</code>
+    <define>SIMPLE_METERING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Metering Cluster Server - Attributes -->
+    <!-- Metering Cluster Server - Reading Information Attribute Set -->
+    <attribute side="server" code="0x0000" define="CURRENT_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="false">current summation delivered</attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current summation received</attribute>
+    <attribute side="server" code="0x0002" define="CURRENT_MAX_DEMAND_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current max demand delivered</attribute>
+    <attribute side="server" code="0x0003" define="CURRENT_MAX_DEMAND_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current max demand received</attribute>
+    <attribute side="server" code="0x0004" define="DFT_SUMMATION" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">dft summation</attribute>
+    <attribute side="server" code="0x0005" define="DAILY_FREEZE_TIME" type="INT16U" min="0x0000" max="0x173B" writable="false" default="0x0000" optional="true">daily freeze time</attribute>
+    <attribute side="server" code="0x0006" define="POWER_FACTOR" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor</attribute>
+    <attribute side="server" code="0x0007" define="READING_SNAP_SHOT_TIME" type="UTC_TIME" writable="false" optional="true">reading snapshot time</attribute>
+    <attribute side="server" code="0x0008" define="CURRENT_MAX_DEMAND_DELIVERED_TIME" type="UTC_TIME" writable="false" optional="true">current max demand delivered time</attribute>
+    <attribute side="server" code="0x0009" define="CURRENT_MAX_DEMAND_RECEIVED_TIME" type="UTC_TIME" writable="false" optional="true">current max demand received time</attribute>
+    <attribute side="server" code="0x000A" define="DEFAULT_UPDATE_PERIOD" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x1E" optional="true" introducedIn="se-1.1-07-5356-16">default update period</attribute>
+    <attribute side="server" code="0x000B" define="FAST_POLL_UPDATE_PERIOD" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x05" optional="true" introducedIn="se-1.1-07-5356-16">fast poll update period</attribute>
+    <attribute side="server" code="0x000C" define="CURRENT_BLOCK_PERIOD_CONSUMPTION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current block period consumption delivered</attribute>
+    <attribute side="server" code="0x000D" define="DAILY_CONSUMPTION_TARGET" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">daily consumption target</attribute>
+    <attribute side="server" code="0x000E" define="CURRENT_BLOCK" type="ENUM8" min="0x00" max="0x10" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current block</attribute>
+    <attribute side="server" code="0x000F" define="PROFILE_INTERVAL_PERIOD" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">profile interval period</attribute>
+    <attribute side="server" code="0x0010" define="INTERVAL_READ_REPORTING_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="se-1.1-07-5356-16">interval read reporting period</attribute>
+    <attribute side="server" code="0x0011" define="PRESET_READING_TIME" type="INT16U" min="0x0000" max="0x173B" writable="false" default="0x0000" optional="true" introducedIn="se-1.1-07-5356-16">preset reading time</attribute>
+    <attribute side="server" code="0x0012" define="VOLUME_PER_REPORT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">volume per report</attribute>
+    <attribute side="server" code="0x0013" define="FLOW_RESTRICTION" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">flow restriction</attribute>
+    <attribute side="server" code="0x0014" define="SUPPLY_STATUS" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">supply status</attribute>
+    <attribute side="server" code="0x0015" define="CURRENT_INLET_ENERGY_CARRIER_SUMMATION" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current inlet energy carrier summation</attribute>
+    <attribute side="server" code="0x0016" define="CURRENT_OUTLET_ENERGY_CARRIER_SUMMATION" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current outlet energy carrier summation</attribute>
+    <attribute side="server" code="0x0017" define="INLET_TEMPERATURE" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">inlet temperature</attribute>
+    <attribute side="server" code="0x0018" define="OUTLET_TEMPERATURE" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">outlet temperature</attribute>
+    <attribute side="server" code="0x0019" define="CONTROL_TEMPERATURE" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">control temperature</attribute>
+    <attribute side="server" code="0x001A" define="CURRENT_INLET_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current inlet energy carrier demand</attribute>
+    <attribute side="server" code="0x001B" define="CURRENT_OUTLET_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current outlet energy carrier demand</attribute>
+    <attribute side="server" code="0x001C" define="PREVIOUS_BLOCK_PERIOD_CONSUMIPTION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1b-07-5356-18">previous block period consumption delivered</attribute>
+    <attribute side="server" code="0x001D" define="CURRENT_BLOCK_PERIOD_CONSUMPTION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current block period consumption received</attribute>
+    <attribute side="server" code="0x001E" define="CURRENT_BLOCK_RECEIVED" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current block received</attribute>
+    <attribute side="server" code="0x001F" define="DFT_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">dft summation received</attribute>
+    <attribute side="server" code="0x0020" define="ACTIVE_REGISTER_TIER_DELIVERED" type="ENUM8" min="0" max="48" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">active register tier delivered</attribute>
+    <attribute side="server" code="0x0021" define="ACTIVE_REGISTER_TIER_RECEIVED" type="ENUM8" min="0" max="48" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">active register tier received</attribute>
+    <attribute side="server" code="0x0022" define="LAST_BLOCK_SWITCH_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">last block switch time</attribute>
+    <!-- Metering Cluster Server - Summation TOU Information Attribute Set -->
+    <attribute side="server" code="0x0100" define="CURRENT_TIER1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 1 summation delivered</attribute>
+    <attribute side="server" code="0x0101" define="CURRENT_TIER1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 1 summation received</attribute>
+    <attribute side="server" code="0x0102" define="CURRENT_TIER2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 2 summation delivered</attribute>
+    <attribute side="server" code="0x0103" define="CURRENT_TIER2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 2 summation received</attribute>
+    <attribute side="server" code="0x0104" define="CURRENT_TIER3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 3 summation delivered</attribute>
+    <attribute side="server" code="0x0105" define="CURRENT_TIER3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 3 summation received</attribute>
+    <attribute side="server" code="0x0106" define="CURRENT_TIER4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 4 summation delivered</attribute>
+    <attribute side="server" code="0x0107" define="CURRENT_TIER4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 4 summation received</attribute>
+    <attribute side="server" code="0x0108" define="CURRENT_TIER5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 5 summation delivered</attribute>
+    <attribute side="server" code="0x0109" define="CURRENT_TIER5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 5 summation received</attribute>
+    <attribute side="server" code="0x010A" define="CURRENT_TIER6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 6 summation delivered</attribute>
+    <attribute side="server" code="0x010B" define="CURRENT_TIER6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current tier 6 summation received</attribute>
+    <attribute side="server" code="0x010C" define="CURRENT_TIER7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 summation delivered</attribute>
+    <attribute side="server" code="0x010D" define="CURRENT_TIER7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 summation received</attribute>
+    <attribute side="server" code="0x010E" define="CURRENT_TIER8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 summation delivered</attribute>
+    <attribute side="server" code="0x010F" define="CURRENT_TIER8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 summation received</attribute>
+    <attribute side="server" code="0x0110" define="CURRENT_TIER9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 summation delivered</attribute>
+    <attribute side="server" code="0x0111" define="CURRENT_TIER9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 summation received</attribute>
+    <attribute side="server" code="0x0112" define="CURRENT_TIER10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 summation delivered</attribute>
+    <attribute side="server" code="0x0113" define="CURRENT_TIER10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 summation received</attribute>
+    <attribute side="server" code="0x0114" define="CURRENT_TIER11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 summation delivered</attribute>
+    <attribute side="server" code="0x0115" define="CURRENT_TIER11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 summation received</attribute>
+    <attribute side="server" code="0x0116" define="CURRENT_TIER12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 summation delivered</attribute>
+    <attribute side="server" code="0x0117" define="CURRENT_TIER12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 summation received</attribute>
+    <attribute side="server" code="0x0118" define="CURRENT_TIER13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 summation delivered</attribute>
+    <attribute side="server" code="0x0119" define="CURRENT_TIER13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 summation received</attribute>
+    <attribute side="server" code="0x011A" define="CURRENT_TIER14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 summation delivered</attribute>
+    <attribute side="server" code="0x011B" define="CURRENT_TIER14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 summation received</attribute>
+    <attribute side="server" code="0x011C" define="CURRENT_TIER15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 summation delivered</attribute>
+    <attribute side="server" code="0x011D" define="CURRENT_TIER15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 summation received</attribute>
+    <attribute side="server" code="0x011E" define="CURRENT_TIER16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 16 summation delivered</attribute>
+    <attribute side="server" code="0x011F" define="CURRENT_TIER16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 16 summation received</attribute>
+    <attribute side="server" code="0x0120" define="CURRENT_TIER17_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 17 summation delivered</attribute>
+    <attribute side="server" code="0x0121" define="CURRENT_TIER17_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 17 summation received</attribute>
+    <attribute side="server" code="0x0122" define="CURRENT_TIER18_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 18 summation delivered</attribute>
+    <attribute side="server" code="0x0123" define="CURRENT_TIER18_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 18 summation received</attribute>
+    <attribute side="server" code="0x0124" define="CURRENT_TIER19_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 19 summation delivered</attribute>
+    <attribute side="server" code="0x0125" define="CURRENT_TIER19_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 19 summation received</attribute>
+    <attribute side="server" code="0x0126" define="CURRENT_TIER20_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 20 summation delivered</attribute>
+    <attribute side="server" code="0x0127" define="CURRENT_TIER20_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 20 summation received</attribute>
+    <attribute side="server" code="0x0128" define="CURRENT_TIER21_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 21 summation delivered</attribute>
+    <attribute side="server" code="0x0129" define="CURRENT_TIER21_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 21 summation received</attribute>
+    <attribute side="server" code="0x012A" define="CURRENT_TIER22_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 22 summation delivered</attribute>
+    <attribute side="server" code="0x012B" define="CURRENT_TIER22_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 22 summation received</attribute>
+    <attribute side="server" code="0x012C" define="CURRENT_TIER23_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 23 summation delivered</attribute>
+    <attribute side="server" code="0x012D" define="CURRENT_TIER23_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 23 summation received</attribute>
+    <attribute side="server" code="0x012E" define="CURRENT_TIER24_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 24 summation delivered</attribute>
+    <attribute side="server" code="0x012F" define="CURRENT_TIER24_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 24 summation received</attribute>
+    <attribute side="server" code="0x0130" define="CURRENT_TIER25_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 25 summation delivered</attribute>
+    <attribute side="server" code="0x0131" define="CURRENT_TIER25_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 25 summation received</attribute>
+    <attribute side="server" code="0x0132" define="CURRENT_TIER26_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 26 summation delivered</attribute>
+    <attribute side="server" code="0x0133" define="CURRENT_TIER26_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 26 summation received</attribute>
+    <attribute side="server" code="0x0134" define="CURRENT_TIER27_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 27 summation delivered</attribute>
+    <attribute side="server" code="0x0135" define="CURRENT_TIER27_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 27 summation received</attribute>
+    <attribute side="server" code="0x0136" define="CURRENT_TIER28_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 28 summation delivered</attribute>
+    <attribute side="server" code="0x0137" define="CURRENT_TIER28_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 28 summation received</attribute>
+    <attribute side="server" code="0x0138" define="CURRENT_TIER29_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 29 summation delivered</attribute>
+    <attribute side="server" code="0x0139" define="CURRENT_TIER29_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 29 summation received</attribute>
+    <attribute side="server" code="0x013A" define="CURRENT_TIER30_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 30 summation delivered</attribute>
+    <attribute side="server" code="0x013B" define="CURRENT_TIER30_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 30 summation received</attribute>
+    <attribute side="server" code="0x013C" define="CURRENT_TIER31_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 31 summation delivered</attribute>
+    <attribute side="server" code="0x013D" define="CURRENT_TIER31_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 31 summation received</attribute>
+    <attribute side="server" code="0x013E" define="CURRENT_TIER32_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 32 summation delivered</attribute>
+    <attribute side="server" code="0x013F" define="CURRENT_TIER32_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 32 summation received</attribute>
+    <attribute side="server" code="0x0140" define="CURRENT_TIER33_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 33 summation delivered</attribute>
+    <attribute side="server" code="0x0141" define="CURRENT_TIER33_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 33 summation received</attribute>
+    <attribute side="server" code="0x0142" define="CURRENT_TIER34_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 34 summation delivered</attribute>
+    <attribute side="server" code="0x0143" define="CURRENT_TIER34_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 34 summation received</attribute>
+    <attribute side="server" code="0x0144" define="CURRENT_TIER35_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 35 summation delivered</attribute>
+    <attribute side="server" code="0x0145" define="CURRENT_TIER35_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 35 summation received</attribute>
+    <attribute side="server" code="0x0146" define="CURRENT_TIER36_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 36 summation delivered</attribute>
+    <attribute side="server" code="0x0147" define="CURRENT_TIER36_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 36 summation received</attribute>
+    <attribute side="server" code="0x0148" define="CURRENT_TIER37_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 37 summation delivered</attribute>
+    <attribute side="server" code="0x0149" define="CURRENT_TIER37_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 37 summation received</attribute>
+    <attribute side="server" code="0x014A" define="CURRENT_TIER38_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 38 summation delivered</attribute>
+    <attribute side="server" code="0x014B" define="CURRENT_TIER38_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 38 summation received</attribute>
+    <attribute side="server" code="0x014C" define="CURRENT_TIER39_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 39 summation delivered</attribute>
+    <attribute side="server" code="0x014D" define="CURRENT_TIER39_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 39 summation received</attribute>
+    <attribute side="server" code="0x014E" define="CURRENT_TIER40_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 40 summation delivered</attribute>
+    <attribute side="server" code="0x014F" define="CURRENT_TIER40_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 40 summation received</attribute>
+    <attribute side="server" code="0x0150" define="CURRENT_TIER41_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 41 summation delivered</attribute>
+    <attribute side="server" code="0x0151" define="CURRENT_TIER41_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 41 summation received</attribute>
+    <attribute side="server" code="0x0152" define="CURRENT_TIER42_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 42 summation delivered</attribute>
+    <attribute side="server" code="0x0153" define="CURRENT_TIER42_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 42 summation received</attribute>
+    <attribute side="server" code="0x0154" define="CURRENT_TIER43_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 43 summation delivered</attribute>
+    <attribute side="server" code="0x0155" define="CURRENT_TIER43_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 43 summation received</attribute>
+    <attribute side="server" code="0x0156" define="CURRENT_TIER44_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 44 summation delivered</attribute>
+    <attribute side="server" code="0x0157" define="CURRENT_TIER44_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 44 summation received</attribute>
+    <attribute side="server" code="0x0158" define="CURRENT_TIER45_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 45 summation delivered</attribute>
+    <attribute side="server" code="0x0159" define="CURRENT_TIER45_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 45 summation received</attribute>
+    <attribute side="server" code="0x015A" define="CURRENT_TIER46_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 46 summation delivered</attribute>
+    <attribute side="server" code="0x015B" define="CURRENT_TIER46_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 46 summation received</attribute>
+    <attribute side="server" code="0x015C" define="CURRENT_TIER47_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 47 summation delivered</attribute>
+    <attribute side="server" code="0x015D" define="CURRENT_TIER47_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 47 summation received</attribute>
+    <attribute side="server" code="0x015E" define="CURRENT_TIER48_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 48 summation delivered</attribute>
+    <attribute side="server" code="0x015F" define="CURRENT_TIER48_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 48 summation received</attribute>
+    <attribute side="server" code="0x01FC" define="CPP1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">CPP1 Summation Delivered</attribute>
+    <attribute side="server" code="0x01FE" define="CPP2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">CPP2 Summation Delivered</attribute>
+    <!-- Metering Cluster Server - Meter Status Attribute Set -->
+    <attribute side="server" code="0x0200" define="STATUS" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">status</attribute>
+    <attribute side="server" code="0x0201" define="REMAINING_BATTERY_LIFE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">remaining battery life</attribute>
+    <attribute side="server" code="0x0202" define="HOURS_IN_OPERATION" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">hours in operation</attribute>
+    <attribute side="server" code="0x0203" define="HOURS_IN_FAULT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">hours in fault</attribute>
+    <attribute side="server" code="0x0204" define="EXTENDED_STATUS" type="BITMAP64" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">extended status</attribute>
+    <attribute side="server" code="0x0205" define="REMAINING_BATTERY_LIFE_IN_DAYS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">remaining battery life in days</attribute>
+    <attribute side="server" code="0x0206" define="CURRENT_METER_ID" type="OCTET_STRING" length="254" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current meter id</attribute>
+    <attribute side="server" code="0x0207" define="AMBIENT_CONSUMPTION_INDICATOR" type="ENUM8" min="0x00" max="0x02" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">ambient consumption indicator</attribute>
+    <!-- Metering Cluster Server - Formatting Attribute Set -->
+    <attribute side="server" code="0x0300" define="UNIT_OF_MEASURE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">unit of measure</attribute>
+    <attribute side="server" code="0x0301" define="MULTIPLIER" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">multiplier</attribute>
+    <attribute side="server" code="0x0302" define="DIVISOR" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">divisor</attribute>
+    <attribute side="server" code="0x0303" define="SUMMATION_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">summation formatting</attribute>
+    <attribute side="server" code="0x0304" define="DEMAND_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">demand formatting</attribute>
+    <attribute side="server" code="0x0305" define="HISTORICAL_CONSUMPTION_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">historical consumption formatting</attribute>
+    <attribute side="server" code="0x0306" define="METERING_DEVICE_TYPE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">metering device type</attribute>
+    <attribute side="server" code="0x0307" define="SITE_ID" type="OCTET_STRING" length="32" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">site id</attribute>
+    <attribute side="server" code="0x0308" define="METER_SERIAL_NUMBER" type="OCTET_STRING" length="24" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">meter serial number</attribute>
+    <attribute side="server" code="0x0309" define="ENERGY_CARRIER_UNIT_OF_MEASURE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">energy carrier unit of measure</attribute>
+    <attribute side="server" code="0x030A" define="ENERGY_CARRIER_SUMMATION_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">energy carrier summation formatting</attribute>
+    <attribute side="server" code="0x030B" define="ENERGY_CARRIER_DEMAND_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">energy carrier demand formatting</attribute>
+    <attribute side="server" code="0x030C" define="TEMPERATURE_UNIT_OF_MEASURE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">temperature unit of measure</attribute>
+    <attribute side="server" code="0x030D" define="TEMPERATURE_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">temperature formatting</attribute>
+    <attribute side="server" code="0x030E" define="MODULE_SERIAL_NUMBER" type="OCTET_STRING" length="24" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">module serial number</attribute>
+    <attribute side="server" code="0x030F" define="OPERATING_TARIFF_LABEL_DELIVERED" type="OCTET_STRING" length="24" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">operating tariff label delivered</attribute>
+    <attribute side="server" code="0x0310" define="OPERATING_TARIFF_LABEL_RECEIVED" type="OCTET_STRING" length="24" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">operating tariff label received</attribute>
+    <attribute side="server" code="0x0311" define="CUSTOMER_ID_NUMBER" type="OCTET_STRING" length="24" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">customer id number</attribute>
+    <attribute side="server" code="0x0312" define="ALTERNATIVE_UNIT_OF_MEASURE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">alternative unit of measure</attribute>
+    <attribute side="server" code="0x0313" define="ALTERNATIVE_DEMAND_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">alternative demand formatting</attribute>
+    <attribute side="server" code="0x0314" define="ALTERNATIVE_CONSUMPTION_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">alternative consumption formatting</attribute>
+    <!-- Metering Cluster Server - Historical Consumption Attribute Set -->
+    <attribute side="server" code="0x0400" define="INSTANTANEOUS_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">instantaneous demand</attribute>
+    <attribute side="server" code="0x0401" define="CURRENT_DAY_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current day consumption delivered</attribute>
+    <attribute side="server" code="0x0402" define="CURRENT_DAY_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current day consumption received</attribute>
+    <attribute side="server" code="0x0403" define="PREVIOUS_DAY_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">previous day consumption delivered</attribute>
+    <attribute side="server" code="0x0404" define="PREVIOUS_DAY_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">previous day consumption received</attribute>
+    <attribute side="server" code="0x0405" define="CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED" type="UTC_TIME" writable="false" optional="true">current partial profile interval start time delivered</attribute>
+    <attribute side="server" code="0x0406" define="CURRENT_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED" type="UTC_TIME" writable="false" optional="true">current partial profile interval start time received</attribute>
+    <attribute side="server" code="0x0407" define="CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current partial profile interval value delivered</attribute>
+    <attribute side="server" code="0x0408" define="CURRENT_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current partial profile interval value received</attribute>
+    <attribute side="server" code="0x0409" define="CURRENT_DAY_MAX_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current day max pressure</attribute>
+    <attribute side="server" code="0x040A" define="CURRENT_DAY_MIN_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current day min pressure</attribute>
+    <attribute side="server" code="0x040B" define="PREVIOUS_DAY_MAX_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">previous day max pressure</attribute>
+    <attribute side="server" code="0x040C" define="PREVIOUS_DAY_MIN_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">previous day min pressure</attribute>
+    <attribute side="server" code="0x040D" define="CURRENT_DAY_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current day max demand</attribute>
+    <attribute side="server" code="0x040E" define="PREVIOUS_DAY_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">previous day max demand</attribute>
+    <attribute side="server" code="0x040F" define="CURRENT_MONTH_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current month max demand</attribute>
+    <attribute side="server" code="0x0410" define="CURRENT_YEAR_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current year max demand</attribute>
+    <attribute side="server" code="0x0411" define="CURRENT_DAY_MAX_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current day max energy carrier demand</attribute>
+    <attribute side="server" code="0x0412" define="PREVIOUS_DAY_MAX_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">previous day max energy carrier demand</attribute>
+    <attribute side="server" code="0x0413" define="CURRENT_MONTH_MAX_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current month max energy carrier demand</attribute>
+    <attribute side="server" code="0x0414" define="CURRENT_MONTH_MIN_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current month min energy carrier demand</attribute>
+    <attribute side="server" code="0x0415" define="CURRENT_YEAR_MAX_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current year max energy carrier demand</attribute>
+    <attribute side="server" code="0x0416" define="CURRENT_YEAR_MIN_ENERGY_CARRIER_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current year min energy carrier demand</attribute>
+    <attribute side="server" code="0x0420" define="PREVIOUS_DAY2_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 consumption delivered</attribute>
+    <attribute side="server" code="0x0421" define="PREVIOUS_DAY2_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 consumption received</attribute>
+    <attribute side="server" code="0x0422" define="PREVIOUS_DAY3_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 consumption delivered</attribute>
+    <attribute side="server" code="0x0423" define="PREVIOUS_DAY3_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 consumption received</attribute>
+    <attribute side="server" code="0x0424" define="PREVIOUS_DAY4_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 consumption delivered</attribute>
+    <attribute side="server" code="0x0425" define="PREVIOUS_DAY4_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 consumption received</attribute>
+    <attribute side="server" code="0x0426" define="PREVIOUS_DAY5_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 consumption delivered</attribute>
+    <attribute side="server" code="0x0427" define="PREVIOUS_DAY5_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 consumption received</attribute>
+    <attribute side="server" code="0x0428" define="PREVIOUS_DAY6_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 consumption delivered</attribute>
+    <attribute side="server" code="0x0429" define="PREVIOUS_DAY6_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 consumption received</attribute>
+    <attribute side="server" code="0x042A" define="PREVIOUS_DAY7_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 consumption delivered</attribute>
+    <attribute side="server" code="0x042B" define="PREVIOUS_DAY7_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 consumption received</attribute>
+    <attribute side="server" code="0x042C" define="PREVIOUS_DAY8_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 consumption delivered</attribute>
+    <attribute side="server" code="0x042D" define="PREVIOUS_DAY8_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 consumption received</attribute>
+    <attribute side="server" code="0x0430" define="CURRENT_WEEK_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week consumption delivered</attribute>
+    <attribute side="server" code="0x0431" define="CURRENT_WEEK_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week consumption received</attribute>
+    <attribute side="server" code="0x0432" define="PREVIOUS_WEEK_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week consumption delivered</attribute>
+    <attribute side="server" code="0x0433" define="PREVIOUS_WEEK_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week consumption received</attribute>
+    <attribute side="server" code="0x0434" define="PREVIOUS_WEEK2_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 consumption delivered</attribute>
+    <attribute side="server" code="0x0435" define="PREVIOUS_WEEK2_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 consumption received</attribute>
+    <attribute side="server" code="0x0436" define="PREVIOUS_WEEK3_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 consumption delivered</attribute>
+    <attribute side="server" code="0x0437" define="PREVIOUS_WEEK3_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 consumption received</attribute>
+    <attribute side="server" code="0x0438" define="PREVIOUS_WEEK4_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 consumption delivered</attribute>
+    <attribute side="server" code="0x0439" define="PREVIOUS_WEEK4_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 consumption received</attribute>
+    <attribute side="server" code="0x043A" define="PREVIOUS_WEEK5_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 consumption delivered</attribute>
+    <attribute side="server" code="0x043B" define="PREVIOUS_WEEK5_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 consumption received</attribute>
+    <attribute side="server" code="0x0440" define="CURRENT_MONTH_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month consumption delivered</attribute>
+    <attribute side="server" code="0x0441" define="CURRENT_MONTH_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month consumption received</attribute>
+    <attribute side="server" code="0x0442" define="PREVIOUS_MONTH_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month consumption delivered</attribute>
+    <attribute side="server" code="0x0443" define="PREVIOUS_MONTH_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month consumption received</attribute>
+    <attribute side="server" code="0x0444" define="PREVIOUS_MONTH2_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 consumption delivered</attribute>
+    <attribute side="server" code="0x0445" define="PREVIOUS_MONTH2_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 consumption received</attribute>
+    <attribute side="server" code="0x0446" define="PREVIOUS_MONTH3_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 consumption delivered</attribute>
+    <attribute side="server" code="0x0447" define="PREVIOUS_MONTH3_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 consumption received</attribute>
+    <attribute side="server" code="0x0448" define="PREVIOUS_MONTH4_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 consumption delivered</attribute>
+    <attribute side="server" code="0x0449" define="PREVIOUS_MONTH4_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 consumption received</attribute>
+    <attribute side="server" code="0x044A" define="PREVIOUS_MONTH5_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 consumption delivered</attribute>
+    <attribute side="server" code="0x044B" define="PREVIOUS_MONTH5_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 consumption received</attribute>
+    <attribute side="server" code="0x044C" define="PREVIOUS_MONTH6_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 consumption delivered</attribute>
+    <attribute side="server" code="0x044D" define="PREVIOUS_MONTH6_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 consumption received</attribute>
+    <attribute side="server" code="0x044E" define="PREVIOUS_MONTH7_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 consumption delivered</attribute>
+    <attribute side="server" code="0x044F" define="PREVIOUS_MONTH7_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 consumption received</attribute>
+    <attribute side="server" code="0x0450" define="PREVIOUS_MONTH8_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 consumption delivered</attribute>
+    <attribute side="server" code="0x0451" define="PREVIOUS_MONTH8_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 consumption received</attribute>
+    <attribute side="server" code="0x0452" define="PREVIOUS_MONTH9_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 consumption delivered</attribute>
+    <attribute side="server" code="0x0453" define="PREVIOUS_MONTH9_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 consumption received</attribute>
+    <attribute side="server" code="0x0454" define="PREVIOUS_MONTH10_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 consumption delivered</attribute>
+    <attribute side="server" code="0x0455" define="PREVIOUS_MONTH10_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 consumption received</attribute>
+    <attribute side="server" code="0x0456" define="PREVIOUS_MONTH11_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 consumption delivered</attribute>
+    <attribute side="server" code="0x0457" define="PREVIOUS_MONTH11_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 consumption received</attribute>
+    <attribute side="server" code="0x0458" define="PREVIOUS_MONTH12_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 consumption delivered</attribute>
+    <attribute side="server" code="0x0459" define="PREVIOUS_MONTH12_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 consumption received</attribute>
+    <attribute side="server" code="0x045A" define="PREVIOUS_MONTH13_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 consumption delivered</attribute>
+    <attribute side="server" code="0x045B" define="PREVIOUS_MONTH13_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 consumption received</attribute>
+    <attribute side="server" code="0x045C" define="METERING_HISTORICAL_FREEZE_TIME" type="INT16U" min="0x0000" max="0x173B" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">historical freeze time</attribute>
+    <attribute side="server" code="0x045D" define="CURRENT_DAY_MAX_DEMAND_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day max demand delivered</attribute>
+    <attribute side="server" code="0x045E" define="CURRENT_DAY_MAX_DEMAND_DELIVERED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day max demand delivered time</attribute>
+    <attribute side="server" code="0x045F" define="CURRENT_DAY_MAX_DEMAND_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day max demand received</attribute>
+    <attribute side="server" code="0x0460" define="CURRENT_DAY_MAX_DEMAND_RECEIVED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day max demand received time</attribute>
+    <attribute side="server" code="0x0461" define="PREVIOUS_DAY_MAX_DEMAND_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day max demand delivered</attribute>
+    <attribute side="server" code="0x0462" define="PREVIOUS_DAY_MAX_DEMAND_DELIVERED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day max demand delivered time</attribute>
+    <attribute side="server" code="0x0463" define="PREVIOUS_DAY_MAX_DEMAND_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day max demand received</attribute>
+    <attribute side="server" code="0x0464" define="PREVIOUS_DAY_MAX_DEMAND_RECEIVED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day max demand received time</attribute>
+    <!-- Metering Cluster Server - Load Profile Configuration Attribute Set -->
+    <attribute side="server" code="0x0500" define="MAX_NUMBER_OF_PERIODS_DELIVERED" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x18" optional="true">max number of periods delivered</attribute>
+    <!-- Metering Cluster Server - Supply Limit Attribute Set -->
+    <attribute side="server" code="0x0600" define="CURRENT_DEMAND_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current demand delivered</attribute>
+    <attribute side="server" code="0x0601" define="DEMAND_LIMIT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">demand limit</attribute>
+    <attribute side="server" code="0x0602" define="DEMAND_INTEGRATION_PERIOD" type="INT8U" min="0x01" max="0xFF" writable="false" optional="true">demand integration period</attribute>
+    <attribute side="server" code="0x0603" define="NUMBER_OF_DEMAND_SUBINTERVALS" type="INT8U" min="0x01" max="0xFF" writable="false" optional="true">number of demand subintervals</attribute>
+    <attribute side="server" code="0x0604" define="DEMAND_LIMIT_ARM_DURATION_IN_MINUTES" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x003C" optional="true" introducedIn="se-1.2a-07-5356-19">demand limit arm duration in minutes</attribute>
+    <attribute side="server" code="0x0605" define="LOAD_LIMIT_SUPPLY_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">load limit supply state</attribute>
+    <attribute side="server" code="0x0606" define="LOAD_LIMIT_COUNTER" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x01" optional="true" introducedIn="se-1.2a-07-5356-19">load limit counter</attribute>
+    <attribute side="server" code="0x0607" define="SUPPLY_TAMPER_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">supply tamper state</attribute>
+    <attribute side="server" code="0x0608" define="SUPPLY_DEPLETION_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">supply depletion state</attribute>
+    <attribute side="server" code="0x0609" define="SUPPLY_UNCONTROLLED_FLOW_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">supply uncontrolled flow state</attribute>
+    <!-- Metering Cluster Server - Block Information Attribute Set (Delivered) -->
+    <attribute side="server" code="0x0700" define="CURRENT_NO_TIER_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0701" define="CURRENT_NO_TIER_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0702" define="CURRENT_NO_TIER_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0703" define="CURRENT_NO_TIER_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0704" define="CURRENT_NO_TIER_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0705" define="CURRENT_NO_TIER_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0706" define="CURRENT_NO_TIER_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0707" define="CURRENT_NO_TIER_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0708" define="CURRENT_NO_TIER_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0709" define="CURRENT_NO_TIER_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 10 summation delivered</attribute>
+    <attribute side="server" code="0x070A" define="CURRENT_NO_TIER_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 11 summation delivered</attribute>
+    <attribute side="server" code="0x070B" define="CURRENT_NO_TIER_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 12 summation delivered</attribute>
+    <attribute side="server" code="0x070C" define="CURRENT_NO_TIER_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 13 summation delivered</attribute>
+    <attribute side="server" code="0x070D" define="CURRENT_NO_TIER_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 14 summation delivered</attribute>
+    <attribute side="server" code="0x070E" define="CURRENT_NO_TIER_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 15 summation delivered</attribute>
+    <attribute side="server" code="0x070F" define="CURRENT_NO_TIER_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current no tier block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0710" define="CURRENT_TIER1_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0711" define="CURRENT_TIER1_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0712" define="CURRENT_TIER1_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0713" define="CURRENT_TIER1_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0714" define="CURRENT_TIER1_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0715" define="CURRENT_TIER1_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0716" define="CURRENT_TIER1_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0717" define="CURRENT_TIER1_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0718" define="CURRENT_TIER1_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0719" define="CURRENT_TIER1_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x071A" define="CURRENT_TIER1_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x071B" define="CURRENT_TIER1_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x071C" define="CURRENT_TIER1_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x071D" define="CURRENT_TIER1_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x071E" define="CURRENT_TIER1_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x071F" define="CURRENT_TIER1_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 1 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0720" define="CURRENT_TIER2_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0721" define="CURRENT_TIER2_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0722" define="CURRENT_TIER2_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0723" define="CURRENT_TIER2_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0724" define="CURRENT_TIER2_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0725" define="CURRENT_TIER2_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0726" define="CURRENT_TIER2_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0727" define="CURRENT_TIER2_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0728" define="CURRENT_TIER2_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0729" define="CURRENT_TIER2_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x072A" define="CURRENT_TIER2_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x072B" define="CURRENT_TIER2_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x072C" define="CURRENT_TIER2_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x072D" define="CURRENT_TIER2_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x072E" define="CURRENT_TIER2_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x072F" define="CURRENT_TIER2_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 2 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0730" define="CURRENT_TIER3_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0731" define="CURRENT_TIER3_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0732" define="CURRENT_TIER3_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0733" define="CURRENT_TIER3_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0734" define="CURRENT_TIER3_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0735" define="CURRENT_TIER3_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0736" define="CURRENT_TIER3_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0737" define="CURRENT_TIER3_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0738" define="CURRENT_TIER3_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0739" define="CURRENT_TIER3_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x073A" define="CURRENT_TIER3_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x073B" define="CURRENT_TIER3_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x073C" define="CURRENT_TIER3_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x073D" define="CURRENT_TIER3_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x073E" define="CURRENT_TIER3_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x073F" define="CURRENT_TIER3_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 3 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0740" define="CURRENT_TIER4_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0741" define="CURRENT_TIER4_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0742" define="CURRENT_TIER4_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0743" define="CURRENT_TIER4_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0744" define="CURRENT_TIER4_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0745" define="CURRENT_TIER4_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0746" define="CURRENT_TIER4_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0747" define="CURRENT_TIER4_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0748" define="CURRENT_TIER4_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0749" define="CURRENT_TIER4_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x074A" define="CURRENT_TIER4_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x074B" define="CURRENT_TIER4_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x074C" define="CURRENT_TIER4_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x074D" define="CURRENT_TIER4_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x074E" define="CURRENT_TIER4_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x074F" define="CURRENT_TIER4_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 4 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0750" define="CURRENT_TIER5_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0751" define="CURRENT_TIER5_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0752" define="CURRENT_TIER5_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0753" define="CURRENT_TIER5_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0754" define="CURRENT_TIER5_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0755" define="CURRENT_TIER5_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0756" define="CURRENT_TIER5_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0757" define="CURRENT_TIER5_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0758" define="CURRENT_TIER5_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0759" define="CURRENT_TIER5_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x075A" define="CURRENT_TIER5_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x075B" define="CURRENT_TIER5_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x075C" define="CURRENT_TIER5_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x075D" define="CURRENT_TIER5_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x075E" define="CURRENT_TIER5_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x075F" define="CURRENT_TIER5_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 5 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0760" define="CURRENT_TIER6_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0761" define="CURRENT_TIER6_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0762" define="CURRENT_TIER6_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0763" define="CURRENT_TIER6_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0764" define="CURRENT_TIER6_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0765" define="CURRENT_TIER6_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0766" define="CURRENT_TIER6_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0767" define="CURRENT_TIER6_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0768" define="CURRENT_TIER6_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0769" define="CURRENT_TIER6_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x076A" define="CURRENT_TIER6_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x076B" define="CURRENT_TIER6_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x076C" define="CURRENT_TIER6_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x076D" define="CURRENT_TIER6_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x076E" define="CURRENT_TIER6_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x076F" define="CURRENT_TIER6_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 6 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0770" define="CURRENT_TIER7_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0771" define="CURRENT_TIER7_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0772" define="CURRENT_TIER7_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0773" define="CURRENT_TIER7_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0774" define="CURRENT_TIER7_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0775" define="CURRENT_TIER7_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0776" define="CURRENT_TIER7_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0777" define="CURRENT_TIER7_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0778" define="CURRENT_TIER7_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0779" define="CURRENT_TIER7_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x077A" define="CURRENT_TIER7_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x077B" define="CURRENT_TIER7_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x077C" define="CURRENT_TIER7_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x077D" define="CURRENT_TIER7_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x077E" define="CURRENT_TIER7_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x077F" define="CURRENT_TIER7_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 7 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0780" define="CURRENT_TIER8_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0781" define="CURRENT_TIER8_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0782" define="CURRENT_TIER8_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0783" define="CURRENT_TIER8_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0784" define="CURRENT_TIER8_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0785" define="CURRENT_TIER8_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0786" define="CURRENT_TIER8_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0787" define="CURRENT_TIER8_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0788" define="CURRENT_TIER8_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0789" define="CURRENT_TIER8_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x078A" define="CURRENT_TIER8_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x078B" define="CURRENT_TIER8_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x078C" define="CURRENT_TIER8_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x078D" define="CURRENT_TIER8_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x078E" define="CURRENT_TIER8_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x078F" define="CURRENT_TIER8_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 8 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x0790" define="CURRENT_TIER9_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x0791" define="CURRENT_TIER9_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x0792" define="CURRENT_TIER9_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x0793" define="CURRENT_TIER9_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x0794" define="CURRENT_TIER9_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x0795" define="CURRENT_TIER9_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x0796" define="CURRENT_TIER9_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x0797" define="CURRENT_TIER9_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x0798" define="CURRENT_TIER9_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x0799" define="CURRENT_TIER9_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x079A" define="CURRENT_TIER9_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x079B" define="CURRENT_TIER9_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x079C" define="CURRENT_TIER9_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x079D" define="CURRENT_TIER9_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x079E" define="CURRENT_TIER9_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x079F" define="CURRENT_TIER9_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 9 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07A0" define="CURRENT_TIER10_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07A1" define="CURRENT_TIER10_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07A2" define="CURRENT_TIER10_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07A3" define="CURRENT_TIER10_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07A4" define="CURRENT_TIER10_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07A5" define="CURRENT_TIER10_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07A6" define="CURRENT_TIER10_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07A7" define="CURRENT_TIER10_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07A8" define="CURRENT_TIER10_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07A9" define="CURRENT_TIER10_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07AA" define="CURRENT_TIER10_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07AB" define="CURRENT_TIER10_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07AC" define="CURRENT_TIER10_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07AD" define="CURRENT_TIER10_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07AE" define="CURRENT_TIER10_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07AF" define="CURRENT_TIER10_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 10 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07B0" define="CURRENT_TIER11_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07B1" define="CURRENT_TIER11_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07B2" define="CURRENT_TIER11_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07B3" define="CURRENT_TIER11_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07B4" define="CURRENT_TIER11_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07B5" define="CURRENT_TIER11_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07B6" define="CURRENT_TIER11_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07B7" define="CURRENT_TIER11_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07B8" define="CURRENT_TIER11_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07B9" define="CURRENT_TIER11_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07BA" define="CURRENT_TIER11_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07BB" define="CURRENT_TIER11_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07BC" define="CURRENT_TIER11_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07BD" define="CURRENT_TIER11_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07BE" define="CURRENT_TIER11_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07BF" define="CURRENT_TIER11_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 11 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07C0" define="CURRENT_TIER12_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07C1" define="CURRENT_TIER12_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07C2" define="CURRENT_TIER12_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07C3" define="CURRENT_TIER12_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07C4" define="CURRENT_TIER12_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07C5" define="CURRENT_TIER12_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07C6" define="CURRENT_TIER12_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07C7" define="CURRENT_TIER12_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07C8" define="CURRENT_TIER12_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07C9" define="CURRENT_TIER12_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07CA" define="CURRENT_TIER12_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07CB" define="CURRENT_TIER12_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07CC" define="CURRENT_TIER12_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07CD" define="CURRENT_TIER12_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07CE" define="CURRENT_TIER12_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07CF" define="CURRENT_TIER12_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 12 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07D0" define="CURRENT_TIER13_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07D1" define="CURRENT_TIER13_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07D2" define="CURRENT_TIER13_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07D3" define="CURRENT_TIER13_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07D4" define="CURRENT_TIER13_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07D5" define="CURRENT_TIER13_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07D6" define="CURRENT_TIER13_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07D7" define="CURRENT_TIER13_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07D8" define="CURRENT_TIER13_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07D9" define="CURRENT_TIER13_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07DA" define="CURRENT_TIER13_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07DB" define="CURRENT_TIER13_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07DC" define="CURRENT_TIER13_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07DD" define="CURRENT_TIER13_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07DE" define="CURRENT_TIER13_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07DF" define="CURRENT_TIER13_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 13 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07E0" define="CURRENT_TIER14_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07E1" define="CURRENT_TIER14_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07E2" define="CURRENT_TIER14_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07E3" define="CURRENT_TIER14_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07E4" define="CURRENT_TIER14_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07E5" define="CURRENT_TIER14_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07E6" define="CURRENT_TIER14_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07E7" define="CURRENT_TIER14_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07E8" define="CURRENT_TIER14_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07E9" define="CURRENT_TIER14_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07EA" define="CURRENT_TIER14_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07EB" define="CURRENT_TIER14_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07EC" define="CURRENT_TIER14_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07ED" define="CURRENT_TIER14_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07EE" define="CURRENT_TIER14_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07EF" define="CURRENT_TIER14_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 14 block 16 summation delivered</attribute>
+    <attribute side="server" code="0x07F0" define="CURRENT_TIER15_BLOCK1_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 1 summation delivered</attribute>
+    <attribute side="server" code="0x07F1" define="CURRENT_TIER15_BLOCK2_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 2 summation delivered</attribute>
+    <attribute side="server" code="0x07F2" define="CURRENT_TIER15_BLOCK3_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 3 summation delivered</attribute>
+    <attribute side="server" code="0x07F3" define="CURRENT_TIER15_BLOCK4_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 4 summation delivered</attribute>
+    <attribute side="server" code="0x07F4" define="CURRENT_TIER15_BLOCK5_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 5 summation delivered</attribute>
+    <attribute side="server" code="0x07F5" define="CURRENT_TIER15_BLOCK6_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 6 summation delivered</attribute>
+    <attribute side="server" code="0x07F6" define="CURRENT_TIER15_BLOCK7_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 7 summation delivered</attribute>
+    <attribute side="server" code="0x07F7" define="CURRENT_TIER15_BLOCK8_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 8 summation delivered</attribute>
+    <attribute side="server" code="0x07F8" define="CURRENT_TIER15_BLOCK9_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 9 summation delivered</attribute>
+    <attribute side="server" code="0x07F9" define="CURRENT_TIER15_BLOCK10_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 10 summation delivered</attribute>
+    <attribute side="server" code="0x07FA" define="CURRENT_TIER15_BLOCK11_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 11 summation delivered</attribute>
+    <attribute side="server" code="0x07FB" define="CURRENT_TIER15_BLOCK12_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 12 summation delivered</attribute>
+    <attribute side="server" code="0x07FC" define="CURRENT_TIER15_BLOCK13_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 13 summation delivered</attribute>
+    <attribute side="server" code="0x07FD" define="CURRENT_TIER15_BLOCK14_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 14 summation delivered</attribute>
+    <attribute side="server" code="0x07FE" define="CURRENT_TIER15_BLOCK15_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 15 summation delivered</attribute>
+    <attribute side="server" code="0x07FF" define="CURRENT_TIER15_BLOCK16_SUMMATION_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.1-07-5356-16">current tier 15 block 16 summation delivered</attribute>
+    <!-- Metering Cluster Server - Alarms Attribute Set -->
+    <attribute side="server" code="0x0800" define="GENERIC_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.1-07-5356-16">generic alarm mask</attribute>
+    <attribute side="server" code="0x0801" define="ELECTRICITY_ALARM_MASK" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="true" default="0xFFFFFFFF" optional="true" introducedIn="se-1.1-07-5356-16">electricity alarm mask</attribute>
+    <attribute side="server" code="0x0802" define="GENERIC_FLOW_PRESSURE_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.1-07-5356-16">generic flow/pressure alarm mask</attribute>
+    <attribute side="server" code="0x0803" define="WATER_SPECIFIC_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.1-07-5356-16">water specific alarm mask</attribute>
+    <attribute side="server" code="0x0804" define="HEAT_AND_COOLING_SPECIFIC_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.1-07-5356-16">heat and cooling specific alarm mask</attribute>
+    <attribute side="server" code="0x0805" define="GAS_SPECIFIC_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.1-07-5356-16">gas specific alarm mask</attribute>
+    <attribute side="server" code="0x0806" define="METERING_EXTENDED_GENERIC_ALARM_MASK" type="BITMAP48" min="0x0000" max="0xFFFFFFFFFFFF" writable="true" default="0xFFFFFFFFFFFF" optional="true" introducedIn="se-1.2a-07-5356-19">extended generic alarm mask</attribute>
+    <attribute side="server" code="0x0807" define="METERING_MANUFACTURE_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.2a-07-5356-19">manufacture alarm mask</attribute>
+    <!-- Metering Cluster Server - Block Information Attribute Set (Received) -->
+    <attribute side="server" code="0x0900" define="CURRENT_NO_TIER_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 1 summation received</attribute>
+    <attribute side="server" code="0x0901" define="CURRENT_NO_TIER_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 2 summation received</attribute>
+    <attribute side="server" code="0x0902" define="CURRENT_NO_TIER_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 3 summation received</attribute>
+    <attribute side="server" code="0x0903" define="CURRENT_NO_TIER_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 4 summation received</attribute>
+    <attribute side="server" code="0x0904" define="CURRENT_NO_TIER_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 5 summation received</attribute>
+    <attribute side="server" code="0x0905" define="CURRENT_NO_TIER_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 6 summation received</attribute>
+    <attribute side="server" code="0x0906" define="CURRENT_NO_TIER_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 7 summation received</attribute>
+    <attribute side="server" code="0x0907" define="CURRENT_NO_TIER_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 8 summation received</attribute>
+    <attribute side="server" code="0x0908" define="CURRENT_NO_TIER_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 9 summation received</attribute>
+    <attribute side="server" code="0x0909" define="CURRENT_NO_TIER_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 10 summation received</attribute>
+    <attribute side="server" code="0x090A" define="CURRENT_NO_TIER_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 11 summation received</attribute>
+    <attribute side="server" code="0x090B" define="CURRENT_NO_TIER_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 12 summation received</attribute>
+    <attribute side="server" code="0x090C" define="CURRENT_NO_TIER_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 13 summation received</attribute>
+    <attribute side="server" code="0x090D" define="CURRENT_NO_TIER_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 14 summation received</attribute>
+    <attribute side="server" code="0x090E" define="CURRENT_NO_TIER_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 15 summation received</attribute>
+    <attribute side="server" code="0x090F" define="CURRENT_NO_TIER_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current no tier block 16 summation received</attribute>
+    <attribute side="server" code="0x0910" define="CURRENT_TIER1_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 1 summation received</attribute>
+    <attribute side="server" code="0x0911" define="CURRENT_TIER1_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 2 summation received</attribute>
+    <attribute side="server" code="0x0912" define="CURRENT_TIER1_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 3 summation received</attribute>
+    <attribute side="server" code="0x0913" define="CURRENT_TIER1_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 4 summation received</attribute>
+    <attribute side="server" code="0x0914" define="CURRENT_TIER1_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 5 summation received</attribute>
+    <attribute side="server" code="0x0915" define="CURRENT_TIER1_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 6 summation received</attribute>
+    <attribute side="server" code="0x0916" define="CURRENT_TIER1_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 7 summation received</attribute>
+    <attribute side="server" code="0x0917" define="CURRENT_TIER1_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 8 summation received</attribute>
+    <attribute side="server" code="0x0918" define="CURRENT_TIER1_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 9 summation received</attribute>
+    <attribute side="server" code="0x0919" define="CURRENT_TIER1_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 10 summation received</attribute>
+    <attribute side="server" code="0x091A" define="CURRENT_TIER1_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 11 summation received</attribute>
+    <attribute side="server" code="0x091B" define="CURRENT_TIER1_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 12 summation received</attribute>
+    <attribute side="server" code="0x091C" define="CURRENT_TIER1_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 13 summation received</attribute>
+    <attribute side="server" code="0x091D" define="CURRENT_TIER1_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 14 summation received</attribute>
+    <attribute side="server" code="0x091E" define="CURRENT_TIER1_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 15 summation received</attribute>
+    <attribute side="server" code="0x091F" define="CURRENT_TIER1_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 1 block 16 summation received</attribute>
+    <attribute side="server" code="0x0920" define="CURRENT_TIER2_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 1 summation received</attribute>
+    <attribute side="server" code="0x0921" define="CURRENT_TIER2_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 2 summation received</attribute>
+    <attribute side="server" code="0x0922" define="CURRENT_TIER2_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 3 summation received</attribute>
+    <attribute side="server" code="0x0923" define="CURRENT_TIER2_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 4 summation received</attribute>
+    <attribute side="server" code="0x0924" define="CURRENT_TIER2_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 5 summation received</attribute>
+    <attribute side="server" code="0x0925" define="CURRENT_TIER2_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 6 summation received</attribute>
+    <attribute side="server" code="0x0926" define="CURRENT_TIER2_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 7 summation received</attribute>
+    <attribute side="server" code="0x0927" define="CURRENT_TIER2_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 8 summation received</attribute>
+    <attribute side="server" code="0x0928" define="CURRENT_TIER2_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 9 summation received</attribute>
+    <attribute side="server" code="0x0929" define="CURRENT_TIER2_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 10 summation received</attribute>
+    <attribute side="server" code="0x092A" define="CURRENT_TIER2_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 11 summation received</attribute>
+    <attribute side="server" code="0x092B" define="CURRENT_TIER2_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 12 summation received</attribute>
+    <attribute side="server" code="0x092C" define="CURRENT_TIER2_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 13 summation received</attribute>
+    <attribute side="server" code="0x092D" define="CURRENT_TIER2_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 14 summation received</attribute>
+    <attribute side="server" code="0x092E" define="CURRENT_TIER2_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 15 summation received</attribute>
+    <attribute side="server" code="0x092F" define="CURRENT_TIER2_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 2 block 16 summation received</attribute>
+    <attribute side="server" code="0x0930" define="CURRENT_TIER3_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 1 summation received</attribute>
+    <attribute side="server" code="0x0931" define="CURRENT_TIER3_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 2 summation received</attribute>
+    <attribute side="server" code="0x0932" define="CURRENT_TIER3_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 3 summation received</attribute>
+    <attribute side="server" code="0x0933" define="CURRENT_TIER3_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 4 summation received</attribute>
+    <attribute side="server" code="0x0934" define="CURRENT_TIER3_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 5 summation received</attribute>
+    <attribute side="server" code="0x0935" define="CURRENT_TIER3_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 6 summation received</attribute>
+    <attribute side="server" code="0x0936" define="CURRENT_TIER3_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 7 summation received</attribute>
+    <attribute side="server" code="0x0937" define="CURRENT_TIER3_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 8 summation received</attribute>
+    <attribute side="server" code="0x0938" define="CURRENT_TIER3_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 9 summation received</attribute>
+    <attribute side="server" code="0x0939" define="CURRENT_TIER3_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 10 summation received</attribute>
+    <attribute side="server" code="0x093A" define="CURRENT_TIER3_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 11 summation received</attribute>
+    <attribute side="server" code="0x093B" define="CURRENT_TIER3_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 12 summation received</attribute>
+    <attribute side="server" code="0x093C" define="CURRENT_TIER3_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 13 summation received</attribute>
+    <attribute side="server" code="0x093D" define="CURRENT_TIER3_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 14 summation received</attribute>
+    <attribute side="server" code="0x093E" define="CURRENT_TIER3_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 15 summation received</attribute>
+    <attribute side="server" code="0x093F" define="CURRENT_TIER3_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 3 block 16 summation received</attribute>
+    <attribute side="server" code="0x0940" define="CURRENT_TIER4_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 1 summation received</attribute>
+    <attribute side="server" code="0x0941" define="CURRENT_TIER4_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 2 summation received</attribute>
+    <attribute side="server" code="0x0942" define="CURRENT_TIER4_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 3 summation received</attribute>
+    <attribute side="server" code="0x0943" define="CURRENT_TIER4_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 4 summation received</attribute>
+    <attribute side="server" code="0x0944" define="CURRENT_TIER4_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 5 summation received</attribute>
+    <attribute side="server" code="0x0945" define="CURRENT_TIER4_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 6 summation received</attribute>
+    <attribute side="server" code="0x0946" define="CURRENT_TIER4_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 7 summation received</attribute>
+    <attribute side="server" code="0x0947" define="CURRENT_TIER4_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 8 summation received</attribute>
+    <attribute side="server" code="0x0948" define="CURRENT_TIER4_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 9 summation received</attribute>
+    <attribute side="server" code="0x0949" define="CURRENT_TIER4_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 10 summation received</attribute>
+    <attribute side="server" code="0x094A" define="CURRENT_TIER4_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 11 summation received</attribute>
+    <attribute side="server" code="0x094B" define="CURRENT_TIER4_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 12 summation received</attribute>
+    <attribute side="server" code="0x094C" define="CURRENT_TIER4_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 13 summation received</attribute>
+    <attribute side="server" code="0x094D" define="CURRENT_TIER4_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 14 summation received</attribute>
+    <attribute side="server" code="0x094E" define="CURRENT_TIER4_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 15 summation received</attribute>
+    <attribute side="server" code="0x094F" define="CURRENT_TIER4_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 4 block 16 summation received</attribute>
+    <attribute side="server" code="0x0950" define="CURRENT_TIER5_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 1 summation received</attribute>
+    <attribute side="server" code="0x0951" define="CURRENT_TIER5_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 2 summation received</attribute>
+    <attribute side="server" code="0x0952" define="CURRENT_TIER5_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 3 summation received</attribute>
+    <attribute side="server" code="0x0953" define="CURRENT_TIER5_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 4 summation received</attribute>
+    <attribute side="server" code="0x0954" define="CURRENT_TIER5_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 5 summation received</attribute>
+    <attribute side="server" code="0x0955" define="CURRENT_TIER5_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 6 summation received</attribute>
+    <attribute side="server" code="0x0956" define="CURRENT_TIER5_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 7 summation received</attribute>
+    <attribute side="server" code="0x0957" define="CURRENT_TIER5_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 8 summation received</attribute>
+    <attribute side="server" code="0x0958" define="CURRENT_TIER5_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 9 summation received</attribute>
+    <attribute side="server" code="0x0959" define="CURRENT_TIER5_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 10 summation received</attribute>
+    <attribute side="server" code="0x095A" define="CURRENT_TIER5_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 11 summation received</attribute>
+    <attribute side="server" code="0x095B" define="CURRENT_TIER5_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 12 summation received</attribute>
+    <attribute side="server" code="0x095C" define="CURRENT_TIER5_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 13 summation received</attribute>
+    <attribute side="server" code="0x095D" define="CURRENT_TIER5_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 14 summation received</attribute>
+    <attribute side="server" code="0x095E" define="CURRENT_TIER5_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 15 summation received</attribute>
+    <attribute side="server" code="0x095F" define="CURRENT_TIER5_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 5 block 16 summation received</attribute>
+    <attribute side="server" code="0x0960" define="CURRENT_TIER6_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 1 summation received</attribute>
+    <attribute side="server" code="0x0961" define="CURRENT_TIER6_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 2 summation received</attribute>
+    <attribute side="server" code="0x0962" define="CURRENT_TIER6_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 3 summation received</attribute>
+    <attribute side="server" code="0x0963" define="CURRENT_TIER6_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 4 summation received</attribute>
+    <attribute side="server" code="0x0964" define="CURRENT_TIER6_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 5 summation received</attribute>
+    <attribute side="server" code="0x0965" define="CURRENT_TIER6_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 6 summation received</attribute>
+    <attribute side="server" code="0x0966" define="CURRENT_TIER6_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 7 summation received</attribute>
+    <attribute side="server" code="0x0967" define="CURRENT_TIER6_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 8 summation received</attribute>
+    <attribute side="server" code="0x0968" define="CURRENT_TIER6_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 9 summation received</attribute>
+    <attribute side="server" code="0x0969" define="CURRENT_TIER6_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 10 summation received</attribute>
+    <attribute side="server" code="0x096A" define="CURRENT_TIER6_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 11 summation received</attribute>
+    <attribute side="server" code="0x096B" define="CURRENT_TIER6_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 12 summation received</attribute>
+    <attribute side="server" code="0x096C" define="CURRENT_TIER6_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 13 summation received</attribute>
+    <attribute side="server" code="0x096D" define="CURRENT_TIER6_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 14 summation received</attribute>
+    <attribute side="server" code="0x096E" define="CURRENT_TIER6_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 15 summation received</attribute>
+    <attribute side="server" code="0x096F" define="CURRENT_TIER6_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 6 block 16 summation received</attribute>
+    <attribute side="server" code="0x0970" define="CURRENT_TIER7_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 1 summation received</attribute>
+    <attribute side="server" code="0x0971" define="CURRENT_TIER7_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 2 summation received</attribute>
+    <attribute side="server" code="0x0972" define="CURRENT_TIER7_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 3 summation received</attribute>
+    <attribute side="server" code="0x0973" define="CURRENT_TIER7_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 4 summation received</attribute>
+    <attribute side="server" code="0x0974" define="CURRENT_TIER7_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 5 summation received</attribute>
+    <attribute side="server" code="0x0975" define="CURRENT_TIER7_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 6 summation received</attribute>
+    <attribute side="server" code="0x0976" define="CURRENT_TIER7_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 7 summation received</attribute>
+    <attribute side="server" code="0x0977" define="CURRENT_TIER7_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 8 summation received</attribute>
+    <attribute side="server" code="0x0978" define="CURRENT_TIER7_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 9 summation received</attribute>
+    <attribute side="server" code="0x0979" define="CURRENT_TIER7_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 10 summation received</attribute>
+    <attribute side="server" code="0x097A" define="CURRENT_TIER7_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 11 summation received</attribute>
+    <attribute side="server" code="0x097B" define="CURRENT_TIER7_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 12 summation received</attribute>
+    <attribute side="server" code="0x097C" define="CURRENT_TIER7_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 13 summation received</attribute>
+    <attribute side="server" code="0x097D" define="CURRENT_TIER7_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 14 summation received</attribute>
+    <attribute side="server" code="0x097E" define="CURRENT_TIER7_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 15 summation received</attribute>
+    <attribute side="server" code="0x097F" define="CURRENT_TIER7_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 7 block 16 summation received</attribute>
+    <attribute side="server" code="0x0980" define="CURRENT_TIER8_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 1 summation received</attribute>
+    <attribute side="server" code="0x0981" define="CURRENT_TIER8_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 2 summation received</attribute>
+    <attribute side="server" code="0x0982" define="CURRENT_TIER8_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 3 summation received</attribute>
+    <attribute side="server" code="0x0983" define="CURRENT_TIER8_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 4 summation received</attribute>
+    <attribute side="server" code="0x0984" define="CURRENT_TIER8_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 5 summation received</attribute>
+    <attribute side="server" code="0x0985" define="CURRENT_TIER8_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 6 summation received</attribute>
+    <attribute side="server" code="0x0986" define="CURRENT_TIER8_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 7 summation received</attribute>
+    <attribute side="server" code="0x0987" define="CURRENT_TIER8_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 8 summation received</attribute>
+    <attribute side="server" code="0x0988" define="CURRENT_TIER8_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 9 summation received</attribute>
+    <attribute side="server" code="0x0989" define="CURRENT_TIER8_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 10 summation received</attribute>
+    <attribute side="server" code="0x098A" define="CURRENT_TIER8_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 11 summation received</attribute>
+    <attribute side="server" code="0x098B" define="CURRENT_TIER8_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 12 summation received</attribute>
+    <attribute side="server" code="0x098C" define="CURRENT_TIER8_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 13 summation received</attribute>
+    <attribute side="server" code="0x098D" define="CURRENT_TIER8_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 14 summation received</attribute>
+    <attribute side="server" code="0x098E" define="CURRENT_TIER8_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 15 summation received</attribute>
+    <attribute side="server" code="0x098F" define="CURRENT_TIER8_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 8 block 16 summation received</attribute>
+    <attribute side="server" code="0x0990" define="CURRENT_TIER9_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 1 summation received</attribute>
+    <attribute side="server" code="0x0991" define="CURRENT_TIER9_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 2 summation received</attribute>
+    <attribute side="server" code="0x0992" define="CURRENT_TIER9_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 3 summation received</attribute>
+    <attribute side="server" code="0x0993" define="CURRENT_TIER9_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 4 summation received</attribute>
+    <attribute side="server" code="0x0994" define="CURRENT_TIER9_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 5 summation received</attribute>
+    <attribute side="server" code="0x0995" define="CURRENT_TIER9_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 6 summation received</attribute>
+    <attribute side="server" code="0x0996" define="CURRENT_TIER9_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 7 summation received</attribute>
+    <attribute side="server" code="0x0997" define="CURRENT_TIER9_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 8 summation received</attribute>
+    <attribute side="server" code="0x0998" define="CURRENT_TIER9_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 9 summation received</attribute>
+    <attribute side="server" code="0x0999" define="CURRENT_TIER9_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 10 summation received</attribute>
+    <attribute side="server" code="0x099A" define="CURRENT_TIER9_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 11 summation received</attribute>
+    <attribute side="server" code="0x099B" define="CURRENT_TIER9_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 12 summation received</attribute>
+    <attribute side="server" code="0x099C" define="CURRENT_TIER9_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 13 summation received</attribute>
+    <attribute side="server" code="0x099D" define="CURRENT_TIER9_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 14 summation received</attribute>
+    <attribute side="server" code="0x099E" define="CURRENT_TIER9_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 15 summation received</attribute>
+    <attribute side="server" code="0x099F" define="CURRENT_TIER9_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 9 block 16 summation received</attribute>
+    <attribute side="server" code="0x09A0" define="CURRENT_TIER10_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 1 summation received</attribute>
+    <attribute side="server" code="0x09A1" define="CURRENT_TIER10_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 2 summation received</attribute>
+    <attribute side="server" code="0x09A2" define="CURRENT_TIER10_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 3 summation received</attribute>
+    <attribute side="server" code="0x09A3" define="CURRENT_TIER10_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 4 summation received</attribute>
+    <attribute side="server" code="0x09A4" define="CURRENT_TIER10_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 5 summation received</attribute>
+    <attribute side="server" code="0x09A5" define="CURRENT_TIER10_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 6 summation received</attribute>
+    <attribute side="server" code="0x09A6" define="CURRENT_TIER10_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 7 summation received</attribute>
+    <attribute side="server" code="0x09A7" define="CURRENT_TIER10_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 8 summation received</attribute>
+    <attribute side="server" code="0x09A8" define="CURRENT_TIER10_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 9 summation received</attribute>
+    <attribute side="server" code="0x09A9" define="CURRENT_TIER10_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 10 summation received</attribute>
+    <attribute side="server" code="0x09AA" define="CURRENT_TIER10_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 11 summation received</attribute>
+    <attribute side="server" code="0x09AB" define="CURRENT_TIER10_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 12 summation received</attribute>
+    <attribute side="server" code="0x09AC" define="CURRENT_TIER10_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 13 summation received</attribute>
+    <attribute side="server" code="0x09AD" define="CURRENT_TIER10_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 14 summation received</attribute>
+    <attribute side="server" code="0x09AE" define="CURRENT_TIER10_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 15 summation received</attribute>
+    <attribute side="server" code="0x09AF" define="CURRENT_TIER10_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 10 block 16 summation received</attribute>
+    <attribute side="server" code="0x09B0" define="CURRENT_TIER11_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 1 summation received</attribute>
+    <attribute side="server" code="0x09B1" define="CURRENT_TIER11_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 2 summation received</attribute>
+    <attribute side="server" code="0x09B2" define="CURRENT_TIER11_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 3 summation received</attribute>
+    <attribute side="server" code="0x09B3" define="CURRENT_TIER11_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 4 summation received</attribute>
+    <attribute side="server" code="0x09B4" define="CURRENT_TIER11_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 5 summation received</attribute>
+    <attribute side="server" code="0x09B5" define="CURRENT_TIER11_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 6 summation received</attribute>
+    <attribute side="server" code="0x09B6" define="CURRENT_TIER11_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 7 summation received</attribute>
+    <attribute side="server" code="0x09B7" define="CURRENT_TIER11_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 8 summation received</attribute>
+    <attribute side="server" code="0x09B8" define="CURRENT_TIER11_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 9 summation received</attribute>
+    <attribute side="server" code="0x09B9" define="CURRENT_TIER11_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 10 summation received</attribute>
+    <attribute side="server" code="0x09BA" define="CURRENT_TIER11_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 11 summation received</attribute>
+    <attribute side="server" code="0x09BB" define="CURRENT_TIER11_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 12 summation received</attribute>
+    <attribute side="server" code="0x09BC" define="CURRENT_TIER11_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 13 summation received</attribute>
+    <attribute side="server" code="0x09BD" define="CURRENT_TIER11_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 14 summation received</attribute>
+    <attribute side="server" code="0x09BE" define="CURRENT_TIER11_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 15 summation received</attribute>
+    <attribute side="server" code="0x09BF" define="CURRENT_TIER11_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 11 block 16 summation received</attribute>
+    <attribute side="server" code="0x09C0" define="CURRENT_TIER12_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 1 summation received</attribute>
+    <attribute side="server" code="0x09C1" define="CURRENT_TIER12_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 2 summation received</attribute>
+    <attribute side="server" code="0x09C2" define="CURRENT_TIER12_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 3 summation received</attribute>
+    <attribute side="server" code="0x09C3" define="CURRENT_TIER12_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 4 summation received</attribute>
+    <attribute side="server" code="0x09C4" define="CURRENT_TIER12_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 5 summation received</attribute>
+    <attribute side="server" code="0x09C5" define="CURRENT_TIER12_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 6 summation received</attribute>
+    <attribute side="server" code="0x09C6" define="CURRENT_TIER12_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 7 summation received</attribute>
+    <attribute side="server" code="0x09C7" define="CURRENT_TIER12_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 8 summation received</attribute>
+    <attribute side="server" code="0x09C8" define="CURRENT_TIER12_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 9 summation received</attribute>
+    <attribute side="server" code="0x09C9" define="CURRENT_TIER12_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 10 summation received</attribute>
+    <attribute side="server" code="0x09CA" define="CURRENT_TIER12_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 11 summation received</attribute>
+    <attribute side="server" code="0x09CB" define="CURRENT_TIER12_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 12 summation received</attribute>
+    <attribute side="server" code="0x09CC" define="CURRENT_TIER12_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 13 summation received</attribute>
+    <attribute side="server" code="0x09CD" define="CURRENT_TIER12_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 14 summation received</attribute>
+    <attribute side="server" code="0x09CE" define="CURRENT_TIER12_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 15 summation received</attribute>
+    <attribute side="server" code="0x09CF" define="CURRENT_TIER12_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 12 block 16 summation received</attribute>
+    <attribute side="server" code="0x09D0" define="CURRENT_TIER13_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 1 summation received</attribute>
+    <attribute side="server" code="0x09D1" define="CURRENT_TIER13_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 2 summation received</attribute>
+    <attribute side="server" code="0x09D2" define="CURRENT_TIER13_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 3 summation received</attribute>
+    <attribute side="server" code="0x09D3" define="CURRENT_TIER13_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 4 summation received</attribute>
+    <attribute side="server" code="0x09D4" define="CURRENT_TIER13_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 5 summation received</attribute>
+    <attribute side="server" code="0x09D5" define="CURRENT_TIER13_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 6 summation received</attribute>
+    <attribute side="server" code="0x09D6" define="CURRENT_TIER13_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 7 summation received</attribute>
+    <attribute side="server" code="0x09D7" define="CURRENT_TIER13_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 8 summation received</attribute>
+    <attribute side="server" code="0x09D8" define="CURRENT_TIER13_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 9 summation received</attribute>
+    <attribute side="server" code="0x09D9" define="CURRENT_TIER13_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 10 summation received</attribute>
+    <attribute side="server" code="0x09DA" define="CURRENT_TIER13_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 11 summation received</attribute>
+    <attribute side="server" code="0x09DB" define="CURRENT_TIER13_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 12 summation received</attribute>
+    <attribute side="server" code="0x09DC" define="CURRENT_TIER13_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 13 summation received</attribute>
+    <attribute side="server" code="0x09DD" define="CURRENT_TIER13_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 14 summation received</attribute>
+    <attribute side="server" code="0x09DE" define="CURRENT_TIER13_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 15 summation received</attribute>
+    <attribute side="server" code="0x09DF" define="CURRENT_TIER13_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 13 block 16 summation received</attribute>
+    <attribute side="server" code="0x09E0" define="CURRENT_TIER14_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 1 summation received</attribute>
+    <attribute side="server" code="0x09E1" define="CURRENT_TIER14_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 2 summation received</attribute>
+    <attribute side="server" code="0x09E2" define="CURRENT_TIER14_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 3 summation received</attribute>
+    <attribute side="server" code="0x09E3" define="CURRENT_TIER14_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 4 summation received</attribute>
+    <attribute side="server" code="0x09E4" define="CURRENT_TIER14_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 5 summation received</attribute>
+    <attribute side="server" code="0x09E5" define="CURRENT_TIER14_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 6 summation received</attribute>
+    <attribute side="server" code="0x09E6" define="CURRENT_TIER14_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 7 summation received</attribute>
+    <attribute side="server" code="0x09E7" define="CURRENT_TIER14_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 8 summation received</attribute>
+    <attribute side="server" code="0x09E8" define="CURRENT_TIER14_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 9 summation received</attribute>
+    <attribute side="server" code="0x09E9" define="CURRENT_TIER14_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 10 summation received</attribute>
+    <attribute side="server" code="0x09EA" define="CURRENT_TIER14_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 11 summation received</attribute>
+    <attribute side="server" code="0x09EB" define="CURRENT_TIER14_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 12 summation received</attribute>
+    <attribute side="server" code="0x09EC" define="CURRENT_TIER14_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 13 summation received</attribute>
+    <attribute side="server" code="0x09ED" define="CURRENT_TIER14_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 14 summation received</attribute>
+    <attribute side="server" code="0x09EE" define="CURRENT_TIER14_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 15 summation received</attribute>
+    <attribute side="server" code="0x09EF" define="CURRENT_TIER14_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 14 block 16 summation received</attribute>
+    <attribute side="server" code="0x09F0" define="CURRENT_TIER15_BLOCK1_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 1 summation received</attribute>
+    <attribute side="server" code="0x09F1" define="CURRENT_TIER15_BLOCK2_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 2 summation received</attribute>
+    <attribute side="server" code="0x09F2" define="CURRENT_TIER15_BLOCK3_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 3 summation received</attribute>
+    <attribute side="server" code="0x09F3" define="CURRENT_TIER15_BLOCK4_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 4 summation received</attribute>
+    <attribute side="server" code="0x09F4" define="CURRENT_TIER15_BLOCK5_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 5 summation received</attribute>
+    <attribute side="server" code="0x09F5" define="CURRENT_TIER15_BLOCK6_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 6 summation received</attribute>
+    <attribute side="server" code="0x09F6" define="CURRENT_TIER15_BLOCK7_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 7 summation received</attribute>
+    <attribute side="server" code="0x09F7" define="CURRENT_TIER15_BLOCK8_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 8 summation received</attribute>
+    <attribute side="server" code="0x09F8" define="CURRENT_TIER15_BLOCK9_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 9 summation received</attribute>
+    <attribute side="server" code="0x09F9" define="CURRENT_TIER15_BLOCK10_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 10 summation received</attribute>
+    <attribute side="server" code="0x09FA" define="CURRENT_TIER15_BLOCK11_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 11 summation received</attribute>
+    <attribute side="server" code="0x09FB" define="CURRENT_TIER15_BLOCK12_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 12 summation received</attribute>
+    <attribute side="server" code="0x09FC" define="CURRENT_TIER15_BLOCK13_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 13 summation received</attribute>
+    <attribute side="server" code="0x09FD" define="CURRENT_TIER15_BLOCK14_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 14 summation received</attribute>
+    <attribute side="server" code="0x09FE" define="CURRENT_TIER15_BLOCK15_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 15 summation received</attribute>
+    <attribute side="server" code="0x09FF" define="CURRENT_TIER15_BLOCK16_SUMMATION_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current tier 15 block 16 summation received</attribute>
+    <!-- Metering Cluster Server - Billing Attribute Set -->
+    <attribute side="server" code="0x0A00" define="BILL_TO_DATE_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">bill to date delivered</attribute>
+    <attribute side="server" code="0x0A01" define="BILL_TO_DATE_TIME_STAMP_DELIVERED" type="UTC_TIME" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">bill to date time stamp delivered</attribute>
+    <attribute side="server" code="0x0A02" define="PROJECTED_BILL_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">projected bill delivered</attribute>
+    <attribute side="server" code="0x0A03" define="PROJECTED_BILL_TIME_STAMP_DELIVERED" type="UTC_TIME" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">projected bill time stamp delivered</attribute>
+    <attribute side="server" code="0x0A04" define="BILL_DELIVERED_TRAILING_DIGIT" type="BITMAP8" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">bill delivered trailing digit</attribute>
+    <attribute side="server" code="0x0A10" define="BILL_TO_DATE_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">bill to date received</attribute>
+    <attribute side="server" code="0x0A11" define="BILL_TO_DATE_TIME_STAMP_RECEIVED" type="UTC_TIME" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">bill to date time stamp received</attribute>
+    <attribute side="server" code="0x0A12" define="PROJECTED_BILL_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">projected bill received</attribute>
+    <attribute side="server" code="0x0A13" define="PROJECTED_BILL_TIME_STAMP_RECEIVED" type="UTC_TIME" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">projected bill time stamp received</attribute>
+    <attribute side="server" code="0x0A14" define="BILL_RECEIVED_TRAILING_DIGIT" type="BITMAP8" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">bill received trailing digit</attribute>
+    <!-- Metering Cluster Server - Supply Control Attribute Set -->
+    <attribute side="server" code="0x0B00" define="PROPOSED_CHANGE_SUPPLY_IMPLEMENTATION_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">proposed change supply implementation time</attribute>
+    <attribute side="server" code="0x0B01" define="PROPOSED_CHANGE_SUPPLY_STATUS" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">proposed change supply status</attribute>
+    <attribute side="server" code="0x0B10" define="UNCONTROLLED_FLOW_THESHOLD" type="INT16U" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">uncontrolled flow threshold</attribute>
+    <attribute side="server" code="0x0B11" define="UNCONTROLLED_FLOW_THESHOLD_UNIT_OF_MEASURE" type="ENUM8" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">uncontrolled flow threshold unit of measure</attribute>
+    <attribute side="server" code="0x0B12" define="UNCONTROLLED_FLOW_MULTIPLIER" type="INT16U" writable="false" default="0x0001" optional="true" introducedIn="se-1.2a-07-5356-19">uncontrolled flow threshold multiplier</attribute>
+    <attribute side="server" code="0x0B13" define="UNCONTROLLED_FLOW_DIVISOR" type="INT16U" writable="false" default="0x0001" optional="true" introducedIn="se-1.2a-07-5356-19">uncontrolled flow threshold divisor</attribute>
+    <attribute side="server" code="0x0B14" define="FLOW_STABILIZATION_PERIOD" type="INT8U" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">flow stabilization period</attribute>
+    <attribute side="server" code="0x0B15" define="FLOW_MEASUREMENT_PERIOD" type="INT16U" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">flow measurement period</attribute>
+    <!-- Metering Cluster Server - Alternative Historical Consumption Attribute Set-->
+    <attribute side="server" code="0x0C00" define="ALTERNATIVE_INSTANTANEOUS_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">alternative instantaneous demand</attribute>
+    <attribute side="server" code="0x0C01" define="CURRENT_ALTERNATIVE_DAY_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current day alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C02" define="CURRENT_ALTERNATIVE_DAY_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current day alternative consumption received</attribute>
+    <attribute side="server" code="0x0C03" define="PREVIOUS_DAY_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">previous day alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C04" define="PREVIOUS_DAY_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">previous day alternative consumption received</attribute>
+    <attribute side="server" code="0x0C05" define="CURRENT_ALTERNATIVE_PARTIAL_PROFILE_INTERVAL_START_TIME_DELIVERED" type="UTC_TIME" writable="false" optional="true">current alternative partial profile interval start time delivered</attribute>
+    <attribute side="server" code="0x0C06" define="CURRENT_ALTERNATIVE_PARTIAL_PROFILE_INTERVAL_START_TIME_RECEIVED" type="UTC_TIME" writable="false" optional="true">current alternative partial profile interval start time received</attribute>
+    <attribute side="server" code="0x0C07" define="CURRENT_ALTERNATIVE_PARTIAL_PROFILE_INTERVAL_VALUE_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current alternative partial profile interval value delivered</attribute>
+    <attribute side="server" code="0x0C08" define="CURRENT_ALTERNATIVE_PARTIAL_PROFILE_INTERVAL_VALUE_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true">current alternative partial profile interval value received</attribute>
+    <attribute side="server" code="0x0C09" define="CURRENT_ALTERNATIVE_DAY_MAX_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current alternative day max pressure</attribute>
+    <attribute side="server" code="0x0C0A" define="CURRENT_ALTERNATIVE_DAY_MIN_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">current alternative day min pressure</attribute>
+    <attribute side="server" code="0x0C0B" define="PREVIOUS_DAY_ALTERNATIVE_MAX_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">previous day alternative max pressure</attribute>
+    <attribute side="server" code="0x0C0C" define="PREVIOUS_DAY_ALTERNATIVE_MIN_PRESSURE" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true">previous day alternative min pressure</attribute>
+    <attribute side="server" code="0x0C0D" define="CURRENT_ALTERNATIVE_DAY_ALTERNATIVE_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true">current alternative day max demand</attribute>
+    <attribute side="server" code="0x0C0E" define="PREVIOUS_DAY_ALTERNATIVE_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true">previous day alternative max demand</attribute>
+    <attribute side="server" code="0x0C0F" define="CURRENT_ALTERNATIVE_MONTH_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true">current alternative month max demand</attribute>
+    <attribute side="server" code="0x0C10" define="CURRENT_ALTERNATIVE_YEAR_MAX_DEMAND" type="INT24S" min="0x800001" max="0x7FFFFF" writable="false" optional="true">current alternative year max demand</attribute>
+    <attribute side="server" code="0x0C20" define="PREVIOUS_DAY2_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C21" define="PREVIOUS_DAY2_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C22" define="PREVIOUS_DAY3_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C23" define="PREVIOUS_DAY3_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C24" define="PREVIOUS_DAY4_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C25" define="PREVIOUS_DAY4_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C26" define="PREVIOUS_DAY5_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C27" define="PREVIOUS_DAY5_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C28" define="PREVIOUS_DAY6_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C29" define="PREVIOUS_DAY6_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C2A" define="PREVIOUS_DAY7_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C2B" define="PREVIOUS_DAY7_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C2C" define="PREVIOUS_DAY8_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C2D" define="PREVIOUS_DAY8_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C30" define="CURRENT_WEEK_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C31" define="CURRENT_WEEK_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week alternative consumption received</attribute>
+    <attribute side="server" code="0x0C32" define="PREVIOUS_WEEK_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C33" define="PREVIOUS_WEEK_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week alternative consumption received</attribute>
+    <attribute side="server" code="0x0C34" define="PREVIOUS_WEEK2_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C35" define="PREVIOUS_WEEK2_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C36" define="PREVIOUS_WEEK3_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C37" define="PREVIOUS_WEEK3_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C38" define="PREVIOUS_WEEK4_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C39" define="PREVIOUS_WEEK4_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C3A" define="PREVIOUS_WEEK5_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C3B" define="PREVIOUS_WEEK5_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT24U" min="0x000000" max="0xFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C40" define="CURRENT_MONTH_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C41" define="CURRENT_MONTH_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month alternative consumption received</attribute>
+    <attribute side="server" code="0x0C42" define="PREVIOUS_MONTH_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C43" define="PREVIOUS_MONTH_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month alternative consumption received</attribute>
+    <attribute side="server" code="0x0C44" define="PREVIOUS_MONTH2_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C45" define="PREVIOUS_MONTH2_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C46" define="PREVIOUS_MONTH3_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C47" define="PREVIOUS_MONTH3_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C48" define="PREVIOUS_MONTH4_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C49" define="PREVIOUS_MONTH4_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C4A" define="PREVIOUS_MONTH5_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C4B" define="PREVIOUS_MONTH5_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C4C" define="PREVIOUS_MONTH6_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C4D" define="PREVIOUS_MONTH6_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C4E" define="PREVIOUS_MONTH7_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C4F" define="PREVIOUS_MONTH7_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C50" define="PREVIOUS_MONTH8_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C51" define="PREVIOUS_MONTH8_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C52" define="PREVIOUS_MONTH9_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C53" define="PREVIOUS_MONTH9_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C54" define="PREVIOUS_MONTH10_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C55" define="PREVIOUS_MONTH10_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C56" define="PREVIOUS_MONTH11_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C57" define="PREVIOUS_MONTH11_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C58" define="PREVIOUS_MONTH12_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C59" define="PREVIOUS_MONTH12_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C5A" define="PREVIOUS_MONTH13_ALTERNATIVE_CONSUMPTION_DELIVERED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 alternative consumption delivered</attribute>
+    <attribute side="server" code="0x0C5B" define="PREVIOUS_MONTH13_ALTERNATIVE_CONSUMPTION_RECEIVED" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 alternative consumption received</attribute>
+    <attribute side="server" code="0x0C5C" define="CURRENT_DAY_ALTERNATIVE_MAX_DEMAND_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day alternative max demand delivered</attribute>
+    <attribute side="server" code="0x0C5D" define="CURRENT_DAY_ALTERNATIVE_MAX_DEMAND_DELIVERED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day alternative max demand delivered time</attribute>
+    <attribute side="server" code="0x0C5E" define="CURRENT_DAY_ALTERNATIVE_MAX_DEMAND_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day alternative max demand received</attribute>
+    <attribute side="server" code="0x0C5F" define="CURRENT_DAY_ALTERNATIVE_MAX_DEMAND_RECEIVED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current day alternative max demand received time</attribute>
+    <attribute side="server" code="0x0C60" define="PREVIOUS_DAY_ALTERNATIVE_MAX_DEMAND_DELIVERED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day alternative max demand delivered</attribute>
+    <attribute side="server" code="0x0C61" define="PREVIOUS_DAY_ALTERNATIVE_MAX_DEMAND_DELIVERED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day alternative max demand delivered time</attribute>
+    <attribute side="server" code="0x0C62" define="PREVIOUS_DAY_ALTERNATIVE_MAX_DEMAND_RECEIVED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day alternative max demand received</attribute>
+    <attribute side="server" code="0x0C63" define="PREVIOUS_DAY_ALTERNATIVE_MAX_DEMAND_RECEIVED_TIME" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">previous day alternative max demand received time</attribute>
+    <!-- Metering Cluster Server - Four-Quadrant Electricity Summations Attribute Set-->
+    <attribute side="server" code="0x0D01" define="CURRENT_ACTIVE_SUMMATION_Q1" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current active summation q1</attribute>
+    <attribute side="server" code="0x0D02" define="CURRENT_ACTIVE_SUMMATION_Q2" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current active summation q2</attribute>
+    <attribute side="server" code="0x0D03" define="CURRENT_ACTIVE_SUMMATION_Q3" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current active summation q3</attribute>
+    <attribute side="server" code="0x0D04" define="CURRENT_ACTIVE_SUMMATION_Q4" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current active summation q4</attribute>
+    <attribute side="server" code="0x0D05" define="CURRENT_REACTIVE_SUMMATION_Q1" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current reactive summation q1</attribute>
+    <attribute side="server" code="0x0D06" define="CURRENT_REACTIVE_SUMMATION_Q2" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current reactive summation q2</attribute>
+    <attribute side="server" code="0x0D07" define="CURRENT_REACTIVE_SUMMATION_Q3" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current reactive summation q3</attribute>
+    <attribute side="server" code="0x0D08" define="CURRENT_REACTIVE_SUMMATION_Q4" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.4-17-05019-001">current reactive summation q4</attribute>
+    <!-- Metering Cluster Client - Attributes -->
+    <!-- Metering Cluster Client - Notification Attribute Set -->
+    <attribute side="client" code="0x0000" define="FUNCTIONAL_NOTIFICATION_FLAGS" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">functional notification flags</attribute>
+    <attribute side="client" code="0x0001" define="NOTIFICATION_FLAGS_2" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 2</attribute>
+    <attribute side="client" code="0x0002" define="NOTIFICATION_FLAGS_3" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 3</attribute>
+    <attribute side="client" code="0x0003" define="NOTIFICATION_FLAGS_4" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 4</attribute>
+    <attribute side="client" code="0x0004" define="NOTIFICATION_FLAGS_5" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 5</attribute>
+    <attribute side="client" code="0x0005" define="NOTIFICATION_FLAGS_6" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 6</attribute>
+    <attribute side="client" code="0x0006" define="NOTIFICATION_FLAGS_7" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 7</attribute>
+    <attribute side="client" code="0x0007" define="NOTIFICATION_FLAGS_8" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="se-1.2a-07-5356-19">notification flags 8</attribute>
+    <!-- Metering Cluster Server - Commands -->
+    <command source="server" code="0x00" name="GetProfileResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        This command is generated when the Client command GetProfile is received.
+      </description>
+      <arg name="endTime" type="UTC_TIME"/>
+      <arg name="status" type="AmiGetProfileStatus"/>
+      <arg name="profileIntervalPeriod" type="AmiIntervalPeriod"/>
+      <arg name="numberOfPeriodsDelivered" type="INT8U"/>
+      <arg name="intervals" type="INT24U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="RequestMirror" optional="true" cli="zcl metering request-mirror">
+      <description>
+        This command is used to request the ESI to mirror Metering Device data.
+      </description>
+    </command>
+    <command source="server" code="0x02" name="RemoveMirror" optional="true" cli="zcl metering remove-mirror">
+      <description>
+        This command is used to request the ESI to remove its mirror of Metering Device data.
+      </description>
+    </command>
+    <command source="server" code="0x03" name="RequestFastPollModeResponse" optional="true" introducedIn="se-1.1-07-5356-16" disableDefaultResponse="true">
+      <description>
+        This command is generated when the client command Request Fast Poll Mode is received.
+      </description>
+      <arg name="appliedUpdatePeriod" type="INT8U"/>
+      <arg name="fastPollModeEndtime" type="UTC_TIME"/>
+    </command>
+    <command source="server" code="0x04" name="ScheduleSnapshotResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering sch-snapshot-resp" disableDefaultResponse="true">
+      <description>
+        This command is generated in response to a ScheduleSnapshot command, and is sent to confirm whether the requested snapshot schedule has been set up.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="snapshotResponsePayload" type="SnapshotResponsePayload" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="TakeSnapshotResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering take-snapshot-resp" disableDefaultResponse="true">
+      <description>
+        This command is generated in response to a TakeSnapshot command, and is sent to confirm whether the requested snapshot has been accepted and successfully taken.
+      </description>
+      <arg name="snapshotId" type="INT32U"/>
+      <arg name="snapshotConfirmation" type="SnapshotConfirmation"/>
+    </command>
+    <command source="server" code="0x06" name="PublishSnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering pub-ss">
+      <description>
+        This command is generated in response to a GetSnapshot command. It is used to return a single snapshot to the client.
+      </description>
+      <arg name="snapshotId" type="INT32U"/>
+      <arg name="snapshotTime" type="UTC_TIME"/>
+      <arg name="totalSnapshotsFound" type="INT8U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalCommands" type="INT8U"/>
+      <arg name="snapshotCause" type="SnapshotCause"/>
+      <arg name="snapshotPayloadType" type="SnapshotPayloadType"/>
+      <arg name="snapshotPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="GetSampledDataResponse" optional="true" introducedIn="se-1.2a-07-5356-19" disableDefaultResponse="true">
+      <description>
+        This command is used to send the requested sample data to the client. It is generated in response to a GetSampledData command.
+      </description>
+      <arg name="sampleId" type="INT16U"/>
+      <arg name="sampleStartTime" type="UTC_TIME"/>
+      <arg name="sampleType" type="SampleType"/>
+      <arg name="sampleRequestInterval" type="INT16U"/>
+      <arg name="numberOfSamples" type="INT16U"/>
+      <arg name="samples" type="INT24U" array="true"/>
+    </command>
+    <command source="server" code="0x08" name="ConfigureMirror" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering cfg-mirror">
+      <description>
+        ConfigureMirror is sent to the mirror once the mirror has been created. The command deals with the operational configuration of the Mirror.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="reportingInterval" type="INT24U"/>
+      <arg name="mirrorNotificationReporting" type="BOOLEAN"/>
+      <arg name="notificationScheme" type="INT8U"/>
+    </command>
+    <command source="server" code="0x09" name="ConfigureNotificationScheme" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering cfg-nft-scheme">
+      <description>
+        The ConfigureNotificationScheme is sent to the mirror once the mirror has been created. The command deals with the operational configuration of the Mirror and the device that reports to the mirror. No default schemes are allowed to be overwritten.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="notificationScheme" type="INT8U"/>
+      <arg name="notificationFlagOrder" type="BITMAP32"/>
+    </command>
+    <command source="server" code="0x0A" name="ConfigureNotificationFlags" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering cfg-nft-flags">
+      <description>
+        The ConfigureNotificationFlags command is used to set the commands relating to the bit value for each NotificationFlags attribute that the scheme is proposing to use.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="notificationScheme" type="INT8U"/>
+      <arg name="notificationFlagAttributeId" type="INT16U"/>
+      <arg name="clusterId" type="INT16U"/>
+      <arg name="manufacturerCode" type="INT16U"/>
+      <arg name="numberOfCommands" type="INT8U"/>
+      <arg name="commandIds" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x0B" name="GetNotifiedMessage" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering get-ntfy-msg">
+      <description>
+        The GetNotifiedMessage command is used only when a BOMD is being mirrored. This command provides a method for the BOMD to notify the Mirror message queue that it wants to receive commands that the Mirror has queued. The Notification flags set within the command shall inform the mirror of the commands that the BOMD is requesting.
+      </description>
+      <arg name="notificationScheme" type="INT8U"/>
+      <arg name="notificationFlagAttributeId" type="INT16U"/>
+      <arg name="notificationFlagsN" type="BITMAP32"/>
+    </command>
+    <command source="server" code="0x0C" name="SupplyStatusResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering sup-stat-rsp" disableDefaultResponse="true">
+      <description>
+        This command is transmitted by a Metering Device in response to a ChangeSupply command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="supplyStatus" type="MeteringSupplyStatus"/>
+    </command>
+    <command source="server" code="0x0D" name="StartSamplingResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering start-samp-rsp" disableDefaultResponse="true">
+      <description>
+        This command is transmitted by a Metering Device in response to a StartSampling command.
+      </description>
+      <arg name="sampleId" type="INT16U"/>
+    </command>
+    <!-- Metering Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetProfile" optional="true" cli="zcl metering get-profile">
+      <description>
+        The GetProfile command is generated when a client device wishes to retrieve a list of captured Energy, Gas or water consumption for profiling purposes.
+      </description>
+      <arg name="intervalChannel" type="AmiIntervalChannel"/>
+      <arg name="endTime" type="UTC_TIME"/>
+      <arg name="numberOfPeriods" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="RequestMirrorResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        The Request Mirror Response Command allows the ESI to inform a sleepy Metering Device it has the ability to store and mirror its data.
+      </description>
+      <arg name="endpointId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="MirrorRemoved" optional="true" cli="zcl metering mirror-removed">
+      <description>
+        The Mirror Removed Command allows the ESI to inform a sleepy Metering Device mirroring support has been removed or halted.
+      </description>
+      <arg name="endpointId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x03" name="RequestFastPollMode" optional="true" introducedIn="se-1.1-07-5356-16" cli="zcl metering req-fast-poll-mode">
+      <description>
+        The Request Fast Poll Mode command is generated when the metering client wishes to receive near real-time updates of InstantaneousDemand.
+      </description>
+      <arg name="fastPollUpdatePeriod" type="INT8U"/>
+      <arg name="duration" type="INT8U"/>
+    </command>
+    <command source="client" code="0x04" name="ScheduleSnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering sch-snapshot">
+      <description>
+        This command is used to set up a schedule of when the device shall create snapshot data.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="commandCount" type="INT8U"/>
+      <arg name="snapshotSchedulePayload" type="SnapshotSchedulePayload" array="true"/>
+    </command>
+    <command source="client" code="0x05" name="TakeSnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering take-snapshot">
+      <description>
+        This command is used to instruct the cluster server to take a single snapshot.
+      </description>
+      <arg name="snapshotCause" type="SnapshotCause"/>
+    </command>
+    <command source="client" code="0x06" name="GetSnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering get-snapshot">
+      <description>
+        This command is used to request snapshot data from the cluster server.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="latestEndTime" type="UTC_TIME"/>
+      <arg name="snapshotOffset" type="INT8U"/>
+      <arg name="snapshotCause" type="SnapshotCause"/>
+    </command>
+    <command source="client" code="0x07" name="StartSampling" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering start-sampling">
+      <description>
+        The sampling mechanism allows a set of samples of the specified type of data to be taken, commencing at the stipulated start time. This mechanism may run concurrently with the capturing of profile data, and may refer the same parameters, albeit possibly at a different sampling rate.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startSamplingTime" type="UTC_TIME"/>
+      <arg name="sampleType" type="SampleType"/>
+      <arg name="sampleRequestInterval" type="INT16U"/>
+      <arg name="maxNumberOfSamples" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="GetSampledData" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering get-sampled-data">
+      <description>
+        This command is used to request sampled data from the server. Note that it is the responsibility of the client to ensure that it does not request more samples than can be held in a single command payload.
+      </description>
+      <arg name="sampleId" type="INT16U"/>
+      <arg name="earliestSampleTime" type="UTC_TIME"/>
+      <arg name="sampleType" type="SampleType"/>
+      <arg name="numberOfSamples" type="INT16U"/>
+    </command>
+    <command source="client" code="0x09" name="MirrorReportAttributeResponse" optional="true" introducedIn="se-1.2a-07-5356-19" disableDefaultResponse="true">
+      <description>
+        This command is sent in response to the ReportAttribute command when the MirrorReporting attribute is set.
+      </description>
+      <arg name="notificationScheme" type="INT8U"/>
+      <arg name="notificationFlags" type="BITMAP32" array="true"/>
+    </command>
+    <command source="client" code="0x0A" name="ResetLoadLimitCounter" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering rst-load-limit-ctr">
+      <description>
+        The ResetLoadLimitCounter command shall cause the LoadLimitCounter attribute to be reset.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0B" name="ChangeSupply" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering chg-supply">
+      <description>
+        This command is sent from the Head-end or ESI to the Metering Device to instruct it to change the status of the valve or load switch, i.e. the supply.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="requestDateTime" type="UTC_TIME"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="proposedSupplyStatus" type="MeteringSupplyStatus"/>
+      <arg name="supplyControlBits" type="SupplyControlBits"/>
+    </command>
+    <command source="client" code="0x0C" name="LocalChangeSupply" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering local-chg-supply">
+      <description>
+        This command is a simplified version of the ChangeSupply command, intended to be sent from an IHD to a meter as the consequence of a user action on the IHD. Its purpose is to provide a local disconnection/reconnection button on the IHD in addition to the one on the meter.
+      </description>
+      <arg name="proposedSupplyStatus" type="ProposedSupplyStatus"/>
+    </command>
+    <command source="client" code="0x0D" name="SetSupplyStatus" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering set-supply-status">
+      <description>
+        This command is used to specify the required status of the supply following the occurance of certain events on the meter.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="supplyTamperState" type="SupplyStatus"/>
+      <arg name="supplyDepletionState" type="SupplyStatus"/>
+      <arg name="supplyUncontrolledFlowState" type="SupplyStatus"/>
+      <arg name="loadLimitSupplyState" type="SupplyStatus"/>
+    </command>
+    <command source="client" code="0x0E" name="SetUncontrolledFlowThreshold" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl metering set-uncntrl-flow-threshold">
+      <description>
+        This command is used to update the 'Uncontrolled Flow Rate' configuration data used by flow meters.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="uncontrolledFlowThreshold" type="INT16U"/>
+      <arg name="unitOfMeasure" type="AmiUnitOfMeasure"/>
+      <arg name="multiplier" type="INT16U"/>
+      <arg name="divisor" type="INT16U"/>
+      <arg name="stabilisationPeriod" type="INT8U"/>
+      <arg name="measurementPeriod" type="INT16U"/>
+    </command>
+  </cluster>
+  <!-- Messaging Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="MessagingControlMask" type="BITMAP8">
+    <field name="transMechanism" mask="0x03"/>
+    <field name="messageUrgency" mask="0x0C"/>
+    <field name="enhancedConfirmationRequest" mask="0x20"/>
+    <field name="messageConfirmation" mask="0x80"/>
+  </bitmap>
+  <enum name="MessagingControlTransmission" type="ENUM8">
+    <item name="normal" value="0x00"/>
+    <item name="normalAndAnonymous" value="0x01"/>
+    <item name="anonymous" value="0x02"/>
+    <item name="reserved" value="0x03"/>
+  </enum>
+  <enum name="MessagingControlImportance" type="ENUM8">
+    <item name="low" value="0x00"/>
+    <item name="medium" value="0x04"/>
+    <item name="high" value="0x08"/>
+    <item name="critical" value="0x0C"/>
+  </enum>
+  <enum name="MessagingControlEnhancedConfirmation" type="ENUM8">
+    <item name="notRequired" value="0x00"/>
+    <item name="required" value="0x20"/>
+  </enum>
+  <enum name="MessagingControlConfirmation" type="ENUM8">
+    <item name="notRequired" value="0x00"/>
+    <item name="required" value="0x80"/>
+  </enum>
+  <bitmap name="MessagingExtendedControlMask" type="BITMAP8">
+    <field name="messageConfirmationStatus" mask="0x01"/>
+  </bitmap>
+  <bitmap name="MessagingConfirmationControl" type="BITMAP8">
+    <field name="NoReturned" mask="0x01"/>
+    <field name="YesReturned" mask="0x02"/>
+  </bitmap>
+  <!-- Messaging Cluster -->
+  <cluster>
+    <name>Messaging</name>
+    <domain>SE</domain>
+    <description>This cluster provides an interface for passing text messages between SE devices.</description>
+    <code>0x0703</code>
+    <define>MESSAGING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Messaging Cluster Server - Attributes -->
+    <!-- Messaging Cluster Client - Attributes -->
+    <!-- Messaging Cluster Server - Commands -->
+    <command source="server" code="0x00" name="DisplayMessage" optional="false" cli="zcl msg disp">
+      <description>
+        Command description for DisplayMessage
+      </description>
+      <arg name="messageId" type="INT32U"/>
+      <arg name="messageControl" type="MessagingControlMask"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="message" type="CHAR_STRING"/>
+      <arg name="optionalExtendedMessageControl" type="MessagingExtendedControlMask" introducedIn="se-1.2a-07-5356-19" default="0x00"/>
+    </command>
+    <command source="server" code="0x01" name="CancelMessage" optional="false" cli="zcl msg cancel">
+      <description>
+        The CancelMessage command provides the ability to cancel the sending or acceptance of previously sent messages.
+      </description>
+      <arg name="messageId" type="INT32U"/>
+      <arg name="messageControl" type="MessagingControlMask"/>
+    </command>
+    <command source="server" code="0x02" name="DisplayProtectedMessage" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl msg disp-protd">
+      <description>
+        The DisplayProtected Message command is for use with messages that are protected by a password or PIN.
+      </description>
+      <arg name="messageId" type="INT32U"/>
+      <arg name="messageControl" type="MessagingControlMask"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="message" type="CHAR_STRING"/>
+      <arg name="optionalExtendedMessageControl" type="MessagingExtendedControlMask"/>
+    </command>
+    <command source="server" code="0x03" name="CancelAllMessages" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl msg x-all">
+      <description>
+        The CancelAllMessages command indicates to a client device that it should cancel all display messages currently held by it.
+      </description>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+    </command>
+    <!-- Messaging Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetLastMessage" optional="false" cli="zcl msg get">
+      <description>
+        Command description for GetLastMessage
+      </description>
+    </command>
+    <command source="client" code="0x01" name="MessageConfirmation" optional="false" cli="zcl msg confirm">
+      <description>
+        The Message Confirmation command provides an indication that a Utility Customer has acknowledged and/or accepted the contents of a previously sent message.  Enhanced Message Confirmation commands shall contain an answer of 'NO', 'YES' and/or a message confirmation string.
+      </description>
+      <arg name="messageId" type="INT32U"/>
+      <arg name="confirmationTime" type="UTC_TIME"/>
+      <arg name="messageConfirmationControl" type="BITMAP8" introducedIn="se-1.2a-07-5356-19"/>
+      <arg name="messageResponse" type="OCTET_STRING" introducedIn="se-1.2a-07-5356-19"/>
+    </command>
+    <command source="client" code="0x02" name="GetMessageCancellation" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl msg get-msg-x">
+      <description>
+        This command initiates the return of the first (and maybe only) Cancel All Messages command held on the associated server, and which has an implementation time equal to or later than the value indicated in the payload.
+      </description>
+      <arg name="earliestImplementationTime" type="UTC_TIME"/>
+    </command>
+  </cluster>
+  <!-- Tunneling Cluster - Structs, BITMAPs & ENUMs -->
+  <enum name="TunnelingProtocolId" type="ENUM8">
+    <item name="DLMS_COSEM" value="0x00"/>
+    <item name="IEC_61107" value="0x01"/>
+    <item name="ANSI_C12" value="0x02"/>
+    <item name="M_BUS" value="0x03"/>
+    <item name="SML" value="0x04"/>
+    <item name="ClimateTalk" value="0x05"/>
+    <item name="GB_HRGP" value="0x06"/>
+    <item name="IP_V4" value="0x07"/>
+    <item name="IP_V6" value="0x08"/>
+    <item name="Test" value="0xC7"/>
+  </enum>
+  <enum name="TunnelingTransferDataStatus" type="ENUM8">
+    <item name="NoSuchTunnel" value="0x00"/>
+    <item name="WrongDevice" value="0x01"/>
+    <item name="DataOverflow" value="0x02"/>
+  </enum>
+  <enum name="TunnelingTunnelStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="Busy" value="0x01"/>
+    <item name="NoMoreTunnelIds" value="0x02"/>
+    <item name="ProtocolNotSupported" value="0x03"/>
+    <item name="FlowControlNotSupported" value="0x04"/>
+  </enum>
+  <struct name="Protocol">
+    <item name="manufacturerCode" type="INT16U"/>
+    <item name="protocolId" type="INT8U"/>
+  </struct>
+  <!-- Tunneling Cluster -->
+  <cluster introducedIn="se-1.1-07-5356-16">
+    <name>Tunneling</name>
+    <domain>SE</domain>
+    <description>The tunneling cluster provides an interface for tunneling protocols.</description>
+    <code>0x0704</code>
+    <define>TUNNELING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Tunneling Cluster Server - Attributes -->
+    <attribute side="server" code="0x0000" define="CLOSE_TUNNEL_TIMEOUT" type="INT16U" min="0x0001" max="0xFFFF" writable="false" default="0xFFFF" optional="false">close tunnel timeout</attribute>
+    <!-- Tunneling Cluster Client - Attributes -->
+    <!-- Tunneling Cluster Client - Commands -->
+    <command source="client" code="0x00" name="RequestTunnel" optional="false" cli="zcl tunneling request">
+      <description>
+        RequestTunnel is the client command used to setup a tunnel association with the server. The request payload specifies the protocol identifier for the requested tunnel, a manufacturer code in case of proprietary protocols and the use of flow control for streaming protocols.
+      </description>
+      <arg name="protocolId" type="INT8U"/>
+      <arg name="manufacturerCode" type="INT16U"/>
+      <arg name="flowControlSupport" type="BOOLEAN"/>
+      <arg name="maximumIncomingTransferSize" type="INT16U" introducedIn="se-1.1a-07-5356-17"/>
+    </command>
+    <command source="client" code="0x01" name="CloseTunnel" optional="false" cli="zcl tunneling close">
+      <description>
+        Client command used to close the tunnel with the server. The parameter in the payload specifies the tunnel identifier of the tunnel that has to be closed. The server leaves the tunnel open and the assigned resources allocated until the client sends the CloseTunnel command or the CloseTunnelTimeout fires.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="TransferDataClientToServer" optional="false">
+      <description>
+        Command that indicates (if received) that the client has sent data to the server. The data itself is contained within the payload.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="data" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="TransferDataErrorClientToServer" optional="false">
+      <description>
+        This command is generated by the receiver of a TransferData command if the tunnel status indicates that something is wrong. There are two three cases in which TransferDataError is sent: (1) The TransferData received contains a TunnelID that does not match to any of the active tunnels of the receiving device. This could happen if a (sleeping) device sends a TransferData command to a tunnel that has been closed by the server after the CloseTunnelTimeout.  (2) The TransferData received contains a proper TunnelID of an active tunnel, but the device sending the data does not match to it.  (3) The TransferData received contains more data than indicated by the MaximumIncomingTransferSize of the receiving device.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="transferDataStatus" type="TunnelingTransferDataStatus"/>
+    </command>
+    <command source="client" code="0x04" name="AckTransferDataClientToServer" optional="true">
+      <description>
+        Command sent in response to each TransferData command in case - and only in case - flow control has been requested by the client in the TunnelRequest command and is supported by both tunnel endpoints. The response payload indicates the number of octets that may still be received by the receiver.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="numberOfBytesLeft" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="ReadyDataClientToServer" optional="true">
+      <description>
+        The ReadyData command is generated - after a receiver had to stop the dataflow using the AckTransferData(0) command - to indicate that the device is now ready to continue receiving data. The parameter NumberOfOctetsLeft gives a hint on how much space is left for the next data transfer. The ReadyData command is only issued if flow control is enabled.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="numberOfOctetsLeft" type="INT16U"/>
+    </command>
+    <command source="client" code="0x06" name="GetSupportedTunnelProtocols" optional="true" introducedIn="se-1.1a-07-5356-17">
+      <description>
+        Get Supported Tunnel Protocols is the client command used to determine the Tunnel protocols supported on another device.
+      </description>
+      <arg name="protocolOffset" type="INT8U"/>
+    </command>
+    <!-- Tunneling Cluster Server - Commands -->
+    <command source="server" code="0x00" name="RequestTunnelResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        RequestTunnelResponse is sent by the server in response to a RequestTunnel command previously received from the client. The response contains the status of the RequestTunnel command and a tunnel identifier corresponding to the tunnel that has been set-up in the server in case of success.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="tunnelStatus" type="TunnelingTunnelStatus"/>
+      <arg name="maximumIncomingTransferSize" type="INT16U" introducedIn="se-1.1a-07-5356-17"/>
+    </command>
+    <command source="server" code="0x01" name="TransferDataServerToClient" optional="false">
+      <description>
+        Command that transfers data from server to the client. The data itself has to be placed within the payload.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="data" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="TransferDataErrorServerToClient" optional="false">
+      <description>
+        This command is generated by the receiver of a TransferData command if the tunnel status indicates that something is wrong. There are two three cases in which TransferDataError is sent: (1) The TransferData received contains a TunnelID that does not match to any of the active tunnels of the receiving device. This could happen if a (sleeping) device sends a TransferData command to a tunnel that has been closed by the server after the CloseTunnelTimeout.  (2) The TransferData received contains a proper TunnelID of an active tunnel, but the device sending the data does not match to it.  (3) The TransferData received contains more data than indicated by the MaximumIncomingTransferSize of the receiving device.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="transferDataStatus" type="TunnelingTransferDataStatus"/>
+    </command>
+    <command source="server" code="0x03" name="AckTransferDataServerToClient" optional="true">
+      <description>
+        Command sent in response to each TransferData command in case - and only in case - flow control has been requested by the client in the TunnelRequest command and is supported by both tunnel endpoints. The response payload indicates the number of octets that may still be received by the receiver.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="numberOfBytesLeft" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="ReadyDataServerToClient" optional="true">
+      <description>
+        The ReadyData command is generated - after a receiver had to stop the dataflow using the AckTransferData(0) command - to indicate that the device is now ready to continue receiving data. The parameter NumberOfOctetsLeft gives a hint on how much space is left for the next data transfer. The ReadyData command is only issued if flow control is enabled.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+      <arg name="numberOfOctetsLeft" type="INT16U"/>
+    </command>
+    <command source="server" code="0x05" name="SupportedTunnelProtocolsResponse" optional="true" introducedIn="se-1.1a-07-5356-17" disableDefaultResponse="true">
+      <description>
+        Supported Tunnel Protocol Response is sent in response to a Get Supported Tunnel Protocols command previously received. The response contains a list of Tunnel protocols supported by the device; the payload of the response should be capable of holding up to 16 protocols.
+      </description>
+      <arg name="protocolListComplete" type="BOOLEAN"/>
+      <arg name="protocolCount" type="INT8U"/>
+      <arg name="protocolList" type="Protocol" array="true"/>
+      <!-- the protocolCount is followed by 'n' number of data structures (where n=protocolCount) of the following format: 2-byte manufacturer code, 1-byte protocol ID -->
+    </command>
+    <command source="server" code="0x06" name="TunnelClosureNotification" optional="true" introducedIn="se-1.1a-07-5356-17">
+      <description>
+        TunnelClosureNotification is sent by the server to indicate that a tunnel has been closed due to expiration of a CloseTunnelTimeout.
+      </description>
+      <arg name="tunnelId" type="INT16U"/>
+    </command>
+  </cluster>
+  <!-- Prepayment Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="PaymentControlConfiguration" type="BITMAP16">
+    <field name="DisconnectionEnabled" mask="0x0001"/>
+    <field name="PrepaymentEnabled" mask="0x0002"/>
+    <field name="CreditManagementEnabled" mask="0x0004"/>
+    <field name="CreditDisplayEnabled" mask="0x0010"/>
+    <field name="AccountBase" mask="0x0040"/>
+    <field name="ContactorFitted" mask="0x0080"/>
+    <field name="StandingChargeConfiguration" mask="0x0100"/>
+    <field name="EmergencyStandingChargeConfiguration" mask="0x0200"/>
+    <field name="DebtConfiguration" mask="0x0400"/>
+    <field name="EmergencyDebtConfiguration" mask="0x0800"/>
+  </bitmap>
+  <bitmap name="CreditStatus" type="BITMAP8">
+    <field name="CreditOk" mask="0x01"/>
+    <field name="LowCredit" mask="0x02"/>
+    <field name="EmergencyCreditEnabled" mask="0x04"/>
+    <field name="EmergencyCreditAvailable" mask="0x08"/>
+    <field name="EmergencyCreditSelected" mask="0x10"/>
+    <field name="EmergencyCreditInUse" mask="0x20"/>
+    <field name="CreditExhausted" mask="0x40"/>
+  </bitmap>
+  <enum name="DebtRecoveryMethod" type="ENUM8">
+    <item name="TimeBased" value="0x00"/>
+    <item name="PercentageBased" value="0x01"/>
+    <item name="CatchUpBased" value="0x02"/>
+  </enum>
+  <enum name="DebtRecoveryFrequency" type="ENUM8">
+    <item name="PerHour" value="0x00"/>
+    <item name="PerDay" value="0x01"/>
+    <item name="PerWeek" value="0x02"/>
+    <item name="PerMonth" value="0x03"/>
+    <item name="PerQuarter" value="0x04"/>
+  </enum>
+  <bitmap name="PrepaymentAlarmStatus" type="BITMAP16">
+    <field name="LowCreditWarning" mask="0x0001"/>
+    <field name="TopUpCodeError" mask="0x0002"/>
+    <field name="TopUpCodeAlreadyUsed" mask="0x0004"/>
+    <field name="TopUpCodeInvalid" mask="0x0008"/>
+    <field name="FriendlyCreditInUse" mask="0x0010"/>
+    <field name="FriendlyCreditPeriodEndWarning" mask="0x0020"/>
+    <field name="EcAvailable" mask="0x0040"/>
+    <field name="UnauthorisedEnergyUse" mask="0x0080"/>
+    <field name="DisconnectedSupplyDueToCredit" mask="0x0100"/>
+    <field name="DisconnectedSupplyDueToTamper" mask="0x0200"/>
+    <field name="DisconnectedSupplyDueToHes" mask="0x0400"/>
+    <field name="PhysicalAttack" mask="0x0800"/>
+    <field name="ElectronicAttack" mask="0x1000"/>
+    <field name="ManufactureAlarmCodeA" mask="0x2000"/>
+    <field name="ManufactureAlarmCodeB" mask="0x4000"/>
+  </bitmap>
+  <enum name="PrePayGenericAlarmGroup" type="ENUM8">
+    <item name="LowCredit" value="0x00"/>
+    <item name="NoCredit" value="0x01"/>
+    <item name="CreditExhausted" value="0x02"/>
+    <item name="EmergencyCreditEnabled" value="0x03"/>
+    <item name="EmergencyCreditExhausted" value="0x04"/>
+    <item name="IhdLowCreditWarning" value="0x05"/>
+    <item name="EventLogCleared" value="0x06"/>
+  </enum>
+  <enum name="PrepaySwitchAlarmGroup" type="ENUM8">
+    <item name="SupplyOn" value="0x10"/>
+    <item name="SupplyArm" value="0x11"/>
+    <item name="SupplyOff" value="0x12"/>
+    <item name="DisconnectionFailure" value="0x13"/>
+    <item name="DisconnectedDueToTamperDetected" value="0x14"/>
+    <item name="DisconnectedDueToCutOffValue" value="0x15"/>
+    <item name="RemoteDisconnected" value="0x16"/>
+  </enum>
+  <enum name="PrepayEventAlarmGroup" type="ENUM8">
+    <item name="PhysicalAttackOnThePrepayMeter" value="0x20"/>
+    <item name="ElectronicAttackOnThePrepayMeter" value="0x21"/>
+    <item name="DiscountApplied" value="0x22"/>
+    <item name="CreditAdjustment" value="0x23"/>
+    <item name="CreditAdjustmentFail" value="0x24"/>
+    <item name="DebtAdjustment" value="0x25"/>
+    <item name="DebtAdjustmentFail" value="0x26"/>
+    <item name="ModeChange" value="0x27"/>
+    <item name="TopupCodeError" value="0x28"/>
+    <item name="TopupAlreadyUsed" value="0x29"/>
+    <item name="TopupCodeInvalid" value="0x2A"/>
+    <item name="FriendlyCreditInUse" value="0x2B"/>
+    <item name="FriendlyCreditPeriodEndWarning" value="0x2C"/>
+    <item name="FriendlyCreditPeriodEnd" value="0x2D"/>
+    <item name="ErrorRegClear" value="0x30"/>
+    <item name="AlarmRegClear" value="0x31"/>
+    <item name="PrepayClusterNotFound" value="0x32"/>
+    <item name="ModeCredit2Prepay" value="0x41"/>
+    <item name="ModePrepay2Credit" value="0x42"/>
+    <item name="ModeDefault" value="0x43"/>
+  </enum>
+  <enum name="OriginatingDevice" type="ENUM8">
+    <item name="EnergyServiceInterface" value="0x00"/>
+    <item name="Meter" value="0x01"/>
+    <item name="InHomeDisplayDevice" value="0x02"/>
+  </enum>
+  <bitmap name="OriginatorIdSupplyControlBits" type="BITMAP8">
+    <field name="AcknowledgeRequired" mask="0x01"/>
+  </bitmap>
+  <enum name="DebtAmountType" type="ENUM8">
+    <item name="Type1Absolute" value="0x00"/>
+    <item name="Type1Incremental" value="0x01"/>
+    <item name="Type2Absolute" value="0x02"/>
+    <item name="Type2Incremental" value="0x03"/>
+    <item name="Type3Absolute" value="0x04"/>
+    <item name="Type3Incremental" value="0x05"/>
+  </enum>
+  <enum name="CreditAdjustmentType" type="ENUM8">
+    <item name="CreditIncremental" value="0x00"/>
+    <item name="CreditAbsolute" value="0x01"/>
+  </enum>
+  <bitmap name="PrepaySnapshotPayloadCause" type="BITMAP32">
+    <field name="General" mask="0x00000001"/>
+    <field name="ChangeOfTariffInformation" mask="0x00000008"/>
+    <field name="ChangeOfPriceMatrix" mask="0x00000010"/>
+    <field name="ManuallyTriggeredFromClient" mask="0x00000400"/>
+    <field name="ChangeOfTenancy" mask="0x00001000"/>
+    <field name="ChangeOfSupplier" mask="0x00002000"/>
+    <field name="ChangeOfMeterMode" mask="0x00004000"/>
+    <field name="TopUpAddition" mask="0x00040000"/>
+    <field name="DebtCreditAddition" mask="0x00080000"/>
+  </bitmap>
+  <enum name="RepaymentDebtType" type="ENUM8">
+    <item name="Debt1" value="0x00"/>
+    <item name="Debt2" value="0x01"/>
+    <item name="Debt3" value="0x02"/>
+    <item name="AllDebts" value="0xFF"/>
+  </enum>
+  <enum name="PrepaySnapshotPayloadType" type="ENUM8">
+    <item name="DebtCreditStatus" value="0x00"/>
+    <item name="NotUsed" value="0xFF"/>
+  </enum>
+  <bitmap name="FriendlyCredit" type="BITMAP8">
+    <field name="FriendlyCreditEnabled" mask="0x01"/>
+  </bitmap>
+  <enum name="ResultType" type="ENUM8">
+    <item name="Accepted" value="0x00"/>
+    <item name="RejectedInvalidTopUp" value="0x01"/>
+    <item name="RejectedDuplicateTopUp" value="0x02"/>
+    <item name="RejectedError" value="0x03"/>
+    <item name="RejectedMaxCreditReached" value="0x04"/>
+    <item name="RejectedKeypadLock" value="0x05"/>
+    <item name="RejectedTopUpValueTooLarge" value="0x06"/>
+    <item name="AcceptedSupplyEnabled" value="0x10"/>
+    <item name="AcceptedSupplyDisabled" value="0x11"/>
+    <item name="AcceptedSupplyArmed" value="0x12"/>
+  </enum>
+  <struct name="TopUpPayload">
+    <item name="topUpCode" type="OCTET_STRING"/>
+    <item name="topUpAmount" type="INT32S"/>
+    <item name="topUpTime" type="UTC_TIME"/>
+  </struct>
+  <struct name="DebtPayload">
+    <item name="collectionTime" type="UTC_TIME"/>
+    <item name="amountCollected" type="INT32U"/>
+    <item name="debtType" type="RepaymentDebtType"/>
+    <item name="outstandingDebt" type="INT32U"/>
+  </struct>
+  <!-- Prepayment Cluster -->
+  <cluster introducedIn="se-1.1-07-5356-16">
+    <name>Prepayment</name>
+    <domain>SE</domain>
+    <description>The Prepayment Cluster provides the facility to pass messages relating to prepayment between devices on the HAN.</description>
+    <code>0x0705</code>
+    <define>PREPAYMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Prepayment Cluster Server - Attributes -->
+    <!-- Prepayment Cluster Server - Prepayment Information Attribute Set -->
+    <attribute side="server" code="0x0000" define="PAYMENT_CONTROL_CONFIGURATION" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">payment control configuration</attribute>
+    <attribute side="server" code="0x0001" define="CREDIT_REMAINING" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">credit remaining</attribute>
+    <attribute side="server" code="0x0002" define="EMERGENCY_CREDIT_REMAINING" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">emergency credit remaining</attribute>
+    <attribute side="server" code="0x0003" define="CREDIT_STATUS" type="BITMAP8" min="0x00" max="0x40" writable="false" default="0x00" optional="true">credit status</attribute>
+    <attribute side="server" code="0x0004" define="CREDIT_REMAINING_TIMESTAMP" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">credit remaining timestamp</attribute>
+    <attribute side="server" code="0x0005" define="ACCUMULATED_DEBT" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">accumulated debt</attribute>
+    <attribute side="server" code="0x0006" define="OVERALL_DEBT_CAP" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">overall debt cap</attribute>
+    <attribute side="server" code="0x0010" define="EMERGENCY_CREDIT_LIMIT_ALLOWANCE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">emergency credit limit allowance</attribute>
+    <attribute side="server" code="0x0011" define="EMERGENCY_CREDIT_THRESHOLD" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">emergency credit threshold</attribute>
+    <attribute side="server" code="0x0020" define="TOTAL_CREDIT_ADDED" type="INT48U" min="0x000000000000" max="0xFFFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">total credit added</attribute>
+    <attribute side="server" code="0x0021" define="MAX_CREDIT_LIMIT" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">max credit limit</attribute>
+    <attribute side="server" code="0x0022" define="MAX_CREDIT_PER_TOP_UP" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">max credit per top up</attribute>
+    <attribute side="server" code="0x0030" define="FRIENDLY_CREDIT_WARNING" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x0A" optional="true" introducedIn="se-1.2a-07-5356-19">friendly credit warning</attribute>
+    <attribute side="server" code="0x0031" define="LOW_CREDIT_WARNING" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">low credit warning level</attribute>
+    <attribute side="server" code="0x0032" define="IHD_LOW_CREDIT_WARNING" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="true" optional="true" introducedIn="se-1.2a-07-5356-19">IHD low credit warning level</attribute>
+    <attribute side="server" code="0x0033" define="INTERRUPT_SUSPEND_TIME" type="INT8U" min="0x00" max="0xFF" writable="false" default="60" optional="true" introducedIn="se-1.2a-07-5356-19">Interrupt Suspend Time</attribute>
+    <attribute side="server" code="0x0034" define="REMAINING_FRIENDLY_CREDIT_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">remaining friendly credit time</attribute>
+    <attribute side="server" code="0x0035" define="NEXT_FRIENDLY_CREDIT_PERIOD" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">next friendly credit period</attribute>
+    <attribute side="server" code="0x0040" define="CUT_OFF_VALUE" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">cut off value</attribute>
+    <attribute side="server" code="0x0080" define="TOKEN_CARRIER_ID" type="OCTET_STRING" length="20" writable="true" optional="true" introducedIn="se-1.2a-07-5356-19">token carrier id</attribute>
+    <!-- Prepayment Cluster Server - Top-Up Attribute Set -->
+    <attribute side="server" code="0x0100" define="TOP_UP_DATE_TIME_1" type="UTC_TIME" writable="false" optional="true">top up date/time #1</attribute>
+    <attribute side="server" code="0x0101" define="TOP_UP_AMOUNT_1" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">top up amount #1</attribute>
+    <attribute side="server" code="0x0102" define="TOP_UP_ORIGINATING_DEVICE_1" type="ENUM8" writable="false" optional="true">top up originating device #1</attribute>
+    <attribute side="server" code="0x0103" define="TOP_UP_CODE_1" type="OCTET_STRING" length="25" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">top up code #1</attribute>
+    <attribute side="server" code="0x0110" define="TOP_UP_DATE_TIME_2" type="UTC_TIME" writable="false" optional="true">top up date/time #2</attribute>
+    <attribute side="server" code="0x0111" define="TOP_UP_AMOUNT_2" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">top up amount #2</attribute>
+    <attribute side="server" code="0x0112" define="TOP_UP_ORIGINATING_DEVICE_2" type="ENUM8" writable="false" optional="true">top up originating device #2</attribute>
+    <attribute side="server" code="0x0113" define="TOP_UP_CODE_2" type="OCTET_STRING" length="25" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">top up code #2</attribute>
+    <attribute side="server" code="0x0120" define="TOP_UP_DATE_TIME_3" type="UTC_TIME" writable="false" optional="true">top up date/time #3</attribute>
+    <attribute side="server" code="0x0121" define="TOP_UP_AMOUNT_3" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">top up amount #3</attribute>
+    <attribute side="server" code="0x0122" define="TOP_UP_ORIGINATING_DEVICE_3" type="ENUM8" writable="false" optional="true">top up originating device #3</attribute>
+    <attribute side="server" code="0x0123" define="TOP_UP_CODE_3" type="OCTET_STRING" length="25" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">top up code #3</attribute>
+    <attribute side="server" code="0x0130" define="TOP_UP_DATE_TIME_4" type="UTC_TIME" writable="false" optional="true">top up date/time #4</attribute>
+    <attribute side="server" code="0x0131" define="TOP_UP_AMOUNT_4" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">top up amount #4</attribute>
+    <attribute side="server" code="0x0132" define="TOP_UP_ORIGINATING_DEVICE_4" type="ENUM8" writable="false" optional="true">top up originating device #4</attribute>
+    <attribute side="server" code="0x0133" define="TOP_UP_CODE_4" type="OCTET_STRING" length="25" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">top up code #4</attribute>
+    <attribute side="server" code="0x0140" define="TOP_UP_DATE_TIME_5" type="UTC_TIME" writable="false" optional="true">top up date/time #5</attribute>
+    <attribute side="server" code="0x0141" define="TOP_UP_AMOUNT_5" type="INT32S" min="-2147483647" max="2147483647" writable="false" optional="true">top up amount #5</attribute>
+    <attribute side="server" code="0x0142" define="TOP_UP_ORIGINATING_DEVICE_5" type="ENUM8" writable="false" optional="true">top up originating device #5</attribute>
+    <attribute side="server" code="0x0143" define="TOP_UP_CODE_5" type="OCTET_STRING" length="25" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">top up code #5</attribute>
+    <!-- Prepayment Cluster Server - Debt Attribute Set -->
+    <!-- removedIn is not supported for attributes so just commenting these attributes out
+    <attribute side="server" code="0x0200" define="FUEL_DEBT_REMAINING"                type="INT48U"       min="0x000000000000"  max="0xFFFFFFFFFFFF"     writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >fuel debt remaining</attribute>
+    <attribute side="server" code="0x0201" define="FUEL_DEBT_RECOVERY_RATE"            type="INT32U"       min="0x00000000"  max="0xFFFFFFFF"             writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >fuel debt recovery rate</attribute>
+    <attribute side="server" code="0x0202" define="FUEL_DEBT_RECOVERY_PERIOD"          type="ENUM8"        min="0x00"        max="0xFF"                   writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >fuel debt recovery period</attribute>
+    <attribute side="server" code="0x0203" define="NON_FUEL_DEBT_REMAINING"            type="INT48U"       min="0x000000000000"  max="0xFFFFFFFFFFFF"     writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >non fuel debt remaining</attribute>
+    <attribute side="server" code="0x0204" define="NON_FUEL_DEBT_RECOVERY_RATE"        type="INT32U"       min="0x00000000"  max="0xFFFFFFFF"             writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >non fuel debt recovery rate</attribute>
+    <attribute side="server" code="0x0205" define="NON_FUEL_DEBT_RECOVERY_PERIOD"      type="ENUM8"        min="0x00"        max="0xFF"                   writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >non fuel debt recovery period</attribute>
+    -->
+    <attribute side="server" code="0x0210" define="DEBT_LABEL_1" type="OCTET_STRING" length="12" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt label 1</attribute>
+    <attribute side="server" code="0x0211" define="DEBT_AMOUNT_1" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt amount 1</attribute>
+    <attribute side="server" code="0x0212" define="DEBT_RECOVERY_METHOD_1" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery method 1</attribute>
+    <attribute side="server" code="0x0213" define="DEBT_RECOVERY_START_TIME_1" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery start time 1</attribute>
+    <attribute side="server" code="0x0214" define="DEBT_RECOVERY_COLLECTION_TIME_1" type="INT16U" min="0x0000" max="0x05A0" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery collection time 1</attribute>
+    <attribute side="server" code="0x0216" define="DEBT_RECOVERY_FREQUENCY_1" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery frequency 1</attribute>
+    <attribute side="server" code="0x0217" define="DEBT_RECOVERY_AMOUNT_1" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery amount 1</attribute>
+    <attribute side="server" code="0x0219" define="DEBT_RECOVERY_TOP_UP_PERCENTAGE_1" type="INT16U" min="0x0000" max="0x2710" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery top up percentage 1</attribute>
+    <attribute side="server" code="0x0220" define="DEBT_LABEL_2" type="OCTET_STRING" length="12" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt label 2</attribute>
+    <attribute side="server" code="0x0221" define="DEBT_AMOUNT_2" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt amount 2</attribute>
+    <attribute side="server" code="0x0222" define="DEBT_RECOVERY_METHOD_2" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery method 2</attribute>
+    <attribute side="server" code="0x0223" define="DEBT_RECOVERY_START_TIME_2" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery start time 2</attribute>
+    <attribute side="server" code="0x0224" define="DEBT_RECOVERY_COLLECTION_TIME_2" type="INT16U" min="0x0000" max="0x05A0" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery collection time 2</attribute>
+    <attribute side="server" code="0x0226" define="DEBT_RECOVERY_FREQUENCY_2" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery frequency 2</attribute>
+    <attribute side="server" code="0x0227" define="DEBT_RECOVERY_AMOUNT_2" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery amount 2</attribute>
+    <attribute side="server" code="0x0229" define="DEBT_RECOVERY_TOP_UP_PERCENTAGE_2" type="INT16U" min="0x0000" max="0x2710" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery top up percentage 2</attribute>
+    <attribute side="server" code="0x0230" define="DEBT_LABEL_3" type="OCTET_STRING" length="12" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt label 3</attribute>
+    <attribute side="server" code="0x0231" define="DEBT_AMOUNT_3" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt amount 3</attribute>
+    <attribute side="server" code="0x0232" define="DEBT_RECOVERY_METHOD_3" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery method 3</attribute>
+    <attribute side="server" code="0x0233" define="DEBT_RECOVERY_START_TIME_3" type="UTC_TIME" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery start time 3</attribute>
+    <attribute side="server" code="0x0234" define="DEBT_RECOVERY_COLLECTION_TIME_3" type="INT16U" min="0x0000" max="0x05A0" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery collection time 3</attribute>
+    <attribute side="server" code="0x0236" define="DEBT_RECOVERY_FREQUENCY_3" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery frequency 3</attribute>
+    <attribute side="server" code="0x0237" define="DEBT_RECOVERY_AMOUNT_3" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery amount 3</attribute>
+    <attribute side="server" code="0x0239" define="DEBT_RECOVERY_TOP_UP_PERCENTAGE_3" type="INT16U" min="0x0000" max="0x2710" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">debt recovery top up percentage 3</attribute>
+    <!-- Prepayment Cluster Server - Supply Control Attribute Attribute Set -->
+    <!-- removedIn is not supported for attributes so just commenting these attributes out
+    <attribute side="server" code="0x0300" define="PROPOSED_CHANGE_PROVIDER_ID"              type="INT32U"       min="0x00000000"  max="0xFFFFFFFF"       writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >proposed change provider id</attribute>
+    <attribute side="server" code="0x0301" define="PROPOSED_CHANGE_IMPLEMENTATION_TIME"      type="UTC_TIME"                                              writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >proposed change implementation time</attribute>
+    <attribute side="server" code="0x0302" define="PROPOSED_CHANGE_SUPPLY_STATUS"            type="ENUM8"        min="0x00"        max="0xFF"             writable="false"                  optional="true" removedIn="se-1.2a-07-5356-19"    >proposed change supply status</attribute>
+    <attribute side="server" code="0x0303" define="DELAYED_SUPPLY_INTERRUPT_VALUE_REMAINING" type="INT16U"       min="0x0000"      max="0xFFFF"           writable="true"                   optional="true" removedIn="se-1.2a-07-5356-19"    >delayed supply interrupt value remaining</attribute>
+    <attribute side="server" code="0x0304" define="DELAYED_SUPPLY_INTERRUPT_VALUE_TYPE"      type="ENUM8"        min="0x00"        max="0xFF"             writable="true"                   optional="true" removedIn="se-1.2a-07-5356-19"    >delayed supply interrupt value type</attribute>
+    -->
+    <!-- Prepayment Cluster Server - Alarms Attribute Set -->
+    <attribute side="server" code="0x0400" define="PREPAYMENT_ALARM_STATUS" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-21">prepayment alarm status</attribute>
+    <attribute side="server" code="0x0401" define="PREPAY_GENERIC_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.2a-07-5356-19">prepay generic alarm mask</attribute>
+    <attribute side="server" code="0x0402" define="PREPAY_SWITCH_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.2a-07-5356-19">prepay switch alarm mask</attribute>
+    <attribute side="server" code="0x0403" define="PREPAY_EVENT_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true" introducedIn="se-1.2a-07-5356-19">prepay event alarm mask</attribute>
+    <!-- Prepayment Cluster Server - Historical Cost Consumption Information Attribute Set -->
+    <attribute side="server" code="0x0500" define="HISTORICAL_COST_CONSUMPTION_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">historical cost consumption formatting</attribute>
+    <attribute side="server" code="0x0501" define="CONSUMPTION_UNIT_OF_MEASUREMENT" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="se-1.2a-07-5356-19">consumption unit of measurement</attribute>
+    <attribute side="server" code="0x0502" define="CURRENCY_SCALING_FACTOR" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">currency scaling factor</attribute>
+    <attribute side="server" code="0x0503" define="PREPAYMANT_CURRENCY" type="INT16U" min="0x0000" max="0x0FFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">currency</attribute>
+    <attribute side="server" code="0x051C" define="CURRENT_DAY_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current day cost consumption delivered</attribute>
+    <attribute side="server" code="0x051D" define="CURRENT_DAY_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current day cost consumption received</attribute>
+    <attribute side="server" code="0x051E" define="PREVIOUS_DAY_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day cost consumption delivered</attribute>
+    <attribute side="server" code="0x051F" define="PREVIOUS_DAY_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day cost consumption received</attribute>
+    <attribute side="server" code="0x0520" define="PREVIOUS_DAY_2_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0521" define="PREVIOUS_DAY_2_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 2 cost consumption received</attribute>
+    <attribute side="server" code="0x0522" define="PREVIOUS_DAY_3_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0523" define="PREVIOUS_DAY_3_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 3 cost consumption received</attribute>
+    <attribute side="server" code="0x0524" define="PREVIOUS_DAY_4_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0525" define="PREVIOUS_DAY_4_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 4 cost consumption received</attribute>
+    <attribute side="server" code="0x0526" define="PREVIOUS_DAY_5_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0527" define="PREVIOUS_DAY_5_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 5 cost consumption received</attribute>
+    <attribute side="server" code="0x0528" define="PREVIOUS_DAY_6_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0529" define="PREVIOUS_DAY_6_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 6 cost consumption received</attribute>
+    <attribute side="server" code="0x052A" define="PREVIOUS_DAY_7_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 cost consumption delivered</attribute>
+    <attribute side="server" code="0x052B" define="PREVIOUS_DAY_7_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 7 cost consumption received</attribute>
+    <attribute side="server" code="0x052C" define="PREVIOUS_DAY_8_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 cost consumption delivered</attribute>
+    <attribute side="server" code="0x052D" define="PREVIOUS_DAY_8_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous day 8 cost consumption received</attribute>
+    <attribute side="server" code="0x0530" define="CURRENT_WEEK_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week cost consumption delivered</attribute>
+    <attribute side="server" code="0x0531" define="CURRENT_WEEK_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current week cost consumption received</attribute>
+    <attribute side="server" code="0x0532" define="PREVIOUS_WEEK_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week cost consumption delivered</attribute>
+    <attribute side="server" code="0x0533" define="PREVIOUS_WEEK_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week cost consumption received</attribute>
+    <attribute side="server" code="0x0534" define="PREVIOUS_WEEK_2_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0535" define="PREVIOUS_WEEK_2_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 2 cost consumption received</attribute>
+    <attribute side="server" code="0x0536" define="PREVIOUS_WEEK_3_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0537" define="PREVIOUS_WEEK_3_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 3 cost consumption received</attribute>
+    <attribute side="server" code="0x0538" define="PREVIOUS_WEEK_4_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0539" define="PREVIOUS_WEEK_4_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 4 cost consumption received</attribute>
+    <attribute side="server" code="0x053A" define="PREVIOUS_WEEK_5_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 cost consumption delivered</attribute>
+    <attribute side="server" code="0x053B" define="PREVIOUS_WEEK_5_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous week 5 cost consumption received</attribute>
+    <attribute side="server" code="0x0540" define="CURRENT_MONTH_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month cost consumption delivered</attribute>
+    <attribute side="server" code="0x0541" define="CURRENT_MONTH_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">current month cost consumption received</attribute>
+    <attribute side="server" code="0x0542" define="PREVIOUS_MONTH_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month cost consumption delivered</attribute>
+    <attribute side="server" code="0x0543" define="PREVIOUS_MONTH_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month cost consumption received</attribute>
+    <attribute side="server" code="0x0544" define="PREVIOUS_MONTH_2_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0545" define="PREVIOUS_MONTH_2_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 2 cost consumption received</attribute>
+    <attribute side="server" code="0x0546" define="PREVIOUS_MONTH_3_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0547" define="PREVIOUS_MONTH_3_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 3 cost consumption received</attribute>
+    <attribute side="server" code="0x0548" define="PREVIOUS_MONTH_4_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0549" define="PREVIOUS_MONTH_4_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 4 cost consumption received</attribute>
+    <attribute side="server" code="0x054A" define="PREVIOUS_MONTH_5_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 cost consumption delivered</attribute>
+    <attribute side="server" code="0x054B" define="PREVIOUS_MONTH_5_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 5 cost consumption received</attribute>
+    <attribute side="server" code="0x054C" define="PREVIOUS_MONTH_6_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 cost consumption delivered</attribute>
+    <attribute side="server" code="0x054D" define="PREVIOUS_MONTH_6_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 6 cost consumption received</attribute>
+    <attribute side="server" code="0x054E" define="PREVIOUS_MONTH_7_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 cost consumption delivered</attribute>
+    <attribute side="server" code="0x054F" define="PREVIOUS_MONTH_7_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 7 cost consumption received</attribute>
+    <attribute side="server" code="0x0550" define="PREVIOUS_MONTH_8_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0551" define="PREVIOUS_MONTH_8_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 8 cost consumption received</attribute>
+    <attribute side="server" code="0x0552" define="PREVIOUS_MONTH_9_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0553" define="PREVIOUS_MONTH_9_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 9 cost consumption received</attribute>
+    <attribute side="server" code="0x0554" define="PREVIOUS_MONTH_10_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0555" define="PREVIOUS_MONTH_10_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 10 cost consumption received</attribute>
+    <attribute side="server" code="0x0556" define="PREVIOUS_MONTH_11_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0557" define="PREVIOUS_MONTH_11_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 11 cost consumption received</attribute>
+    <attribute side="server" code="0x0558" define="PREVIOUS_MONTH_12_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 cost consumption delivered</attribute>
+    <attribute side="server" code="0x0559" define="PREVIOUS_MONTH_12_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 12 cost consumption received</attribute>
+    <attribute side="server" code="0x055A" define="PREVIOUS_MONTH_13_COST_CONSUMPTION_DELIVERED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 cost consumption delivered</attribute>
+    <attribute side="server" code="0x055B" define="PREVIOUS_MONTH_13_COST_CONSUMPTION_RECEIVED" type="INT48U" min="0x0000000000" max="0xFFFFFFFFFF" writable="false" optional="true" introducedIn="se-1.2a-07-5356-19">previous month 13 cost consumption received</attribute>
+    <attribute side="server" code="0x055C" define="PREPAYMENT_HISTORICAL_FREEZE_TIME" type="INT16U" min="0x0000" max="0x173C" writable="false" default="0x0000" optional="true" introducedIn="se-1.2a-07-5356-19">historical freeze time</attribute>
+    <!-- Prepayment Cluster Client - Attributes -->
+    <!-- Prepayment Cluster Client - Commands -->
+    <command source="client" code="0x00" name="SelectAvailableEmergencyCredit" optional="true" cli="zcl prepayment sel-av-em-cred">
+      <description>
+        This command is sent to the Metering Device to activate the use of any Emergency Credit available on the Metering Device.
+      </description>
+      <arg name="commandIssueDateTime" type="UTC_TIME"/>
+      <arg name="originatingDevice" type="OriginatingDevice"/>
+      <arg name="siteId" type="OCTET_STRING" removedIn="se-1.2a-07-5356-19"/>
+      <arg name="meterSerialNumber" type="OCTET_STRING" removedIn="se-1.2a-07-5356-19"/>
+    </command>
+    <command source="client" code="0x02" name="ChangeDebt" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment chg-debt">
+      <description>
+        The ChangeDebt command is send to the Metering Device to change the fuel or Non fuel debt values.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="debtLabel" type="OCTET_STRING"/>
+      <arg name="debtAmount" type="INT32U"/>
+      <arg name="debtRecoveryMethod" type="DebtRecoveryMethod"/>
+      <arg name="debtAmountType" type="DebtAmountType"/>
+      <arg name="debtRecoveryStartTime" type="UTC_TIME"/>
+      <arg name="debtRecoveryCollectionTime" type="INT16U"/>
+      <arg name="debtRecoveryFrequency" type="DebtRecoveryFrequency"/>
+      <arg name="debtRecoveryAmount" type="INT32U"/>
+      <arg name="debtRecoveryBalancePercentage" type="INT16U"/>
+    </command>
+    <command source="client" code="0x03" name="EmergencyCreditSetup" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment em-cred-setup">
+      <description>
+        This command is a method to set up the parameters for the emergency credit.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="emergencyCreditLimit" type="INT32U"/>
+      <arg name="emergencyCreditThreshold" type="INT32U"/>
+    </command>
+    <command source="client" code="0x04" name="ConsumerTopUp" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment cons-top-up">
+      <description>
+        The ConsumerTopUp command is used by the IPD and the ESI as a method of applying credit top up values to the prepayment meter.
+      </description>
+      <arg name="originatingDevice" type="OriginatingDevice"/>
+      <arg name="topUpCode" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x05" name="CreditAdjustment" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment cred-adj">
+      <description>
+        The CreditAdjustment command is sent to update the accounting base for the Prepayment meter.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="creditAdjustmentType" type="CreditAdjustmentType"/>
+      <arg name="creditAdjustmentValue" type="INT32U"/>
+    </command>
+    <command source="client" code="0x06" name="ChangePaymentMode" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment chg-pmt-mode">
+      <description>
+        This command is sent to a Metering Device to instruct it to change its mode of operation. i.e. from Credit to Prepayment.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="proposedPaymentControlConfiguration" type="PaymentControlConfiguration"/>
+      <arg name="cutOffValue" type="INT32U"/>
+    </command>
+    <command source="client" code="0x07" name="GetPrepaySnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment get-pp-ss">
+      <description>
+        This command is used to request the cluster server for snapshot data.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="latestEndTime" type="UTC_TIME"/>
+      <arg name="snapshotOffset" type="INT8U"/>
+      <arg name="snapshotCause" type="PrepaySnapshotPayloadCause"/>
+    </command>
+    <command source="client" code="0x08" name="GetTopUpLog" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment get-top-up-log">
+      <description>
+        This command is sent to the Metering Device to retrieve the log of Top Up codes received by the meter.
+      </description>
+      <arg name="latestEndTime" type="UTC_TIME"/>
+      <arg name="numberOfRecords" type="INT8U"/>
+    </command>
+    <command source="client" code="0x09" name="SetLowCreditWarningLevel" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment set-low-cred-wng-lvl">
+      <description>
+        This command is sent from client to a Prepayment server to set the warning level for low credit.
+      </description>
+      <arg name="lowCreditWarningLevel" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0A" name="GetDebtRepaymentLog" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment get-debt-repmt-log">
+      <description>
+        This command is used to request the contents of the repayment log.
+      </description>
+      <arg name="latestEndTime" type="UTC_TIME"/>
+      <arg name="numberOfDebts" type="INT8U"/>
+      <arg name="debtType" type="RepaymentDebtType"/>
+    </command>
+    <command source="client" code="0x0B" name="SetMaximumCreditLimit" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment set-max-cred-lmt">
+      <description>
+        This command is sent from a client to the Prepayment server to set the maximum credit level allowed in the meter.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="maximumCreditLevel" type="INT32U"/>
+      <arg name="maximumCreditPerTopUp" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0C" name="SetOverallDebtCap" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment set-oa-debt-cap">
+      <description>
+        This command is sent from a client to the Prepayment server to set the overall debt cap allowed in the meter.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="overallDebtCap" type="INT32U"/>
+    </command>
+    <command source="server" code="0x01" name="PublishPrepaySnapshot" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment pub-prep-ss">
+      <description>
+        This command is generated in response to a GetPrepaySnapshot command. It is used to return a single snapshot to the client.
+      </description>
+      <arg name="snapshotId" type="INT32U"/>
+      <arg name="snapshotTime" type="UTC_TIME"/>
+      <arg name="totalSnapshotsFound" type="INT8U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="snapshotCause" type="PrepaySnapshotPayloadCause"/>
+      <arg name="snapshotPayloadType" type="PrepaySnapshotPayloadType"/>
+      <arg name="snapshotPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="ChangePaymentModeResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment chg-pmt-mode-resp" disableDefaultResponse="true">
+      <description>
+        This command is send in response to the ChangePaymentMode Command.
+      </description>
+      <arg name="friendlyCredit" type="FriendlyCredit"/>
+      <arg name="friendlyCreditCalendarId" type="INT32U"/>
+      <arg name="emergencyCreditLimit" type="INT32U"/>
+      <arg name="emergencyCreditThreshold" type="INT32U"/>
+    </command>
+    <command source="server" code="0x03" name="ConsumerTopUpResponse" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment cons-top-up-resp" disableDefaultResponse="true">
+      <description>
+        This command is send in response to the ConsumerTopUp Command.
+      </description>
+      <arg name="resultType" type="ResultType"/>
+      <arg name="topUpValue" type="INT32U"/>
+      <arg name="sourceOfTopUp" type="OriginatingDevice"/>
+      <arg name="creditRemaining" type="INT32U"/>
+    </command>
+    <command source="server" code="0x05" name="PublishTopUpLog" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment pub-top-up-log">
+      <description>
+        This command is used to send the Top Up Code Log entries to the client.
+      </description>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="topUpPayload" type="TopUpPayload" array="true"/>
+    </command>
+    <command source="server" code="0x06" name="PublishDebtLog" optional="true" introducedIn="se-1.2a-07-5356-19" cli="zcl prepayment pub-debt-log">
+      <description>
+        This command is used to send the contents of the Repayment Log.
+      </description>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="debtPayload" type="DebtPayload" array="true"/>
+    </command>
+  </cluster>
+  <!-- Energy Management Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="LoadControlState" type="BITMAP8">
+    <field name="RelayOpenOrConsumptionInterupted" mask="0x01"/>
+    <field name="EventInProgress" mask="0x02"/>
+    <field name="PowerStabilizing" mask="0x04"/>
+    <field name="OtherLoadReduction" mask="0x08"/>
+    <field name="CurrentFlowOrConsumingCommodity" mask="0x10"/>
+    <field name="LoadCall" mask="0x20"/>
+  </bitmap>
+  <bitmap name="CurrentEventStatus" type="BITMAP8">
+    <field name="RandomizedStartTime" mask="0x01"/>
+    <field name="RandomizedDuration" mask="0x02"/>
+    <field name="ExtendedBitsPresent" mask="0x04"/>
+    <field name="EventActive" mask="0x08"/>
+    <field name="DeviceParticipatingInEvent" mask="0x10"/>
+    <field name="ReducingLoad" mask="0x20"/>
+    <field name="OnAtEndOfEvent" mask="0x40"/>
+  </bitmap>
+  <!-- Energy Management Cluster -->
+  <cluster introducedIn="se-1.2a-07-5356-19">
+    <name>Energy Management</name>
+    <domain>SE</domain>
+    <description>This cluster provides attributes and commands to assist applications in creating resource monitoring protocols.</description>
+    <code>0x0706</code>
+    <define>ENERGY_MANAGEMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Energy Management Cluster Server - Attributes -->
+    <attribute side="server" code="0x0000" define="LOAD_CONTROL_STATE" type="BITMAP8" writable="false" optional="false" min="0x00" max="0xFF" default="0x00">Load Control State</attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_EVENT_ID" type="INT32U" writable="false" optional="false" min="0x00000000" max="0xFFFFFFFE" default="0xFFFFFFFF">Current Event ID</attribute>
+    <attribute side="server" code="0x0002" define="CURRENT_EVENT_STATUS" type="BITMAP8" writable="false" optional="false" min="0x00" max="0xFF" default="0x00">Current Event Status</attribute>
+    <attribute side="server" code="0x0003" define="CONFORMANCE_LEVEL" type="INT8U" writable="true" optional="false" min="0x00" max="0x07" default="0x00">Conformance Level</attribute>
+    <attribute side="server" code="0x0004" define="MINIMUM_OFF_TIME" type="INT16U" writable="true" optional="false" min="0x0000" max="0xFFFF">Minimum Off Time</attribute>
+    <attribute side="server" code="0x0005" define="MINIMUM_ON_TIME" type="INT16U" writable="true" optional="false" min="0x0000" max="0xFFFF">Minimum On Time</attribute>
+    <attribute side="server" code="0x0006" define="MINIMUM_CYCLE_PERIOD" type="INT16U" writable="true" optional="false" min="0x0000" max="0xFFFF">Minimum Cycle Period</attribute>
+    <!-- Energy Management Cluster Client - Attributes -->
+    <!-- Energy Management Cluster Server - Commands -->
+    <command source="server" code="0x00" name="ReportEventStatus" optional="false">
+      <description>
+        This command is reused from the DRLC cluster. This command is generated in response to the Manage Event command.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="eventStatus" type="AmiEventStatus"/>
+      <arg name="eventStatusTime" type="UTC_TIME"/>
+      <arg name="criticalityLevelApplied" type="AmiCriticalityLevel"/>
+      <arg name="coolingTemperatureSetPointApplied" type="INT16U"/>
+      <arg name="heatingTemperatureSetPointApplied" type="INT16U"/>
+      <arg name="averageLoadAdjustmentPercentageApplied" type="INT8S"/>
+      <arg name="dutyCycleApplied" type="INT8U"/>
+      <arg name="eventControl" type="AmiEventControl"/>
+    </command>
+    <!-- Energy Management Cluster Client - Commands -->
+    <command source="client" code="0x00" name="ManageEvent" optional="false">
+      <description>
+        The Manage Event command allows a remote device (such as an IHD or web portal) to change the behavior of a DRLC cluster client when responding to a DRLC Load Control Event.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="deviceClass" type="AmiDeviceClass"/>
+      <arg name="utilityEnrollmentGroup" type="INT8U"/>
+      <arg name="actionRequired" type="INT8U"/>
+    </command>
+  </cluster>
+  <!-- Calendar Cluster - Structs, BITMAPs & ENUMs -->
+  <enum name="CalendarType" type="ENUM8">
+    <item name="DeliveredCalendar" value="0x00"/>
+    <item name="ReceivedCalendar" value="0x01"/>
+    <item name="DeliveredAndReceivedCalendar" value="0x02"/>
+    <item name="FriendlyCreditCalendar" value="0x03"/>
+    <item name="AuxilliaryLoadSwitchCalendar" value="0x04"/>
+  </enum>
+  <enum name="CalendarTimeReference" type="ENUM8">
+    <item name="UtcTime" value="0x00"/>
+    <item name="StandardTime" value="0x01"/>
+    <item name="LocalTime" value="0x02"/>
+  </enum>
+  <struct name="ScheduleEntry">
+    <item name="startTime" type="INT16U"/>
+    <item name="activePriceTierOrFriendlyCreditEnable" type="INT8U"/>
+  </struct>
+  <struct name="ScheduleEntryRateSwitchTimes">
+    <item name="startTime" type="INT16U"/>
+    <item name="priceTier" type="PriceTier"/>
+  </struct>
+  <struct name="ScheduleEntryFriendlyCreditSwitchTimes">
+    <item name="startTime" type="INT16U"/>
+    <item name="friendlyCreditEnable" type="BOOLEAN"/>
+  </struct>
+  <bitmap name="AuxiliaryLoadSwitchState" type="BITMAP8">
+    <field name="AuxiliarySwitch1" mask="0x01"/>
+    <field name="AuxiliarySwitch2" mask="0x02"/>
+    <field name="AuxiliarySwitch3" mask="0x04"/>
+    <field name="AuxiliarySwitch4" mask="0x08"/>
+    <field name="AuxiliarySwitch5" mask="0x10"/>
+    <field name="AuxiliarySwitch6" mask="0x20"/>
+    <field name="AuxiliarySwitch7" mask="0x40"/>
+    <field name="AuxiliarySwitch8" mask="0x80"/>
+  </bitmap>
+  <struct name="ScheduleEntryAuxilliaryLoadSwitchTimes">
+    <item name="startTime" type="INT16U"/>
+    <item name="auxiliaryLoadSwitchState" type="AuxiliaryLoadSwitchState"/>
+  </struct>
+  <struct name="SeasonEntry">
+    <item name="seasonStartDate" type="DATE"/>
+    <item name="weekIdRef" type="INT8U"/>
+  </struct>
+  <struct name="SpecialDay">
+    <item name="specialDayDate" type="DATE"/>
+    <item name="dayIdRef" type="INT8U"/>
+  </struct>
+  <!-- Calendar Cluster -->
+  <cluster introducedIn="se-1.2a-07-5356-19">
+    <name>Calendar</name>
+    <domain>SE</domain>
+    <description>This cluster provides attributes and commands to assist applications in developing time and date based protocol.</description>
+    <code>0x0707</code>
+    <define>CALENDAR_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Calendar Cluster Server - Attributes -->
+    <attribute side="server" code="0x0000" define="AUXILIARY_SWITCH_1_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 1">Auxiliary Switch 1 Label</attribute>
+    <attribute side="server" code="0x0001" define="AUXILIARY_SWITCH_2_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 2">Auxiliary Switch 2 Label</attribute>
+    <attribute side="server" code="0x0002" define="AUXILIARY_SWITCH_3_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 3">Auxiliary Switch 3 Label</attribute>
+    <attribute side="server" code="0x0003" define="AUXILIARY_SWITCH_4_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 4">Auxiliary Switch 4 Label</attribute>
+    <attribute side="server" code="0x0004" define="AUXILIARY_SWITCH_5_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 5">Auxiliary Switch 5 Label</attribute>
+    <attribute side="server" code="0x0005" define="AUXILIARY_SWITCH_6_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 6">Auxiliary Switch 6 Label</attribute>
+    <attribute side="server" code="0x0006" define="AUXILIARY_SWITCH_7_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 7">Auxiliary Switch 7 Label</attribute>
+    <attribute side="server" code="0x0007" define="AUXILIARY_SWITCH_8_LABEL" type="OCTET_STRING" writable="true" length="22" optional="true" default="Auxiliary 8">Auxiliary Switch 8 Label</attribute>
+    <!-- Calendar Cluster Server - Commands -->
+    <command source="server" code="0x00" name="PublishCalendar" optional="false">
+      <description>
+        The PublishCalendar command is published in response to a GetCalendar command or if new calendar information is available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="calendarType" type="CalendarType"/>
+      <arg name="calendarTimeReference" type="CalendarTimeReference"/>
+      <arg name="calendarName" type="OCTET_STRING"/>
+      <arg name="numberOfSeasons" type="INT8U"/>
+      <arg name="numberOfWeekProfiles" type="INT8U"/>
+      <arg name="numberOfDayProfiles" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="PublishDayProfile" optional="false">
+      <description>
+        The PublishDayProfile command is published in response to a GetDayProfile command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="dayId" type="INT8U"/>
+      <arg name="totalNumberOfScheduleEntries" type="INT8U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="calendarType" type="CalendarType"/>
+      <arg name="dayScheduleEntries" type="ScheduleEntry" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="PublishWeekProfile" optional="false">
+      <description>
+        The PublishWeekProfile command is published in response to a GetWeekProfile command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="weekId" type="INT8U"/>
+      <arg name="dayIdRefMonday" type="INT8U"/>
+      <arg name="dayIdRefTuesday" type="INT8U"/>
+      <arg name="dayIdRefWednesday" type="INT8U"/>
+      <arg name="dayIdRefThursday" type="INT8U"/>
+      <arg name="dayIdRefFriday" type="INT8U"/>
+      <arg name="dayIdRefSaturday" type="INT8U"/>
+      <arg name="dayIdRefSunday" type="INT8U"/>
+    </command>
+    <command source="server" code="0x03" name="PublishSeasons" optional="false">
+      <description>
+        The PublishSeasons command is published in response to a GetSeason command.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="seasonEntries" type="SeasonEntry" array="true"/>
+    </command>
+    <command source="server" code="0x04" name="PublishSpecialDays" optional="false">
+      <description>
+        The PublishSpecialDays command is published in response to a GetSpecialDays command or if a calendar update is available.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="calendarType" type="CalendarType"/>
+      <arg name="totalNumberOfSpecialDays" type="INT8U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="specialDayEntries" type="SpecialDay" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="CancelCalendar" optional="true">
+      <description>
+        The CancelCalendar command indicates that all data associated with a particular calendar instance should be discarded.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="calendarType" type="CalendarType"/>
+    </command>
+    <!-- Calendar Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetCalendar" optional="true" cli="zcl calendar get-calendar">
+      <description>
+        This command initiates PublishCalendar command(s) for scheduled Calendar updates.
+      </description>
+      <arg name="earliestStartTime" type="UTC_TIME"/>
+      <arg name="minIssuerEventId" type="INT32U"/>
+      <arg name="numberOfCalendars" type="INT8U"/>
+      <arg name="calendarType" type="CalendarType"/>
+      <arg name="providerId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x01" name="GetDayProfiles" optional="true" cli="zcl calendar get-day-profiles">
+      <description>
+        This command initiates one or more PublishDayProfile commands for the referenced Calendar.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="startDayId" type="INT8U"/>
+      <arg name="numberOfDays" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="GetWeekProfiles" optional="true" cli="zcl calendar get-week-profiles">
+      <description>
+        This command initiates one or more PublishWeekProfile commands for the referenced Calendar.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+      <arg name="startWeekId" type="INT8U"/>
+      <arg name="numberOfWeeks" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="GetSeasons" optional="true" cli="zcl calendar get-seasons">
+      <description>
+        This command initiates one or more PublishSeasons commands for the referenced Calendar.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x04" name="GetSpecialDays" optional="false" cli="zcl calendar get-special-days">
+      <description>
+        This command initiates one or more PublishSpecialDays commands for the scheduled Special Day Table updates.
+      </description>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="numberOfEvents" type="INT8U"/>
+      <arg name="calendarType" type="CalendarType"/>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerCalendarId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x05" name="GetCalendarCancellation" optional="false" cli="zcl calendar get-cancellation">
+      <description>
+        This command initiates the return of the last CancelCalendar command held on the associated server.
+      </description>
+    </command>
+  </cluster>
+  <!-- Device Management Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="ProposedChangeControl" type="BITMAP32">
+    <field name="PreSnapshots" mask="0x00000001"/>
+    <field name="PostSnapshots" mask="0x00000002"/>
+    <field name="ResetCreditRegister" mask="0x00000004"/>
+    <field name="ResetDebitRegister" mask="0x00000008"/>
+    <field name="ResetBillingPeriod" mask="0x00000010"/>
+    <field name="ClearTariffPlan" mask="0x00000020"/>
+    <field name="ClearStandingCharge" mask="0x00000040"/>
+    <field name="BlockHistoricalLoadProfileInformation" mask="0x00000080"/>
+    <field name="ClearHistoricalLoadProfileInformation" mask="0x00000100"/>
+    <field name="ClearIhdDataConsumer" mask="0x00000200"/>
+    <field name="ClearIhdDataSupplier" mask="0x00000400"/>
+    <field name="MeterConnectorStateOnOffArmed" mask="0x00001800"/>
+    <field name="ClearTransactionLog" mask="0x00002000"/>
+    <field name="ClearPrepaymentLog" mask="0x00004000"/>
+  </bitmap>
+  <enum name="EventConfigurationLogAction" type="ENUM8">
+    <item name="DoNotLog" value="0x00"/>
+    <item name="LogAsTamper" value="0x01"/>
+    <item name="LogAsFault" value="0x02"/>
+    <item name="LogAsGeneralEvent" value="0x03"/>
+    <item name="LogAsSecurityEvent" value="0x04"/>
+    <item name="LogAsNetworkEvent" value="0x05"/>
+  </enum>
+  <bitmap name="EventConfiguration" type="BITMAP8">
+    <field name="LogAction" mask="0x07"/>
+    <field name="PushEventToWAN" mask="0x08"/>
+    <field name="PushEventToHAN" mask="0x10"/>
+    <field name="RaiseAlarmZigBee" mask="0x20"/>
+    <field name="RaiseAlarmPhysical" mask="0x40"/>
+  </bitmap>
+  <enum name="PasswordType" type="ENUM8">
+    <item name="Password1ServiceMenuAccess" value="0x01"/>
+    <item name="Password2ConsumerMenuAccess" value="0x02"/>
+    <item name="Password3" value="0x03"/>
+    <item name="Password4" value="0x04"/>
+  </enum>
+  <struct name="EventConfigurationPayload">
+    <item name="eventId" type="INT16U"/>
+    <item name="eventConfiguration" type="EventConfiguration"/>
+  </struct>
+  <enum name="WanStatus" type="ENUM8">
+    <item name="ConnectionToWanIsNotAvailable" value="0x00"/>
+    <item name="ConnectionToWanIsAvailable" value="0x01"/>
+  </enum>
+  <enum name="EventConfigurationControl" type="ENUM8">
+    <item name="ApplyByList" value="0x00"/>
+    <item name="ApplyByEventGroup" value="0x01"/>
+    <item name="ApplyByLogType" value="0x02"/>
+    <item name="ApplyByConfigurationMatch" value="0x03"/>
+  </enum>
+  <!-- Device Management Cluster -->
+  <cluster introducedIn="se-1.2a-07-5356-19">
+    <name>Device Management</name>
+    <domain>SE</domain>
+    <description>This cluster provides attributes and commands to support device-cognisant application layer protocols.</description>
+    <code>0x0708</code>
+    <define>DEVICE_MANAGEMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Device Management Server - Attributes -->
+    <!-- Device Management Server - Supplier Control Attribute Set -->
+    <attribute side="server" code="0x0100" define="PROVIDER_ID_SERVER" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true">provider id (server)</attribute>
+    <attribute side="server" code="0x0101" define="PROVIDER_NAME" type="OCTET_STRING" length="16" writable="false" optional="true">provider name</attribute>
+    <attribute side="server" code="0x0102" define="PROVIDER_CONTACT_DETAILS" type="OCTET_STRING" length="19" writable="false" optional="true">provider contact details</attribute>
+    <attribute side="server" code="0x0110" define="PROPOSED_PROVIDER_ID" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">proposed provider id</attribute>
+    <attribute side="server" code="0x0111" define="PROPOSED_PROVIDER_NAME" type="OCTET_STRING" length="16" writable="false" optional="true">proposed provider name</attribute>
+    <attribute side="server" code="0x0112" define="PROPOSED_PROVIDER_CHANGE_DATE_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">proposed provider change date time</attribute>
+    <attribute side="server" code="0x0113" define="PROPOSED_PROVIDER_CHANGE_CONTROL" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">proposed provider change control</attribute>
+    <attribute side="server" code="0x0120" define="RECEIVED_PROVIDER_ID_SERVER" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">received provider id (server)</attribute>
+    <attribute side="server" code="0x0121" define="RECEIVED_PROVIDER_NAME" type="OCTET_STRING" length="16" writable="false" optional="true">received provider name</attribute>
+    <attribute side="server" code="0x0122" define="RECEIVED_PROVIDER_CONTACT_DETAILS" type="OCTET_STRING" length="19" writable="false" optional="true">received provider contact details</attribute>
+    <attribute side="server" code="0x0130" define="RECEIVED_PROPOSED_PROVIDER_ID" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">received proposed provider id</attribute>
+    <attribute side="server" code="0x0131" define="RECEIVED_PROPOSED_PROVIDER_NAME" type="OCTET_STRING" length="16" writable="false" optional="true">received proposed provider name</attribute>
+    <attribute side="server" code="0x0132" define="RECEIVED_PROPOSED_PROVIDER_CHANGE_DATE_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">received proposed provider change date time</attribute>
+    <attribute side="server" code="0x0133" define="RECEIVED_PROPOSED_PROVIDER_CHANGE_CONTROL" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">received proposed provider change control</attribute>
+    <!-- Device Management Server - Tenancy Control Attribute Set -->
+    <attribute side="server" code="0x0200" define="CHANGE_OF_TENANCY_UPDATE_DATE_TIME" type="UTC_TIME" writable="false" optional="true">change of tenancy update date time</attribute>
+    <attribute side="server" code="0x0201" define="PROPOSED_TENANCY_CHANGE_CONTROL" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">proposed tenancy change control</attribute>
+    <!-- Device Management Server - Backhaul Control Attribute Set -->
+    <attribute side="server" code="0x0300" define="WAN_STATUS" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true">wan status</attribute>
+    <!-- Device Management Server - HAN Control Attribute Set -->
+    <attribute side="server" code="0x0400" define="LOW_MEDIUM_THRESHOLD" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">low medium threshold</attribute>
+    <attribute side="server" code="0x0401" define="MEDIUM_HIGH_THRESHOLD" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">medium high threshold</attribute>
+    <!-- Device Management Client - Attributes -->
+    <!-- Device Management Client - Supplier Attribute Set 0x0000 -->
+    <attribute side="client" code="0x0000" define="PROVIDER_ID_CLIENT" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">provider id (client)</attribute>
+    <attribute side="client" code="0x0010" define="RECEIVED_PROVIDER_ID_CLIENT" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">received provider id (client)</attribute>
+    <!-- Device Management Client - Price Event Configuration Attribute Set 0x0100 -->
+    <attribute side="client" code="0x0100" define="TOU_TARIFF_ACTIVATION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tou tariff activation</attribute>
+    <attribute side="client" code="0x0101" define="BLOCK_TARIFF_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">block tariff activated</attribute>
+    <attribute side="client" code="0x0102" define="BLOCK_TOU_TARIFF_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">block tou tariff activated</attribute>
+    <attribute side="client" code="0x0103" define="SINGLE_TARIFF_RATE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">single tariff rate activated</attribute>
+    <attribute side="client" code="0x0104" define="ASYNCHRONOUS_BILLING_OCCURRED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">asynchronous billing occurred</attribute>
+    <attribute side="client" code="0x0105" define="SYNCHRONOUS_BILLING_OCCURRED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">synchronous billing occurred</attribute>
+    <attribute side="client" code="0x0106" define="TARIFF_NOT_SUPPORTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tariff not supported</attribute>
+    <attribute side="client" code="0x0107" define="PRICE_CLUSTER_NOT_FOUND" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">price cluster not found</attribute>
+    <attribute side="client" code="0x0108" define="CURRENCY_CHANGE_PASSIVE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">currency change passive activated</attribute>
+    <attribute side="client" code="0x0109" define="CURRENCY_CHANGE_PASSIVE_UPDATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">currency change passive updated</attribute>
+    <attribute side="client" code="0x010A" define="PRICE_MATRIX_PASSIVE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">price matrix passive activated</attribute>
+    <attribute side="client" code="0x010B" define="PRICE_MATRIX_PASSIVE_UPDATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">price matrix passive updated</attribute>
+    <attribute side="client" code="0x010C" define="TARIFF_CHANGE_PASSIVE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tariff change passive activated</attribute>
+    <attribute side="client" code="0x010D" define="TARIFF_CHANGE_PASSIVE_UPDATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tariff change passive updated</attribute>
+    <attribute side="client" code="0x01B0" define="PUBLISH_PRICE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price received</attribute>
+    <attribute side="client" code="0x01B1" define="PUBLISH_PRICE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price actioned</attribute>
+    <attribute side="client" code="0x01B2" define="PUBLISH_PRICE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price cancelled</attribute>
+    <attribute side="client" code="0x01B3" define="PUBLISH_PRICE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price rejected</attribute>
+    <attribute side="client" code="0x01B4" define="PUBLISH_TARIFF_INFO_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tariff information received</attribute>
+    <attribute side="client" code="0x01B5" define="PUBLISH_TARIFF_INFO_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tariff information actioned</attribute>
+    <attribute side="client" code="0x01B6" define="PUBLISH_TARIFF_INFO_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tariff information cancelled</attribute>
+    <attribute side="client" code="0x01B7" define="PUBLISH_TARIFF_INFO_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tariff information rejected</attribute>
+    <attribute side="client" code="0x01B8" define="PUBLISH_PRICE_MATRIX_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price matrix received</attribute>
+    <attribute side="client" code="0x01B9" define="PUBLISH_PRICE_MATRIX_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price matrix actioned</attribute>
+    <attribute side="client" code="0x01BA" define="PUBLISH_PRICE_MATRIX_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price matrix cancelled</attribute>
+    <attribute side="client" code="0x01BB" define="PUBLISH_PRICE_MATRIX_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish price matrix rejected</attribute>
+    <attribute side="client" code="0x01BC" define="PUBLISH_BLOCK_THRESHOLDS_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block thresholds received</attribute>
+    <attribute side="client" code="0x01BD" define="PUBLISH_BLOCK_THRESHOLDS_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block thresholds actioned</attribute>
+    <attribute side="client" code="0x01BE" define="PUBLISH_BLOCK_THRESHOLDS_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block thresholds cancelled</attribute>
+    <attribute side="client" code="0x01BF" define="PUBLISH_BLOCK_THRESHOLDS_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block thresholds rejected</attribute>
+    <attribute side="client" code="0x01C0" define="PUBLISH_CALORIFIC_VALUE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calorific value received</attribute>
+    <attribute side="client" code="0x01C1" define="PUBLISH_CALORIFIC_VALUE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calorific value actioned</attribute>
+    <attribute side="client" code="0x01C2" define="PUBLISH_CALORIFIC_VALUE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calorific value cancelled</attribute>
+    <attribute side="client" code="0x01C3" define="PUBLISH_CALORIFIC_VALUE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calorific value rejected</attribute>
+    <attribute side="client" code="0x01C4" define="PUBLISH_CONVERSION_FACTOR_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor received</attribute>
+    <attribute side="client" code="0x01C5" define="PUBLISH_CONVERSION_FACTOR_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor actioned</attribute>
+    <attribute side="client" code="0x01C6" define="PUBLISH_CONVERSION_FACTOR_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor cancelled</attribute>
+    <attribute side="client" code="0x01C7" define="PUBLISH_CONVERSION_FACTOR_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor rejected</attribute>
+    <attribute side="client" code="0x01C8" define="PUBLISH_CO2_VALUE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish co2 value received</attribute>
+    <attribute side="client" code="0x01C9" define="PUBLISH_CO2_VALUE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish co2 value actioned</attribute>
+    <attribute side="client" code="0x01CA" define="PUBLISH_CO2_VALUE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish co2 value cancelled</attribute>
+    <attribute side="client" code="0x01CB" define="PUBLISH_CO2_VALUE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish co2 value rejected</attribute>
+    <attribute side="client" code="0x01CC" define="PUBLISH_CPP_EVENT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cpp event received</attribute>
+    <attribute side="client" code="0x01CD" define="PUBLISH_CPP_EVENT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cpp event actioned</attribute>
+    <attribute side="client" code="0x01CE" define="PUBLISH_CPP_EVENT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cpp event cancelled</attribute>
+    <attribute side="client" code="0x01CF" define="PUBLISH_CPP_EVENT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cpp event rejected</attribute>
+    <attribute side="client" code="0x01D0" define="PUBLISH_TIER_LABELS_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tier labels received</attribute>
+    <attribute side="client" code="0x01D1" define="PUBLISH_TIER_LABELS_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tier labels actioned</attribute>
+    <attribute side="client" code="0x01D2" define="PUBLISH_TIER_LABELS_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tier labels cancelled</attribute>
+    <attribute side="client" code="0x01D3" define="PUBLISH_TIER_LABELS_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish tier labels rejected</attribute>
+    <attribute side="client" code="0x01D4" define="PUBLISH_BILLING_PERIOD_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish billing period received</attribute>
+    <attribute side="client" code="0x01D5" define="PUBLISH_BILLING_PERIOD_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish billing period actioned</attribute>
+    <attribute side="client" code="0x01D6" define="PUBLISH_BILLING_PERIOD_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish billing period cancelled</attribute>
+    <attribute side="client" code="0x01D7" define="PUBLISH_BILLING_PERIOD_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish billing period rejected</attribute>
+    <attribute side="client" code="0x01D8" define="PUBLISH_CONSOLIDATED_BILL_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish consolidated bill received</attribute>
+    <attribute side="client" code="0x01D9" define="PUBLISH_CONSOLIDATED_BILL_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish consolidated bill actioned</attribute>
+    <attribute side="client" code="0x01DA" define="PUBLISH_CONSOLIDATED_BILL_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish consolidated bill cancelled</attribute>
+    <attribute side="client" code="0x01DB" define="PUBLISH_CONSOLIDATED_BILL_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish consolidated bill rejected</attribute>
+    <attribute side="client" code="0x01DC" define="PUBLISH_BLOCK_PERIOD_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block period received</attribute>
+    <attribute side="client" code="0x01DD" define="PUBLISH_BLOCK_PERIOD_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block period actioned</attribute>
+    <attribute side="client" code="0x01DE" define="PUBLISH_BLOCK_PERIOD_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block period cancelled</attribute>
+    <attribute side="client" code="0x01DF" define="PUBLISH_BLOCK_PERIOD_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish block period rejected</attribute>
+    <attribute side="client" code="0x01E0" define="PUBLISH_CREDIT_PAYMENT_INFO_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish credit payment info received</attribute>
+    <attribute side="client" code="0x01E1" define="PUBLISH_CREDIT_PAYMENT_INFO_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish credit payment info actioned</attribute>
+    <attribute side="client" code="0x01E2" define="PUBLISH_CREDIT_PAYMENT_INFO_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish credit payment info cancelled</attribute>
+    <attribute side="client" code="0x01E3" define="PUBLISH_CREDIT_PAYMENT_INFO_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish credit payment info rejected</attribute>
+    <attribute side="client" code="0x01E4" define="PUBLISH_CURRENCY_CONVERSION_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor received</attribute>
+    <attribute side="client" code="0x01E5" define="PUBLISH_CURRENCY_CONVERSION_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor actioned</attribute>
+    <attribute side="client" code="0x01E6" define="PUBLISH_CURRENCY_CONVERSION_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor cancelled</attribute>
+    <attribute side="client" code="0x01E7" define="PUBLISH_CURRENCY_CONVERSION_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish conversion factor rejected</attribute>
+    <!-- Device Management Client - Metering Event Configuration Attribute Set 0x0200 -->
+    <attribute side="client" code="0x0200" define="CHECK_METER" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">check meter</attribute>
+    <attribute side="client" code="0x0201" define="LOW_BATTERY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">low battery</attribute>
+    <attribute side="client" code="0x0202" define="TAMPER_DETECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tamper detect</attribute>
+    <attribute side="client" code="0x0203" define="DEVICE_MANAGEMENT_SUPPLY_STATUS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply status</attribute>
+    <attribute side="client" code="0x0204" define="SUPPLY_QUALITY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply quality</attribute>
+    <attribute side="client" code="0x0205" define="LEAK_DETECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">leak detect</attribute>
+    <attribute side="client" code="0x0206" define="SERVICE_DISCONNECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">service disconnect</attribute>
+    <!-- NOTE:  There is a SECOND "Reverse Flow" attribute in this attribute set.  It is unclear why this exists but there are two of them.  This one I have relabelled "Reverse Flow General" so as not to conflict.  -->
+    <attribute side="client" code="0x0207" define="REVERSE_FLOW_GENERAL" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">reverse flow general</attribute>
+    <attribute side="client" code="0x0208" define="METER_COVER_REMOVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter cover removed</attribute>
+    <attribute side="client" code="0x0209" define="METER_COVER_CLOSED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter cover closed</attribute>
+    <attribute side="client" code="0x020A" define="STRONG_MAGNETIC_FIELD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">strong magnetic field</attribute>
+    <attribute side="client" code="0x020B" define="NO_STRONG_MAGNETIC_FIELD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">no strong magnetic field</attribute>
+    <attribute side="client" code="0x020C" define="BATTERY_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">battery failure</attribute>
+    <attribute side="client" code="0x020D" define="PROGRAM_MEMORY_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">program memory error</attribute>
+    <attribute side="client" code="0x020E" define="RAM_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ram error</attribute>
+    <attribute side="client" code="0x020F" define="NV_MEMORY_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">nv memory error</attribute>
+    <attribute side="client" code="0x0210" define="LOW_VOLTAGE_L1" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">low voltage L1</attribute>
+    <attribute side="client" code="0x0211" define="HIGH_VOLTAGE_L1" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">high voltage L1</attribute>
+    <attribute side="client" code="0x0212" define="LOW_VOLTAGE_L2" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">low voltage L2</attribute>
+    <attribute side="client" code="0x0213" define="HIGH_VOLTAGE_L2" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">high voltage L2</attribute>
+    <attribute side="client" code="0x0214" define="LOW_VOLTAGE_L3" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">low voltage L3</attribute>
+    <attribute side="client" code="0x0215" define="HIGH_VOLTAGE_L3" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">high voltage L3</attribute>
+    <attribute side="client" code="0x0216" define="OVER_CURRENT_L1" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">over current L1</attribute>
+    <attribute side="client" code="0x0217" define="OVER_CURRENT_L2" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">over current L2</attribute>
+    <attribute side="client" code="0x0218" define="OVER_CURRENT_L3" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">over current L3</attribute>
+    <attribute side="client" code="0x0219" define="FREQUENCY_TOO_LOW_L1" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too low L1</attribute>
+    <attribute side="client" code="0x021A" define="FREQUENCY_TOO_HIGH_L1" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too high L1</attribute>
+    <attribute side="client" code="0x021B" define="FREQUENCY_TOO_LOW_L2" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too low L2</attribute>
+    <attribute side="client" code="0x021C" define="FREQUENCY_TOO_HIGH_L2" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too high L2</attribute>
+    <attribute side="client" code="0x021D" define="FREQUENCY_TOO_LOW_L3" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too low L3</attribute>
+    <attribute side="client" code="0x021E" define="FREQUENCY_TOO_HIGH_L3" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">frequency too high L3</attribute>
+    <attribute side="client" code="0x021F" define="GROUND_FAULT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ground fault</attribute>
+    <attribute side="client" code="0x0220" define="ELECTRIC_TAMPER_DETECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">electric tamper detect</attribute>
+    <attribute side="client" code="0x0221" define="INCORRECT_POLARITY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">incorrect polarity</attribute>
+    <attribute side="client" code="0x0222" define="CURRENT_NO_VOLTAGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">current no voltage</attribute>
+    <attribute side="client" code="0x0223" define="UNDER_VOLTAGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">under voltage</attribute>
+    <attribute side="client" code="0x0224" define="OVER_VOLTAGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">over voltage</attribute>
+    <attribute side="client" code="0x0225" define="NORMAL_VOLTAGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">normal voltage</attribute>
+    <attribute side="client" code="0x0226" define="PF_BELOW_THRESHOLD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">pf below threshold</attribute>
+    <attribute side="client" code="0x0227" define="PF_ABOVE_THRESHOLD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">pf above threshold</attribute>
+    <attribute side="client" code="0x0228" define="TERMINAL_COVER_REMOVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">terminal cover removed</attribute>
+    <attribute side="client" code="0x0229" define="TERMINAL_COVER_CLOSED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">terminal cover closed</attribute>
+    <attribute side="client" code="0x0230" define="BURST_DETECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">burst detect</attribute>
+    <attribute side="client" code="0x0231" define="PRESSURE_TOO_LOW" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">pressure too low</attribute>
+    <attribute side="client" code="0x0232" define="PRESSURE_TOO_HIGH" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">pressure too high</attribute>
+    <attribute side="client" code="0x0233" define="FLOW_SENSOR_COMMUNICATION_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">flow sensor communication error</attribute>
+    <attribute side="client" code="0x0234" define="FLOW_SENSOR_MEASUREMENT_FAULT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">flow sensor measurement fault</attribute>
+    <attribute side="client" code="0x0235" define="FLOW_SENSOR_REVERSE_FLOW" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">flow sensor reverse flow</attribute>
+    <attribute side="client" code="0x0236" define="FLOW_SENSOR_AIR_DETECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">flow sensor air detect</attribute>
+    <attribute side="client" code="0x0237" define="PIPE_EMPTY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">pipe empty</attribute>
+    <attribute side="client" code="0x0250" define="INLET_TEMP_SENSOR_FAULT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">inlet temperature sensor fault</attribute>
+    <attribute side="client" code="0x0251" define="OUTLET_TEMP_SENSOR_FAULT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">outlet temperature sensor fault</attribute>
+    <attribute side="client" code="0x0260" define="REVERSE_FLOW" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">reverse flow</attribute>
+    <attribute side="client" code="0x0261" define="TILT_TAMPER" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tilt tamper</attribute>
+    <attribute side="client" code="0x0262" define="BATTERY_COVER_REMOVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">battery cover removed</attribute>
+    <attribute side="client" code="0x0263" define="BATTERY_COVER_CLOSED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">battery cover closed</attribute>
+    <attribute side="client" code="0x0264" define="EXCESS_FLOW" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">excess flow</attribute>
+    <attribute side="client" code="0x0265" define="TILT_TAMPER_ENABLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tilt tamper enabled</attribute>
+    <attribute side="client" code="0x0270" define="MEASUREMENT_SYSTEM_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">measurement system error</attribute>
+    <attribute side="client" code="0x0271" define="WATCHDOG_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">watchdog error</attribute>
+    <attribute side="client" code="0x0272" define="SUPPLY_DISCONNECT_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply disconnect failure</attribute>
+    <attribute side="client" code="0x0273" define="SUPPLY_CONNECT_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply connect failure</attribute>
+    <attribute side="client" code="0x0274" define="MEASUREMENT_SOFTWARE_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">measurement software changed</attribute>
+    <attribute side="client" code="0x0275" define="DST_ENABLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">dst enabled</attribute>
+    <attribute side="client" code="0x0276" define="DST_DISABLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">dst disabled</attribute>
+    <attribute side="client" code="0x0277" define="CLOCK_ADJ_BACKWARD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">clock adj backward</attribute>
+    <attribute side="client" code="0x0278" define="CLOCK_ADJ_FORWARD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">clock adj forward</attribute>
+    <attribute side="client" code="0x0279" define="CLOCK_INVALID" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">clock invalid</attribute>
+    <attribute side="client" code="0x027A" define="COMMUNICATION_ERROR_HAN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">communication error han</attribute>
+    <attribute side="client" code="0x027B" define="COMMUNICATION_OK_HAN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">communication ok han</attribute>
+    <attribute side="client" code="0x027C" define="METER_FRAUD_ATTEMPT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter fraud attempt</attribute>
+    <attribute side="client" code="0x027D" define="POWER_LOSS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">power loss</attribute>
+    <attribute side="client" code="0x027E" define="UNUSUAL_HAN_TRAFFIC" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unusual han traffic</attribute>
+    <attribute side="client" code="0x027F" define="UNEXPECTED_CLOCK_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unexpected clock change</attribute>
+    <attribute side="client" code="0x0280" define="COMMS_USING_UNAUTHENTICATED_COMPONENT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">comms using unauthenticated component</attribute>
+    <!-- NOTE:  ErrorRegClear and AlarmRegClear are used by both the Metering Event Configuration Attribute set and the Prepayment Attribute Set, both a part of the Device Management Cluster Client attributes.
+         Therefore we must prefix them with a unique prefix even though the spec does not uniquely name them. -->
+    <attribute side="client" code="0x0281" define="METERING_ERROR_REG_CLEAR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">metering error reg clear</attribute>
+    <attribute side="client" code="0x0282" define="METERING_ALARM_REG_CLEAR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">metering alarm reg clear</attribute>
+    <attribute side="client" code="0x0283" define="UNEXPECTED_HW_RESET" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unexpected hw reset</attribute>
+    <attribute side="client" code="0x0284" define="UNEXPECTED_PROGRAM_EXECUTION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unexpected program execution</attribute>
+    <attribute side="client" code="0x0285" define="LIMIT_THRESHOLD_EXCEEDED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">limit threshold exceeded</attribute>
+    <attribute side="client" code="0x0286" define="LIMIT_THRESHOLD_OK" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">limit threshold ok</attribute>
+    <attribute side="client" code="0x0287" define="LIMIT_THRESHOLD_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">limit threshold changed</attribute>
+    <attribute side="client" code="0x0288" define="MAXIMUM_DEMAND_EXCEEDED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">maximum demand exceeded</attribute>
+    <attribute side="client" code="0x0289" define="PROFILE_CLEARED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">profile cleared</attribute>
+    <attribute side="client" code="0x028A" define="LOAD_PROFILE_CLEARED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">load profile cleared</attribute>
+    <attribute side="client" code="0x028B" define="BATTERY_WARN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">battery warn</attribute>
+    <attribute side="client" code="0x028C" define="WRONG_SIGNATURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">wrong signature</attribute>
+    <attribute side="client" code="0x028D" define="NO_SIGNATURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">no signature</attribute>
+    <attribute side="client" code="0x028E" define="SIGNATURE_NOT_VALID" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">signature not valid</attribute>
+    <attribute side="client" code="0x028F" define="UNAUTHORISE_ACTION_FROM_HAN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unauthorise action from HAN</attribute>
+    <attribute side="client" code="0x0290" define="FAST_POLLING_START" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">fast polling start </attribute>
+    <attribute side="client" code="0x0291" define="FAST_POLLING_END" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">fast polling end</attribute>
+    <attribute side="client" code="0x0292" define="METER_REPORTING_INTERVAL_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter reporting interval changed</attribute>
+    <attribute side="client" code="0x0293" define="DISCONNECT_TO_LOAD_LIMIT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">disconnect to load limit</attribute>
+    <attribute side="client" code="0x0294" define="METER_SUPPLY_STATUS_REGISTER_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter supply status register changed</attribute>
+    <attribute side="client" code="0x0295" define="METER_ALARM_STATUS_REGISTER_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">meter alarm status register changed</attribute>
+    <attribute side="client" code="0x0296" define="EXTENDED_METER_ALARM_STATUS_REGISTER_CHANGED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">extended meter alarm status register changed</attribute>
+    <attribute side="client" code="0x0297" define="DATA_ACCESS_VIA_LOCAL_PORT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">data access via local port</attribute>
+    <attribute side="client" code="0x0298" define="CONFIGURE_MIRROR_SUCCESS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure mirror success</attribute>
+    <attribute side="client" code="0x0299" define="CONFIGURE_MIRROR_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure mirror failure</attribute>
+    <attribute side="client" code="0x029A" define="CONFIGURE_NOTIFICATION_FLAG_SCHEME_SUCCESS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure notification flag scheme success</attribute>
+    <attribute side="client" code="0x029B" define="CONFIGURE_NOTIFICATION_FLAG_SCHEME_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure notification flag scheme failure</attribute>
+    <attribute side="client" code="0x029C" define="CONFIGURE_NOTIFICATION_FLAGS_SUCCESS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure notification flags success</attribute>
+    <attribute side="client" code="0x029D" define="CONFIGURE_NOTIFICATION_FLAGS_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">configure notification flags failure</attribute>
+    <attribute side="client" code="0x029E" define="STAY_AWAKE_REQUEST_HAN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">stay awake request han</attribute>
+    <attribute side="client" code="0x029F" define="STAY_AWAKE_REQUEST_WAN" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">stay awake request wan</attribute>
+    <attribute side="client" code="0x02B0" define="MANUFACTURER_SPECIFIC_A" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific a</attribute>
+    <attribute side="client" code="0x02B1" define="MANUFACTURER_SPECIFIC_B" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific b</attribute>
+    <attribute side="client" code="0x02B2" define="MANUFACTURER_SPECIFIC_C" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific c</attribute>
+    <attribute side="client" code="0x02B3" define="MANUFACTURER_SPECIFIC_D" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific d</attribute>
+    <attribute side="client" code="0x02B4" define="MANUFACTURER_SPECIFIC_E" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific e</attribute>
+    <attribute side="client" code="0x02B5" define="MANUFACTURER_SPECIFIC_F" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific f</attribute>
+    <attribute side="client" code="0x02B6" define="MANUFACTURER_SPECIFIC_G" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific g</attribute>
+    <attribute side="client" code="0x02B7" define="MANUFACTURER_SPECIFIC_H" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific h</attribute>
+    <attribute side="client" code="0x02B8" define="MANUFACTURER_SPECIFIC_I" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manufacturer specific i</attribute>
+    <attribute side="client" code="0x02C0" define="GET_PROFILE_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get profile command received</attribute>
+    <attribute side="client" code="0x02C1" define="GET_PROFILE_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get profile command actioned</attribute>
+    <attribute side="client" code="0x02C2" define="GET_PROFILE_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get profile command cancelled</attribute>
+    <attribute side="client" code="0x02C3" define="GET_PROFILE_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get profile command rejected</attribute>
+    <attribute side="client" code="0x02C4" define="REQUEST_MIRROR_RESPONSE_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request mirror response command received</attribute>
+    <attribute side="client" code="0x02C5" define="REQUEST_MIRROR_RESPONSE_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request mirror response command actioned</attribute>
+    <attribute side="client" code="0x02C6" define="REQUEST_MIRROR_RESPONSE_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request mirror response command cancelled</attribute>
+    <attribute side="client" code="0x02C7" define="REQUEST_MIRROR_RESPONSE_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request mirror response command rejected</attribute>
+    <attribute side="client" code="0x02C8" define="MIRROR_REMOVED_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror removed command received</attribute>
+    <attribute side="client" code="0x02C9" define="MIRROR_REMOVED_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror removed command actioned</attribute>
+    <attribute side="client" code="0x02CA" define="MIRROR_REMOVED_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror removed command cancelled</attribute>
+    <attribute side="client" code="0x02CB" define="MIRROR_REMOVED_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror removed command rejected</attribute>
+    <attribute side="client" code="0x02CC" define="GET_SNAPSHOT_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get snapshot command received</attribute>
+    <attribute side="client" code="0x02CD" define="GET_SNAPSHOT_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get snapshot command actioned</attribute>
+    <attribute side="client" code="0x02CE" define="GET_SNAPSHOT_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get snapshot command cancelled</attribute>
+    <attribute side="client" code="0x02CF" define="GET_SNAPSHOT_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get snapshot command rejected</attribute>
+    <attribute side="client" code="0x02D0" define="TAKE_SNAPSHOT_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">take snapshot command received</attribute>
+    <attribute side="client" code="0x02D1" define="TAKE_SNAPSHOT_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">take snapshot command actioned</attribute>
+    <attribute side="client" code="0x02D2" define="TAKE_SNAPSHOT_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">take snapshot command cancelled</attribute>
+    <attribute side="client" code="0x02D3" define="TAKE_SNAPSHOT_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">take snapshot command rejected</attribute>
+    <attribute side="client" code="0x02D4" define="MIRROR_REPORT_ATTRIBUTE_RESPONSE_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror report attribute response command received</attribute>
+    <attribute side="client" code="0x02D5" define="MIRROR_REPORT_ATTRIBUTE_RESPONSE_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror report attribute response command actioned</attribute>
+    <attribute side="client" code="0x02D6" define="MIRROR_REPORT_ATTRIBUTE_RESPONSE_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror report attribute response command cancelled</attribute>
+    <attribute side="client" code="0x02D7" define="MIRROR_REPORT_ATTRIBUTE_RESPONSE_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mirror report attribute response command rejected</attribute>
+    <attribute side="client" code="0x02D8" define="SCHEDULE_SNAPSHOT_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">schedule snapshot command received</attribute>
+    <attribute side="client" code="0x02D9" define="SCHEDULE_SNAPSHOT_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">schedule snapshot command actioned</attribute>
+    <attribute side="client" code="0x02DA" define="SCHEDULE_SNAPSHOT_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">schedule snapshot command cancelled</attribute>
+    <attribute side="client" code="0x02DB" define="SCHEDULE_SNAPSHOT_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">schedule snapshot command rejected</attribute>
+    <attribute side="client" code="0x02DC" define="START_SAMPLING_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">start sampling command received</attribute>
+    <attribute side="client" code="0x02DD" define="START_SAMPLING_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">start sampling command actioned</attribute>
+    <attribute side="client" code="0x02DE" define="START_SAMPLING_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">start sampling command cancelled</attribute>
+    <attribute side="client" code="0x02DF" define="START_SAMPLING_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">start sampling command rejected</attribute>
+    <attribute side="client" code="0x02E0" define="GET_SAMPLED_DATA_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get sampled data command received</attribute>
+    <attribute side="client" code="0x02E1" define="GET_SAMPLED_DATA_COMMAND_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get sampled data command actioned</attribute>
+    <attribute side="client" code="0x02E2" define="GET_SAMPLED_DATA_COMMAND_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get sampled data command cancelled</attribute>
+    <attribute side="client" code="0x02E3" define="GET_SAMPLED_DATA_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get sampled data command rejected</attribute>
+    <attribute side="client" code="0x02E4" define="SUPPLY_ON" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply on</attribute>
+    <attribute side="client" code="0x02E5" define="SUPPLY_ARMED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply armed</attribute>
+    <attribute side="client" code="0x02E6" define="SUPPLY_OFF" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">supply off</attribute>
+    <attribute side="client" code="0x02E7" define="DISCONNECTED_DUE_TO_TAMPER_DETECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">disconnected due to tamper detected</attribute>
+    <attribute side="client" code="0x02E8" define="MANUAL_DISCONNECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manual disconnect</attribute>
+    <attribute side="client" code="0x02E9" define="MANUAL_CONNECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">manual connect</attribute>
+    <attribute side="client" code="0x02EA" define="REMOTE_DISCONNECTION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">remote disconnection</attribute>
+    <attribute side="client" code="0x02EB" define="REMOTE_CONNECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">remote connect</attribute>
+    <attribute side="client" code="0x02EC" define="LOCAL_DISCONNECTION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local disconnection</attribute>
+    <attribute side="client" code="0x02ED" define="LOCAL_CONNECT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local connect</attribute>
+    <attribute side="client" code="0x02EE" define="CHANGE_SUPPLY_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change supply received</attribute>
+    <attribute side="client" code="0x02EF" define="CHANGE_SUPPLY_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change supply actioned</attribute>
+    <attribute side="client" code="0x02F0" define="CHANGE_SUPPLY_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change supply cancelled</attribute>
+    <attribute side="client" code="0x02F1" define="CHANGE_SUPPLY_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change supply rejected</attribute>
+    <attribute side="client" code="0x02F2" define="LOCAL_CHANGE_SUPPLY_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local change supply received</attribute>
+    <attribute side="client" code="0x02F3" define="LOCAL_CHANGE_SUPPLY_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local change supply actioned</attribute>
+    <attribute side="client" code="0x02F4" define="LOCAL_CHANGE_SUPPLY_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local change supply cancelled</attribute>
+    <attribute side="client" code="0x02F5" define="LOCAL_CHANGE_SUPPLY_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">local change supply rejected</attribute>
+    <attribute side="client" code="0x02F6" define="PUBLISH_UNCONTROLLED_FLOW_THRESHOLD_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish uncontrolled flow threshold received</attribute>
+    <attribute side="client" code="0x02F7" define="PUBLISH_UNCONTROLLED_FLOW_THRESHOLD_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish uncontrolled flow threshold actioned</attribute>
+    <attribute side="client" code="0x02F8" define="PUBLISH_UNCONTROLLED_FLOW_THRESHOLD_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish uncontrolled flow threshold cancelled</attribute>
+    <attribute side="client" code="0x02F9" define="PUBLISH_UNCONTROLLED_FLOW_THRESHOLD_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish uncontrolled flow threshold rejected</attribute>
+    <!-- Device Management Client - Messaging Event Configuration Attribute Set 0x0300 -->
+    <attribute side="client" code="0x0300" define="MESSAGE_CONFIRMATION_SENT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">message confirmation sent</attribute>
+    <attribute side="client" code="0x03C0" define="DISPLAY_MESSAGE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">display message received</attribute>
+    <attribute side="client" code="0x03C1" define="DISPLAY_MESSAGE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">display message actioned</attribute>
+    <attribute side="client" code="0x03C2" define="DISPLAY_MESSAGE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">display message cancelled</attribute>
+    <attribute side="client" code="0x03C3" define="DISPLAY_MESSAGE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">display message rejected</attribute>
+    <attribute side="client" code="0x03C4" define="CANCEL_MESSAGE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">cancel message received</attribute>
+    <attribute side="client" code="0x03C5" define="CANCEL_MESSAGE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">cancel message actioned</attribute>
+    <attribute side="client" code="0x03C6" define="CANCEL_MESSAGE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">cancel message cancelled</attribute>
+    <attribute side="client" code="0x03C7" define="CANCEL_MESSAGE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">cancel message rejected</attribute>
+    <!-- Device Management Client - Prepay Event Configuration Attribute Set 0x0400  -->
+    <attribute side="client" code="0x0400" define="LOW_CREDIT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">low credit</attribute>
+    <attribute side="client" code="0x0401" define="NO_CREDIT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">no credit</attribute>
+    <attribute side="client" code="0x0402" define="CREDIT_EXHAUSTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit exhausted</attribute>
+    <attribute side="client" code="0x0403" define="EMERGENCY_CREDIT_ENABLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit enabled</attribute>
+    <attribute side="client" code="0x0404" define="EMERGENCY_CREDIT_EXHAUSTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit exhausted</attribute>
+    <attribute side="client" code="0x0405" define="PREPAY_IHD_LOW_CREDIT_WARNING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">IHD low credit warning</attribute>
+    <attribute side="client" code="0x0420" define="PHYSICAL_ATTACK_ON_THE_PREPAY_METER" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">physical attack on the prepay meter</attribute>
+    <attribute side="client" code="0x0421" define="ELECTRONIC_ATTACK_ON_THE_PREPAY_METER" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">electronic attack on the prepay meter</attribute>
+    <attribute side="client" code="0x0422" define="DISCOUNT_APPLIED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">discount applied</attribute>
+    <attribute side="client" code="0x0423" define="CREDIT_ADJUSTMENT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjustment</attribute>
+    <attribute side="client" code="0x0424" define="CREDIT_ADJUST_FAIL" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjust fail</attribute>
+    <attribute side="client" code="0x0425" define="DEBT_ADJUSTMENT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">debt adjustment</attribute>
+    <attribute side="client" code="0x0426" define="DEBT_ADJUST_FAIL" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">debt adjust fail</attribute>
+    <attribute side="client" code="0x0427" define="MODE_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mode change</attribute>
+    <attribute side="client" code="0x0428" define="TOPUP_CODE_ERROR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup code error</attribute>
+    <attribute side="client" code="0x0429" define="TOPUP_ALREADY_USED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup already used</attribute>
+    <attribute side="client" code="0x042A" define="TOPUP_CODE_INVALID" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup code invalid</attribute>
+    <attribute side="client" code="0x042B" define="TOPUP_ACCEPTED_VIA_REMOTE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup accepted via remote</attribute>
+    <attribute side="client" code="0x042C" define="TOPUP_ACCEPTED_VIA_MANUAL_ENTRY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup accepted via manual entry</attribute>
+    <attribute side="client" code="0x042D" define="FRIENDLY_CREDIT_IN_USE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">friendly credit in use</attribute>
+    <attribute side="client" code="0x042E" define="FRIENDLY_CREDIT_END_WARNING" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">friendly credit end warning</attribute>
+    <attribute side="client" code="0x042F" define="FRIENDLY_CREDIT_PERIOD_END" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">friendly credit period end</attribute>
+    <!-- NOTE:  ErrorRegClear and AlarmRegClear are used by both the Metering Event Configuration Attribute set and the Prepayment Attribute Set, both a part of the Device Management Cluster Client attributes.
+         Therefore we must prefix them with a unique prefix even though the spec does not uniquely name them. -->
+    <attribute side="client" code="0x0430" define="PREPAY_ERROR_REG_CLEAR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">prepay error reg clear</attribute>
+    <attribute side="client" code="0x0431" define="PREPAY_ALARM_REG_CLEAR" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">prepay alarm reg clear</attribute>
+    <attribute side="client" code="0x0432" define="PREPAY_CLUSTER_NOT_FOUND" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">prepay cluster not found</attribute>
+    <attribute side="client" code="0x0433" define="TOPUP_VALUE_TOO_LARGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">topup value too large</attribute>
+    <attribute side="client" code="0x0441" define="MODE_CREDIT_2_PREPAY" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mode credit 2 prepay</attribute>
+    <attribute side="client" code="0x0442" define="MODE_PREPAY_2_CREDIT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mode prepay 2 credit</attribute>
+    <attribute side="client" code="0x0443" define="MODE_DEFAULT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">mode default</attribute>
+    <attribute side="client" code="0x04C0" define="SELECT_AVAILABLE_EMERGENCY_CREDIT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">select available emergency credit received</attribute>
+    <attribute side="client" code="0x04C1" define="SELECT_AVAILABLE_EMERGENCY_CREDIT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">select available emergency credit actioned</attribute>
+    <attribute side="client" code="0x04C2" define="SELECT_AVAILABLE_EMERGENCY_CREDIT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">select available emergency credit cancelled</attribute>
+    <attribute side="client" code="0x04C3" define="SELECT_AVAILABLE_EMERGENCY_CREDIT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">select available emergency credit rejected</attribute>
+    <attribute side="client" code="0x04C4" define="CHANGE_DEBT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change debt received</attribute>
+    <attribute side="client" code="0x04C5" define="CHANGE_DEBT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change debt actioned</attribute>
+    <attribute side="client" code="0x04C6" define="CHANGE_DEBT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change debt cancelled</attribute>
+    <attribute side="client" code="0x04C7" define="CHANGE_DEBT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change debt rejected</attribute>
+    <attribute side="client" code="0x04C8" define="EMERGENCY_CREDIT_SETUP_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit setup received</attribute>
+    <attribute side="client" code="0x04C9" define="EMERGENCY_CREDIT_SETUP_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit setup actioned</attribute>
+    <attribute side="client" code="0x04CA" define="EMERGENCY_CREDIT_SETUP_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit setup cancelled</attribute>
+    <attribute side="client" code="0x04CB" define="EMERGENCY_CREDIT_SETUP_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">emergency credit setup rejected</attribute>
+    <attribute side="client" code="0x04CC" define="CONSUMER_TOPUP_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">consumer topup received</attribute>
+    <attribute side="client" code="0x04CD" define="CONSUMER_TOPUP_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">consumer topup actioned</attribute>
+    <attribute side="client" code="0x04CE" define="CONSUMER_TOPUP_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">consumer topup cancelled</attribute>
+    <attribute side="client" code="0x04CF" define="CONSUMER_TOPUP_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">consumer topup rejected</attribute>
+    <attribute side="client" code="0x04D0" define="CREDIT_ADJUSTMENT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjustment received</attribute>
+    <attribute side="client" code="0x04D1" define="CREDIT_ADJUSTMENT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjustment actioned</attribute>
+    <attribute side="client" code="0x04D2" define="CREDIT_ADJUSTMENT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjustment cancelled</attribute>
+    <attribute side="client" code="0x04D3" define="CREDIT_ADJUSTMENT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">credit adjustment rejected</attribute>
+    <attribute side="client" code="0x04D4" define="CHANGE_PAYMENT_MODE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change payment mode received</attribute>
+    <attribute side="client" code="0x04D5" define="CHANGE_PAYMENT_MODE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change payment mode actioned</attribute>
+    <attribute side="client" code="0x04D6" define="CHANGE_PAYMENT_MODE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change payment mode cancelled</attribute>
+    <attribute side="client" code="0x04D7" define="CHANGE_PAYMENT_MODE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change payment mode rejected</attribute>
+    <attribute side="client" code="0x04D8" define="GET_PREPAY_SNAPSHOT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get prepay snapshot received</attribute>
+    <attribute side="client" code="0x04D9" define="GET_PREPAY_SNAPSHOT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get prepay snapshot actioned</attribute>
+    <attribute side="client" code="0x04DA" define="GET_PREPAY_SNAPSHOT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get prepay snapshot cancelled</attribute>
+    <attribute side="client" code="0x04DB" define="GET_PREPAY_SNAPSHOT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get prepay snapshot rejected</attribute>
+    <attribute side="client" code="0x04DC" define="GET_TOPUP_LOG_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get topup log received</attribute>
+    <attribute side="client" code="0x04DD" define="GET_TOPUP_LOG_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get topup log actioned</attribute>
+    <attribute side="client" code="0x04DE" define="GET_TOPUP_LOG_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get topup log cancelled</attribute>
+    <attribute side="client" code="0x04DF" define="GET_TOPUP_LOG_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get topup log rejected</attribute>
+    <attribute side="client" code="0x04E0" define="SET_LOW_CREDIT_WARNING_LEVEL_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set low credit warning level received</attribute>
+    <attribute side="client" code="0x04E1" define="SET_LOW_CREDIT_WARNING_LEVEL_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set low credit warning level actioned</attribute>
+    <attribute side="client" code="0x04E2" define="SET_LOW_CREDIT_WARNING_LEVEL_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set low credit warning level cancelled</attribute>
+    <attribute side="client" code="0x04E3" define="SET_LOW_CREDIT_WARNING_LEVEL_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set low credit warning level rejected</attribute>
+    <attribute side="client" code="0x04E4" define="GET_DEBT_REPAY_LOG_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get debt repay log received</attribute>
+    <attribute side="client" code="0x04E5" define="GET_DEBT_REPAY_LOG_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get debt repay log actioned</attribute>
+    <attribute side="client" code="0x04E6" define="GET_DEBT_REPAY_LOG_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get debt repay log cancelled</attribute>
+    <attribute side="client" code="0x04E7" define="GET_DEBT_REPAY_LOG_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get debt repay log rejected</attribute>
+    <attribute side="client" code="0x04E8" define="SET_MAXIMUM_CREDIT_LIMIT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set maximum credit limit received</attribute>
+    <attribute side="client" code="0x04E9" define="SET_MAXIMUM_CREDIT_LIMIT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set maximum credit limit actioned</attribute>
+    <attribute side="client" code="0x04EA" define="SET_MAXIMUM_CREDIT_LIMIT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set maximum credit limit cancelled</attribute>
+    <attribute side="client" code="0x04EB" define="SET_MAXIMUM_CREDIT_LIMIT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set maximum credit limit rejected</attribute>
+    <attribute side="client" code="0x04EC" define="SET_OVERALL_DEBT_CAP_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set overall debt cap received</attribute>
+    <attribute side="client" code="0x04ED" define="SET_OVERALL_DEBT_CAP_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set overall debt cap actioned</attribute>
+    <attribute side="client" code="0x04EE" define="SET_OVERALL_DEBT_CAP_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set overall debt cap cancelled</attribute>
+    <attribute side="client" code="0x04EF" define="SET_OVERALL_DEBT_CAP_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set overall debt cap rejected</attribute>
+    <!-- Device Management Client - Calendar Event Configuration Attribute Set 0x0500 -->
+    <attribute side="client" code="0x0500" define="CALENDAR_CLUSTER_NOT_FOUND" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">calendar cluster not found</attribute>
+    <attribute side="client" code="0x0501" define="CALENDAR_CHANGE_PASSIVE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">calendar change passive activated</attribute>
+    <attribute side="client" code="0x0502" define="CALENDAR_CHANGE_PASSIVE_UPDATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">calendar change passive updated</attribute>
+    <attribute side="client" code="0x05C0" define="PUBLISH_CALENDAR_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calendar received</attribute>
+    <attribute side="client" code="0x05C1" define="PUBLISH_CALENDAR_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calendar actioned</attribute>
+    <attribute side="client" code="0x05C2" define="PUBLISH_CALENDAR_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calendar cancelled</attribute>
+    <attribute side="client" code="0x05C3" define="PUBLISH_CALENDAR_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish calendar rejected</attribute>
+    <attribute side="client" code="0x05C4" define="PUBLISH_DAY_PROFILE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish day profile received</attribute>
+    <attribute side="client" code="0x05C5" define="PUBLISH_DAY_PROFILE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish day profile actioned</attribute>
+    <attribute side="client" code="0x05C6" define="PUBLISH_DAY_PROFILE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish day profile cancelled</attribute>
+    <attribute side="client" code="0x05C7" define="PUBLISH_DAY_PROFILE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish day profile rejected</attribute>
+    <attribute side="client" code="0x05C8" define="PUBLISH_WEEK_PROFILE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish week profile received</attribute>
+    <attribute side="client" code="0x05C9" define="PUBLISH_WEEK_PROFILE_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish week profile actioned</attribute>
+    <attribute side="client" code="0x05CA" define="PUBLISH_WEEK_PROFILE_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish week profile cancelled</attribute>
+    <attribute side="client" code="0x05CB" define="PUBLISH_WEEK_PROFILE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish week profile rejected</attribute>
+    <attribute side="client" code="0x05CC" define="PUBLISH_SEASONS_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish seasons received</attribute>
+    <attribute side="client" code="0x05CD" define="PUBLISH_SEASONS_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish seasons actioned</attribute>
+    <attribute side="client" code="0x05CE" define="PUBLISH_SEASONS_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish seasons cancelled</attribute>
+    <attribute side="client" code="0x05CF" define="PUBLISH_SEASONS_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish seasons rejected</attribute>
+    <attribute side="client" code="0x05D0" define="PUBLISH_SPECIAL_DAYS_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish special days received</attribute>
+    <attribute side="client" code="0x05D1" define="PUBLISH_SPECIAL_DAYS_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish special days actioned</attribute>
+    <attribute side="client" code="0x05D2" define="PUBLISH_SPECIAL_DAYS_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish special days cancelled</attribute>
+    <attribute side="client" code="0x05D3" define="PUBLISH_SPECIAL_DAYS_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish special days rejected</attribute>
+    <!-- Device Management Client - Event Configuration Attribute set 0x0600 -->
+    <attribute side="client" code="0x0600" define="PASSWORD_1_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">password 1 change</attribute>
+    <attribute side="client" code="0x0601" define="PASSWORD_2_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">password 2 change</attribute>
+    <attribute side="client" code="0x0602" define="PASSWORD_3_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">password 3 change</attribute>
+    <attribute side="client" code="0x0603" define="PASSWORD_4_CHANGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">password 4 change</attribute>
+    <attribute side="client" code="0x0604" define="EVENT_LOG_CLEARED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">event log cleared</attribute>
+    <attribute side="client" code="0x0610" define="ZIGBEE_APS_TIMEOUT" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">zigbee aps timeout</attribute>
+    <attribute side="client" code="0x0611" define="ZIGBEE_IEEE_TRANSMISSION_FAILURE_OVER_THRESHOLD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">zigbee ieee transmission failure over threshold</attribute>
+    <attribute side="client" code="0x0612" define="ZIGBEE_IEEE_FRAME_CHECK_SEQUENCE_THRESHOLD" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">zigbee ieee frame check sequence threshold</attribute>
+    <attribute side="client" code="0x0613" define="ERROR_CERTIFICATE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">error certificate</attribute>
+    <attribute side="client" code="0x0614" define="ERROR_SIGNATURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">error signature</attribute>
+    <attribute side="client" code="0x0615" define="ERROR_PROGRAM_STORAGE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">error program storage</attribute>
+    <attribute side="client" code="0x06C0" define="PUBLISH_COT_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cot received</attribute>
+    <attribute side="client" code="0x06C1" define="PUBLISH_COT_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cot actioned</attribute>
+    <attribute side="client" code="0x06C2" define="PUBLISH_COT_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cot cancelled</attribute>
+    <attribute side="client" code="0x06C3" define="PUBLISH_COT_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cot rejected</attribute>
+    <attribute side="client" code="0x06C4" define="PUBLISH_COS_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cos received</attribute>
+    <attribute side="client" code="0x06C5" define="PUBLISH_COS_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cos actioned</attribute>
+    <attribute side="client" code="0x06C6" define="PUBLISH_COS_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cos cancelled</attribute>
+    <attribute side="client" code="0x06C7" define="PUBLISH_COS_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">publish cos rejected</attribute>
+    <attribute side="client" code="0x06C8" define="CHANGE_PASSWORD_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change password received</attribute>
+    <attribute side="client" code="0x06C9" define="CHANGE_PASSWORD_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change password actioned</attribute>
+    <attribute side="client" code="0x06CA" define="CHANGE_PASSWORD_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change password cancelled</attribute>
+    <attribute side="client" code="0x06CB" define="CHANGE_PASSWORD_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">change password rejected</attribute>
+    <attribute side="client" code="0x06CC" define="SET_EVENT_CONFIGURATION_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set event configuration received</attribute>
+    <attribute side="client" code="0x06CD" define="SET_EVENT_CONFIGURATION_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set event configuration actioned</attribute>
+    <attribute side="client" code="0x06CE" define="SET_EVENT_CONFIGURATION_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set event configuration cancelled</attribute>
+    <attribute side="client" code="0x06CF" define="SET_EVENT_CONFIGURATION_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">set event configuration rejected</attribute>
+    <attribute side="client" code="0x06D0" define="UPDATE_SITE_ID_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update site id received</attribute>
+    <attribute side="client" code="0x06D1" define="UPDATE_SITE_ID_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update site id actioned</attribute>
+    <attribute side="client" code="0x06D2" define="UPDATE_SITE_ID_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update site id cancelled</attribute>
+    <attribute side="client" code="0x06D3" define="UPDATE_SITE_ID_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update site id rejected</attribute>
+    <attribute side="client" code="0x06D4" define="UPDATE_CIN_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update cin received</attribute>
+    <attribute side="client" code="0x06D5" define="UPDATE_CIN_ACTIONED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update cin actioned</attribute>
+    <attribute side="client" code="0x06D6" define="UPDATE_CIN_CANCELLED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update cin cancelled</attribute>
+    <attribute side="client" code="0x06D7" define="UPDATE_CIN_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">update cin rejected</attribute>
+    <!-- Device Management Client - Tunnel Event Configuration Attribute Set 0x0700 -->
+    <attribute side="client" code="0x0700" define="TUNNELING_CLUSTER_NOT_FOUND" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">tunneling cluster not found</attribute>
+    <attribute side="client" code="0x0701" define="UNSUPPORTED_PROTOCOL" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unsupported protocol</attribute>
+    <attribute side="client" code="0x0702" define="INCORRECT_PROTOCOL" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">unsupported protocol</attribute>
+    <attribute side="client" code="0x07C0" define="REQUEST_TUNNEL_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request tunnel command received</attribute>
+    <attribute side="client" code="0x07C1" define="REQUEST_TUNNEL_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request tunnel command rejected</attribute>
+    <attribute side="client" code="0x07C2" define="REQUEST_TUNNEL_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">request tunnel command generated</attribute>
+    <attribute side="client" code="0x07C3" define="CLOSE_TUNNEL_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">close tunnel command received</attribute>
+    <attribute side="client" code="0x07C4" define="CLOSE_TUNNEL_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">close tunnel command rejected</attribute>
+    <attribute side="client" code="0x07C5" define="CLOSE_TUNNEL_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">close tunnel command generated</attribute>
+    <attribute side="client" code="0x07C6" define="TRANSFER_DATA_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data command received</attribute>
+    <attribute side="client" code="0x07C7" define="TRANSFER_DATA_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data command rejected</attribute>
+    <attribute side="client" code="0x07C8" define="TRANSFER_DATA_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data command generated</attribute>
+    <attribute side="client" code="0x07C9" define="TRANSFER_DATA_ERROR_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data error command received</attribute>
+    <attribute side="client" code="0x07CA" define="TRANSFER_DATA_ERROR_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data error command rejected</attribute>
+    <attribute side="client" code="0x07CB" define="TRANSFER_DATA_ERROR_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">transfer data error command generated</attribute>
+    <attribute side="client" code="0x07CC" define="ACK_TRANSFER_DATA_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ack transfer data command received</attribute>
+    <attribute side="client" code="0x07CD" define="ACK_TRANSFER_DATA_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ack transfer data command rejected</attribute>
+    <attribute side="client" code="0x07CE" define="ACK_TRANSFER_DATA_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ack transfer data command generated</attribute>
+    <attribute side="client" code="0x07CF" define="READY_DATA_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ready data command received</attribute>
+    <attribute side="client" code="0x07D0" define="READY_DATA_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ready data command rejected</attribute>
+    <attribute side="client" code="0x07D1" define="READY_DATA_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">ready data command generated</attribute>
+    <attribute side="client" code="0x07D2" define="GET_SUPPORTED_TUNNEL_PROTOCOLS_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get supported tunnel protocols command received</attribute>
+    <attribute side="client" code="0x07D3" define="GET_SUPPORTED_TUNNEL_PROTOCOLS_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get supported tunnel protocols command rejected</attribute>
+    <attribute side="client" code="0x07D4" define="GET_SUPPORTED_TUNNEL_PROTOCOLS_COMMAND_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">get supported tunnel protocols command generated</attribute>
+    <!-- Device Management Client - OTA Event Configuration Attribute Set 0x0800 -->
+    <attribute side="client" code="0x0800" define="FIRMWARE_READY_FOR_ACTIVATION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">firmware ready for activation</attribute>
+    <attribute side="client" code="0x0801" define="FIRMWARE_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">firmware activated</attribute>
+    <attribute side="client" code="0x0802" define="FIRMWARE_ACTIVATION_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">firmware activation failure</attribute>
+    <attribute side="client" code="0x0803" define="PATCH_READY_FOR_ACTIVATION" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">patch ready for activation</attribute>
+    <attribute side="client" code="0x0804" define="PATCH_ACTIVATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">patch activated</attribute>
+    <attribute side="client" code="0x0805" define="PATCH_FAILURE" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">patch failure</attribute>
+    <attribute side="client" code="0x08C0" define="IMAGE_NOTIFY_COMMAND_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image notify command received</attribute>
+    <attribute side="client" code="0x08C1" define="IMAGE_NOTIFY_COMMAND_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image notify command rejected</attribute>
+    <attribute side="client" code="0x08C2" define="QUERY_NEXT_IMAGE_REQUEST_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query next image request generated</attribute>
+    <attribute side="client" code="0x08C3" define="QUERY_NEXT_IMAGE_RESPONSE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query next image response received</attribute>
+    <attribute side="client" code="0x08C4" define="QUERY_NEXT_IMAGE_RESPONSE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query next image response rejected</attribute>
+    <attribute side="client" code="0x08C5" define="IMAGE_BLOCK_REQUEST_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image block request generated</attribute>
+    <attribute side="client" code="0x08C6" define="IMAGE_PAGE_REQUEST_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image page request generated</attribute>
+    <attribute side="client" code="0x08C7" define="IMAGE_BLOCK_RESPONSE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image block response received</attribute>
+    <attribute side="client" code="0x08C8" define="IMAGE_BLOCK_RESPONSE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">image block response rejected</attribute>
+    <attribute side="client" code="0x08C9" define="UPGRADE_END_REQUEST_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">upgrade end request generated</attribute>
+    <attribute side="client" code="0x08CA" define="UPGRADE_END_RESPONSE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">upgrade end response received</attribute>
+    <attribute side="client" code="0x08CB" define="UPGRADE_END_RESPONSE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">upgrade end response rejected</attribute>
+    <attribute side="client" code="0x08CC" define="QUERY_SPECIFIC_FILE_REQUEST_GENERATED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query specific file request generated</attribute>
+    <attribute side="client" code="0x08CD" define="QUERY_SPECIFIC_FILE_RESPONSE_RECEIVED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query specific file response received</attribute>
+    <attribute side="client" code="0x08CE" define="QUERY_SPECIFIC_FILE_RESPONSE_REJECTED" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="true">query specific file response rejected</attribute>
+    <!-- Device Management Client - Commands -->
+    <command source="client" code="0x00" name="GetChangeOfTenancy" optional="true" cli="zcl dm get-chg-of-tenancy">
+      <description>
+        This command is used to request the ESI to respond with information regarding any available change of tenancy.
+      </description>
+    </command>
+    <command source="client" code="0x01" name="GetChangeOfSupplier" optional="true" cli="zcl dm get-chg-of-supplier">
+      <description>
+        This command is used to request the ESI to respond with information regarding any available change of supplier.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="RequestNewPassword" optional="true" cli="zcl dm req-new-pass">
+      <description>
+        This command is used to request the current password from the server.
+      </description>
+      <arg name="passwordType" type="PasswordType"/>
+    </command>
+    <command source="client" code="0x03" name="GetSiteId" optional="true" cli="zcl dm get-site-id">
+      <description>
+        This command is used to request the ESI to respond with information regarding any pending change of Site ID.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="ReportEventConfiguration" cli="zcl dm rpt-event-config" optional="true">
+      <description>
+        This command is sent in response to a GetEventConfiguration command.
+      </description>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalCommands" type="INT8U"/>
+      <arg name="eventConfigurationPayload" type="EventConfigurationPayload" array="true"/>
+    </command>
+    <command source="client" code="0x05" name="GetCIN" optional="true" cli="zcl dm get-cin">
+      <description>
+        This command is used to request the ESI to respond with information regarding any pending change of Customer ID Number.
+      </description>
+    </command>
+    <!-- Device Management Server - Commands -->
+    <command source="server" code="0x00" name="PublishChangeOfTenancy" optional="true">
+      <description>
+        This command is used to change the tenancy of a meter.
+      </description>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="tariffType" type="TariffType"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="proposedTenancyChangeControl" type="ProposedChangeControl"/>
+    </command>
+    <command source="server" code="0x01" name="PublishChangeOfSupplier" optional="true" cli="zcl dm pub-chg-of-supplier">
+      <description>
+        This command is used to change the Supplier (energy supplier) that is supplying the meter (s).
+      </description>
+      <arg name="currentProviderId" type="INT32U"/>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="tariffType" type="TariffType"/>
+      <arg name="proposedProviderId" type="INT32U"/>
+      <arg name="providerChangeImplementationTime" type="UTC_TIME"/>
+      <arg name="providerChangeControl" type="ProposedChangeControl"/>
+      <arg name="proposedProviderName" type="OCTET_STRING"/>
+      <arg name="proposedProviderContactDetails" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x02" name="RequestNewPasswordResponse" optional="true" cli="zcl dm req-new-pass-resp" disableDefaultResponse="true">
+      <description>
+        This command is used to send the current password to the client.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationDateTime" type="UTC_TIME"/>
+      <arg name="durationInMinutes" type="INT16U"/>
+      <arg name="passwordType" type="PasswordType"/>
+      <arg name="password" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x03" name="UpdateSiteId" optional="true">
+      <description>
+        This command is used to set the siteID.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="siteIdTime" type="UTC_TIME"/>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="siteId" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x04" name="SetEventConfiguration" optional="true" cli="zcl dm set-event-config">
+      <description>
+        This command provides a method to set the event configuration attributes, held in a client device.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="startDateTime" type="UTC_TIME"/>
+      <arg name="eventConfiguration" type="EventConfiguration"/>
+      <arg name="configurationControl" type="EventConfigurationControl"/>
+      <arg name="eventConfigurationPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="GetEventConfiguration" optional="true" cli="zcl dm get-event-config">
+      <description>
+        This command allows the server to request details of event configurations.
+      </description>
+      <arg name="eventId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x06" name="UpdateCIN" optional="true">
+      <description>
+        This command is used to set the CustomerIDNumber attribute held in the Metering cluster.
+      </description>
+      <arg name="issuerEventId" type="INT32U"/>
+      <arg name="implementationTime" type="UTC_TIME"/>
+      <arg name="providerId" type="INT32U"/>
+      <arg name="customerIdNumber" type="OCTET_STRING"/>
+    </command>
+  </cluster>
+  <!-- Events Cluster - Structs, BITMAPs & ENUMs -->
+  <bitmap name="EventControlLogId" type="BITMAP8">
+    <field name="LogId" mask="0x0F"/>
+    <field name="EventControl" mask="0xF0"/>
+  </bitmap>
+  <enum name="EventControl" type="ENUM8">
+    <item name="RetrieveMinimalInformation" value="0x00"/>
+    <item name="RetrieveFullInformation" value="0x10"/>
+  </enum>
+  <enum name="EventLogId" type="ENUM8">
+    <item name="AllLogs" value="0x00"/>
+    <item name="TamperLog" value="0x01"/>
+    <item name="FaultLog" value="0x02"/>
+    <item name="GeneralEventLog" value="0x03"/>
+    <item name="SecurityEventLog" value="0x04"/>
+    <item name="NetworkEventLog" value="0x05"/>
+    <item name="GbcsGeneralEventLog" value="0x06"/>
+    <item name="GbcsSecurityEventLog" value="0x07"/>
+  </enum>
+  <bitmap name="EventActionControl" type="BITMAP8">
+    <field name="ReportEventToHANDevices" mask="0x01"/>
+    <field name="ReportEventToWAN" mask="0x02"/>
+  </bitmap>
+  <bitmap name="NumberOfEventsLogPayloadControl" type="BITMAP8">
+    <field name="LogPayloadControl" mask="0x0F"/>
+    <field name="NumberOfEvents" mask="0xF0"/>
+  </bitmap>
+  <enum name="EventLogPayloadControl" type="ENUM8">
+    <item name="EventsDoNotCrossFrameBoundary" value="0x00"/>
+    <item name="EventCrossesFrameBoundary" value="0x01"/>
+  </enum>
+  <struct name="EventLogPayload">
+    <item name="logId" type="EventLogId"/>
+    <item name="eventId" type="INT16U"/>
+    <item name="eventTime" type="UTC_TIME"/>
+    <item name="eventData" type="OCTET_STRING"/>
+  </struct>
+  <bitmap name="ClearedEventsLogs" type="BITMAP8">
+    <field name="AllLogsCleared" mask="0x01"/>
+    <field name="TamperLogCleared" mask="0x02"/>
+    <field name="FaultLogCleared" mask="0x04"/>
+    <field name="GeneralEventLogCleared" mask="0x08"/>
+    <field name="SecurityEventLogCleared" mask="0x10"/>
+    <field name="NetworkEventLogCleared" mask="0x20"/>
+  </bitmap>
+  <!-- Events Cluster -->
+  <cluster introducedIn="se-1.2a-07-5356-19">
+    <name>Events</name>
+    <domain>SE</domain>
+    <description>This cluster provides an interface on which applications can use event-based protocols.</description>
+    <code>0x0709</code>
+    <define>EVENTS_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Events Cluster Server - Attributes -->
+    <!-- Events Cluster Client - Attributes -->
+    <!-- Events Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetEventLog" optional="true" cli="zcl events get-event-log">
+      <description>
+        The GetEventLog command allows a client to request events from a server's event logs. One or more PublishEventLog commands are returned on receipt of this command.
+      </description>
+      <arg name="eventControlLogId" type="EventControlLogId"/>
+      <arg name="eventId" type="INT16U"/>
+      <arg name="startTime" type="UTC_TIME"/>
+      <arg name="endTime" type="UTC_TIME"/>
+      <arg name="numberOfEvents" type="INT8U"/>
+      <arg name="eventOffset" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="ClearEventLogRequest" optional="true" cli="zcl events clear-event-log">
+      <description>
+        The ClearEventLogRequest command requests that an Events server device clear the specified event log(s).
+      </description>
+      <arg name="logId" type="EventLogId"/>
+    </command>
+    <!-- Events Cluster Server - Commands -->
+    <command source="server" code="0x00" name="PublishEvent" optional="true">
+      <description>
+        The PublishEvent command is generated upon an event trigger from within the reporting device and, if supported, the associated Event Configuration attribute in the Device Management cluster.
+      </description>
+      <arg name="logId" type="EventLogId"/>
+      <arg name="eventId" type="INT16U"/>
+      <arg name="eventTime" type="UTC_TIME"/>
+      <arg name="eventControl" type="EventActionControl"/>
+      <arg name="eventData" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x01" name="PublishEventLog" optional="true">
+      <description>
+        This command is generated on receipt of a GetEventLog command. The command returns the most recent event first and up to the number of events requested.
+      </description>
+      <arg name="totalNumberOfEvents" type="INT16U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalCommands" type="INT8U"/>
+      <arg name="logPayloadControl" type="NumberOfEventsLogPayloadControl"/>
+      <arg name="logPayload" type="EventLogPayload" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="ClearEventLogResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        This command is generated on receipt of a Clear Event Log Request command.
+      </description>
+      <arg name="clearedEventsLogs" type="ClearedEventsLogs"/>
+    </command>
+  </cluster>
+  <!-- MDU Pairing Cluster -->
+  <cluster introducedIn="se-1.2a-07-5356-19">
+    <name>MDU Pairing</name>
+    <domain>SE</domain>
+    <description>This cluster seeks to assist in the commissioning of networks that include multi-dwelling units (MDUs).</description>
+    <code>0x070A</code>
+    <define>MDU_PAIRING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- MDU Pairing Cluster Server - Attributes -->
+    <!-- MDU Pairing Cluster Client - Attributes -->
+    <!-- MDU Pairing Cluster Server - Commands -->
+    <command source="server" code="0x00" name="PairingResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        The Pairing Response command provides a device joining a MDU network with a list of the devices that will constitute the 'virtual HAN' for the household in which the joining device is to operate.
+      </description>
+      <arg name="pairingInformationVersion" type="INT32U"/>
+      <arg name="totalNumberOfDevices" type="INT8U"/>
+      <arg name="commandIndex" type="INT8U"/>
+      <arg name="totalNumberOfCommands" type="INT8U"/>
+      <arg name="eui64s" type="IEEE_ADDRESS" array="true"/>
+    </command>
+    <!-- MDU Pairing Cluster Client - Commands -->
+    <command source="client" code="0x00" name="PairingRequest" optional="false">
+      <description>
+        The Pairing Request command allows a device joining a MDU network to determine the devices that will constitute the 'virtual HAN' for the household in which it is to operate.
+      </description>
+      <arg name="localPairingInformationVersion" type="INT32U"/>
+      <arg name="eui64OfRequestingDevice" type="IEEE_ADDRESS"/>
+    </command>
+  </cluster>
+  <!-- Sub-GHz Cluster -->
+  <bitmap name="ChannelMask" type="BITMAP32">
+    <field name="Channel0" mask="0x00000001"/>
+    <!-- Page 0, 2.4 GHz -->
+    <field name="863Channel0" mask="0x00000001"/>
+    <!-- Page 28, 863-876 MHz -->
+    <field name="863Channel27" mask="0x00000001"/>
+    <!-- Page 29, 863-876 MHz -->
+    <field name="863Channel35" mask="0x00000001"/>
+    <!-- Page 30, 863-876 MHz -->
+    <field name="915Channel0" mask="0x00000001"/>
+    <!-- Page 31, 915-921 MHz -->
+    <field name="Channel1" mask="0x00000002"/>
+    <field name="863Channel1" mask="0x00000002"/>
+    <field name="863Channel28" mask="0x00000002"/>
+    <field name="853Channel36" mask="0x00000002"/>
+    <field name="915Channel1" mask="0x00000002"/>
+    <field name="Channel2" mask="0x00000004"/>
+    <field name="863Channel2" mask="0x00000004"/>
+    <field name="863Channel29" mask="0x00000004"/>
+    <field name="863Channel37" mask="0x00000004"/>
+    <field name="915Channel2" mask="0x00000004"/>
+    <field name="Channel3" mask="0x00000008"/>
+    <field name="863Channel3" mask="0x00000008"/>
+    <field name="863Channel30" mask="0x00000008"/>
+    <field name="863Channel38" mask="0x00000008"/>
+    <field name="915Channel3" mask="0x00000008"/>
+    <field name="Channel4" mask="0x00000010"/>
+    <field name="863Channel4" mask="0x00000010"/>
+    <field name="863Channel31" mask="0x00000010"/>
+    <field name="863Channel39" mask="0x00000010"/>
+    <field name="915Channel4" mask="0x00000010"/>
+    <field name="Channel5" mask="0x00000020"/>
+    <field name="863Channel5" mask="0x00000020"/>
+    <field name="863Channel32" mask="0x00000020"/>
+    <field name="863Channel40" mask="0x00000020"/>
+    <field name="915Channel5" mask="0x00000020"/>
+    <field name="Channel6" mask="0x00000040"/>
+    <field name="863Channel6" mask="0x00000040"/>
+    <field name="863Channel33" mask="0x00000040"/>
+    <field name="863Channel41" mask="0x00000040"/>
+    <field name="915Channel6" mask="0x00000040"/>
+    <field name="Channel7" mask="0x00000080"/>
+    <field name="863Channel7" mask="0x00000080"/>
+    <field name="863Channel34" mask="0x00000080"/>
+    <field name="863Channel42" mask="0x00000080"/>
+    <field name="915Channel7" mask="0x00000080"/>
+    <field name="Channel8" mask="0x00000100"/>
+    <field name="863Channel8" mask="0x00000100"/>
+    <field name="863Channel62" mask="0x00000100"/>
+    <!-- Page 29 anomaly, 863 Channel 61 is in Page 29-->
+    <field name="863Channel43" mask="0x00000100"/>
+    <field name="915Channel8" mask="0x00000100"/>
+    <field name="Channel9" mask="0x00000200"/>
+    <!-- Page 0, 2.4 GHz -->
+    <field name="863Channel9" mask="0x00000200"/>
+    <!-- Page 28, 863-876 MHz -->
+    <field name="863Channel44" mask="0x00000200"/>
+    <!-- Page 30, 863-876 MHz; no Page 29 beyond 863 Channel 8/62 -->
+    <field name="915Channel9" mask="0x00000200"/>
+    <!-- Page 31, 915-921 MHz -->
+    <field name="Channel10" mask="0x00000400"/>
+    <field name="863Channel10" mask="0x00000400"/>
+    <field name="863Channel45" mask="0x00000400"/>
+    <field name="915Channel10" mask="0x00000400"/>
+    <field name="Channel11" mask="0x00000800"/>
+    <field name="863Channel11" mask="0x00000800"/>
+    <field name="863Channel46" mask="0x00000800"/>
+    <field name="915Channel11" mask="0x00000800"/>
+    <field name="Channel12" mask="0x00001000"/>
+    <field name="863Channel12" mask="0x00001000"/>
+    <field name="863Channel47" mask="0x00001000"/>
+    <field name="915Channel12" mask="0x00001000"/>
+    <field name="Channel13" mask="0x00002000"/>
+    <field name="863Channel13" mask="0x00002000"/>
+    <field name="863Channel48" mask="0x00002000"/>
+    <field name="915Channel13" mask="0x00002000"/>
+    <field name="Channel14" mask="0x00004000"/>
+    <field name="863Channel14" mask="0x00004000"/>
+    <field name="863Channel49" mask="0x00004000"/>
+    <field name="915Channel14" mask="0x00004000"/>
+    <field name="Channel15" mask="0x00008000"/>
+    <field name="863Channel15" mask="0x00008000"/>
+    <field name="863Channel50" mask="0x00008000"/>
+    <field name="915Channel15" mask="0x00008000"/>
+    <field name="Channel16" mask="0x00010000"/>
+    <field name="863Channel16" mask="0x00010000"/>
+    <field name="863Channel51" mask="0x00010000"/>
+    <field name="915Channel16" mask="0x00010000"/>
+    <field name="Channel17" mask="0x00020000"/>
+    <field name="863Channel17" mask="0x00020000"/>
+    <field name="863Channel52" mask="0x00020000"/>
+    <field name="915Channel17" mask="0x00020000"/>
+    <field name="Channel18" mask="0x00040000"/>
+    <field name="863Channel18" mask="0x00040000"/>
+    <field name="863Channel53" mask="0x00040000"/>
+    <field name="915Channel18" mask="0x00040000"/>
+    <field name="Channel19" mask="0x00080000"/>
+    <field name="863Channel19" mask="0x00080000"/>
+    <field name="863Channel54" mask="0x00080000"/>
+    <field name="915Channel19" mask="0x00080000"/>
+    <field name="Channel20" mask="0x00100000"/>
+    <field name="863Channel20" mask="0x00100000"/>
+    <field name="863Channel55" mask="0x00100000"/>
+    <field name="915Channel20" mask="0x00100000"/>
+    <field name="Channel21" mask="0x00200000"/>
+    <field name="863Channel21" mask="0x00200000"/>
+    <field name="863Channel56" mask="0x00200000"/>
+    <field name="915Channel21" mask="0x00200000"/>
+    <field name="Channel22" mask="0x00400000"/>
+    <field name="863Channel22" mask="0x00400000"/>
+    <field name="863Channel57" mask="0x00400000"/>
+    <field name="915Channel22" mask="0x00400000"/>
+    <field name="Channel23" mask="0x00800000"/>
+    <field name="863Channel23" mask="0x00800000"/>
+    <field name="863Channel58" mask="0x00800000"/>
+    <field name="915Channel23" mask="0x00800000"/>
+    <field name="Channel24" mask="0x01000000"/>
+    <field name="863Channel24" mask="0x01000000"/>
+    <field name="863Channel59" mask="0x01000000"/>
+    <field name="915Channel24" mask="0x01000000"/>
+    <field name="Channel25" mask="0x02000000"/>
+    <field name="863Channel25" mask="0x02000000"/>
+    <field name="863Channel60" mask="0x02000000"/>
+    <field name="915Channel25" mask="0x02000000"/>
+    <field name="Channel26" mask="0x04000000"/>
+    <field name="863Channel26" mask="0x04000000"/>
+    <field name="863Channel61" mask="0x04000000"/>
+    <field name="915Channel26" mask="0x04000000"/>
+    <field name="Page" mask="0xF8000000"/>
+  </bitmap>
+  <cluster singleton="true">
+    <!-- introducedIn="..." -->
+    <name>Sub-GHz</name>
+    <domain>SE</domain>
+    <description>Used by the Smart Energy profile for duty cycle monitoring and frequency agility.</description>
+    <code>0x070B</code>
+    <define>SUB_GHZ_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Sub-GHz Cluster Server - Attributes -->
+    <attribute side="server" code="0x0000" define="SUB_GHZ_CLUSTER_CHANNEL_CHANGE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="false">sub-GHz channel change (server)</attribute>
+    <attribute side="server" code="0x0001" define="SUB_GHZ_CLUSTER_PAGE_28_CHANNEL_MASK" type="BITMAP32" min="0xE0000000" max="0xE7FFFFFF" writable="false" default="0xE7FFFFFF" optional="false">sub-GHz page 28 channel mask (server)</attribute>
+    <attribute side="server" code="0x0002" define="SUB_GHZ_CLUSTER_PAGE_29_CHANNEL_MASK" type="BITMAP32" min="0xE8000000" max="0xE80001FF" writable="false" default="0xE80001FF" optional="false">sub-GHz page 29 channel mask (server)</attribute>
+    <attribute side="server" code="0x0003" define="SUB_GHZ_CLUSTER_PAGE_30_CHANNEL_MASK" type="BITMAP32" min="0xF0000000" max="0xF7FFFFFF" writable="false" default="0xF7FFFFFF" optional="false">sub-GHz page 30 channel mask (server)</attribute>
+    <attribute side="server" code="0x0004" define="SUB_GHZ_CLUSTER_PAGE_31_CHANNEL_MASK" type="BITMAP32" min="0xF8000000" max="0xFFFFFFFF" writable="false" default="0xFFFFFFFF" optional="false">sub-GHz page 31 channel mask (server)</attribute>
+    <!-- Sub-GHz Cluster Client - Attributes -->
+    <!-- Sub-GHz Cluster Server - Commands -->
+    <command source="server" code="0x00" name="SuspendZclMessages" optional="false" disableDefaultResponse="false">
+      <description>
+        The server sends it to temporarily suspend ZCL messages from clients it identifies as causing too much traffic.
+      </description>
+      <arg name="period" type="INT8U"/>
+    </command>
+    <!-- Sub-GHz Cluster Client - Commands -->
+    <command source="client" code="0x00" name="GetSuspendZclMessagesStatus" optional="false">
+      <description>
+        The client sends it to determine the current status of its ZCL communications from the server.
+      </description>
+    </command>
+  </cluster>
+  <!-- Key Establishment Cluster - Structs, BITMAPs & ENUMs -->
+  <enum name="AmiKeyEstablishmentStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="UnknownIssuer" value="0x01"/>
+    <item name="BadKeyConfirm" value="0x02"/>
+    <item name="BadMessage" value="0x03"/>
+    <item name="NoResources" value="0x04"/>
+    <item name="UnsupportedSuite" value="0x05"/>
+    <item name="InvalidKeyUsage" value="0x06"/>
+  </enum>
+  <struct name="Identity" length="48"/>
+  <struct name="EphemeralData" length="22"/>
+  <struct name="Smac" length="16"/>
+  <!-- Key Establishment Cluster -->
+  <cluster singleton="true">
+    <name>Key Establishment</name>
+    <domain>General</domain>
+    <description>Key Establishment cluster</description>
+    <code>0x0800</code>
+    <define>KEY_ESTABLISHMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <!-- Key Establishment Server - Attributes -->
+    <attribute side="server" code="0x0000" define="KEY_ESTABLISHMENT_SUITE_SERVER" type="ENUM16" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">key establishment suite (server)</attribute>
+    <!-- Key Establishment Client - Attributes -->
+    <attribute side="client" code="0x0000" define="KEY_ESTABLISHMENT_SUITE_CLIENT" type="ENUM16" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">key establishment suite (client)</attribute>
+    <!-- Key Establishment Client - Commands -->
+    <command source="client" code="0x00" name="InitiateKeyEstablishmentRequest" optional="false">
+      <description>
+        Command description for InitiateKeyEstablishmentRequest
+      </description>
+      <arg name="keyEstablishmentSuite" type="BITMAP16"/>
+      <arg name="ephemeralDataGenerateTime" type="INT8U"/>
+      <arg name="confirmKeyGenerateTime" type="INT8U"/>
+      <arg name="identity" type="Identity"/>
+    </command>
+    <command source="client" code="0x01" name="EphemeralDataRequest" optional="false">
+      <description>
+        Command description for EphemeralDataRequest
+      </description>
+      <arg name="ephemeralData" type="EphemeralData"/>
+    </command>
+    <command source="client" code="0x02" name="ConfirmKeyDataRequest" optional="false">
+      <description>
+        Command description for ConfirmKeyDataRequest
+      </description>
+      <arg name="secureMessageAuthenticationCode" type="Smac"/>
+    </command>
+    <!-- Key Establishment Client & Server - Commands -->
+    <command source="either" code="0x03" name="TerminateKeyEstablishment" optional="false">
+      <description>
+        Command description for TerminateKeyEstablishment
+      </description>
+      <arg name="statusCode" type="AmiKeyEstablishmentStatus"/>
+      <arg name="waitTime" type="INT8U"/>
+      <arg name="keyEstablishmentSuite" type="BITMAP16"/>
+    </command>
+    <!-- Key Establishment Server - Commands -->
+    <command source="server" code="0x00" name="InitiateKeyEstablishmentResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for InitiateKeyEstablishmentResponse
+      </description>
+      <arg name="requestedKeyEstablishmentSuite" type="BITMAP16"/>
+      <arg name="ephemeralDataGenerateTime" type="INT8U"/>
+      <arg name="confirmKeyGenerateTime" type="INT8U"/>
+      <arg name="identity" type="Identity"/>
+    </command>
+    <command source="server" code="0x01" name="EphemeralDataResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for EphemeralDataResponse
+      </description>
+      <arg name="ephemeralData" type="EphemeralData"/>
+    </command>
+    <command source="server" code="0x02" name="ConfirmKeyDataResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ConfirmKeyDataResponse
+      </description>
+      <arg name="secureMessageAuthenticationCode" type="Smac"/>
+    </command>
+  </cluster>
+  <cluster singleton="true">
+    <name>Keep-Alive</name>
+    <!-- The intention seems to be to make this a generic cluster even though it is specified in the Smart Energy spec.  Any server can inform other clients of how often they should send in a keep-alive. -->
+    <domain>SE</domain>
+    <description>This cluster supports the commands and attributes directed to the network Trust Center in order to determine whether communication with the Trust Center is still available.</description>
+    <code>0x0025</code>
+    <define>KEEPALIVE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Keep-Alive Cluster Client - Attributes -->
+    <!-- Keep-Alive Cluster Server - Attributes -->
+    <attribute side="server" code="0x0000" define="KEEPALIVE_BASE" type="INT8U" min="0x01" max="0xFF" writable="false" default="1" optional="false" introducedIn="se-1.2b-15-0131-02">Keep-Alive Base</attribute>
+    <attribute side="server" code="0x0001" define="KEEPALIVE_JITTER" type="INT16U" min="0x0000" max="0x0200" writable="false" default="60" optional="false" introducedIn="se-1.2b-15-0131-02">Keep-Alive Jitter</attribute>
+    <!-- Keep-Alive Cluster Client - Commands -->
+    <!-- Keep-Alive Cluster Server - Commands -->
+  </cluster>
+  <!-- SE extension to the Alarms cluster. -->
+  <enum name="EventId" type="ENUM8">
+    <item value="0x00" name="MeterCoverRemoved"/>
+    <item value="0x01" name="MeterCoverClosed"/>
+    <item value="0x02" name="StrongMagneticField"/>
+    <item value="0x03" name="NoStrongMagneticField"/>
+    <item value="0x04" name="BatteryFailure"/>
+    <item value="0x05" name="LowBattery"/>
+    <item value="0x06" name="ProgramMemoryError"/>
+    <item value="0x07" name="RamError"/>
+    <item value="0x08" name="NvMemoryError"/>
+    <item value="0x09" name="MeasurementSystemError"/>
+    <item value="0x0A" name="WatchdogError"/>
+    <item value="0x0B" name="SupplyDisconnectFailure"/>
+    <item value="0x0C" name="SupplyConnectFailure"/>
+    <item value="0x0D" name="MeasurmentSoftwareChanged"/>
+    <item value="0x0E" name="DstEnabled"/>
+    <item value="0x0F" name="DstDisabled"/>
+    <item value="0x10" name="ClockAdjBackward"/>
+    <item value="0x11" name="ClockAdjForward"/>
+    <item value="0x12" name="ClockInvalid"/>
+    <item value="0x13" name="CommsErrorHan"/>
+    <item value="0x14" name="CommsOkHan"/>
+    <item value="0x15" name="FraudAttempt"/>
+    <item value="0x16" name="PowerLoss"/>
+    <item value="0x17" name="IncorrectProtocol"/>
+    <item value="0x18" name="UnusualHanTraffic"/>
+    <item value="0x19" name="UnexpectedClockChange"/>
+    <item value="0x1A" name="CommsUsingUnauthenticatedComponent"/>
+    <item value="0x1B" name="ErrorRegClear"/>
+    <item value="0x1C" name="AlarmRegClear"/>
+    <item value="0x1D" name="UnexpectedHwReset"/>
+    <item value="0x1E" name="UnexpectedProgramExecution"/>
+    <item value="0x1F" name="EventLogCleared"/>
+    <item value="0x20" name="ManualDisconnect"/>
+    <item value="0x21" name="ManualConnect"/>
+    <item value="0x22" name="RemoteDisconnection"/>
+    <item value="0x23" name="LocalDisconnection"/>
+    <item value="0x24" name="LimitThresholdExceeded"/>
+    <item value="0x25" name="LimitThresholdOk"/>
+    <item value="0x26" name="LimitThresholdChanged"/>
+    <item value="0x27" name="MaximumDemandExceeded"/>
+    <item value="0x28" name="ProfileCleared"/>
+    <item value="0x29" name="FirmwareReadyForActivation"/>
+    <item value="0x2A" name="FirmwareActivated"/>
+    <item value="0x2B" name="PatchFailure"/>
+    <item value="0x2C" name="TouTariffActivation"/>
+    <item value="0x2D" name="8x8Tariffactivated"/>
+    <item value="0x2E" name="SingleTariffRateActivated"/>
+    <item value="0x2F" name="AsynchronousBillingOccurred"/>
+    <item value="0x30" name="SynchronousBillingOccurred"/>
+    <item value="0x80" name="IncorrectPolarity"/>
+    <item value="0x81" name="CurrentNoVoltage"/>
+    <item value="0x82" name="UnderVoltage"/>
+    <item value="0x83" name="OverVoltage"/>
+    <item value="0x84" name="NormalVoltage"/>
+    <item value="0x85" name="PfBelowThreshold"/>
+    <item value="0x86" name="PfAboveThreshold"/>
+    <item value="0x87" name="TerminalCoverRemoved"/>
+    <item value="0x88" name="TerminalCoverClosed"/>
+    <item value="0xA0" name="ReverseFlow"/>
+    <item value="0xA1" name="TiltTamper"/>
+    <item value="0xA2" name="BatteryCoverRemoved"/>
+    <item value="0xA3" name="BatteryCoverClosed"/>
+    <item value="0xA4" name="ExcessFlow"/>
+    <item value="0xC0" name="CreditOk"/>
+    <item value="0xC1" name="LowCredit"/>
+    <item value="0xC0" name="EmergencyCreditInUse"/>
+    <item value="0xC1" name="EmergencyCreditExhausted"/>
+    <item value="0xC2" name="ZeroCreditEcNotSelected"/>
+    <item value="0xC3" name="SupplyOn"/>
+    <item value="0xC4" name="SupplyOffAarmed"/>
+    <item value="0xC5" name="SupplyOff"/>
+    <item value="0xC6" name="DiscountApplied"/>
+    <item value="0xE0" name="ManufacturerSpecificA"/>
+    <item value="0xE1" name="ManufacturerSpecificB"/>
+    <item value="0xE2" name="ManufacturerSpecificC"/>
+    <item value="0xE3" name="ManufacturerSpecificD"/>
+    <item value="0xE4" name="ManufacturerSpecificE"/>
+    <item value="0xE5" name="ManufacturerSpecificF"/>
+    <item value="0xE6" name="ManufacturerSpecificG"/>
+    <item value="0xE7" name="ManufacturerSpecificH"/>
+    <item value="0xE8" name="ManufacturerSpecificI"/>
+  </enum>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/cba-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/cba-devices.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>BACnet Tunneled Device</name>
+    <domain>CBA</domain>
+    <typeName>CBA BACnet Tunneled Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0105</profileId>
+    <deviceId editable="false">0x000a</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">BACnet Protocol Tunnel</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>CBA-onofflight</name>
+    <domain>CBA</domain>
+    <typeName>CBA On/Off Light</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x109</profileId>
+    <deviceId editable="false">0x0100</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Commissioning</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>CBA-onofflightswitch</name>
+    <domain>CBA</domain>
+    <typeName>CBA On/Off Light Switch</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x105</profileId>
+    <deviceId editable="false">0x0103</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/Off Switch Configuration</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Commissioning</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>CBA-tstat</name>
+    <domain>CBA</domain>
+    <typeName>CBA Thermostat</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x105</profileId>
+    <deviceId editable="false">0x0301</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Thermostat</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Thermostat User Interface Configuration</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Fan control</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Temperature measurement</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Relative Humidity Measurement</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Commissioning</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>CBA-tempsensor</name>
+    <domain>CBA</domain>
+    <typeName>CBA Temperature Sensor</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x105</profileId>
+    <deviceId editable="false">0x0302</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Temperature measurement</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Commissioning</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>CBA-config</name>
+    <domain>CBA</domain>
+    <typeName>CBA Config Tool</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0105</profileId>
+    <deviceId editable="false">0x0005</deviceId>
+    <clusters lockOthers="false">
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Commissioning</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/cba.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/cba.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="CBA" spec="cba-1.0-05-3516-12" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  <cluster>
+    <name>Generic Tunnel</name>
+    <domain>CBA</domain>
+    <description>The minimum common commands and attributes required to tunnel any protocol.</description>
+    <code>0x0600</code>
+    <define>GENERIC_TUNNEL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0001" define="MAXIMUM_INCOMING_TRANSFER_SIZE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">maximum incoming transfer size</attribute>
+    <attribute side="server" code="0x0002" define="MAXIMUM_OUTGOING_TRANSFER_SIZE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">maximum outgoing transfer size</attribute>
+    <attribute side="server" code="0x0003" define="PROTOCOL_ADDRESS" type="OCTET_STRING" length="254" writable="true" optional="false">protocol address</attribute>
+    <command source="client" code="0x00" name="MatchProtocolAddress" optional="false" cli="zcl tunnel match">
+      <description>
+        This command is generated when an application wishes to find the ZigBee address (node, endpoint) of the Generic Tunnel server cluster with a given ProtocolAddress attribute. The command is typically multicast to a group of inter-communicating Generic Tunnel clusters
+      </description>
+      <arg name="protocolAddress" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x00" name="MatchProtocolAddressResponse" optional="false" cli="zcl tunnel response" disableDefaultResponse="true">
+      <description>
+      This command is generated upon receipt of a Match Protocol Address command to indicate that the Protocol Address was successfully matched.
+      </description>
+      <arg name="deviceIeeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="protocolAddress" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x01" name="AdvertiseProtocolAddress" optional="false" cli="zcl tunnel advertise">
+      <description>
+      This command is typically sent upon startup, and whenever the ProtocolAddress attribute changes. It is typically multicast to a group of inter-communicating Generic Tunnel clusters.
+      </description>
+      <arg name="protocolAddress" type="OCTET_STRING"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>BACnet Protocol Tunnel</name>
+    <domain>CBA</domain>
+    <description>Commands and attributes required to tunnel the BACnet protocol.</description>
+    <code>0x0601</code>
+    <define>BACNET_PROTOCOL_TUNNEL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="TransferNpdu" optional="false" cli="zcl bacnet transfer-npdu random">
+      <description>
+      This command is generated when a BACnet network layer wishes to transfer a BACnet NPDU across a ZigBee tunnel to another BACnet network layer.
+      </description>
+      <arg name="npdu" type="DATA8" array="true"/>
+    </command>
+  </cluster>
+  <!-- EO CBA Clusters -->
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/chip.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/chip.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+    <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <enum name="NetworkProvisioningError" type="ENUM8">
+        <item name="Success" value="0x0"/>
+        <item name="OutOfRange" value="0x1"/>
+        <item name="BoundsExceeded" value="0x2"/>
+        <item name="NetworkIDNotFound" value="0x3"/>
+        <item name="DuplicateNetworkID" value="0x4"/>
+        <item name="NetworkNotFound" value="0x5"/>
+        <item name="RegulatoryError" value="0x6"/>
+        <item name="AuthFailure" value="0x7"/>
+        <item name="UnsupportedSecurity" value="0x8"/>
+        <item name="OtherConnectionFailure" value="0x9"/>
+        <item name="IPV6Failed" value="0xa"/>
+        <item name="IPBindFailed" value="0xb"/>
+        <item name="Label9" value="0xc"/>
+        <item name="Label10" value="0xd"/>
+        <item name="Label11" value="0xe"/>
+        <item name="Label12" value="0xf"/>
+        <item name="Label13" value="0x10"/>
+        <item name="Label14" value="0x11"/>
+        <item name="Label15" value="0x12"/>
+        <item name="UnknownError" value="0x13"/>
+    </enum>
+    <bitmap name="ShadeClosureStatus" type="BITMAP8">
+        <field name="Unencrypted" mask="0x1"/>
+        <field name="WEP-PERSONAL" mask="0x2"/>
+        <field name="WPA-PERSONAL" mask="0x4"/>
+        <field name="WPA2-PERSONAL" mask="0x8"/>
+        <field name="WPA3-PERSONAL" mask="0x10"/>
+    </bitmap>
+    <struct name="WiFiInterfaceScanResult">
+        <item name="Security" type="BITMAP8"/>
+        <item name="SSID" type="OCTET_STRING"/>
+        <item name="BSSID" type="OCTET_STRING"/>
+        <item name="Channel" type="INT8U"/>
+        <item name="FrequencyBand" type="INT32U"/>
+    </struct>
+    <struct name="ThreadInterfaceScanResult">
+        <item name="DiscoveryResponse" type="OCTET_STRING"/>
+    </struct>
+    <cluster>
+        <name>Network Provisioning</name>
+        <domain>CHIP</domain>
+        <description>TODO</description>
+        <code>0x9999</code>
+        <define>NWPROV_CLUSTER</define>
+        <client tick="false" init="false">true</client>
+        <server tick="false" init="false">true</server>
+        <command source="client" code="0x01" name="ScanNetworks" optional="false" cli="chip nwprov scannetworks">
+            <description>TODO</description>
+            <arg name="SSID" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x02" name="ScanNetworksResp" optional="false" cli="chip nwprov scannetworksresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+            <arg name="WiFiScanResults" type="WiFiInterfaceScanResult" array="true"/>
+            <arg name="ThreadScanResults" type="ThreadInterfaceScanResult" array="true"/>
+        </command>
+        <command source="client" code="0x03" name="AddWiFiNetwork" optional="false" cli="chip nwprov addwifinetwork">
+            <description>TODO</description>
+            <arg name="SSID" type="OCTET_STRING"/>
+            <arg name="Credentials" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x04" name="AddWiFiNetworkResp" optional="false" cli="chip nwprov addwifiresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x05" name="UpdateWiFiNetwork" optional="false" cli="chip nwprov updatewifinetwork">
+            <description>TODO</description>
+            <arg name="SSID" type="OCTET_STRING"/>
+            <arg name="Credentials" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x06" name="UpdateWiFiNetworkResp" optional="false" cli="chip nwprov updatewifiresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x07" name="AddThreadNetwork" optional="false" cli="chip nwprov addthreadnetwork">
+            <description>TODO</description>
+            <arg name="OperationalDataset" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x08" name="AddThreadNetworkResp" optional="false" cli="chip nwprov addthreadnetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x09" name="UpdateThreadNetwork" optional="false" cli="chip nwprov updatethreadnetwork">
+            <description>TODO</description>
+            <arg name="OperationalDataset" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x0a" name="UpdateThreadNetworkResp" optional="false" cli="chip nwprov updatethreadnetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x0f" name="RemoveNetwork" optional="false" cli="chip nwprov removenetwork">
+            <description>TODO</description>
+            <arg name="NetworkID" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x10" name="RemoveNetworkResp" optional="false" cli="chip nwprov removenetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x11" name="EnableNetwork" optional="false" cli="chip nwprov enablenetwork">
+            <description>TODO</description>
+            <arg name="NetworkID" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x12" name="EnableNetworkResp" optional="false" cli="chip nwprov enablenetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x13" name="DisableNetwork" optional="false" cli="chip nwprov disablenetwork">
+            <description>TODO</description>
+            <arg name="NetworkID" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x14" name="DisableNetworkResp" optional="false" cli="chip nwprov disablenetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x15" name="TestNetwork" optional="false" cli="chip nwprov testnetwork">
+            <description>TODO</description>
+            <arg name="NetworkID" type="OCTET_STRING"/>
+            <arg name="Breadcrumb" type="INT64U"/>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+        <command source="client" code="0x16" name="TestNetworkResp" optional="false" cli="chip nwprov testnetworkresponse">
+            <description>TODO</description>
+            <arg name="ErrorCode" type="INT8U"/>
+            <arg name="DebugText" type="CHAR_STRING"/>
+        </command>
+        <command source="client" code="0x17" name="GetLastNetworkProvisioningResult" optional="false" cli="chip nwprov getlastnetworkprovisioningresult">
+            <description>TODO</description>
+            <arg name="TimeoutMs" type="INT32U"/>
+        </command>
+    </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/general-thread.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general-thread.xml
@@ -1,0 +1,970 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="General" spec="zcl-7.0-07-5123-07" certifiable="false">
+    <older spec="zcl-6.0-15-02017-001"/>
+  </domain>
+  <domain name="Lighting &amp; Occupancy" spec="l&amp;o-1.0-15-0014-04" certifiable="false"/>
+  <domain name="HA" spec="ha-1.2.1-05-3520-30" dependsOn="zcl-1.0-07-5123-03" certifiable="false">
+    <older spec="ha-1.2-05-3520-29" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="ha-1.1-05-3520-27" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <global>
+    <command code="0x00" name="ReadAttributes" source="either">
+      <description>
+        Command description for ReadAttributes
+      </description>
+      <arg name="attributeIds" type="ATTRIBUTE_ID" array="true"/>
+    </command>
+    <command code="0x01" name="ReadAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ReadAttributesResponse
+      </description>
+      <arg name="readAttributeStatusRecords" type="ReadAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x02" name="WriteAttributes" source="either">
+      <description>
+        Command description for WriteAttributes
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x03" name="WriteAttributesUndivided" source="either">
+      <description>
+        Command description for WriteAttributesUndivided
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x04" name="WriteAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesResponse
+      </description>
+      <arg name="writeAttributeStatusRecords" type="WriteAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x05" name="WriteAttributesNoResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesNoResponse
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x06" name="ConfigureReporting" source="either">
+      <description>
+        Command description for ConfigureReporting
+      </description>
+      <arg name="configureReportingRecords" type="ConfigureReportingRecord" array="true"/>
+    </command>
+    <command code="0x07" name="ConfigureReportingResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ConfigureReportingResponse
+      </description>
+      <arg name="configureReportingStatusRecords" type="ConfigureReportingStatusRecord" array="true"/>
+    </command>
+    <command code="0x08" name="ReadReportingConfiguration" source="either">
+      <description>
+        Command description for ReadReportingConfiguration
+      </description>
+      <arg name="readReportingConfigurationAttributeRecords" type="ReadReportingConfigurationAttributeRecord" array="true"/>
+    </command>
+    <command code="0x09" name="ReadReportingConfigurationResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ReadReportingConfigurationResponse
+      </description>
+      <arg name="readReportingConfigurationRecords" type="ReadReportingConfigurationRecord" array="true"/>
+    </command>
+    <command code="0x0A" name="ReportAttributes" source="either">
+      <description>
+        Command description for ReportAttributes
+      </description>
+      <arg name="reportAttributeRecords" type="ReportAttributeRecord" array="true"/>
+    </command>
+    <command code="0x0B" name="DefaultResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for DefaultResponse
+      </description>
+      <arg name="commandId" type="INT8U"/>
+      <arg name="status" type="Status"/>
+    </command>
+    <command code="0x0C" name="DiscoverAttributes" source="either">
+      <description>
+        Command description for DiscoverAttributes
+      </description>
+      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="maxAttributeIds" type="INT8U"/>
+    </command>
+    <command code="0x0D" name="DiscoverAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for DiscoverAttributesResponse
+      </description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="discoverAttributesInfoRecords" type="DiscoverAttributesInfoRecord" array="true"/>
+    </command>
+    <command code="0x0E" name="ReadAttributesStructured" source="either">
+      <description>
+        Command description for ReadAttributesStructured
+      </description>
+      <arg name="readStructuredAttributeRecords" type="ReadStructuredAttributeRecord" array="true"/>
+    </command>
+    <command code="0x0F" name="WriteAttributesStructured" source="either">
+      <description>
+        Command description for WriteAttributesStructured
+      </description>
+      <arg name="writeStructuredAttributeRecords" type="WriteStructuredAttributeRecord" array="true"/>
+    </command>
+    <command code="0x10" name="WriteAttributesStructuredResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesStructuredResponse
+      </description>
+      <arg name="writeStructuredAttributeStatusRecords" type="WriteStructuredAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x11" name="DiscoverCommandsReceived" source="either">
+      <description>This command may be used to discover all commands processed (received) by this cluster, including optional or manufacturer specific commands.</description>
+      <arg name="startCommandId" type="INT8U"/>
+      <arg name="maxCommandIds" type="INT8U"/>
+    </command>
+    <command code="0x12" name="DiscoverCommandsReceivedResponse" source="either" disableDefaultResponse="true">
+      <description>The discover commands received response command is sent in response to a discover commands received command, and is used to discover which commands a particular cluster can process.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="commandIds" type="INT8U" array="true"/>
+    </command>
+    <command code="0x13" name="DiscoverCommandsGenerated" source="either">
+      <description>This command may be used to discover all commands which may be generated (sent) by the cluster, including optional or manufacturer specific commands.</description>
+      <arg name="startCommandId" type="INT8U"/>
+      <arg name="maxCommandIds" type="INT8U"/>
+    </command>
+    <command code="0x14" name="DiscoverCommandsGeneratedResponse" source="either" disableDefaultResponse="true">
+      <description>The discover client commands response command is sent in response to a discover client commands command, and is used to discover which commands a particular cluster supports.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="commandIds" type="INT8U" array="true"/>
+    </command>
+    <command code="0x15" name="DiscoverAttributesExtended" source="either">
+      <description>This command is similar to the discover attributes command, but also includes a field to indicate whether the attribute is readable, writeable or reportable.</description>
+      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="maxAttributeIds" type="INT8U"/>
+    </command>
+    <command code="0x16" name="DiscoverAttributesExtendedResponse" source="either" disableDefaultResponse="true">
+      <description>This command is sent in response to a discover attribute extended command and is used to determine if attributes are readable, writable or reportable.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="extendedDiscoverAttributesInfoRecords" type="ExtendedDiscoverAttributesInfoRecord" array="true"/>
+    </command>
+    <attribute side="client" code="0xFFFD" define="CLUSTER_REVISION_CLIENT" type="INT16U" min="0x0001" max="0xFFFE" writable="false" default="0x0001" optional="false" introducedIn="zcl-6.0-15-02017-001">cluster revision</attribute>
+    <attribute side="client" code="0xFFFE" define="REPORTING_STATUS_CLIENT" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="zcl-6.0-15-02017-001">reporting status</attribute>
+    <attribute side="server" code="0xFFFD" define="CLUSTER_REVISION_SERVER" type="INT16U" min="0x0001" max="0xFFFE" writable="false" default="0x0001" optional="false" introducedIn="zcl-6.0-15-02017-001">cluster revision</attribute>
+    <attribute side="server" code="0xFFFE" define="REPORTING_STATUS_SERVER" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="zcl-6.0-15-02017-001">reporting status</attribute>
+  </global>
+  <cluster singleton="true">
+    <name>Basic</name>
+    <domain>General</domain>
+    <description>Attributes for determining basic information about a device, setting user device information such as location, and enabling a device.</description>
+    <code>0x0000</code>
+    <define>BASIC_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x03" optional="false">ZCL version</attribute>
+    <!-- ZCL_VERSION -->
+    <attribute side="server" code="0x0001" define="APPLICATION_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">application version</attribute>
+    <attribute side="server" code="0x0002" define="STACK_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">stack version</attribute>
+    <attribute side="server" code="0x0003" define="HW_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">hardware version</attribute>
+    <attribute side="server" code="0x0004" define="MANUFACTURER_NAME" type="CHAR_STRING" length="32" writable="false" default="" optional="true">manufacturer name</attribute>
+    <attribute side="server" code="0x0005" define="MODEL_IDENTIFIER" type="CHAR_STRING" length="32" writable="false" default="" optional="true">model identifier</attribute>
+    <attribute side="server" code="0x0006" define="DATE_CODE" type="CHAR_STRING" length="16" writable="false" default="" optional="true">date code</attribute>
+    <attribute side="server" code="0x0007" define="POWER_SOURCE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">power source</attribute>
+    <attribute side="server" code="0x0008" define="GENERIC_DEVICE_CLASS" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">generic device class</attribute>
+    <attribute side="server" code="0x0009" define="GENERIC_DEVICE_TYPE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">generic device type</attribute>
+    <attribute side="server" code="0x000A" define="PRODUCT_CODE" type="OCTET_STRING" length="16" writable="false" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">product code</attribute>
+    <attribute side="server" code="0x000B" define="PRODUCT_URL" type="CHAR_STRING" length="64" writable="false" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">product url</attribute>
+    <attribute side="server" code="0x0010" define="LOCATION_DESCRIPTION" type="CHAR_STRING" length="16" writable="true" default="" optional="true">location description</attribute>
+    <attribute side="server" code="0x0011" define="PHYSICAL_ENVIRONMENT" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">physical environment</attribute>
+    <attribute side="server" code="0x0012" define="DEVICE_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x01" optional="true">device enabled</attribute>
+    <attribute side="server" code="0x0013" define="ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">alarm mask</attribute>
+    <attribute side="server" code="0x0014" define="DISABLE_LOCAL_CONFIG" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">disable local config</attribute>
+    <command source="client" code="0x00" name="ResetToFactoryDefaults" optional="true" cli="zcl basic rtfd">
+      <description>Command that resets all attribute values to factory default.</description>
+    </command>
+  </cluster>
+  <cluster singleton="true">
+    <name>Power Configuration</name>
+    <domain>General</domain>
+    <description>Attributes for determining more detailed information about a device's power source(s), and for configuring under/over voltage alarms.</description>
+    <code>0x0001</code>
+    <define>POWER_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="MAINS_VOLTAGE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">mains voltage</attribute>
+    <attribute side="server" code="0x0001" define="MAINS_FREQUENCY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">mains frequency</attribute>
+    <attribute side="server" code="0x0010" define="MAINS_ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">mains alarm mask</attribute>
+    <attribute side="server" code="0x0011" define="MAINS_VOLTAGE_MIN_THRESHOLD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">mains voltage min threshold</attribute>
+    <attribute side="server" code="0x0012" define="MAINS_VOLTAGE_MAX_THRESHOLD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true">mains voltage max threshold</attribute>
+    <attribute side="server" code="0x0013" define="MAINS_VOLTAGE_DWELL_TRIP_POINT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">mains voltage dwell trip</attribute>
+    <attribute side="server" code="0x0020" define="BATTERY_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">battery voltage</attribute>
+    <attribute side="server" code="0x0021" define="BATTERY_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage remaining</attribute>
+    <attribute side="server" code="0x0030" define="BATTERY_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true">battery manufacturer</attribute>
+    <attribute side="server" code="0x0031" define="BATTERY_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true">battery size</attribute>
+    <attribute side="server" code="0x0032" define="BATTERY_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">battery ahr rating</attribute>
+    <attribute side="server" code="0x0033" define="BATTERY_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">battery quantity</attribute>
+    <attribute side="server" code="0x0034" define="BATTERY_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">battery rated voltage</attribute>
+    <attribute side="server" code="0x0035" define="BATTERY_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">battery alarm mask</attribute>
+    <attribute side="server" code="0x0036" define="BATTERY_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">battery voltage min threshold</attribute>
+    <attribute side="server" code="0x0037" define="BATTERY_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 1</attribute>
+    <attribute side="server" code="0x0038" define="BATTERY_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 2</attribute>
+    <attribute side="server" code="0x0039" define="BATTERY_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 3</attribute>
+    <attribute side="server" code="0x003a" define="BATTERY_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage min threshold</attribute>
+    <attribute side="server" code="0x003b" define="BATTERY_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 1</attribute>
+    <attribute side="server" code="0x003c" define="BATTERY_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 2</attribute>
+    <attribute side="server" code="0x003d" define="BATTERY_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 3</attribute>
+    <attribute side="server" code="0x003e" define="BATTERY_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery alarm state</attribute>
+    <attribute side="server" code="0x0040" define="BATTERY_2_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage</attribute>
+    <attribute side="server" code="0x0041" define="BATTERY_2_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage remaining</attribute>
+    <attribute side="server" code="0x0050" define="BATTERY_2_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 manufacturer</attribute>
+    <attribute side="server" code="0x0051" define="BATTERY_2_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 size</attribute>
+    <attribute side="server" code="0x0052" define="BATTERY_2_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 ahr rating</attribute>
+    <attribute side="server" code="0x0053" define="BATTERY_2_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 quantity</attribute>
+    <attribute side="server" code="0x0054" define="BATTERY_2_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 rated voltage</attribute>
+    <attribute side="server" code="0x0055" define="BATTERY_2_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 alarm mask</attribute>
+    <attribute side="server" code="0x0056" define="BATTERY_2_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage min threshold</attribute>
+    <attribute side="server" code="0x0057" define="BATTERY_2_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 1</attribute>
+    <attribute side="server" code="0x0058" define="BATTERY_2_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 2</attribute>
+    <attribute side="server" code="0x0059" define="BATTERY_2_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 3</attribute>
+    <attribute side="server" code="0x005a" define="BATTERY_2_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage min threshold</attribute>
+    <attribute side="server" code="0x005b" define="BATTERY_2_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 1</attribute>
+    <attribute side="server" code="0x005c" define="BATTERY_2_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 2</attribute>
+    <attribute side="server" code="0x005d" define="BATTERY_2_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 3</attribute>
+    <attribute side="server" code="0x005e" define="BATTERY_2_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 alarm state</attribute>
+    <attribute side="server" code="0x0060" define="BATTERY_3_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage</attribute>
+    <attribute side="server" code="0x0061" define="BATTERY_3_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage remaining</attribute>
+    <attribute side="server" code="0x0070" define="BATTERY_3_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 manufacturer</attribute>
+    <attribute side="server" code="0x0071" define="BATTERY_3_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 size</attribute>
+    <attribute side="server" code="0x0072" define="BATTERY_3_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 ahr rating</attribute>
+    <attribute side="server" code="0x0073" define="BATTERY_3_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 quantity</attribute>
+    <attribute side="server" code="0x0074" define="BATTERY_3_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 rated voltage</attribute>
+    <attribute side="server" code="0x0075" define="BATTERY_3_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 alarm mask</attribute>
+    <attribute side="server" code="0x0076" define="BATTERY_3_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage min threshold</attribute>
+    <attribute side="server" code="0x0077" define="BATTERY_3_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 1</attribute>
+    <attribute side="server" code="0x0078" define="BATTERY_3_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 2</attribute>
+    <attribute side="server" code="0x0079" define="BATTERY_3_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 3</attribute>
+    <attribute side="server" code="0x007a" define="BATTERY_3_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage min threshold</attribute>
+    <attribute side="server" code="0x007b" define="BATTERY_3_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 1</attribute>
+    <attribute side="server" code="0x007c" define="BATTERY_3_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 2</attribute>
+    <attribute side="server" code="0x007d" define="BATTERY_3_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 3</attribute>
+    <attribute side="server" code="0x007e" define="BATTERY_3_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 alarm state</attribute>
+  </cluster>
+  <cluster>
+    <name>Device Temperature Configuration</name>
+    <domain>General</domain>
+    <description>Attributes for determining information about a device's internal temperature, and for configuring under/over temperature alarms.</description>
+    <code>0x0002</code>
+    <define>DEVICE_TEMP_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CURRENT_TEMPERATURE" type="INT16S" min="-200" max="200" writable="false" optional="false">current temperature</attribute>
+    <attribute side="server" code="0x0001" define="MIN_TEMP_EXPERIENCED" type="INT16S" min="-200" max="200" writable="false" optional="true">min temp experienced</attribute>
+    <attribute side="server" code="0x0002" define="MAX_TEMP_EXPERIENCED" type="INT16S" min="-200" max="200" writable="false" optional="true">max temp experienced</attribute>
+    <attribute side="server" code="0x0003" define="OVER_TEMP_TOTAL_DWELL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">over temp total dwell</attribute>
+    <attribute side="server" code="0x0010" define="DEVICE_TEMP_ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">device temp alarm mask</attribute>
+    <attribute side="server" code="0x0011" define="LOW_TEMP_THRESHOLD" type="INT16S" min="-200" max="200" writable="true" optional="true">low temp threshold</attribute>
+    <attribute side="server" code="0x0012" define="HIGH_TEMP_THRESHOLD" type="INT16S" min="-200" max="200" writable="true" optional="true">high temp threshold</attribute>
+    <attribute side="server" code="0x0013" define="LOW_TEMP_DWELL_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="true" optional="true">low temp dwell trip point</attribute>
+    <attribute side="server" code="0x0014" define="HIGH_TEMP_DWELL_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="true" optional="true">high temp dwell trip point</attribute>
+  </cluster>
+  <cluster>
+    <name>Identify</name>
+    <domain>General</domain>
+    <description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light).</description>
+    <code>0x0003</code>
+    <define>IDENTIFY_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="IDENTIFY_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="false">identify time</attribute>
+    <attribute side="server" code="0x0001" define="COMMISSION_STATE" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">commission state</attribute>
+    <command source="client" code="0x00" name="Identify" optional="false" cli="zcl identify id">
+      <description>
+        Command description for Identify
+      </description>
+      <arg name="identifyTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="IdentifyQuery" optional="false" cli="zcl identify query">
+      <description>
+        Command description for IdentifyQuery
+      </description>
+    </command>
+    <command source="client" code="0x02" name="EZModeInvoke" optional="true" cli="zcl identify ez-mode">
+      <description>
+	   Invoke EZMode on an Identify Server
+      </description>
+      <arg name="action" type="BITMAP8"/>
+    </command>
+    <command source="client" code="0x03" name="UpdateCommissionState" optional="true">
+      <description>
+          Update Commission State on the server device.
+      </description>
+      <arg name="action" type="ENUM8"/>
+      <arg name="commissionStateMask" type="BITMAP8"/>
+    </command>
+    <command source="server" code="0x00" name="IdentifyQueryResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for IdentifyQueryResponse
+      </description>
+      <arg name="timeout" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Groups</name>
+    <domain>General</domain>
+    <description>Attributes and commands for group configuration and manipulation.</description>
+    <code>0x0004</code>
+    <define>GROUPS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
+    <!-- NAME_SUPPORT -->
+    <command source="client" code="0x00" name="AddGroup" optional="false" cli="zcl groups add">
+      <description>
+        Command description for AddGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+      <arg name="addrAssignmentMode" type="INT8U"/>
+      <arg name="groupMcastAddress" type="OCTET_STRING"/>
+      <arg name="groupUdpPort" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="ViewGroup" optional="false" cli="zcl groups view">
+      <description>
+        Command description for ViewGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="GetGroupMembership" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
+      <description>
+        Command description for GetGroupMembership
+      </description>
+      <arg name="groupCount" type="INT8U" arrayLength="true"/>
+      <arg name="groupList" type="INT16U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="RemoveGroup" optional="false" cli="zcl groups remove">
+      <description>
+        Command description for RemoveGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="RemoveAllGroups" optional="false" cli="zcl groups rmall">
+      <description>
+        Command description for RemoveAllGroups
+      </description>
+    </command>
+    <command source="client" code="0x05" name="AddGroupIfIdentifying" optional="false" cli="zcl groups add-if-id">
+      <description>
+        Command description for AddGroupIfIdentifying
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+      <arg name="addrAssignmentMode" type="INT8U"/>
+      <arg name="groupMcastAddress" type="OCTET_STRING"/>
+      <arg name="groupUdpPort" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="AddGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for AddGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="ViewGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ViewGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+      <arg name="addrAssignmentMode" type="INT8U"/>
+      <arg name="groupMcastAddress" type="OCTET_STRING"/>
+      <arg name="groupUdpPort" type="INT16U"/>
+    </command>
+    <command source="server" code="0x02" name="GetGroupMembershipResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetGroupMembershipResponse
+      </description>
+      <arg name="capacity" type="INT8U"/>
+      <arg name="groupCount" type="INT8U" arrayLength="true"/>
+      <arg name="groupList" type="INT16U" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="RemoveGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Scenes</name>
+    <domain>General</domain>
+    <description>Attributes and commands for scene configuration and manipulation.</description>
+    <code>0x0005</code>
+    <define>SCENES_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SCENE_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">scene count</attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_SCENE" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">current scene</attribute>
+    <attribute side="server" code="0x0002" define="CURRENT_GROUP" type="INT16U" min="0x0000" max="0xFFF7" writable="false" default="0x0000" optional="false">current group</attribute>
+    <attribute side="server" code="0x0003" define="SCENE_VALID" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">scene valid</attribute>
+    <attribute side="server" code="0x0004" define="SCENE_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
+    <!-- NAME_SUPPORT -->
+    <attribute side="server" code="0x0005" define="LAST_CONFIGURED_BY" type="IEEE_ADDRESS" writable="false" optional="true">last configured by</attribute>
+    <command source="client" code="0x00" name="AddScene" optional="false" cli="zcl scenes add">
+      <description>
+        Add a scene to the scene table. Extension field sets are supported, and are inputed as arrays of the form [[cluster ID] [length] [value0...n] ...]
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="ViewScene" optional="false" cli="zcl scenes view">
+      <description>
+        Command description for ViewScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="RemoveScene" optional="false" cli="zcl scenes remove">
+      <description>
+        Command description for RemoveScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="RemoveAllScenes" optional="false" cli="zcl scenes rmall">
+      <description>
+        Command description for RemoveAllScenes
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="StoreScene" optional="false" cli="zcl scenes store">
+      <description>
+        Command description for StoreScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="RecallScene" optional="false" cli="zcl scenes recall">
+      <description>
+        Command description for RecallScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U" introducedIn="zcl-7.0-07-5123-07"/>
+    </command>
+    <command source="client" code="0x06" name="GetSceneMembership" optional="false" cli="zcl scenes get">
+      <description>
+        Command description for GetSceneMembership
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="AddSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for AddSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="ViewSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ViewSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U" presentIf="status==0"/>
+      <arg name="sceneName" type="CHAR_STRING" presentIf="status==0"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true" presentIf="status==0"/>
+    </command>
+    <command source="server" code="0x02" name="RemoveSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x03" name="RemoveAllScenesResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveAllScenesResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="StoreSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for StoreSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x06" name="GetSceneMembershipResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetSceneMembershipResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="capacity" type="INT8U"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneCount" type="INT8U" arrayLength="true" presentIf="status==0"/>
+      <arg name="sceneList" type="INT8U" array="true" presentIf="status==0"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>On/off</name>
+    <domain>General</domain>
+    <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
+    <code>0x0006</code>
+    <define>ON_OFF_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ON_OFF" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">on/off</attribute>
+    <attribute side="server" code="0x4003" define="START_UP_ON_OFF" type="ENUM8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">start up on off</attribute>
+    <command source="client" code="0x00" name="Off" optional="false" cli="zcl on-off off">
+      <description>
+        Command description for Off
+      </description>
+    </command>
+    <command source="client" code="0x01" name="On" optional="false" cli="zcl on-off on">
+      <description>
+        Command description for On
+      </description>
+    </command>
+    <command source="client" code="0x02" name="Toggle" optional="false" cli="zcl on-off toggle">
+      <description>
+        Command description for Toggle
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>On/off Switch Configuration</name>
+    <domain>General</domain>
+    <description>Attributes and commands for configuring On/Off switching devices.</description>
+    <code>0x0007</code>
+    <define>ON_OFF_SWITCH_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SWITCH_TYPE" type="ENUM8" min="0x00" max="0x01" writable="false" optional="false">switch type</attribute>
+    <attribute side="server" code="0x0010" define="SWITCH_ACTIONS" type="ENUM8" min="0x00" max="0x02" writable="true" default="0x00" optional="false">switch actions</attribute>
+  </cluster>
+  <cluster>
+    <name>Level Control</name>
+    <domain>General</domain>
+    <description>Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'</description>
+    <code>0x0008</code>
+    <define>LEVEL_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CURRENT_LEVEL" type="INT8U" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="false">current level</attribute>
+    <attribute side="server" code="0x0001" define="LEVEL_CONTROL_REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">remaining time</attribute>
+    <!-- REMAINING_TIME -->
+    <attribute side="server" code="0x0010" define="ON_OFF_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">on off transition time</attribute>
+    <attribute side="server" code="0x0011" define="ON_LEVEL" type="INT8U" min="0x00" max="0xFF" writable="true" default="0xFE" optional="true">on level</attribute>
+    <attribute side="server" code="0x0012" define="ON_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">on transition time</attribute>
+    <attribute side="server" code="0x0013" define="OFF_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">off transition time</attribute>
+    <attribute side="server" code="0x0014" define="DEFAULT_MOVE_RATE" type="INT8U" min="0x00" max="0xFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">default move rate</attribute>
+    <attribute side="server" code="0x000F" define="OPTIONS" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">options</attribute>
+    <attribute side="server" code="0x4000" define="START_UP_CURRENT_LEVEL" type="INT8U" min="0x01" max="0xFF" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">start up current level</attribute>
+    <command source="client" code="0x00" name="MoveToLevel" optional="false" cli="zcl level-control mv-to-level">
+      <description>
+        Command description for MoveToLevel
+      </description>
+      <arg name="level" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="Move" optional="false" cli="zcl level-control move">
+      <description>
+        Command description for Move
+      </description>
+      <arg name="moveMode" type="MoveMode"/>
+      <arg name="rate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="Step" optional="false" cli="zcl level-control step">
+      <description>
+        Command description for Step
+      </description>
+      <arg name="stepMode" type="StepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x03" name="Stop" optional="false" cli="zcl level-control stop">
+      <description>
+        Command description for Stop
+      </description>
+    </command>
+    <command source="client" code="0x04" name="MoveToLevelWithOnOff" optional="false" cli="zcl level-control o-mv-to-level">
+      <description>
+        Command description for MoveToLevelWithOnOff
+      </description>
+      <arg name="level" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="MoveWithOnOff" optional="false" cli="zcl level-control o-move">
+      <description>
+        Command description for MoveWithOnOff
+      </description>
+      <arg name="moveMode" type="MoveMode"/>
+      <arg name="rate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="StepWithOnOff" optional="false" cli="zcl level-control o-step">
+      <description>
+        Command description for StepWithOnOff
+      </description>
+      <arg name="stepMode" type="StepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="StopWithOnOff" optional="false" cli="zcl level-control o-stop">
+      <description>
+        Command description for StopWithOnOff
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Alarms</name>
+    <domain>General</domain>
+    <description>Attributes and commands for sending notifications and configuring alarm functionality.</description>
+    <code>0x0009</code>
+    <define>ALARM_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ALARM_COUNT" type="INT16U" min="0x00" writable="false" default="0x00" optional="true">alarm count</attribute>
+    <command source="client" code="0x00" name="ResetAlarm" optional="false">
+      <description>
+        Command description for ResetAlarm
+      </description>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="client" code="0x01" name="ResetAllAlarms" optional="false">
+      <description>
+        Command description for ResetAllAlarms
+      </description>
+    </command>
+    <command source="client" code="0x02" name="GetAlarm" optional="true">
+      <description>
+        Command description for GetAlarm
+      </description>
+    </command>
+    <command source="client" code="0x03" name="ResetAlarmLog" optional="true">
+      <description>
+        Command description for ResetAlarmLog
+      </description>
+    </command>
+    <command source="server" code="0x00" name="Alarm" optional="false">
+      <description>
+        Command description for Alarm
+      </description>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="server" code="0x01" name="GetAlarmResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for GetAlarmResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+      <arg name="timeStamp" type="INT32U"/>
+    </command>
+  </cluster>
+  <cluster singleton="true">
+    <name>Time</name>
+    <domain>General</domain>
+    <description>Attributes and commands that provide a basic interface to a real-time clock.</description>
+    <code>0x000A</code>
+    <define>TIME_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="false">time</attribute>
+    <attribute side="server" code="0x0001" define="TIME_STATUS" type="BITMAP8" min="0x00" max="0x0F" writable="true" default="0x00" optional="false">time status</attribute>
+    <attribute side="server" code="0x0002" define="TIME_ZONE" type="INT32S" min="0xFFFEAE80" max="0x00015180" writable="true" default="0x00000000" optional="true">time zone</attribute>
+    <attribute side="server" code="0x0003" define="DST_START" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="true">dst start</attribute>
+    <attribute side="server" code="0x0004" define="DST_END" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="true">dst end</attribute>
+    <attribute side="server" code="0x0005" define="DST_SHIFT" type="INT32S" min="0xFFFEAE80" max="0x00015180" writable="true" default="0x00000000" optional="true">dst shift</attribute>
+    <attribute side="server" code="0x0006" define="STANDARD_TIME" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" optional="true">standard time</attribute>
+    <attribute side="server" code="0x0007" define="LOCAL_TIME" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" optional="true">local time</attribute>
+    <attribute side="server" code="0x0008" define="LAST_SET_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0xFFFFFFFF" optional="true">last set time</attribute>
+    <attribute side="server" code="0x0009" define="VALID_UNTIL_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="true" default="0xFFFFFFFF" optional="true">valid until time</attribute>
+  </cluster>
+  <cluster>
+    <name>RSSI Location</name>
+    <domain>General</domain>
+    <description>Attributes and commands that provide a means for exchanging location information and channel parameters among devices.</description>
+    <code>0x000B</code>
+    <define>RSSI_LOCATION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LOCATION_TYPE" type="DATA8" min="0x00" max="0x0F" writable="false" optional="false">location type</attribute>
+    <attribute side="server" code="0x0001" define="LOCATION_METHOD" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">location method</attribute>
+    <attribute side="server" code="0x0002" define="LOCATION_AGE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">location age</attribute>
+    <attribute side="server" code="0x0003" define="QUALITY_MEASURE" type="INT8U" min="0x00" max="0x64" writable="false" optional="true">quality measure</attribute>
+    <attribute side="server" code="0x0004" define="NUMBER_OF_DEVICES" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">number of devices</attribute>
+    <attribute side="server" code="0x0010" define="COORDINATE1" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">coordinate 1</attribute>
+    <attribute side="server" code="0x0011" define="COORDINATE2" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">coordinate 2</attribute>
+    <attribute side="server" code="0x0012" define="COORDINATE3" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="true">coordinate 3</attribute>
+    <attribute side="server" code="0x0013" define="POWER" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">power</attribute>
+    <attribute side="server" code="0x0014" define="PATH_LOSS_EXPONENT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false">path loss exponent</attribute>
+    <attribute side="server" code="0x0015" define="REPORTING_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">reporting period</attribute>
+    <attribute side="server" code="0x0016" define="CALCULATION_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">calculation period</attribute>
+    <attribute side="server" code="0x0017" define="NUMBER_RSSI_MEASUREMENTS" type="INT8U" min="0x01" max="0xFF" writable="true" optional="false">number rssi measurements</attribute>
+    <command source="client" code="0x00" name="SetAbsoluteLocation" optional="false">
+      <description>
+        Command description for SetAbsoluteLocation
+      </description>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="SetDeviceConfiguration" optional="false">
+      <description>
+        Command description for SetDeviceConfiguration
+      </description>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="reportingPeriod" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="GetDeviceConfiguration" optional="false">
+      <description>
+        Command description for GetDeviceConfiguration
+      </description>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command source="client" code="0x03" name="GetLocationData" optional="false">
+      <description>
+        Command description for GetLocationData
+      </description>
+      <arg name="flags" type="GetLocationDataFlags"/>
+      <arg name="numberResponses" type="INT8U"/>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command source="client" code="0x04" name="RssiResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for RssiResponse
+      </description>
+      <arg name="replyingDevice" type="IEEE_ADDRESS"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="rssi" type="INT8S"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="SendPings" optional="true">
+      <description>
+        Command description for SendPings
+      </description>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+    </command>
+    <command source="client" code="0x06" name="AnchorNodeAnnounce" optional="true">
+      <description>
+        Command description for AnchorNodeAnnounce
+      </description>
+      <arg name="anchorNodeIeeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+    </command>
+    <command source="server" code="0x00" name="DeviceConfigurationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for DeviceConfigurationResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="reportingPeriod" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="LocationDataResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for LocationDataResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="locationMethod" type="LocationMethod"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x02" name="LocationDataNotification" optional="false">
+      <description>
+        Command description for LocationDataNotification
+      </description>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="locationMethod" type="LocationMethod"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x03" name="CompactLocationDataNotification" optional="false">
+      <description>
+        Command description for CompactLocationDataNotification
+      </description>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="RssiPing" optional="false">
+      <description>
+        Command description for RssiPing
+      </description>
+      <arg name="locationType" type="LocationType"/>
+    </command>
+    <command source="server" code="0x05" name="RssiRequest" optional="true">
+      <description>
+        Command description for RssiRequest
+      </description>
+    </command>
+    <command source="server" code="0x06" name="ReportRssiMeasurements" optional="true">
+      <description>
+        Command description for ReportRssiMeasurements
+      </description>
+      <arg name="measuringDevice" type="IEEE_ADDRESS"/>
+      <arg name="neighbors" type="INT8U"/>
+      <arg name="neighborsInfo" type="NeighborInfo" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="RequestOwnLocation" optional="true">
+      <description>
+        Command description for RequestOwnLocation
+      </description>
+      <arg name="blindNode" type="IEEE_ADDRESS"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Binary Input (Basic)</name>
+    <domain>General</domain>
+    <description>An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. </description>
+    <code>0x000F</code>
+    <define>BINARY_INPUT_BASIC_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0004" define="ACTIVE_TEXT" type="CHAR_STRING" length="16" writable="true" default="" optional="true">active text</attribute>
+    <attribute side="server" code="0x001C" define="DESCRIPTION" type="CHAR_STRING" length="16" writable="true" default="" optional="true">description</attribute>
+    <attribute side="server" code="0x002E" define="INACTIVE_TEXT" type="CHAR_STRING" length="16" writable="true" default="" optional="true">inactive text</attribute>
+    <attribute side="server" code="0x0051" define="OUT_OF_SERVICE" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x00" optional="false">out of service</attribute>
+    <attribute side="server" code="0x0054" define="POLARITY" type="ENUM8" writable="false" default="0x00" optional="true">polarity</attribute>
+    <attribute side="server" code="0x0055" define="PRESENT_VALUE" type="BOOLEAN" writable="true" reportable="true" optional="false">present value</attribute>
+    <attribute side="server" code="0x0067" define="RELIABILITY" type="ENUM8" writable="true" default="0x00" optional="true">reliability</attribute>
+    <attribute side="server" code="0x006F" define="STATUS_FLAGS" type="BITMAP8" min="0x00" max="0x0F" writable="false" default="0x00" reportable="true" optional="false">status flags</attribute>
+    <attribute side="server" code="0x0100" define="APPLICATION_TYPE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">application type</attribute>
+  </cluster>
+  <cluster>
+    <name>Commissioning</name>
+    <domain>General</domain>
+    <description>Attributes and commands for commissioning and managing a ZigBee device.</description>
+    <code>0x0015</code>
+    <define>COMMISSIONING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SHORT_ADDRESS" type="INT16U" min="0x0000" max="0xFFF7" writable="true" default="0xFFFF" optional="false">short address</attribute>
+    <attribute side="server" code="0x0001" define="EXTENDED_PAN_ID" type="IEEE_ADDRESS" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFE" writable="true" default="0xFFFFFFFFFFFFFFFF" optional="false">extended pan id</attribute>
+    <attribute side="server" code="0x0002" define="PAN_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="false">pan id</attribute>
+    <attribute side="server" code="0x0003" define="CHANNEL_MASK" type="BITMAP32" writable="true" default="0x07FFF800" optional="false">channel mask</attribute>
+    <attribute side="server" code="0x0004" define="PROTOCOL_VERSION" type="INT8U" min="0x02" max="0x02" writable="true" default="0x02" optional="false">protocol version</attribute>
+    <attribute side="server" code="0x0005" define="STACK_PROFILE" type="INT8U" min="0x01" max="0x02" writable="true" default="0x02" optional="false">stack profile</attribute>
+    <attribute side="server" code="0x0006" define="STARTUP_CONTROL" type="ENUM8" min="0x00" max="0x03" writable="true" default="0x03" optional="false">startup control</attribute>
+    <attribute side="server" code="0x0010" define="TRUST_CENTER_ADDRESS" type="IEEE_ADDRESS" writable="true" default="0x0000000000000000" optional="false">trust center address</attribute>
+    <attribute side="server" code="0x0011" define="TRUST_CENTER_MASTER_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="true">trust center master key</attribute>
+    <attribute side="server" code="0x0012" define="NETWORK_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="false">network key</attribute>
+    <attribute side="server" code="0x0013" define="USE_INSECURE_JOIN" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x01" optional="false">use insecure join</attribute>
+    <attribute side="server" code="0x0014" define="PRECONFIGURED_LINK_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="false">preconfigured link key</attribute>
+    <attribute side="server" code="0x0015" define="NETWORK_KEY_SEQUENCE_NUMBER" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="false">network key sequence number</attribute>
+    <attribute side="server" code="0x0016" define="NETWORK_KEY_TYPE" type="ENUM8" writable="true" default="0x05" optional="false">network key type</attribute>
+    <attribute side="server" code="0x0017" define="NETWORK_MANAGER_ADDRESS" type="INT16U" writable="true" default="0x0000" optional="false">network manager address</attribute>
+    <attribute side="server" code="0x0020" define="SCAN_ATTEMPTS" type="INT8U" min="0x01" max="0xFF" writable="true" default="0x05" optional="false">scan attempts</attribute>
+    <attribute side="server" code="0x0021" define="TIME_BETWEEN_SCANS" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0064" optional="false">time between scans</attribute>
+    <attribute side="server" code="0x0022" define="REJOIN_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x003C" optional="false">rejoin interval</attribute>
+    <attribute side="server" code="0x0023" define="MAX_REJOIN_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0E10" optional="false">max rejoin interval</attribute>
+    <attribute side="server" code="0x0030" define="INDIRECT_POLL_RATE" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false">indirect poll rate</attribute>
+    <attribute side="server" code="0x0031" define="PARENT_RETRY_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" optional="false">parent retry threshold</attribute>
+    <attribute side="server" code="0x0040" define="CONCENTRATOR_FLAG" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x00" optional="false">concentrator flag</attribute>
+    <attribute side="server" code="0x0041" define="CONCENTRATOR_RADIUS" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x0F" optional="false">concentrator radius</attribute>
+    <attribute side="server" code="0x0042" define="CONCENTRATOR_DISCOVERY_TIME" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="false">concentrator discovery time</attribute>
+    <command source="client" code="0x00" name="RestartDevice" optional="false">
+      <description>
+        Command description for RestartDevice
+      </description>
+      <arg name="options" type="RestartOptions"/>
+      <arg name="delay" type="INT8U"/>
+      <arg name="jitter" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="SaveStartupParameters" optional="true">
+      <description>
+        Command description for SaveStartupParameters
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="RestoreStartupParameters" optional="true">
+      <description>
+        Command description for RestoreStartupParameters
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="ResetStartupParameters" optional="false">
+      <description>
+        Command description for ResetStartupParameters
+      </description>
+      <arg name="options" type="ResetOptions"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="RestartDeviceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RestartDeviceResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x01" name="SaveStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for SaveStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x02" name="RestoreStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RestoreStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x03" name="ResetStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ResetStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -1,0 +1,981 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="General" spec="zcl-8.0-07-5123-08" certifiable="true">
+    <older spec="zcl-7.0-07-5123-07" certifiable="true"/>
+    <older spec="zcl6-errata-14-0129-15"/>
+    <older spec="zcl-6.0-15-02017-001"/>
+    <older spec="zcl-1.0-07-5123-03"/>
+  </domain>
+  <domain name="Lighting &amp; Occupancy" spec="l&amp;o-1.0-15-0014-04" certifiable="false"/>
+  <domain name="HA" spec="ha-1.2.1-05-3520-30" dependsOn="zcl-1.0-07-5123-03" certifiable="false">
+    <older spec="ha-1.2-05-3520-29" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="ha-1.1-05-3520-27" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <global>
+    <command code="0x00" name="ReadAttributes" source="either">
+      <description>
+        Command description for ReadAttributes
+      </description>
+      <arg name="attributeIds" type="ATTRIBUTE_ID" array="true"/>
+    </command>
+    <command code="0x01" name="ReadAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ReadAttributesResponse
+      </description>
+      <arg name="readAttributeStatusRecords" type="ReadAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x02" name="WriteAttributes" source="either">
+      <description>
+        Command description for WriteAttributes
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x03" name="WriteAttributesUndivided" source="either">
+      <description>
+        Command description for WriteAttributesUndivided
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x04" name="WriteAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesResponse
+      </description>
+      <arg name="writeAttributeStatusRecords" type="WriteAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x05" name="WriteAttributesNoResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesNoResponse
+      </description>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command code="0x06" name="ConfigureReporting" source="either">
+      <description>
+        Command description for ConfigureReporting
+      </description>
+      <arg name="configureReportingRecords" type="ConfigureReportingRecord" array="true"/>
+    </command>
+    <command code="0x07" name="ConfigureReportingResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ConfigureReportingResponse
+      </description>
+      <arg name="configureReportingStatusRecords" type="ConfigureReportingStatusRecord" array="true"/>
+    </command>
+    <command code="0x08" name="ReadReportingConfiguration" source="either">
+      <description>
+        Command description for ReadReportingConfiguration
+      </description>
+      <arg name="readReportingConfigurationAttributeRecords" type="ReadReportingConfigurationAttributeRecord" array="true"/>
+    </command>
+    <command code="0x09" name="ReadReportingConfigurationResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for ReadReportingConfigurationResponse
+      </description>
+      <arg name="readReportingConfigurationRecords" type="ReadReportingConfigurationRecord" array="true"/>
+    </command>
+    <command code="0x0A" name="ReportAttributes" source="either">
+      <description>
+        Command description for ReportAttributes
+      </description>
+      <arg name="reportAttributeRecords" type="ReportAttributeRecord" array="true"/>
+    </command>
+    <command code="0x0B" name="DefaultResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for DefaultResponse
+      </description>
+      <arg name="commandId" type="INT8U"/>
+      <arg name="status" type="Status"/>
+    </command>
+    <command code="0x0C" name="DiscoverAttributes" source="either">
+      <description>
+        Command description for DiscoverAttributes
+      </description>
+      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="maxAttributeIds" type="INT8U"/>
+    </command>
+    <command code="0x0D" name="DiscoverAttributesResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for DiscoverAttributesResponse
+      </description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="discoverAttributesInfoRecords" type="DiscoverAttributesInfoRecord" array="true"/>
+    </command>
+    <command code="0x0E" name="ReadAttributesStructured" source="either">
+      <description>
+        Command description for ReadAttributesStructured
+      </description>
+      <arg name="readStructuredAttributeRecords" type="ReadStructuredAttributeRecord" array="true"/>
+    </command>
+    <command code="0x0F" name="WriteAttributesStructured" source="either">
+      <description>
+        Command description for WriteAttributesStructured
+      </description>
+      <arg name="writeStructuredAttributeRecords" type="WriteStructuredAttributeRecord" array="true"/>
+    </command>
+    <command code="0x10" name="WriteAttributesStructuredResponse" source="either" disableDefaultResponse="true">
+      <description>
+        Command description for WriteAttributesStructuredResponse
+      </description>
+      <arg name="writeStructuredAttributeStatusRecords" type="WriteStructuredAttributeStatusRecord" array="true"/>
+    </command>
+    <command code="0x11" name="DiscoverCommandsReceived" source="either">
+      <description>This command may be used to discover all commands processed (received) by this cluster, including optional or manufacturer specific commands.</description>
+      <arg name="startCommandId" type="INT8U"/>
+      <arg name="maxCommandIds" type="INT8U"/>
+    </command>
+    <command code="0x12" name="DiscoverCommandsReceivedResponse" source="either" disableDefaultResponse="true">
+      <description>The discover commands received response command is sent in response to a discover commands received command, and is used to discover which commands a particular cluster can process.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="commandIds" type="INT8U" array="true"/>
+    </command>
+    <command code="0x13" name="DiscoverCommandsGenerated" source="either">
+      <description>This command may be used to discover all commands which may be generated (sent) by the cluster, including optional or manufacturer specific commands.</description>
+      <arg name="startCommandId" type="INT8U"/>
+      <arg name="maxCommandIds" type="INT8U"/>
+    </command>
+    <command code="0x14" name="DiscoverCommandsGeneratedResponse" source="either" disableDefaultResponse="true">
+      <description>The discover client commands response command is sent in response to a discover client commands command, and is used to discover which commands a particular cluster supports.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="commandIds" type="INT8U" array="true"/>
+    </command>
+    <command code="0x15" name="DiscoverAttributesExtended" source="either">
+      <description>This command is similar to the discover attributes command, but also includes a field to indicate whether the attribute is readable, writeable or reportable.</description>
+      <arg name="startId" type="ATTRIBUTE_ID"/>
+      <arg name="maxAttributeIds" type="INT8U"/>
+    </command>
+    <command code="0x16" name="DiscoverAttributesExtendedResponse" source="either" disableDefaultResponse="true">
+      <description>This command is sent in response to a discover attribute extended command and is used to determine if attributes are readable, writable or reportable.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="extendedDiscoverAttributesInfoRecords" type="ExtendedDiscoverAttributesInfoRecord" array="true"/>
+    </command>
+    <attribute side="client" code="0xFFFD" define="CLUSTER_REVISION_CLIENT" type="INT16U" min="0x0001" max="0xFFFE" writable="false" default="0x0001" optional="false" introducedIn="zcl-6.0-15-02017-001">cluster revision</attribute>
+    <attribute side="client" code="0xFFFE" define="REPORTING_STATUS_CLIENT" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="zcl-6.0-15-02017-001">reporting status</attribute>
+    <attribute side="server" code="0xFFFD" define="CLUSTER_REVISION_SERVER" type="INT16U" min="0x0001" max="0xFFFE" writable="false" default="0x0001" optional="false" introducedIn="zcl-6.0-15-02017-001">cluster revision</attribute>
+    <attribute side="server" code="0xFFFE" define="REPORTING_STATUS_SERVER" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="zcl-6.0-15-02017-001">reporting status</attribute>
+  </global>
+  <cluster singleton="true">
+    <name>Basic</name>
+    <domain>General</domain>
+    <description>Attributes for determining basic information about a device, setting user device information such as location, and enabling a device.</description>
+    <code>0x0000</code>
+    <define>BASIC_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x08" optional="false">ZCL version</attribute>
+    <!-- ZCL_VERSION -->
+    <attribute side="server" code="0x0001" define="APPLICATION_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">application version</attribute>
+    <attribute side="server" code="0x0002" define="STACK_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">stack version</attribute>
+    <attribute side="server" code="0x0003" define="HW_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">hardware version</attribute>
+    <attribute side="server" code="0x0004" define="MANUFACTURER_NAME" type="CHAR_STRING" length="32" writable="false" default="" optional="true">manufacturer name</attribute>
+    <attribute side="server" code="0x0005" define="MODEL_IDENTIFIER" type="CHAR_STRING" length="32" writable="false" default="" optional="true">model identifier</attribute>
+    <attribute side="server" code="0x0006" define="DATE_CODE" type="CHAR_STRING" length="16" writable="false" default="" optional="true">date code</attribute>
+    <attribute side="server" code="0x0007" define="POWER_SOURCE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">power source</attribute>
+    <attribute side="server" code="0x0008" define="GENERIC_DEVICE_CLASS" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">generic device class</attribute>
+    <attribute side="server" code="0x0009" define="GENERIC_DEVICE_TYPE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">generic device type</attribute>
+    <attribute side="server" code="0x000A" define="PRODUCT_CODE" type="OCTET_STRING" length="16" writable="false" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">product code</attribute>
+    <attribute side="server" code="0x000B" define="PRODUCT_URL" type="CHAR_STRING" length="64" writable="false" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">product url</attribute>
+    <attribute side="server" code="0x0010" define="LOCATION_DESCRIPTION" type="CHAR_STRING" length="16" writable="true" default="" optional="true">location description</attribute>
+    <attribute side="server" code="0x0011" define="PHYSICAL_ENVIRONMENT" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">physical environment</attribute>
+    <attribute side="server" code="0x0012" define="DEVICE_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x01" optional="true">device enabled</attribute>
+    <attribute side="server" code="0x0013" define="ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">alarm mask</attribute>
+    <attribute side="server" code="0x0014" define="DISABLE_LOCAL_CONFIG" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">disable local config</attribute>
+    <command source="client" code="0x00" name="ResetToFactoryDefaults" optional="true" cli="zcl basic rtfd">
+      <description>Command that resets all attribute values to factory default.</description>
+    </command>
+  </cluster>
+  <cluster singleton="true">
+    <name>Power Configuration</name>
+    <domain>General</domain>
+    <description>Attributes for determining more detailed information about a device's power source(s), and for configuring under/over voltage alarms.</description>
+    <code>0x0001</code>
+    <define>POWER_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="MAINS_VOLTAGE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">mains voltage</attribute>
+    <attribute side="server" code="0x0001" define="MAINS_FREQUENCY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">mains frequency</attribute>
+    <attribute side="server" code="0x0010" define="MAINS_ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">mains alarm mask</attribute>
+    <attribute side="server" code="0x0011" define="MAINS_VOLTAGE_MIN_THRESHOLD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">mains voltage min threshold</attribute>
+    <attribute side="server" code="0x0012" define="MAINS_VOLTAGE_MAX_THRESHOLD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true">mains voltage max threshold</attribute>
+    <attribute side="server" code="0x0013" define="MAINS_VOLTAGE_DWELL_TRIP_POINT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">mains voltage dwell trip</attribute>
+    <attribute side="server" code="0x0020" define="BATTERY_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">battery voltage</attribute>
+    <attribute side="server" code="0x0021" define="BATTERY_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage remaining</attribute>
+    <attribute side="server" code="0x0030" define="BATTERY_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true">battery manufacturer</attribute>
+    <attribute side="server" code="0x0031" define="BATTERY_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true">battery size</attribute>
+    <attribute side="server" code="0x0032" define="BATTERY_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">battery ahr rating</attribute>
+    <attribute side="server" code="0x0033" define="BATTERY_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">battery quantity</attribute>
+    <attribute side="server" code="0x0034" define="BATTERY_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">battery rated voltage</attribute>
+    <attribute side="server" code="0x0035" define="BATTERY_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">battery alarm mask</attribute>
+    <attribute side="server" code="0x0036" define="BATTERY_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">battery voltage min threshold</attribute>
+    <attribute side="server" code="0x0037" define="BATTERY_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 1</attribute>
+    <attribute side="server" code="0x0038" define="BATTERY_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 2</attribute>
+    <attribute side="server" code="0x0039" define="BATTERY_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery voltage threshold 3</attribute>
+    <attribute side="server" code="0x003a" define="BATTERY_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage min threshold</attribute>
+    <attribute side="server" code="0x003b" define="BATTERY_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 1</attribute>
+    <attribute side="server" code="0x003c" define="BATTERY_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 2</attribute>
+    <attribute side="server" code="0x003d" define="BATTERY_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery percentage threshold 3</attribute>
+    <attribute side="server" code="0x003e" define="BATTERY_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" reportable="true" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery alarm state</attribute>
+    <attribute side="server" code="0x0040" define="BATTERY_2_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage</attribute>
+    <attribute side="server" code="0x0041" define="BATTERY_2_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage remaining</attribute>
+    <attribute side="server" code="0x0050" define="BATTERY_2_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 manufacturer</attribute>
+    <attribute side="server" code="0x0051" define="BATTERY_2_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 size</attribute>
+    <attribute side="server" code="0x0052" define="BATTERY_2_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 ahr rating</attribute>
+    <attribute side="server" code="0x0053" define="BATTERY_2_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 quantity</attribute>
+    <attribute side="server" code="0x0054" define="BATTERY_2_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 rated voltage</attribute>
+    <attribute side="server" code="0x0055" define="BATTERY_2_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 alarm mask</attribute>
+    <attribute side="server" code="0x0056" define="BATTERY_2_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage min threshold</attribute>
+    <attribute side="server" code="0x0057" define="BATTERY_2_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 1</attribute>
+    <attribute side="server" code="0x0058" define="BATTERY_2_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 2</attribute>
+    <attribute side="server" code="0x0059" define="BATTERY_2_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 voltage threshold 3</attribute>
+    <attribute side="server" code="0x005a" define="BATTERY_2_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage min threshold</attribute>
+    <attribute side="server" code="0x005b" define="BATTERY_2_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 1</attribute>
+    <attribute side="server" code="0x005c" define="BATTERY_2_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 2</attribute>
+    <attribute side="server" code="0x005d" define="BATTERY_2_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 percentage threshold 3</attribute>
+    <attribute side="server" code="0x005e" define="BATTERY_2_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery 2 alarm state</attribute>
+    <attribute side="server" code="0x0060" define="BATTERY_3_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage</attribute>
+    <attribute side="server" code="0x0061" define="BATTERY_3_PERCENTAGE_REMAINING" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage remaining</attribute>
+    <attribute side="server" code="0x0070" define="BATTERY_3_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" default="" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 manufacturer</attribute>
+    <attribute side="server" code="0x0071" define="BATTERY_3_SIZE" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 size</attribute>
+    <attribute side="server" code="0x0072" define="BATTERY_3_AHR_RATING" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 ahr rating</attribute>
+    <attribute side="server" code="0x0073" define="BATTERY_3_QUANTITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 quantity</attribute>
+    <attribute side="server" code="0x0074" define="BATTERY_3_RATED_VOLTAGE" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 rated voltage</attribute>
+    <attribute side="server" code="0x0075" define="BATTERY_3_ALARM_MASK" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 alarm mask</attribute>
+    <attribute side="server" code="0x0076" define="BATTERY_3_VOLTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage min threshold</attribute>
+    <attribute side="server" code="0x0077" define="BATTERY_3_VOLTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 1</attribute>
+    <attribute side="server" code="0x0078" define="BATTERY_3_VOLTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 2</attribute>
+    <attribute side="server" code="0x0079" define="BATTERY_3_VOLTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 voltage threshold 3</attribute>
+    <attribute side="server" code="0x007a" define="BATTERY_3_PERCENTAGE_MIN_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage min threshold</attribute>
+    <attribute side="server" code="0x007b" define="BATTERY_3_PERCENTAGE_THRESHOLD_1" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 1</attribute>
+    <attribute side="server" code="0x007c" define="BATTERY_3_PERCENTAGE_THRESHOLD_2" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 2</attribute>
+    <attribute side="server" code="0x007d" define="BATTERY_3_PERCENTAGE_THRESHOLD_3" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 percentage threshold 3</attribute>
+    <attribute side="server" code="0x007e" define="BATTERY_3_ALARM_STATE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">battery 3 alarm state</attribute>
+  </cluster>
+  <cluster>
+    <name>Device Temperature Configuration</name>
+    <domain>General</domain>
+    <description>Attributes for determining information about a device's internal temperature, and for configuring under/over temperature alarms.</description>
+    <code>0x0002</code>
+    <define>DEVICE_TEMP_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CURRENT_TEMPERATURE" type="INT16S" min="-200" max="200" writable="false" optional="false">current temperature</attribute>
+    <attribute side="server" code="0x0001" define="MIN_TEMP_EXPERIENCED" type="INT16S" min="-200" max="200" writable="false" optional="true">min temp experienced</attribute>
+    <attribute side="server" code="0x0002" define="MAX_TEMP_EXPERIENCED" type="INT16S" min="-200" max="200" writable="false" optional="true">max temp experienced</attribute>
+    <attribute side="server" code="0x0003" define="OVER_TEMP_TOTAL_DWELL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">over temp total dwell</attribute>
+    <attribute side="server" code="0x0010" define="DEVICE_TEMP_ALARM_MASK" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true">device temp alarm mask</attribute>
+    <attribute side="server" code="0x0011" define="LOW_TEMP_THRESHOLD" type="INT16S" min="-200" max="200" writable="true" optional="true">low temp threshold</attribute>
+    <attribute side="server" code="0x0012" define="HIGH_TEMP_THRESHOLD" type="INT16S" min="-200" max="200" writable="true" optional="true">high temp threshold</attribute>
+    <attribute side="server" code="0x0013" define="LOW_TEMP_DWELL_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="true" optional="true">low temp dwell trip point</attribute>
+    <attribute side="server" code="0x0014" define="HIGH_TEMP_DWELL_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFF" writable="true" optional="true">high temp dwell trip point</attribute>
+  </cluster>
+  <cluster>
+    <name>Identify</name>
+    <domain>General</domain>
+    <description>Attributes and commands for putting a device into Identification mode (e.g. flashing a light).</description>
+    <code>0x0003</code>
+    <define>IDENTIFY_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="IDENTIFY_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="false">identify time</attribute>
+    <attribute side="server" code="0x0001" define="COMMISSION_STATE" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x00" optional="true">commission state</attribute>
+    <command source="client" code="0x00" name="Identify" optional="false" cli="zcl identify id">
+      <description>
+        Command description for Identify
+      </description>
+      <arg name="identifyTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="IdentifyQuery" optional="false" cli="zcl identify query">
+      <description>
+        Command description for IdentifyQuery
+      </description>
+    </command>
+    <command source="client" code="0x02" name="EZModeInvoke" optional="true" cli="zcl identify ez-mode">
+      <description>
+	   Invoke EZMode on an Identify Server
+      </description>
+      <arg name="action" type="BITMAP8"/>
+    </command>
+    <command source="client" code="0x03" name="UpdateCommissionState" optional="true">
+      <description>
+          Update Commission State on the server device.
+      </description>
+      <arg name="action" type="ENUM8"/>
+      <arg name="commissionStateMask" type="BITMAP8"/>
+    </command>
+    <command source="server" code="0x00" name="IdentifyQueryResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for IdentifyQueryResponse
+      </description>
+      <arg name="timeout" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Groups</name>
+    <domain>General</domain>
+    <description>Attributes and commands for group configuration and manipulation.</description>
+    <code>0x0004</code>
+    <define>GROUPS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
+    <!-- NAME_SUPPORT -->
+    <command source="client" code="0x00" name="AddGroup" optional="false" cli="zcl groups add">
+      <description>
+        Command description for AddGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x01" name="ViewGroup" optional="false" cli="zcl groups view">
+      <description>
+        Command description for ViewGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="GetGroupMembership" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
+      <description>
+        Command description for GetGroupMembership
+      </description>
+      <arg name="groupCount" type="INT8U" arrayLength="true"/>
+      <arg name="groupList" type="INT16U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="RemoveGroup" optional="false" cli="zcl groups remove">
+      <description>
+        Command description for RemoveGroup
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="RemoveAllGroups" optional="false" cli="zcl groups rmall">
+      <description>
+        Command description for RemoveAllGroups
+      </description>
+    </command>
+    <command source="client" code="0x05" name="AddGroupIfIdentifying" optional="false" cli="zcl groups add-if-id">
+      <description>
+        Command description for AddGroupIfIdentifying
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x00" name="AddGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for AddGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="ViewGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ViewGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="groupName" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x02" name="GetGroupMembershipResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetGroupMembershipResponse
+      </description>
+      <arg name="capacity" type="INT8U"/>
+      <arg name="groupCount" type="INT8U" arrayLength="true"/>
+      <arg name="groupList" type="INT16U" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="RemoveGroupResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveGroupResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Scenes</name>
+    <domain>General</domain>
+    <description>Attributes and commands for scene configuration and manipulation.</description>
+    <code>0x0005</code>
+    <define>SCENES_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="SCENE_COUNT" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">scene count</attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_SCENE" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">current scene</attribute>
+    <attribute side="server" code="0x0002" define="CURRENT_GROUP" type="INT16U" min="0x0000" max="0xFFF7" writable="false" default="0x0000" optional="false">current group</attribute>
+    <attribute side="server" code="0x0003" define="SCENE_VALID" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">scene valid</attribute>
+    <attribute side="server" code="0x0004" define="SCENE_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
+    <!-- NAME_SUPPORT -->
+    <attribute side="server" code="0x0005" define="LAST_CONFIGURED_BY" type="IEEE_ADDRESS" writable="false" optional="true">last configured by</attribute>
+    <command source="client" code="0x00" name="AddScene" optional="false" cli="zcl scenes add">
+      <description>
+        Add a scene to the scene table. Extension field sets are supported, and are inputed as arrays of the form [[cluster ID] [length] [value0...n] ...]
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="ViewScene" optional="false" cli="zcl scenes view">
+      <description>
+        Command description for ViewScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="RemoveScene" optional="false" cli="zcl scenes remove">
+      <description>
+        Command description for RemoveScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="RemoveAllScenes" optional="false" cli="zcl scenes rmall">
+      <description>
+        Command description for RemoveAllScenes
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="StoreScene" optional="false" cli="zcl scenes store">
+      <description>
+        Command description for StoreScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="RecallScene" optional="false" cli="zcl scenes recall">
+      <description>
+        Command description for RecallScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U" introducedIn="zcl-7.0-07-5123-07" optional="1"/>
+    </command>
+    <command source="client" code="0x06" name="GetSceneMembership" optional="false" cli="zcl scenes get">
+      <description>
+        Command description for GetSceneMembership
+      </description>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="AddSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for AddSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="ViewSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ViewSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U" presentIf="status==0"/>
+      <arg name="sceneName" type="CHAR_STRING" presentIf="status==0"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true" presentIf="status==0"/>
+    </command>
+    <command source="server" code="0x02" name="RemoveSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x03" name="RemoveAllScenesResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RemoveAllScenesResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="StoreSceneResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for StoreSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x06" name="GetSceneMembershipResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetSceneMembershipResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="capacity" type="INT8U"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneCount" type="INT8U" arrayLength="true" presentIf="status==0"/>
+      <arg name="sceneList" type="INT8U" array="true" presentIf="status==0"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>On/off</name>
+    <domain>General</domain>
+    <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
+    <code>0x0006</code>
+    <define>ON_OFF_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="ON_OFF" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">on/off</attribute>
+    <attribute side="server" code="0x4003" define="START_UP_ON_OFF" type="ENUM8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">start up on off</attribute>
+    <command source="client" code="0x00" name="Off" optional="false" cli="zcl on-off off">
+      <description>
+        Command description for Off
+      </description>
+    </command>
+    <command source="client" code="0x01" name="On" optional="false" cli="zcl on-off on">
+      <description>
+        Command description for On
+      </description>
+    </command>
+    <command source="client" code="0x02" name="Toggle" optional="false" cli="zcl on-off toggle">
+      <description>
+        Command description for Toggle
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>On/off Switch Configuration</name>
+    <domain>General</domain>
+    <description>Attributes and commands for configuring On/Off switching devices.</description>
+    <code>0x0007</code>
+    <define>ON_OFF_SWITCH_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SWITCH_TYPE" type="ENUM8" min="0x00" max="0x01" writable="false" optional="false">switch type</attribute>
+    <attribute side="server" code="0x0010" define="SWITCH_ACTIONS" type="ENUM8" min="0x00" max="0x02" writable="true" default="0x00" optional="false">switch actions</attribute>
+  </cluster>
+  <cluster>
+    <name>Level Control</name>
+    <domain>General</domain>
+    <description>Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'</description>
+    <code>0x0008</code>
+    <define>LEVEL_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="CURRENT_LEVEL" type="INT8U" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="false">current level</attribute>
+    <attribute side="server" code="0x0001" define="LEVEL_CONTROL_REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">remaining time</attribute>
+    <!-- REMAINING_TIME -->
+    <attribute side="server" code="0x0010" define="ON_OFF_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">on off transition time</attribute>
+    <attribute side="server" code="0x0011" define="ON_LEVEL" type="INT8U" min="0x00" max="0xFF" writable="true" default="0xFE" optional="true">on level</attribute>
+    <attribute side="server" code="0x0012" define="ON_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">on transition time</attribute>
+    <attribute side="server" code="0x0013" define="OFF_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">off transition time</attribute>
+    <attribute side="server" code="0x0014" define="DEFAULT_MOVE_RATE" type="INT8U" min="0x00" max="0xFE" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">default move rate</attribute>
+    <attribute side="server" code="0x000F" define="OPTIONS" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">options</attribute>
+    <attribute side="server" code="0x4000" define="START_UP_CURRENT_LEVEL" type="INT8U" min="0x01" max="0xFF" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">start up current level</attribute>
+    <command source="client" code="0x00" name="MoveToLevel" optional="false" cli="zcl level-control mv-to-level">
+      <description>
+        Command description for MoveToLevel
+      </description>
+      <arg name="level" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x01" name="Move" optional="false" cli="zcl level-control move">
+      <description>
+        Command description for Move
+      </description>
+      <arg name="moveMode" type="MoveMode"/>
+      <arg name="rate" type="INT8U"/>
+      <arg name="optionMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x02" name="Step" optional="false" cli="zcl level-control step">
+      <description>
+        Command description for Step
+      </description>
+      <arg name="stepMode" type="StepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x03" name="Stop" optional="false" cli="zcl level-control stop">
+      <description>
+        Command description for Stop
+      </description>
+      <arg name="optionMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x04" name="MoveToLevelWithOnOff" optional="false" cli="zcl level-control o-mv-to-level">
+      <description>
+        Command description for MoveToLevelWithOnOff
+      </description>
+      <arg name="level" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="MoveWithOnOff" optional="false" cli="zcl level-control o-move">
+      <description>
+        Command description for MoveWithOnOff
+      </description>
+      <arg name="moveMode" type="MoveMode"/>
+      <arg name="rate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="StepWithOnOff" optional="false" cli="zcl level-control o-step">
+      <description>
+        Command description for StepWithOnOff
+      </description>
+      <arg name="stepMode" type="StepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="StopWithOnOff" optional="false" cli="zcl level-control o-stop">
+      <description>
+        Command description for StopWithOnOff
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Alarms</name>
+    <domain>General</domain>
+    <description>Attributes and commands for sending notifications and configuring alarm functionality.</description>
+    <code>0x0009</code>
+    <define>ALARM_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ALARM_COUNT" type="INT16U" min="0x00" writable="false" default="0x00" optional="true">alarm count</attribute>
+    <command source="client" code="0x00" name="ResetAlarm" optional="false">
+      <description>
+        Command description for ResetAlarm
+      </description>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="client" code="0x01" name="ResetAllAlarms" optional="false">
+      <description>
+        Command description for ResetAllAlarms
+      </description>
+    </command>
+    <command source="client" code="0x02" name="GetAlarm" optional="true">
+      <description>
+        Command description for GetAlarm
+      </description>
+    </command>
+    <command source="client" code="0x03" name="ResetAlarmLog" optional="true">
+      <description>
+        Command description for ResetAlarmLog
+      </description>
+    </command>
+    <command source="server" code="0x00" name="Alarm" optional="false">
+      <description>
+        Command description for Alarm
+      </description>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="server" code="0x01" name="GetAlarmResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for GetAlarmResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="alarmCode" type="ENUM8"/>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+      <arg name="timeStamp" type="INT32U"/>
+    </command>
+  </cluster>
+  <cluster singleton="true">
+    <name>Time</name>
+    <domain>General</domain>
+    <description>Attributes and commands that provide a basic interface to a real-time clock.</description>
+    <code>0x000A</code>
+    <define>TIME_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="false">time</attribute>
+    <attribute side="server" code="0x0001" define="TIME_STATUS" type="BITMAP8" min="0x00" max="0x0F" writable="true" default="0x00" optional="false">time status</attribute>
+    <attribute side="server" code="0x0002" define="TIME_ZONE" type="INT32S" min="0xFFFEAE80" max="0x00015180" writable="true" default="0x00000000" optional="true">time zone</attribute>
+    <attribute side="server" code="0x0003" define="DST_START" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="true">dst start</attribute>
+    <attribute side="server" code="0x0004" define="DST_END" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="true" optional="true">dst end</attribute>
+    <attribute side="server" code="0x0005" define="DST_SHIFT" type="INT32S" min="0xFFFEAE80" max="0x00015180" writable="true" default="0x00000000" optional="true">dst shift</attribute>
+    <attribute side="server" code="0x0006" define="STANDARD_TIME" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" optional="true">standard time</attribute>
+    <attribute side="server" code="0x0007" define="LOCAL_TIME" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" optional="true">local time</attribute>
+    <attribute side="server" code="0x0008" define="LAST_SET_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0xFFFFFFFF" optional="true">last set time</attribute>
+    <attribute side="server" code="0x0009" define="VALID_UNTIL_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="true" default="0xFFFFFFFF" optional="true">valid until time</attribute>
+  </cluster>
+  <cluster>
+    <name>RSSI Location</name>
+    <domain>General</domain>
+    <description>Attributes and commands that provide a means for exchanging location information and channel parameters among devices.</description>
+    <code>0x000B</code>
+    <define>RSSI_LOCATION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LOCATION_TYPE" type="DATA8" min="0x00" max="0x0F" writable="false" optional="false">location type</attribute>
+    <attribute side="server" code="0x0001" define="LOCATION_METHOD" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">location method</attribute>
+    <attribute side="server" code="0x0002" define="LOCATION_AGE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">location age</attribute>
+    <attribute side="server" code="0x0003" define="QUALITY_MEASURE" type="INT8U" min="0x00" max="0x64" writable="false" optional="true">quality measure</attribute>
+    <attribute side="server" code="0x0004" define="NUMBER_OF_DEVICES" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">number of devices</attribute>
+    <attribute side="server" code="0x0010" define="COORDINATE1" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">coordinate 1</attribute>
+    <attribute side="server" code="0x0011" define="COORDINATE2" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">coordinate 2</attribute>
+    <attribute side="server" code="0x0012" define="COORDINATE3" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="true">coordinate 3</attribute>
+    <attribute side="server" code="0x0013" define="POWER" type="INT16S" min="0x8000" max="0x7FFF" writable="true" optional="false">power</attribute>
+    <attribute side="server" code="0x0014" define="PATH_LOSS_EXPONENT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false">path loss exponent</attribute>
+    <attribute side="server" code="0x0015" define="REPORTING_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">reporting period</attribute>
+    <attribute side="server" code="0x0016" define="CALCULATION_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true">calculation period</attribute>
+    <attribute side="server" code="0x0017" define="NUMBER_RSSI_MEASUREMENTS" type="INT8U" min="0x01" max="0xFF" writable="true" optional="false">number rssi measurements</attribute>
+    <command source="client" code="0x00" name="SetAbsoluteLocation" optional="false">
+      <description>
+        Command description for SetAbsoluteLocation
+      </description>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="SetDeviceConfiguration" optional="false">
+      <description>
+        Command description for SetDeviceConfiguration
+      </description>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="reportingPeriod" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="GetDeviceConfiguration" optional="false">
+      <description>
+        Command description for GetDeviceConfiguration
+      </description>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command source="client" code="0x03" name="GetLocationData" optional="false">
+      <description>
+        Command description for GetLocationData
+      </description>
+      <arg name="flags" type="GetLocationDataFlags"/>
+      <arg name="numberResponses" type="INT8U"/>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command source="client" code="0x04" name="RssiResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for RssiResponse
+      </description>
+      <arg name="replyingDevice" type="IEEE_ADDRESS"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="rssi" type="INT8S"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="SendPings" optional="true">
+      <description>
+        Command description for SendPings
+      </description>
+      <arg name="targetAddress" type="IEEE_ADDRESS"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+    </command>
+    <command source="client" code="0x06" name="AnchorNodeAnnounce" optional="true">
+      <description>
+        Command description for AnchorNodeAnnounce
+      </description>
+      <arg name="anchorNodeIeeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+    </command>
+    <command source="server" code="0x00" name="DeviceConfigurationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for DeviceConfigurationResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="calculationPeriod" type="INT16U"/>
+      <arg name="numberRssiMeasurements" type="INT8U"/>
+      <arg name="reportingPeriod" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="LocationDataResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for LocationDataResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="locationMethod" type="LocationMethod"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x02" name="LocationDataNotification" optional="false">
+      <description>
+        Command description for LocationDataNotification
+      </description>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="power" type="INT16S"/>
+      <arg name="pathLossExponent" type="INT16U"/>
+      <arg name="locationMethod" type="LocationMethod"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x03" name="CompactLocationDataNotification" optional="false">
+      <description>
+        Command description for CompactLocationDataNotification
+      </description>
+      <arg name="locationType" type="LocationType"/>
+      <arg name="coordinate1" type="INT16S"/>
+      <arg name="coordinate2" type="INT16S"/>
+      <arg name="coordinate3" type="INT16S"/>
+      <arg name="qualityMeasure" type="INT8U"/>
+      <arg name="locationAge" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="RssiPing" optional="false">
+      <description>
+        Command description for RssiPing
+      </description>
+      <arg name="locationType" type="LocationType"/>
+    </command>
+    <command source="server" code="0x05" name="RssiRequest" optional="true">
+      <description>
+        Command description for RssiRequest
+      </description>
+    </command>
+    <command source="server" code="0x06" name="ReportRssiMeasurements" optional="true">
+      <description>
+        Command description for ReportRssiMeasurements
+      </description>
+      <arg name="measuringDevice" type="IEEE_ADDRESS"/>
+      <arg name="neighbors" type="INT8U"/>
+      <arg name="neighborsInfo" type="NeighborInfo" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="RequestOwnLocation" optional="true">
+      <description>
+        Command description for RequestOwnLocation
+      </description>
+      <arg name="blindNode" type="IEEE_ADDRESS"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Binary Input (Basic)</name>
+    <domain>General</domain>
+    <description>An interface for reading the value of a binary measurement and accessing various characteristics of that measurement. </description>
+    <code>0x000F</code>
+    <define>BINARY_INPUT_BASIC_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0004" define="ACTIVE_TEXT" type="CHAR_STRING" length="16" writable="true" default="" optional="true">active text</attribute>
+    <attribute side="server" code="0x001C" define="DESCRIPTION" type="CHAR_STRING" length="16" writable="true" default="" optional="true">description</attribute>
+    <attribute side="server" code="0x002E" define="INACTIVE_TEXT" type="CHAR_STRING" length="16" writable="true" default="" optional="true">inactive text</attribute>
+    <attribute side="server" code="0x0051" define="OUT_OF_SERVICE" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x00" optional="false">out of service</attribute>
+    <attribute side="server" code="0x0054" define="POLARITY" type="ENUM8" writable="false" default="0x00" optional="true">polarity</attribute>
+    <attribute side="server" code="0x0055" define="PRESENT_VALUE" type="BOOLEAN" writable="true" reportable="true" optional="false">present value</attribute>
+    <attribute side="server" code="0x0067" define="RELIABILITY" type="ENUM8" writable="true" default="0x00" optional="true">reliability</attribute>
+    <attribute side="server" code="0x006F" define="STATUS_FLAGS" type="BITMAP8" min="0x00" max="0x0F" writable="false" default="0x00" reportable="true" optional="false">status flags</attribute>
+    <attribute side="server" code="0x0100" define="APPLICATION_TYPE" type="INT32U" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">application type</attribute>
+  </cluster>
+  <cluster>
+    <name>Commissioning</name>
+    <domain>General</domain>
+    <description>Attributes and commands for commissioning and managing a ZigBee device.</description>
+    <code>0x0015</code>
+    <define>COMMISSIONING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="SHORT_ADDRESS" type="INT16U" min="0x0000" max="0xFFF7" writable="true" default="0xFFFF" optional="false">short address</attribute>
+    <attribute side="server" code="0x0001" define="EXTENDED_PAN_ID" type="IEEE_ADDRESS" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFE" writable="true" default="0xFFFFFFFFFFFFFFFF" optional="false">extended pan id</attribute>
+    <attribute side="server" code="0x0002" define="PAN_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="false">pan id</attribute>
+    <attribute side="server" code="0x0003" define="CHANNEL_MASK" type="BITMAP32" writable="true" default="0x07FFF800" optional="false">channel mask</attribute>
+    <attribute side="server" code="0x0004" define="PROTOCOL_VERSION" type="INT8U" min="0x02" max="0x02" writable="true" default="0x02" optional="false">protocol version</attribute>
+    <attribute side="server" code="0x0005" define="STACK_PROFILE" type="INT8U" min="0x01" max="0x02" writable="true" default="0x02" optional="false">stack profile</attribute>
+    <attribute side="server" code="0x0006" define="STARTUP_CONTROL" type="ENUM8" min="0x00" max="0x03" writable="true" default="0x03" optional="false">startup control</attribute>
+    <attribute side="server" code="0x0010" define="TRUST_CENTER_ADDRESS" type="IEEE_ADDRESS" writable="true" default="0x0000000000000000" optional="false">trust center address</attribute>
+    <attribute side="server" code="0x0011" define="TRUST_CENTER_MASTER_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="true">trust center master key</attribute>
+    <attribute side="server" code="0x0012" define="NETWORK_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="false">network key</attribute>
+    <attribute side="server" code="0x0013" define="USE_INSECURE_JOIN" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x01" optional="false">use insecure join</attribute>
+    <attribute side="server" code="0x0014" define="PRECONFIGURED_LINK_KEY" type="SECURITY_KEY" writable="true" default="0x00000000000000000000000000000000" optional="false">preconfigured link key</attribute>
+    <attribute side="server" code="0x0015" define="NETWORK_KEY_SEQUENCE_NUMBER" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="false">network key sequence number</attribute>
+    <attribute side="server" code="0x0016" define="NETWORK_KEY_TYPE" type="ENUM8" writable="true" default="0x05" optional="false">network key type</attribute>
+    <attribute side="server" code="0x0017" define="NETWORK_MANAGER_ADDRESS" type="INT16U" writable="true" default="0x0000" optional="false">network manager address</attribute>
+    <attribute side="server" code="0x0020" define="SCAN_ATTEMPTS" type="INT8U" min="0x01" max="0xFF" writable="true" default="0x05" optional="false">scan attempts</attribute>
+    <attribute side="server" code="0x0021" define="TIME_BETWEEN_SCANS" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0064" optional="false">time between scans</attribute>
+    <attribute side="server" code="0x0022" define="REJOIN_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x003C" optional="false">rejoin interval</attribute>
+    <attribute side="server" code="0x0023" define="MAX_REJOIN_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0E10" optional="false">max rejoin interval</attribute>
+    <attribute side="server" code="0x0030" define="INDIRECT_POLL_RATE" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false">indirect poll rate</attribute>
+    <attribute side="server" code="0x0031" define="PARENT_RETRY_THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" optional="false">parent retry threshold</attribute>
+    <attribute side="server" code="0x0040" define="CONCENTRATOR_FLAG" type="BOOLEAN" min="0x00" max="0x01" writable="true" default="0x00" optional="false">concentrator flag</attribute>
+    <attribute side="server" code="0x0041" define="CONCENTRATOR_RADIUS" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x0F" optional="false">concentrator radius</attribute>
+    <attribute side="server" code="0x0042" define="CONCENTRATOR_DISCOVERY_TIME" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="false">concentrator discovery time</attribute>
+    <command source="client" code="0x00" name="RestartDevice" optional="false">
+      <description>
+        Command description for RestartDevice
+      </description>
+      <arg name="options" type="RestartOptions"/>
+      <arg name="delay" type="INT8U"/>
+      <arg name="jitter" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="SaveStartupParameters" optional="true">
+      <description>
+        Command description for SaveStartupParameters
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="RestoreStartupParameters" optional="true">
+      <description>
+        Command description for RestoreStartupParameters
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="ResetStartupParameters" optional="false">
+      <description>
+        Command description for ResetStartupParameters
+      </description>
+      <arg name="options" type="ResetOptions"/>
+      <arg name="index" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="RestartDeviceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RestartDeviceResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x01" name="SaveStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for SaveStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x02" name="RestoreStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RestoreStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x03" name="ResetStartupParametersResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ResetStartupParametersResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/green-power-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/green-power-devices.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>GP-proxy</name>
+    <domain>GP</domain>
+    <typeName>GP Proxy</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0060</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-proxy-basic</name>
+    <domain>GP</domain>
+    <typeName>GP Proxy Basic</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0061</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="false" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-target-plus</name>
+    <domain>GP</domain>
+    <typeName>GP Target+</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0062</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-target</name>
+    <domain>GP</domain>
+    <typeName>GP Target</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0063</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-commissioning-tool</name>
+    <domain>GP</domain>
+    <typeName>GP Commissioning Tool</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0064</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="false" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-combo</name>
+    <domain>GP</domain>
+    <typeName>GP Combo</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0065</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-combo-basic</name>
+    <domain>GP</domain>
+    <typeName>GP Combo Basic</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0066</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>GP-test-device</name>
+    <domain>GP</domain>
+    <typeName>GP Test Device</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0xA1E0</profileId>
+    <deviceId editable="false">0x0066</deviceId>
+    <clusters lockOthers="false">
+      <include cluster="Green Power" client="true" server="true" clientLocked="true" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/green-power.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/green-power.xml
@@ -1,0 +1,730 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="GP" spec="gp-1.0a-09-5499-26" certifiable="true">
+    <older spec="gp-1.0-09-5499-24" certifiable="true"/>
+  </domain>
+  <bitmap name="GpGpsFunctionality" type="BITMAP24">
+    <field name="gpFeature" mask="0x000001"/>
+    <field name="directCommunication" mask="0x000002"/>
+    <field name="derivedGroupcastCommunication" mask="0x000004"/>
+    <field name="preCommissionedGroupcastCommunication" mask="0x000008"/>
+    <field name="fullUnicastCommunication" mask="0x000010"/>
+    <field name="lightweightUnicastCommunication" mask="0x000020"/>
+    <field name="proximityBidirectionalCommunication" mask="0x000040"/>
+    <field name="multihopBidirectionalCommunication" mask="0x000080"/>
+    <field name="proxyTableMaintainance" mask="0x000100"/>
+    <field name="proximityCommunication" mask="0x000200"/>
+    <field name="multihopCommunication" mask="0x000400"/>
+    <field name="ctBasedCommissioning" mask="0x000800"/>
+    <field name="maintainanceGpdf" mask="0x001000"/>
+    <field name="gpdSecurityLevel0InOperation" mask="0x002000"/>
+    <field name="gpdSecurityLevel1InOperation" mask="0x004000"/>
+    <field name="gpdSecurityLevel2InOperation" mask="0x008000"/>
+    <field name="gpdSecurityLevel3InOperation" mask="0x010000"/>
+    <field name="sinkTableBasedGroupcastForwarding" mask="0x020000"/>
+    <field name="translationTable" mask="0x040000"/>
+    <field name="gpdIeeeAddress" mask="0x080000"/>
+    <field name="compactAttributeReporting" mask="0x100000"/>
+    <field name="Reserved" mask="0xE00000"/>
+  </bitmap>
+  <bitmap name="GpProxyTableEntryOptions" type="BITMAP32">
+    <field name="applicationId" mask="0x00000007"/>
+    <field name="entryActive" mask="0x00000008"/>
+    <field name="entryValid" mask="0x00000010"/>
+    <field name="sequenceNumberCap" mask="0x00000020"/>
+    <field name="lightweightUnicastGps" mask="0x00000040"/>
+    <field name="derivedGroupGps" mask="0x00000080"/>
+    <field name="commisionedGroupGps" mask="0x00000100"/>
+    <field name="firstToForward" mask="0x00000200"/>
+    <field name="inRange" mask="0x00000400"/>
+    <field name="gpdFixed" mask="0x00000800"/>
+    <field name="hasAllUnicastRoutes" mask="0x00001000"/>
+    <field name="assignedAlias" mask="0x00002000"/>
+    <field name="securityUse" mask="0x00004000"/>
+    <field name="extension" mask="0x00008000"/>
+    <field name="fullUnicastGps" mask="0x00010000"/>
+  </bitmap>
+  <bitmap name="GpProxyTableEntrySecurityOptions" type="BITMAP8">
+    <field name="securityLevel" mask="0x03"/>
+    <field name="securityKeyType" mask="0x1C"/>
+    <field name="reserved" mask="0xE0"/>
+  </bitmap>
+  <bitmap name="GpGpdCommissioningOptions" type="BITMAP8">
+    <field name="macSeqNumCap" mask="0x01"/>
+    <field name="rxOnCap" mask="0x02"/>
+    <field name="applicationInformationPresent" mask="0x04"/>
+    <field name="reserved" mask="0x08"/>
+    <field name="panIdRequest" mask="0x10"/>
+    <field name="gpSecurityKeyRequest" mask="0x20"/>
+    <field name="fixedLocation" mask="0x40"/>
+    <field name="extendedOptionsField" mask="0x80"/>
+  </bitmap>
+  <bitmap name="GpGpdCommissioningExtendedOptions" type="BITMAP8">
+    <field name="SecurityLevelCapabilities" mask="0x03"/>
+    <field name="keyType" mask="0x1C"/>
+    <field name="gpdKeyPresent" mask="0x20"/>
+    <field name="gpdKeyEncryption" mask="0x40"/>
+    <field name="gpdOutgoingCounterPresent" mask="0x80"/>
+  </bitmap>
+  <bitmap name="GpGpdCommissioningReplyOptions" type="BITMAP8">
+    <field name="panIdPresent" mask="0x01"/>
+    <field name="gpdSecurityKeyPresent" mask="0x02"/>
+    <field name="gpdkeyEncryption" mask="0x04"/>
+    <field name="securityLevel" mask="0x18"/>
+    <field name="keyType" mask="0xE0"/>
+  </bitmap>
+  <!-- GpNotification types. -->
+  <bitmap name="GpNotificationOption" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AlsoUnicast" mask="0x0008" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AlsoDerivedGroup" mask="0x0010" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AlsoCommissionedGroup" mask="0x0020" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityLevel" mask="0x00C0" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityKeyType" mask="0x0700" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RxAfterTx" mask="0x0800" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GpTxQueueFull" mask="0x1000" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="BidirectionalCapability" mask="0x2000"/>
+    <field name="ProxyInfoPresent" mask="0x4000"/>
+    <field name="Reserved" mask="0x8000" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpPairing types. -->
+  <enum name="GpPairingOptionsCommunicationMode" type="ENUM8">
+    <item name="FullUnicastForwarding" value="0x00"/>
+    <!-- introduceIn -->
+    <item name="GroupcastForwardingToDGroupId" value="0x01"/>
+    <!-- introduceIn -->
+    <item name="GroupcastForwardingToPreCommUnit" value="0x10"/>
+    <!-- introduceIn -->
+    <item name="UnicastForwardingByProxSupport" value="0x11"/>
+    <!-- introduceIn -->
+  </enum>
+  <!-- GpPairingSearch types. -->
+  <bitmap name="GpPairingSearchOption" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RequestUnicastSinks" mask="0x0008" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RequestDerivedGroupcastSinks" mask="0x0010" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RequestCommissionedGroupcastSinks" mask="0x0020" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RequestGpdSecurityFrameCounter" mask="0x0040" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RequestGpdSecurityKey" mask="0x0080" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xFF00" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpTunnelingStop types. -->
+  <bitmap name="GpTunnelingStopOption" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AlsoDerivedGroup" mask="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AlsoCommissionedGroup" mask="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xE0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpCommissioningNotification types. -->
+  <bitmap name="GpCommissioningNotificationOption" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RxAfterTx" mask="0x0008" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityLevel" mask="0x0030" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityKeyType" mask="0x01C0" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityProcessingFailed" mask="0x0200" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="BidirectionalCapability" mask="0x0400" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="ProxyInfoPresent" mask="0x0800" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xF000" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpSinkCommissioningModeOptions -->
+  <bitmap name="GpSinkCommissioningModeOptions" type="BITMAP8">
+    <field name="Action" mask="0x01"/>
+    <field name="InvolveGpmInSecurity" mask="0x02"/>
+    <field name="InvolveGpmInPairing" mask="0x04"/>
+    <field name="InvolveProxies" mask="0x08"/>
+    <field name="Reserved" mask="0xF0"/>
+  </bitmap>
+  <bitmap name="GpSinkCommissioningModeExitMode" type="BITMAP8">
+    <field name="OnCommissioningWindowExpiration" mask="0x01" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="OnFirstPairingSuccess" mask="0x02" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="OnGpProxyCommissioningModeExit" mask="0x04" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xF8"/>
+  </bitmap>
+  <!-- GpSinkTableRequestOptions -->
+  <bitmap name="GpSinkTableRequestOptions" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07"/>
+    <field name="RequestType" mask="0x18"/>
+    <field name="Reserved" mask="0xE0"/>
+  </bitmap>
+  <enum name="GpSinkTableRequestOptions" type="ENUM8">
+    <item name="RequestTableEntriesByGpdId" value="0x00"/>
+    <item name="RequestTableEntriesByIndex" value="0x01"/>
+  </enum>
+  <!-- GpTranslationTableUpdate types. -->
+  <bitmap name="GpTranslationTableUpdateOption" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Action" mask="0x0018" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="NumberOfTranslations" mask="0x00E0" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AdditionalInformationBlockPresent" mask="0x0100" introducedIn="gp-1.0-16-2607-23"/>
+    <field name="Reserved" mask="0xFE00" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <bitmap name="GpTranslationTableScanLevel" type="BITMAP8">
+    <field name="GpdId" mask="0x01"/>
+    <field name="CmdId" mask="0x02"/>
+    <field name="Payload" mask="0x04"/>
+    <field name="ZbEndpoint" mask="0x08"/>
+    <field name="AdditionalInfoBlock" mask="0x10"/>
+  </bitmap>
+  <enum name="GpTranslationTableUpdateAction" type="ENUM8">
+    <item name="AddTranslationTableEntry" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ReplaceTranslationTableEntry" value="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RemoveTranslationTableEntry" value="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Reserved" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+  </enum>
+  <struct name="GpTranslationTableUpdateTranslation">
+    <item name="index" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="gpdCommandId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="endpoint" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="profile" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="cluster" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="zigbeeCommandId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="zigbeeCommandPayload" type="OCTET_STRING" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="additionalInfoBlock" type="OCTET_STRING" introducedIn="gp-1.0-15-02014-011"/>
+  </struct>
+  <!-- GpPairingConfiguration types. -->
+  <enum name="GpPairingConfigurationAction" type="BITMAP8">
+    <item name="NoAction" value="0x00"/>
+    <item name="ExtendSinkTableEntry" value="0x01"/>
+    <item name="ReplaceSinkTableEntry" value="0x02"/>
+    <item name="RemoveAPairing" value="0x03"/>
+    <item name="RemoveGpd" value="0x04"/>
+    <item name="ApplicationDescription" value="0x05"/>
+  </enum>
+  <bitmap name="GpPairingConfigurationActions" type="BITMAP8">
+    <field name="Action" mask="0x07" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SendGpPairing" mask="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xF0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <bitmap name="GpPairingConfigurationOption" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="CommunicationMode" mask="0x0018" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SequenceNumberCapabilities" mask="0x0020" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RxOnCapability" mask="0x0040" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="FixedLocation" mask="0x0080" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AssignedAlias" mask="0x0100" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityUse" mask="0x0200" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="ApplicationInformationPresent" mask="0x0400"/>
+    <field name="Reserved" mask="0xF800" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <bitmap name="GpApplicationInformation" type="BITMAP8">
+    <field name="manufactureIdPresent" mask="0x01"/>
+    <field name="modelIdPresent" mask="0x02"/>
+    <field name="gpdCommandsPresent" mask="0x04"/>
+    <field name="clusterListPresent" mask="0x08"/>
+    <field name="switchInformationPresent" mask="0x10"/>
+    <field name="applicationDescriptionPresent" mask="0x20"/>
+  </bitmap>
+  <enum name="GpPairingConfigurationOptionCommunicationMode" type="ENUM8">
+    <item name="UnicastForwarding" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GroupcastForwardingToDGroupID" value="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GroupcastForwardingToPreCommissioned" value="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="UnicastForwardingLightweight" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+  </enum>
+  <struct name="GpPairingConfigurationGroupList">
+    <item name="SinkGroup" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Alias" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+  </struct>
+  <!-- GpNotificationResponse types. -->
+  <bitmap name="GpNotificationResponseOption" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="FirstToForward" mask="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="NoPairing" mask="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xE0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpPairing types. -->
+  <bitmap name="GpPairingOption" type="BITMAP24">
+    <field name="ApplicationId" mask="0x000007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AddSink" mask="0x000008" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RemoveGpd" mask="0x000010" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="CommunicationMode" mask="0x000060" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GpdFixed" mask="0x000080" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GpdMacSequenceNumberCapabilities" mask="0x000100" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityLevel" mask="0x000600" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityKeyType" mask="0x003800" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GpdSecurityFrameCounterPresent" mask="0x004000" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GpdSecurityKeyPresent" mask="0x008000" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AssignedAliasPresent" mask="0x010000" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="GroupcastRadiusPresent" mask="0x020000" introducedIn="gp-1.0-15-02014-005"/>
+    <field name="Reserved" mask="0xFC0000" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpDeviceId types. -->
+  <enum name="GpDeviceId" type="ENUM8">
+    <item name="GpSimpleGenericOneStateSwitch" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpSimpleGenericTwoStateSwitch" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpOnOffSwitch" value="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpLevelControlSwitch" value="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpSimpleSensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpAdvancedGenericOneStateSwitch" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpAdvancedGenericTwoStateSwitch" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpColorDimmerSwitch" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpLightSensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpOccpancySensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpDoorLockController" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpTemperatureSensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpPressureSensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpFlowSensor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="GpIndoorEnvironmentSnesor" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+  </enum>
+  <!-- GpProxyCommissioningMode types. -->
+  <bitmap name="GpProxyCommissioningModeOption" type="BITMAP8">
+    <field name="Action" mask="0x01" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="CommissioningWindowPresent" mask="0x02" introducedIn="CCB#2353 gp-1.0-15-02014-011"/>
+    <field name="ExitMode" mask="0x0C" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="ChannelPresent" mask="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="UnicastCommunication" mask="0x20" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xC0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <bitmap name="GpProxyCommissioningModeExitMode" type="BITMAP8">
+    <field name="OnCommissioningWindowExpiration" mask="0x02" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="OnFirstPairingSuccess" mask="0x04" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="OnGpProxyCommissioningModeExit" mask="0x08" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpResponse types. -->
+  <bitmap name="GpResponseOption" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="TransmitOnEndPointMatch" mask="0x08" introducedIn="gp-1.0-16-02607-23"/>
+    <field name="Reserved" mask="0xF0" introducedIn="gp-1.0-16-02607-23"/>
+  </bitmap>
+  <bitmap name="GpResponseTempMasterTxChannel" type="BITMAP8">
+    <field name="TransmitChannel" mask="0x0F" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xF0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <!-- GpSinkTableEntryOptions types. -->
+  <bitmap name="GpSinkTableEntryOptions" type="BITMAP16">
+    <field name="ApplicationId" mask="0x0007" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="CommunicationMode" mask="0x0018" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SequenceNumCapabilities" mask="0x0020" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="RxOnCapability" mask="0x0040" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="FixedLocation" mask="0x0080" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AssignedAlias" mask="0x0100" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="SecurityUse" mask="0x0200" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xFC00" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <bitmap name="GpSinkTableEntrySecurityOptions" type="BITMAP8">
+    <field name="securityLevel" mask="0x03"/>
+    <field name="securityKeyType" mask="0x1C"/>
+    <field name="reserved" mask="0xE0"/>
+  </bitmap>
+  <bitmap name="GpTranslationTableResponseOption" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="AdditionalInformationBlockPresent" mask="0x08" introducedIn="gp-1.0-09-5499-24"/>
+    <field name="Reserved" mask="0xF0" introducedIn="gp-1.0-09-5499-24"/>
+  </bitmap>
+  <enum name="GpTranslationTableResponseStatus" type="ENUM8">
+    <item name="SUCCESS" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="NOT_FOUND" value="0x8B"/>
+  </enum>
+  <enum name="GpSinkTableResponseStatus" type="ENUM8">
+    <item name="SUCCESS" value="0x00"/>
+    <item name="NOT_FOUND" value="0x8B"/>
+  </enum>
+  <!-- The command has been removed per spec docs-14-0563-08 .
+       Keeping it here for now since it is unclear whether we need to support
+       these old commands or not.
+
+       GpTranslationTableResponse types.
+       TODO: Section A.3.3.5.5 of the Green Power specification (09-5499-24)
+       states, "The Status field can take the values of SUCCESS or
+       NOT_SUPPORTED."  However, the numerical value of neither is defined.
+       This is a ZCL command, so the status should be one of the enumerated
+       status values used in the ZCL (section 2.5.3 of 07-5123-04).  SUCCESS
+       is an enumerated status value for ZCL, but NOT_SUPPORTED is not.  Both
+       are APS sub-layer status values (section 2.2.9 of 05-3474-20).  It is
+       not clear that these are the correct values, but here they are, for
+       lack of better options.
+  <bitmap name="GpTranslationTableResponseOption" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07" introducedIn="gp-1.0-09-5499-24" />
+    <field name="Reserved"      mask="0xF8" introducedIn="gp-1.0-09-5499-24" />
+  </bitmap>
+
+  <enum name="GpTranslationTableResponseStatus" type="ENUM8">
+    <item name="Success"      value="0x00" introducedIn="gp-1.0-09-5499-24" />
+    <item name="NotSupported" value="0xAA" introducedIn="gp-1.0-09-5499-24" />
+  </enum>
+  -->
+  <enum name="GpProxyTableResponseStatus" type="ENUM8">
+    <item name="SUCCESS" value="0x00"/>
+    <item name="NOT_FOUND" value="0x8B"/>
+  </enum>
+  <enum name="GpProxyTableRequestOptionsRequestType" type="ENUM8">
+    <item name="ByGpdId" value="0x00"/>
+    <item name="byIndex" value="0x01"/>
+  </enum>
+  <bitmap name="GpProxyTableRequestOptions" type="BITMAP8">
+    <field name="ApplicationId" mask="0x07"/>
+    <field name="RequestType" mask="0x18"/>
+    <field name="Reserved" mask="0xE0"/>
+  </bitmap>
+  <bitmap name="GpGpdChannelRequestChannelTogglingBehaviourRxChannel" type="BITMAP8">
+    <field name="NextAttempt" mask="0x0F"/>
+    <field name="SecondNextAttempt" mask="0xF0"/>
+  </bitmap>
+  <bitmap name="GpGpdChannelConfigurationChannel" type="BITMAP8">
+    <field name="Mask" mask="0x1F"/>
+    <field name="OperationalChannel" mask="0x0F"/>
+    <field name="Basic" mask="0x10"/>
+    <field name="Reserved" mask="0xE0"/>
+  </bitmap>
+  <enum name="GpGpdf" type="ENUM8">
+    <item name="Identify" value="0x00" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MatchOnlyOnGpdAddress" value="0x02" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene0" value="0x10" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene1" value="0x11" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene2" value="0x12" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene3" value="0x13" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene4" value="0x14" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene5" value="0x15" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene6" value="0x16" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RecallScene7" value="0x17" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene0" value="0x18" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene1" value="0x19" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene2" value="0x1A" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene3" value="0x1B" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene4" value="0x1C" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene5" value="0x1D" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene6" value="0x1E" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StoreScene7" value="0x1F" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Off" value="0x20" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="On" value="0x21" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Toggle" value="0x22" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Release" value="0x23" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveUp" value="0x30" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveDown" value="0x31" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepUp" value="0x32" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepDown" value="0x33" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="LevelControlStop" value="0x34" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveUpWithOnOff" value="0x35" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveDownWithOnOff" value="0x36" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepUpWithOnOff" value="0x37" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepDownWithOnOff" value="0x38" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveHueStop" value="0x40" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveHueUp" value="0x41" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveHueDown" value="0x42" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepHueUp" value="0x43" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepHueDown" value="0x44" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveSaturationStop" value="0x45" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveSaturationUp" value="0x46" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveSaturationDown" value="0x47" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepSaturationUp" value="0x48" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepSaturationDown" value="0x49" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MoveColor" value="0x4A" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="StepColor" value="0x4B" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="LockDoor" value="0x50" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="UnlockDoor" value="0x51" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Press1Of1" value="0x60" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Release1Of1" value="0x61" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Press1Of2" value="0x62" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Release1Of2" value="0x63" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Press2Of2" value="0x64" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Release2Of2" value="0x65" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ShortPress1Of1" value="0x66" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ShortPress1Of2" value="0x67" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ShortPress2Of2" value="0x68" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="8bitsVectorPress" value="0x69" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="8bitsVectorRelease" value="0x6A" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="AttributeReporting" value="0xA0" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrSpAttrRptg" value="0xA1" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MultiClusterRptg" value="0xA2" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrSpMultiClusterRptg" value="0xA3" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="RequestAttribute" value="0xA4" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ReadAttrResponse" value="0xA5" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ZclTunnelingWithPayload" value="0xA6" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="CompactAttributeReporting" value="0xA8" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="AnyGpdSensorCmd" value="0xAF" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd0" value="0xB0" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd1" value="0xB1" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd2" value="0xB2" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd3" value="0xB3" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd4" value="0xB4" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd5" value="0xB5" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd6" value="0xB6" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd7" value="0xB7" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd8" value="0xB8" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmd9" value="0xB9" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdA" value="0xBA" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdB" value="0xBB" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdC" value="0xBC" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdD" value="0xBD" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdE" value="0xBE" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="MfrDefGpdCmdF" value="0xBF" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Commissioning" value="0xE0" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Decommissioning" value="0xE1" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="Success" value="0xE2" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ChannelRequest" value="0xE3" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ApplicationDescription" value="0xE4" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="CommissioningReply" value="0xF0" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="WriteAttributes" value="0xF1" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ReadAttributes" value="0xF2" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ChannelConfiguration" value="0xF3" introducedIn="gp-1.0-09-5499-24"/>
+    <item name="ZclTunneling" value="0xF6" introducedIn="gp-1.0-09-5499-24"/>
+  </enum>
+  <enum name="GpSecurityKeyType" type="ENUM8">
+    <item name="None" value="0x00"/>
+    <item name="ZigbeeNetworkKey" value="0x01"/>
+    <item name="GpdGroupKey" value="0x02"/>
+    <item name="NetworkDerivedGroupKey" value="0x03"/>
+    <item name="IndividigualGpdKey" value="0x04"/>
+    <item name="DerivedIndividualGpdKey" value="0x07"/>
+  </enum>
+  <cluster introducedIn="gp-1.0-09-5499-24">
+    <name>Green Power</name>
+    <domain>GP</domain>
+    <description>The Green Power cluster defines the format of the commands exchanged when handling GPDs.</description>
+    <code>0x0021</code>
+    <define>GREEN_POWER_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- Server attributes. -->
+    <attribute side="server" code="0x0000" define="GP_SERVER_GPS_MAX_SINK_TABLE_ENTRIES" type="INT8U" writable="false" default="0x05" optional="false" introducedIn="gp-1.0-09-5499-24">gps max sink table entries</attribute>
+    <attribute side="server" code="0x0001" define="GP_SERVER_SINK_TABLE" type="LONG_OCTET_STRING" length="0" writable="false" optional="false" introducedIn="gp-1.0-09-5499-24">sink table</attribute>
+    <attribute side="server" code="0x0002" define="GP_SERVER_GPS_COMMUNICATION_MODE" type="BITMAP8" writable="true" default="0x01" optional="false" introducedIn="gp-1.0-09-5499-24">gps communication mode</attribute>
+    <attribute side="server" code="0x0003" define="GP_SERVER_GPS_COMMISSIONING_EXIT_MODE" type="BITMAP8" writable="true" default="0x02" optional="false" introducedIn="gp-1.0-09-5499-24">gps commissioning exit mode</attribute>
+    <attribute side="server" code="0x0004" define="GP_SERVER_GPS_COMMISSIONING_WINDOW" type="INT16U" writable="true" default="0x00B4" optional="true" introducedIn="gp-1.0-09-5499-24">gps commissioning window</attribute>
+    <attribute side="server" code="0x0005" define="GP_SERVER_GPS_SECURITY_LEVEL" type="BITMAP8" writable="true" default="0x01" optional="false" introducedIn="gp-1.0-09-5499-24">gps security level</attribute>
+    <attribute side="server" code="0x0006" define="GP_SERVER_GPS_FUNCTIONALITY" type="BITMAP24" writable="false" optional="false" introducedIn="gp-1.0-09-5499-24">gps functionality</attribute>
+    <attribute side="server" code="0x0007" define="GP_SERVER_GPS_ACTIVE_FUNCTIONALITY" type="BITMAP24" writable="false" default="0xFFFFFF" optional="false" introducedIn="gp-1.0-09-5499-24">gps active functionality</attribute>
+    <!-- attributes shared by client and server side of the Green Power cluster. -->
+    <attribute side="server" code="0x0020" define="GP_SERVER_GP_SHARED_SECURITY_KEY_TYPE" type="BITMAP8" min="0x00" max="0x08" writable="true" default="0x03" optional="true" introducedIn="gp-1.0-09-5499-24">gp shared security key type</attribute>
+    <attribute side="server" code="0x0021" define="GP_SERVER_GP_SHARED_SECURITY_KEY" type="SECURITY_KEY" writable="true" optional="true" introducedIn="gp-1.0-09-5499-24">gp shared security key</attribute>
+    <attribute side="server" code="0x0022" define="GP_SERVER_GP_LINK_KEY" type="SECURITY_KEY" writable="true" default="0x5a6967426565416c6c69616e63653039" optional="false" introducedIn="gp-1.0-09-5499-24">gp link key</attribute>
+    <!-- Client attributes. -->
+    <attribute side="client" code="0x0010" define="GP_CLIENT_GPP_MAX_PROXY_TABLE_ENTRIES" type="INT8U" writable="false" default="0x14" optional="false" introducedIn="gp-1.0-09-5499-24">gpp max proxy table entries</attribute>
+    <attribute side="client" code="0x0011" define="GP_CLIENT_PROXY_TABLE" type="LONG_OCTET_STRING" length="0" writable="false" optional="false" introducedIn="gp-1.0-09-5499-24">proxy table</attribute>
+    <attribute side="client" code="0x0012" define="GP_CLIENT_GPP_NOTIFICATION_RETRY_NUMBER" type="INT8U" min="0x00" max="0x05" writable="true" default="0x02" optional="true" introducedIn="gp-1.0-09-5499-24">gpp notification retry number</attribute>
+    <attribute side="client" code="0x0013" define="GP_CLIENT_GPP_NOTIFICATION_RETRY_TIMER" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x64" optional="true" introducedIn="gp-1.0-09-5499-24">gpp notification retry timer</attribute>
+    <attribute side="client" code="0x0014" define="GP_CLIENT_GPP_MAX_SEARCH_COUNTER" type="INT8U" writable="true" default="0x0A" optional="true" introducedIn="gp-1.0-09-5499-24">gpp max search counter</attribute>
+    <attribute side="client" code="0x0015" define="GP_CLIENT_GPP_BLOCKED_GPD_ID" type="LONG_OCTET_STRING" length="0" writable="false" optional="true" introducedIn="gp-1.0-09-5499-24">gpp blocked gpd id</attribute>
+    <attribute side="client" code="0x0016" define="GP_CLIENT_GPP_FUNCTIONALITY" type="BITMAP24" writable="false" default="0x09AC2F" optional="false" introducedIn="gp-1.0-09-5499-24">gpp functionality</attribute>
+    <attribute side="client" code="0x0017" define="GP_CLIENT_GPP_ACTIVE_FUNCTIONALITY" type="BITMAP24" writable="false" default="0xFFFFFF" optional="false" introducedIn="gp-1.0-09-5499-24">gpp active functionality</attribute>
+    <!-- attributes shared by client and server side of the Green Power cluster. -->
+    <attribute side="client" code="0x0020" define="GP_CLIENT_GP_SHARED_SECURITY_KEY_TYPE" type="BITMAP8" min="0x00" max="0x08" writable="true" default="0x03" optional="true" introducedIn="gp-1.0-09-5499-24">gp shared security key type</attribute>
+    <attribute side="client" code="0x0021" define="GP_CLIENT_GP_SHARED_SECURITY_KEY" type="SECURITY_KEY" writable="true" optional="true" introducedIn="gp-1.0-09-5499-24">gp shared security key</attribute>
+    <attribute side="client" code="0x0022" define="GP_CLIENT_GP_LINK_KEY" type="SECURITY_KEY" writable="true" default="0x5a6967426565416c6c69616e63653039" optional="false" introducedIn="gp-1.0-09-5499-24">gp link key</attribute>
+    <!-- Client-to-server commands. -->
+    <command source="client" code="0x00" name="GpNotification" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPP to GPS to tunnel GP frame.
+      </description>
+      <arg name="options" type="GpNotificationOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdEndpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdCommandId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdCommandPayload" type="OCTET_STRING" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppShortAddress" type="INT16U" presentIf="(options &amp; 0x4000) || (options &amp; 0x0800)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppDistance" type="INT8U" presentIf="(options &amp; 0x4000) || (options &amp; 0x0800)" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="client" code="0x01" name="GpPairingSearch" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPP to GPSs in entire network to get pairing indication related to GPD for Proxy Table update.
+      </description>
+      <arg name="options" type="GpPairingSearchOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002"/>
+    </command>
+    <command source="client" code="0x03" name="GpTunnelingStop" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPP to neighbor GPPs to indicate GP Notification sent in unicast mode.
+      </description>
+      <arg name="options" type="GpTunnelingStopOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppShortAddress" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppDistance" type="INT8S" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="client" code="0x04" name="GpCommissioningNotification" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPP to GPS to tunnel GPD commissioning data.
+      </description>
+      <arg name="options" type="GpCommissioningNotificationOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdCommandId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdCommandPayload" type="OCTET_STRING" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppShortAddress" type="INT16U" presentIf="(options &amp; 0x0800) || (options &amp; 0x0008)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gppLink" type="INT8U" presentIf="(options &amp; 0x0800) || (options &amp; 0x0008)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="mic" type="INT32U" presentIf="options &amp; 0x0200" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="client" code="0x05" name="GpSinkCommissioningMode" optional="true">
+      <description>
+        To enable commissioning mode of the sink, over the air
+      </description>
+      <arg name="options" type="GpSinkCommissioningModeOptions"/>
+      <arg name="gpmAddrForSecurity" type="INT16U"/>
+      <arg name="gpmAddrForPairing" type="INT16U"/>
+      <arg name="sinkEndpoint" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="GpTranslationTableUpdate" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        To configure GPD Command Translation Table.
+      </description>
+      <arg name="options" type="GpTranslationTableUpdateOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="translations" type="GpTranslationTableUpdateTranslation" array="true" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="client" code="0x08" name="GpTranslationTableRequest" optional="true">
+      <description>
+        To provide GPD Command Translation Table content.
+      </description>
+      <arg name="startIndex" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="client" code="0x09" name="GpPairingConfiguration" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        To configure Sink Table.
+      </description>
+      <arg name="actions" type="GpPairingConfigurationActions" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="options" type="GpPairingConfigurationOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="deviceId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="groupListCount" type="INT8U" presentIf="(options &amp; 0x0018) == 0x0010" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="groupList" type="GpPairingConfigurationGroupList" array="true" countArg="groupListCount" presentIf="(options &amp; 0x0018) == 0x0010" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdAssignedAlias" type="INT16U" presentIf="(options &amp; 0x0100)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="groupcastRadius" type="INT8U" introducedIn="gp-1.0-15-2014-05-CCB2180"/>
+      <arg name="securityOptions" type="INT8U" presentIf="(options &amp; 0x0200)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" presentIf="(options &amp; 0x0200) || (options &amp; 0x0020)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityKey" type="SECURITY_KEY" presentIf="(options &amp; 0x0200)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="numberOfPairedEndpoints" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="pairedEndpoints" type="INT8U" array="true" countArg="numberOfPairedEndpoints" presentIf="0 &lt; numberOfPairedEndpoints &amp;&amp; numberOfPairedEndpoints &lt; 0xFD" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="applicationInformation" type="GpApplicationInformation" presentIf="(options &amp; 0x0400)"/>
+      <arg name="manufacturerId" type="INT16U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x01)"/>
+      <arg name="modeId" type="INT16U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x02)"/>
+      <arg name="numberOfGpdCommands" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x04)"/>
+      <arg name="gpdCommandIdList" type="INT8U" array="true" countArg="numberOfGpdCommands" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x04)"/>
+      <arg name="clusterIdListCount" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x08)"/>
+      <arg name="clusterListServer" type="INT16U" array="true" countArg="(clusterIdListCount &amp; 0x0F)" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x08) &amp;&amp; ((clusterIdListCount &amp; 0x0F) &gt; 0)"/>
+      <arg name="clusterListClient" type="INT16U" array="true" countArg="(clusterIdListCount &gt;&gt; 4)" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x08) &amp;&amp; ((clusterIdListCount &gt;&gt; 4) &gt; 0)"/>
+      <arg name="switchInformationLength" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x10)"/>
+      <arg name="switchConfiguration" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x10)"/>
+      <arg name="currentContactStatus" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x10)"/>
+      <arg name="totalNumberOfReports" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x20)"/>
+      <arg name="numberOfReports" type="INT8U" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x20)"/>
+      <arg name="reportDescriptor" type="INT8U" array="true" presentIf="(options &amp; 0x0400) &amp;&amp; (applicationInformation &amp; 0x20)"/>
+    </command>
+    <command source="client" code="0x0a" name="GpSinkTableRequest" optional="true">
+      <description>
+        To read out selected Sink Table Entries, by index or by GPD ID.
+      </description>
+      <arg name="options" type="GpSinkTableRequestOptions"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="((options &amp; 0x07) == 0x00) &amp;&amp; ((options &amp; 0x18) == 0x00)"/>
+      <arg name="gpdIeee" type="INT64U" presentIf="((options &amp; 0x07) == 0x02) &amp;&amp; ((options &amp; 0x18) == 0x00)"/>
+      <arg name="endpoint" type="INT8U" presentIf="((options &amp; 0x07) == 0x02) &amp;&amp; ((options &amp; 0x18) == 0x00)"/>
+      <arg name="index" type="INT8U" presentIf="(options &amp; 0x18) == 0x08"/>
+    </command>
+    <command source="client" code="0x0b" name="GpProxyTableResponse" optional="true">
+      <description>
+        To reply with read-out Proxy Table entries, by index or by GPD ID.
+      </description>
+      <arg name="status" type="GpProxyTableResponseStatus"/>
+      <arg name="totalNumberOfNonEmptyProxyTableEntries" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="entriesCount" type="INT8U"/>
+      <arg name="proxyTableEntries" type="INT8U" array="true"/>
+    </command>
+    <!-- Server-to-client commands. -->
+    <command source="server" code="0x00" name="GpNotificationResponse" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPS to GPP to acknowledge GP Notification received in unicast mode.
+      </description>
+      <arg name="options" type="GpNotificationResponseOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x0007) == 0x0000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x0007) == 0x0002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="server" code="0x01" name="GpPairing" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPS to the entire network to (de)register for tunneling service, or for removing GPD from the network.
+      </description>
+      <arg name="options" type="GpPairingOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x000007) == 0x000000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x000007) == 0x000002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x000007) == 0x000002" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="sinkIeeeAddress" type="IEEE_ADDRESS" presentIf="(options &amp; 0x000010) == 0x000000 &amp;&amp; ((options &amp; 0x000060) == 0x000000 || (options &amp; 0x000060) == 0x000060)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="sinkNwkAddress" type="INT16U" presentIf="(options &amp; 0x000010) == 0x000000 &amp;&amp; ((options &amp; 0x000060) == 0x000000 || (options &amp; 0x000060) == 0x000060)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="sinkGroupId" type="INT16U" presentIf="(options &amp; 0x000010) == 0x000000 &amp;&amp; ((options &amp; 0x000060) == 0x000020 || (options &amp; 0x000060) == 0x000040)" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="deviceId" type="GpDeviceId" presentIf="(options &amp; 0x000008) == 0x000008 &amp;&amp; (options &amp; 0x000010) != 0x000010" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSecurityFrameCounter" type="INT32U" presentIf="(options &amp; 0x004000) == 0x004000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdKey" type="SECURITY_KEY" presentIf="(options &amp; 0x008000) == 0x008000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="assignedAlias" type="INT16U" presentIf="(options &amp; 0x010000) == 0x010000" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="groupcastRadius" type="INT8U" presentIf="(options &amp; 0x020000) == 0x020000" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="server" code="0x02" name="GpProxyCommissioningMode" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPS to GPPs in the whole network to indicate commissioning mode.
+      </description>
+      <arg name="options" type="GpProxyCommissioningModeOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="commissioningWindow" type="INT16U" presentIf="(options &amp; 0x02) == 0x02" introducedIn="gp-1.0-15-02014-011"/>
+      <arg name="channel" type="INT8U" presentIf="(options &amp; 0x10) == 0x10" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="server" code="0x06" name="GpResponse" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        From GPS to selected GPP, to provide data to be transmitted to Rx-capable GPD.
+      </description>
+      <arg name="options" type="GpResponseOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="tempMasterShortAddress" type="INT16U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="tempMasterTxChannel" type="BITMAP8" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="(options &amp; 0x07) == 0x00" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdIeee" type="IEEE_ADDRESS" presentIf="(options &amp; 0x07) == 0x02" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x07) == 0x02"/>
+      <arg name="gpdCommandId" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="gpdCommandPayload" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x08" name="GpTranslationTableResponse" optional="true" introducedIn="gp-1.0-09-5499-24">
+      <description>
+        To provide GPD Command Translation Table content.
+      </description>
+      <arg name="status" type="GpTranslationTableResponseStatus" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="options" type="GpTranslationTableResponseOption" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="totalNumberOfEntries" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="startIndex" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="entriesCount" type="INT8U" introducedIn="gp-1.0-09-5499-24"/>
+      <arg name="translationTableList" type="INT8U" array="true" introducedIn="gp-1.0-09-5499-24"/>
+    </command>
+    <command source="server" code="0x0a" name="GpSinkTableResponse" optional="true">
+      <description>
+        To selected Proxy Table entries, by index or by GPD ID.
+      </description>
+      <arg name="status" type="ENUM8"/>
+      <arg name="totalNumberofNonEmptySinkTableEntries" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="sinkTableEntriesCount" type="INT8U"/>
+      <!-- TODO: get appBuilder to understand complex arrays -->
+      <arg name="sinkTableEntries" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x0b" name="GpProxyTableRequest" optional="true">
+      <description>
+        To request selected Proxy Table entries, by index or by GPD ID.
+      </description>
+      <arg name="options" type="GpProxyTableRequestOptions"/>
+      <arg name="gpdSrcId" type="INT32U" presentIf="((options &amp; 0x18) == 0x00) &amp;&amp; ((options &amp; 0x07) == 0x00)"/>
+      <arg name="gpdIeee" type="INT64U" presentIf="((options &amp; 0x18) == 0x00) &amp;&amp; ((options &amp; 0x07) == 0x02)"/>
+      <arg name="endpoint" type="INT8U" presentIf="(options &amp; 0x07) == 0x02"/>
+      <arg name="index" type="INT8U" presentIf="(options &amp; 0x18) == 0x08"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha-devices.xml
@@ -1,0 +1,1031 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>HA-onoff</name>
+    <domain>HA</domain>
+    <typeName>HA On/Off Switch</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-levelcontrol</name>
+    <domain>HA</domain>
+    <typeName>HA Level Control Switch</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0001</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-onnoffoutput</name>
+    <domain>HA</domain>
+    <typeName>HA On/Off Output</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0002</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-levelcontrollableoutput</name>
+    <domain>HA</domain>
+    <typeName>HA Level Controllable Output</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0003</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-sceneselector</name>
+    <domain>HA</domain>
+    <typeName>HA Scene Selector</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0004</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-configurationtool</name>
+    <domain>HA</domain>
+    <typeName>HA Configuration Tool</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0005</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Illuminance Level Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Temperature Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Pressure Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Flow Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Pump Configuration and Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Shade Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Thermostat User Interface Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-remote</name>
+    <domain>HA</domain>
+    <typeName>HA Remote Control</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0006</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Power Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Color control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Pump Configuration and Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Shade Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Temperature Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Illuminance Level Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Illuminance Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Window Covering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Door Lock</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Thermostat</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-combinedinterface</name>
+    <domain>HA</domain>
+    <typeName>HA Combined Interface</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0007</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Color control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Pump Configuration and Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Shade Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Temperature Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Illuminance Level Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Illuminance Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Thermostat User Interface Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Window Covering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Door Lock</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Thermostat</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-rangeextender</name>
+    <domain>HA</domain>
+    <typeName>HA Range Extender</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-mpo</name>
+    <domain>HA</domain>
+    <typeName>HA Mains Power Outlet</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0009</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-doorlock</name>
+    <domain>HA</domain>
+    <typeName>HA Door Lock</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x000A</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Door Lock</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-doorlockcontroller</name>
+    <domain>HA</domain>
+    <typeName>HA Door Lock Controller</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x000B</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Door Lock</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Time</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-simplesensor</name>
+    <domain>HA</domain>
+    <typeName>HA Simple Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x000C</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Binary Input (Basic)</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-onofflight</name>
+    <domain>HA</domain>
+    <typeName>HA On/Off Light</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0100</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-light</name>
+    <domain>HA</domain>
+    <typeName>HA Dimmable Light</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0101</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-colordimmablelight</name>
+    <domain>HA</domain>
+    <typeName>HA Color Dimmable Light</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0102</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Color control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-onofflightswitch</name>
+    <domain>HA</domain>
+    <typeName>HA On/Off Light Switch</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0103</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-switch</name>
+    <domain>HA</domain>
+    <typeName>HA Dimmer Switch</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0104</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-colordimmerswitch</name>
+    <domain>HA</domain>
+    <typeName>HA Color Dimmer Switch</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0105</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Color control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">On/Off Switch Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-lightsensor</name>
+    <domain>HA</domain>
+    <typeName>HA Light Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0106</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Illuminance measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-occupancysensor</name>
+    <domain>HA</domain>
+    <typeName>HA Occupancy Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0107</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-shade</name>
+    <domain>HA</domain>
+    <typeName>HA Shade</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0200</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Shade configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-shadecontroller</name>
+    <domain>HA</domain>
+    <typeName>HA Shade Controller</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0201</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Shade configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-windowcovering</name>
+    <domain>HA</domain>
+    <typeName>HA Window Covering</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0202</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Window Covering</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-windowcoveringcontroller</name>
+    <domain>HA</domain>
+    <typeName>HA Window Covering Controller</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0203</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Window Covering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-heatcool</name>
+    <domain>HA</domain>
+    <typeName>HA Heating Cooling Unit</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0300</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Thermostat</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Fan control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Level control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-tstat</name>
+    <domain>HA</domain>
+    <typeName>HA Thermostat</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0301</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Thermostat</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Scenes</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Thermostat User Interface Configuration</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Fan control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Temperature measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Occupancy Sensing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Relative Humidity Measurement</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-tempsensor</name>
+    <domain>HA</domain>
+    <typeName>HA Temperature Sensor</typeName>
+    <zigbeeType>Sleepy End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0302</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Temperature measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-pump</name>
+    <domain>HA</domain>
+    <typeName>HA Pump</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0303</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Pump Configuration and Control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Scenes</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Level control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Pressure measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Temperature measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Flow measurement</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-pumpcontroller</name>
+    <domain>HA</domain>
+    <typeName>HA Pump Controller</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0304</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Pump Configuration and Control</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Pressure measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Temperature measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Flow measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Level control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-pressuresensor</name>
+    <domain>HA</domain>
+    <typeName>HA Pressure Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0305</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Pressure measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-flowsensor</name>
+    <domain>HA</domain>
+    <typeName>HA Flow Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0306</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Flow measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-ias400</name>
+    <domain>HA</domain>
+    <typeName>HA IAS Control and Indication Equipment</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0400</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">IAS ACE</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">IAS WD</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">IAS Zone</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Scenes</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-ias401</name>
+    <domain>HA</domain>
+    <typeName>HA IAS Ancillary Control Equipment</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0401</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">IAS Zone</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">IAS ACE</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-ias402</name>
+    <domain>HA</domain>
+    <typeName>HA IAS Zone</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0402</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">IAS Zone</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-ias403</name>
+    <domain>HA</domain>
+    <typeName>HA IAS Warning Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0403</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">IAS WD</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">IAS Zone</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Scenes</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-consumptionawarenessdevice</name>
+    <domain>HA</domain>
+    <typeName>HA Consumption Awareness Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x000D</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-homegatewayems</name>
+    <domain>HA</domain>
+    <typeName>HA Home Gateway / Energy Management System</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0050</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Time</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">Simple Metering</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Meter Identification</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Power Profile</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Appliance Statistics</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Appliance Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Appliance Identification</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Appliance Events and Alert</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-smartplug</name>
+    <domain>HA</domain>
+    <typeName>HA Smart Plug</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0051</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/off</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Demand Response and Load Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-whitegoods</name>
+    <domain>HA</domain>
+    <typeName>HA White Goods</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0052</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Meter Identification</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Power Profile</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Appliance Statistics</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Appliance Control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Appliance Identification</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Appliance Events and Alert</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Simple Metering</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HA-meterinterface</name>
+    <domain>HA</domain>
+    <typeName>HA Meter Interface</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0053</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Device Temperature Configuration</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Simple Metering</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Meter Identification</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Poll Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Electrical Measurement</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Time</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Messaging</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Price</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha-thread.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha-thread.xml
@@ -1,0 +1,2462 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="Closures" spec="zcl-6.0-15-02018-001"/>
+  <domain name="HVAC" spec="zcl-6.0-15-02018-001"/>
+  <domain name="Lighting" spec="zcl-6.0-15-02018-001"/>
+  <domain name="Measurement &amp; Sensing" spec="zcl-6.0-15-02018-001"/>
+  <domain name="Security &amp; Safety" spec="zcl-6.0-15-02018-001"/>
+  <domain name="HA" spec="ha-1.2.1-05-3520-30" dependsOn="zcl-1.0-07-5123-03" certifiable="true">
+    <older spec="ha-1.2-05-3520-29" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="ha-1.1-05-3520-27" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <cluster>
+    <name>Shade Configuration</name>
+    <domain>Closures</domain>
+    <description>Attributes and commands for configuring a shade.</description>
+    <code>0x0100</code>
+    <define>SHADE_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SHADE_CONFIG_PHYSICAL_CLOSED_LIMIT" type="INT16U" min="0x0001" max="0xFFFE" writable="false" optional="true">physical closed limit</attribute>
+    <!-- PHYSICAL_CLOSED_LIMIT -->
+    <attribute side="server" code="0x0001" define="SHADE_CONFIG_MOTOR_STEP_SIZE" type="INT8U" min="0x00" max="0xFE" writable="false" optional="true">motor step size</attribute>
+    <!-- MOTOR_STEP_SIZE -->
+    <attribute side="server" code="0x0002" define="SHADE_CONFIG_STATUS" type="BITMAP8" min="0x00" max="0x0F" writable="true" default="0x00" optional="false">status</attribute>
+    <!-- STATUS -->
+    <attribute side="server" code="0x0010" define="SHADE_CONFIG_CLOSED_LIMIT" type="INT16U" min="0x0001" max="0xFFFE" writable="true" default="0x0001" optional="false">closed limit</attribute>
+    <!-- CLOSED_LIMIT -->
+    <attribute side="server" code="0x0011" define="SHADE_CONFIG_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">mode</attribute>
+    <!-- MODE -->
+  </cluster>
+  <cluster>
+    <name>Pump Configuration and Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring and controlling pumps.</description>
+    <code>0x0200</code>
+    <define>PUMP_CONFIG_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="false">max pressure</attribute>
+    <attribute side="server" code="0x0001" define="MAX_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="false">max speed</attribute>
+    <attribute side="server" code="0x0002" define="MAX_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="false">max flow</attribute>
+    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">min const pressure</attribute>
+    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">max const pressure</attribute>
+    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">min comp pressure</attribute>
+    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">max comp pressure</attribute>
+    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">min const speed</attribute>
+    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">max const speed</attribute>
+    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">min const flow</attribute>
+    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">max const flow</attribute>
+    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">min const temp</attribute>
+    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">max const temp</attribute>
+    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="BITMAP16" writable="false" reportable="true" optional="true">pump status</attribute>
+    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective operation mode</attribute>
+    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective control mode</attribute>
+    <attribute side="server" code="0x0013" define="CAPACITY" type="INT16S" min="0x0000" max="0x7FFF" writable="false" reportable="true" optional="false">capacity</attribute>
+    <attribute side="server" code="0x0014" define="SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">speed</attribute>
+    <attribute side="server" code="0x0015" define="LIFETIME_RUNNING_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">lifetime running hours</attribute>
+    <attribute side="server" code="0x0016" define="PUMP_POWER" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" optional="true">power</attribute>
+    <attribute side="server" code="0x0017" define="LIFETIME_ENERGY_CONSUMED" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0x00000000" optional="true">lifetime energy consumed</attribute>
+    <attribute side="server" code="0x0020" define="OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">operation mode</attribute>
+    <attribute side="server" code="0x0021" define="CONTROL_MODE" type="ENUM8" min="0x00" max="0xFe" writable="true" default="0x00" optional="true">control mode</attribute>
+    <attribute side="server" code="0x0022" define="PUMP_ALARM_MASK" type="BITMAP16" writable="false" optional="true">alarm mask</attribute>
+    <!-- ALARM_MASK -->
+  </cluster>
+  <cluster>
+    <name>Thermostat</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring and controlling the functionality of a thermostat.</description>
+    <code>0x0201</code>
+    <define>THERMOSTAT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" reportable="true" optional="false">local temperature</attribute>
+    <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">outdoor temperature</attribute>
+    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="BITMAP8" min="0x00" max="0x01" writable="false" default="0x00" optional="true">occupancy</attribute>
+    <!-- OCCUPANCY -->
+    <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x02BC" optional="true">abs min heat setpoint limit</attribute>
+    <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0BB8" optional="true">abs max heat setpoint limit</attribute>
+    <attribute side="server" code="0x0005" define="ABS_MIN_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0640" optional="true">abs min cool setpoint limit</attribute>
+    <attribute side="server" code="0x0006" define="ABS_MAX_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0C80" optional="true">abs max cool setpoint limit</attribute>
+    <attribute side="server" code="0x0007" define="PI_COOLING_DEMAND" type="INT8U" min="0x00" max="0x64" writable="false" reportable="true" optional="true">pi cooling demand</attribute>
+    <attribute side="server" code="0x0008" define="PI_HEATING_DEMAND" type="INT8U" min="0x00" max="0x64" writable="false" reportable="true" optional="true">pi heating demand</attribute>
+    <attribute side="server" code="0x0009" define="HVAC_SYSTEM_TYPE_CONFIGURATION" type="BITMAP8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">HVAC system type configuration</attribute>
+    <attribute side="server" code="0x0010" define="LOCAL_TEMPERATURE_CALIBRATION" type="INT8S" min="0xE7" max="0x19" writable="true" default="0x00" optional="true">local temperature calibration</attribute>
+    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="INT16S" writable="true" default="0x0A28" optional="false">occupied cooling setpoint</attribute>
+    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="INT16S" writable="true" default="0x07D0" optional="false">occupied heating setpoint</attribute>
+    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="INT16S" writable="true" default="0x0A28" optional="true">unoccupied cooling setpoint</attribute>
+    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="INT16S" writable="true" default="0x07D0" optional="true">unoccupied heating setpoint</attribute>
+    <attribute side="server" code="0x0015" define="MIN_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x02BC" optional="true">min heat setpoint limit</attribute>
+    <attribute side="server" code="0x0016" define="MAX_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0BB8" optional="true">max heat setpoint limit</attribute>
+    <attribute side="server" code="0x0017" define="MIN_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0640" optional="true">min cool setpoint limit</attribute>
+    <attribute side="server" code="0x0018" define="MAX_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0C80" optional="true">max cool setpoint limit</attribute>
+    <attribute side="server" code="0x0019" define="MIN_SETPOINT_DEAD_BAND" type="INT8S" min="0x0A" max="0x19" writable="true" default="0x19" optional="true">min setpoint dead band</attribute>
+    <attribute side="server" code="0x001A" define="REMOTE_SENSING" type="BITMAP8" min="0x00" max="0x07" writable="true" default="0x00" optional="true">remote sensing</attribute>
+    <attribute side="server" code="0x001B" define="CONTROL_SEQUENCE_OF_OPERATION" type="ENUM8" min="0x00" max="0x05" writable="true" default="0x04" optional="false">control sequence of operation</attribute>
+    <attribute side="server" code="0x001C" define="SYSTEM_MODE" type="ENUM8" min="0x00" max="0x07" writable="true" default="0x01" optional="false">system mode</attribute>
+    <attribute side="server" code="0x001D" define="THERMOSTAT_ALARM_MASK" type="BITMAP8" min="0x00" max="0x07" writable="false" default="0x00" optional="true">alarm mask</attribute>
+    <!-- ALARM_MASK -->
+    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ENUM8" min="0x00" max="0x04" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">thermostat running mode</attribute>
+    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="ENUM8" min="0x00" max="0x06" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">start of week</attribute>
+    <attribute side="server" code="0x0021" define="NUMBER_OF_WEEKLY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">number of weekly transitions</attribute>
+    <attribute side="server" code="0x0022" define="NUMBER_OF_DAILY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">number of daily transitions</attribute>
+    <attribute side="server" code="0x0023" define="TEMPERATURE_SETPOINT_HOLD" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">temperature setpoint hold</attribute>
+    <attribute side="server" code="0x0024" define="TEMPERATURE_SETPOINT_HOLD_DURATION" type="INT16U" min="0x0000" max="0x05A0" writable="true" default="0xFFFF" optional="true" introducedIn="ha-1.2-05-3520-29">temperature setpoint hold duration</attribute>
+    <attribute side="server" code="0x0025" define="THERMOSTAT_PROGRAMMING_OPERATION_MODE" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">thermostat programming operation mode</attribute>
+    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="BITMAP16" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">hvac relay state</attribute>
+    <attribute side="server" code="0x0030" define="SETPOINT_CHANGE_SOURCE" type="ENUM8" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change source</attribute>
+    <attribute side="server" code="0x0031" define="SETPOINT_CHANGE_AMOUNT" type="INT16S" writable="false" default="0x8000" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change amount</attribute>
+    <attribute side="server" code="0x0032" define="SETPOINT_CHANGE_SOURCE_TIMESTAMP" type="UTC_TIME" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change source timestamp</attribute>
+    <attribute side="server" code="0x0040" define="AC_TYPE" type="ENUM8" min="0x00" max="0x04" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac type</attribute>
+    <attribute side="server" code="0x0041" define="AC_CAPACITY" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac capacity</attribute>
+    <attribute side="server" code="0x0042" define="AC_REFRIGERANT_TYPE" type="ENUM8" min="0x00" max="0x03" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac refrigerant type</attribute>
+    <attribute side="server" code="0x0043" define="AC_COMPRESSOR" type="ENUM8" min="0x00" max="0x03" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac compressor</attribute>
+    <attribute side="server" code="0x0044" define="AC_ERROR_CODE" type="BITMAP32" min="0x0000" max="0xFFFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac error code</attribute>
+    <attribute side="server" code="0x0045" define="AC_LOUVER_POSITION" type="ENUM8" min="0x00" max="0x05" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac louver position</attribute>
+    <attribute side="server" code="0x0046" define="AC_COIL_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">ac coil temperature</attribute>
+    <attribute side="server" code="0x0047" define="AC_CAPACITY_FORMAT" type="ENUM8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">ac capacity format</attribute>
+    <command source="client" code="0x00" name="SetpointRaiseLower" optional="false" cli="zcl tstat set">
+      <description>
+        Command description for SetpointRaiseLower
+      </description>
+      <arg name="mode" type="SetpointAdjustMode"/>
+      <arg name="amount" type="INT8S"/>
+    </command>
+    <command source="client" code="0x01" name="SetWeeklySchedule" optional="false" cli="zcl tstat sws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        Command description for SetWeeklySchedule
+      </description>
+      <arg name="numberOfTransitionsForSequence" type="ENUM8"/>
+      <arg name="dayOfWeekForSequence" type="DayOfWeek"/>
+      <arg name="modeForSequence" type="ModeForSequence"/>
+      <arg name="payload" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="GetWeeklySchedule" optional="false" cli="zcl tstat gws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        Command description for GetWeeklySchedule
+      </description>
+      <arg name="daysToReturn" type="DayOfWeek"/>
+      <arg name="modeToReturn" type="ModeForSequence"/>
+    </command>
+    <command source="client" code="0x03" name="ClearWeeklySchedule" optional="false" cli="zcl tstat cws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Clear Weekly Schedule command is used to clear the weekly schedule.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="GetRelayStatusLog" optional="false" cli="zcl tstat grs" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Get Relay Status Log command is used to query the thermostat internal relay status log.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="CurrentWeeklySchedule" optional="false" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Current Weekly Schedule Command is sent from the server in response to the Get Weekly Schedule Command.
+      </description>
+      <arg name="numberOfTransitionsForSequence" type="ENUM8"/>
+      <arg name="dayOfWeekForSequence" type="DayOfWeek"/>
+      <arg name="modeForSequence" type="ModeForSequence"/>
+      <arg name="payload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="RelayStatusLog" optional="false" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        This command is sent from the thermostat cluster server in response to the Get  Relay Status Log.
+      </description>
+      <arg name="timeOfDay" type="INT16U"/>
+      <arg name="relayStatus" type="BITMAP16"/>
+      <arg name="localTemperature" type="INT16S"/>
+      <arg name="humidityInPercentage" type="INT8U"/>
+      <arg name="setpoint" type="INT16S"/>
+      <arg name="unreadEntries" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Fan Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for controlling a fan in a heating/cooling system.</description>
+    <code>0x0202</code>
+    <define>FAN_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="FAN_CONTROL_FAN_MODE" type="ENUM8" min="0x00" max="0x06" writable="true" default="0x05" optional="false">fan mode</attribute>
+    <!-- FAN_MODE -->
+    <attribute side="server" code="0x0001" define="FAN_CONTROL_FAN_MODE_SEQUENCE" type="ENUM8" min="0x00" max="0x04" writable="true" default="0x02" optional="false">fan mode sequence</attribute>
+    <!-- FAN_MODE_SEQUENCE -->
+  </cluster>
+  <cluster>
+    <name>Dehumidification Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for controlling dehumidification.</description>
+    <code>0x0203</code>
+    <define>DEHUMID_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY" type="INT8U" min="0x00" max="0x64" writable="false" optional="true">relative humidity</attribute>
+    <attribute side="server" code="0x0001" define="DEHUMIDIFICATION_COOLING" type="INT8U" min="0x00" writable="false" optional="false">dehumidification cooling</attribute>
+    <attribute side="server" code="0x0010" define="RH_DEHUMIDIFICATION_SETPOINT" type="INT8U" min="0x1E" max="0x64" writable="true" default="0x32" optional="false">RH dehumidification setpoint</attribute>
+    <attribute side="server" code="0x0011" define="RELATIVE_HUMIDITY_MODE" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">relative humidity mode</attribute>
+    <attribute side="server" code="0x0012" define="DEHUMIDIFICATION_LOCKOUT" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x01" optional="true">dehumidification lockout</attribute>
+    <attribute side="server" code="0x0013" define="DEHUMIDIFICATION_HYSTERESIS" type="INT8U" min="0x02" max="0x14" writable="true" default="0x02" optional="false">dehumidification hysteresis</attribute>
+    <attribute side="server" code="0x0014" define="DEHUMIDIFICATION_MAX_COOL" type="INT8U" min="0x14" max="0x64" writable="true" default="0x14" optional="false">dehumidification max cool</attribute>
+    <attribute side="server" code="0x0015" define="RELATIVE_HUMIDITY_DISPLAY" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">relative humidity display</attribute>
+  </cluster>
+  <cluster>
+    <name>Thermostat User Interface Configuration</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).</description>
+    <code>0x0204</code>
+    <define>THERMOSTAT_UI_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TEMPERATURE_DISPLAY_MODE" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="false">temperature display mode</attribute>
+    <attribute side="server" code="0x0001" define="KEYPAD_LOCKOUT" type="ENUM8" min="0x00" max="0x05" writable="true" default="0x00" optional="false">keypad lockout</attribute>
+    <attribute side="server" code="0x0002" define="SCHEDULE_PROGRAMMING_VISIBILITY" type="ENUM8" min="0x00" max="0x01" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">schedule programming visibility</attribute>
+  </cluster>
+  <cluster>
+    <name>Color Control</name>
+    <domain>Lighting</domain>
+    <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
+    <code>0x0300</code>
+    <define>COLOR_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="INT8U" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">current hue</attribute>
+    <!-- CURRENT_HUE -->
+    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="INT8U" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">current saturation</attribute>
+    <!-- CURRENT_SATURATION -->
+    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="false" default="0x0000" optional="true">remaining time</attribute>
+    <!-- REMAINING_TIME -->
+    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x616B" optional="false">current x</attribute>
+    <!-- CURRENT_X -->
+    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x607D" optional="false">current y</attribute>
+    <!-- CURRENT_Y -->
+    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="ENUM8" min="0x00" max="0x04" writable="false" optional="true">drift compensation</attribute>
+    <!-- DRIFT_COMPENSATION -->
+    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="CHAR_STRING" length="254" writable="false" optional="true">compensation text</attribute>
+    <!-- COMPENSATION_TEXT -->
+    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x00FA" optional="true">color temperature</attribute>
+    <!-- COLOR_TEMPERATURE -->
+    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ENUM8" min="0x00" max="0x02" writable="false" default="0x01" optional="true">color mode</attribute>
+    <!-- COLOR_MODE -->
+    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x00" optional="false" introducedIn="zcl-6.0-15-02017-001">color control options</attribute>
+    <!-- COLOR_CONTROL_OPTIONS -->
+    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="INT8U" min="0x00" max="0x06" writable="false" optional="true">number of primaries</attribute>
+    <!-- NUMBER_OF_PRIMARIES -->
+    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 1 x</attribute>
+    <!-- PRIMARY_1_X -->
+    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 1 y</attribute>
+    <!-- PRIMARY_1_Y -->
+    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 1 intensity</attribute>
+    <!-- PRIMARY_1_INTENSITY -->
+    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 2 x</attribute>
+    <!-- PRIMARY_2_X -->
+    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 2 y</attribute>
+    <!-- PRIMARY_2_Y -->
+    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 2 intensity</attribute>
+    <!-- PRIMARY_2_INTENSITY -->
+    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 3 x</attribute>
+    <!-- PRIMARY_3_X -->
+    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 3 y</attribute>
+    <!-- PRIMARY_3_Y -->
+    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 3 intensity</attribute>
+    <!-- PRIMARY_3_INTENSITY -->
+    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 4 x</attribute>
+    <!-- PRIMARY_4_X -->
+    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 4 y</attribute>
+    <!-- PRIMARY_4_Y -->
+    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 4 intensity</attribute>
+    <!-- PRIMARY_4_INTENSITY -->
+    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 5 x</attribute>
+    <!-- PRIMARY_5_X -->
+    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 5 y</attribute>
+    <!-- PRIMARY_5_Y -->
+    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 5 intensity</attribute>
+    <!-- PRIMARY_5_INTENSITY -->
+    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 6 x</attribute>
+    <!-- PRIMARY_6_X -->
+    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 6 y</attribute>
+    <!-- PRIMARY_6_Y -->
+    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 6 intensity</attribute>
+    <!-- PRIMARY_6_INTENSITY -->
+    <attribute side="server" code="0x0030" define="COLOR_CONTROL_WHITE_POINT_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">white point x</attribute>
+    <!-- WHITE_POINT_X -->
+    <attribute side="server" code="0x0031" define="COLOR_CONTROL_WHITE_POINT_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">white point y</attribute>
+    <!-- WHITE_POINT_Y -->
+    <attribute side="server" code="0x0032" define="COLOR_CONTROL_COLOR_POINT_R_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point r x</attribute>
+    <!-- COLOR_POINT_R_X -->
+    <attribute side="server" code="0x0033" define="COLOR_CONTROL_COLOR_POINT_R_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point r y</attribute>
+    <!-- COLOR_POINT_R_Y -->
+    <attribute side="server" code="0x0034" define="COLOR_CONTROL_COLOR_POINT_R_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point r intensity</attribute>
+    <!-- COLOR_POINT_R_INTENSITY -->
+    <attribute side="server" code="0x0036" define="COLOR_CONTROL_COLOR_POINT_G_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point g x</attribute>
+    <!-- COLOR_POINT_G_X -->
+    <attribute side="server" code="0x0037" define="COLOR_CONTROL_COLOR_POINT_G_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point g y</attribute>
+    <!-- COLOR_POINT_G_Y -->
+    <attribute side="server" code="0x0038" define="COLOR_CONTROL_COLOR_POINT_G_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point g intensity</attribute>
+    <!-- COLOR_POINT_G_INTENSITY -->
+    <attribute side="server" code="0x003A" define="COLOR_CONTROL_COLOR_POINT_B_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point b x</attribute>
+    <!-- COLOR_POINT_B_X -->
+    <attribute side="server" code="0x003B" define="COLOR_CONTROL_COLOR_POINT_B_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point b y</attribute>
+    <!-- COLOR_POINT_B_Y -->
+    <attribute side="server" code="0x003C" define="COLOR_CONTROL_COLOR_POINT_B_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point b intensity</attribute>
+    <!-- COLOR_POINT_B_INTENSITY -->
+    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false" introducedIn="l&amp;o-1.0-15-0014-04">couple color temp to level min-mireds</attribute>
+    <attribute side="server" code="0x4010" define="START_UP_COLOR_TEMPERATURE_MIREDS" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false" introducedIn="l&amp;o-1.0-15-0014-04">start up color temperature mireds</attribute>
+    <command source="client" code="0x00" name="MoveToHue" optional="true" cli="zcl color-control movetohue">
+      <description>
+        Move to specified hue.
+      </description>
+      <arg name="hue" type="INT8U"/>
+      <arg name="direction" type="HueDirection"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="MoveHue" optional="true" cli="zcl color-control movehue">
+      <description>
+        Move hue up or down at specified rate.
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="StepHue" optional="true" cli="zcl color-control stephue">
+      <description>
+        Step hue up or down by specified size at specified rate.
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="MoveToSaturation" optional="true" cli="zcl color-control movetosat">
+      <description>
+        Move to specified saturation.
+      </description>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="MoveSaturation" optional="true" cli="zcl color-control movesat">
+      <description>
+        Move saturation up or down at specified rate.
+      </description>
+      <arg name="moveMode" type="SaturationMoveMode"/>
+      <arg name="rate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="StepSaturation" optional="true" cli="zcl color-control stepsat">
+      <description>
+        Step saturation up or down by specified size at specified rate.
+      </description>
+      <arg name="stepMode" type="SaturationStepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="MoveToHueAndSaturation" optional="true" cli="zcl color-control movetohueandsat">
+      <description>
+        Move to hue and saturation.
+      </description>
+      <arg name="hue" type="INT8U"/>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="MoveToColor" optional="false" cli="zcl color-control movetocolor">
+      <description>
+        Move to specified color.
+      </description>
+      <arg name="colorX" type="INT16U"/>
+      <arg name="colorY" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="MoveColor" optional="false" cli="zcl color-control movecolor">
+      <description>
+        Moves the color.
+      </description>
+      <arg name="rateX" type="INT16S"/>
+      <arg name="rateY" type="INT16S"/>
+    </command>
+    <command source="client" code="0x09" name="StepColor" optional="false" cli="zcl color-control stepcolor">
+      <description>
+        Steps the lighting to a specific color.
+      </description>
+      <arg name="stepX" type="INT16S"/>
+      <arg name="stepY" type="INT16S"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0A" name="MoveToColorTemperature" optional="true" cli="zcl color-control movetocolortemp">
+      <description>
+        Moves the lighting to a specific color temperature.
+      </description>
+      <arg name="colorTemperature" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Ballast Configuration</name>
+    <domain>Lighting</domain>
+    <description>Attributes and commands for configuring a lighting ballast.</description>
+    <code>0x0301</code>
+    <define>BALLAST_CONFIGURATION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0x01" optional="true">physical min level</attribute>
+    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0xFE" optional="true">physical max level</attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BITMAP8" min="0x00" max="0x03" writable="false" default="0x00" optional="false">ballast status</attribute>
+    <attribute side="server" code="0x0010" define="MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">min level</attribute>
+    <attribute side="server" code="0x0011" define="MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0xFE" optional="true">max level</attribute>
+    <attribute side="server" code="0x0012" define="POWER_ON_LEVEL" type="INT8U" min="0x00" max="0xFE" writable="true" default="0xFE" optional="true">power on level</attribute>
+    <attribute side="server" code="0x0013" define="POWER_ON_FADE_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">power on fade time</attribute>
+    <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="INT8U" min="0x00" max="0xFE" writable="true" optional="true">intrinsic ballast factor</attribute>
+    <attribute side="server" code="0x0015" define="BALLAST_FACTOR_ADJUSTMENT" type="INT8U" min="0x64" writable="true" default="0xFF" optional="true">ballast factor adjustment</attribute>
+    <attribute side="server" code="0x0020" define="LAMP_QUALITY" type="INT8U" min="0x00" max="0xFE" writable="false" optional="true">lamp quality</attribute>
+    <attribute side="server" code="0x0030" define="LAMP_TYPE" type="CHAR_STRING" length="16" writable="true" optional="true">lamp type</attribute>
+    <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" optional="true">lamp manufacturer</attribute>
+    <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0xFFFFFF" optional="true">lamp rated hours</attribute>
+    <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">lamp burn hours</attribute>
+    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">lamp alarm mode</attribute>
+    <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0xFFFFFF" optional="true">lamp burn hours trip point</attribute>
+  </cluster>
+  <cluster>
+    <name>Illuminance Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.</description>
+    <code>0x0400</code>
+    <define>ILLUM_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ILLUM_MEASURED_VALUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ILLUM_MIN_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xFFFD" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ILLUM_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xFFFE" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ILLUM_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+    <attribute side="server" code="0x0004" define="MEASUREMENT_LIGHT_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true">light sensor type</attribute>
+    <!-- LIGHT_SENSOR_TYPE -->
+  </cluster>
+  <cluster>
+    <name>Illuminance Level Sensing</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the sensing of illuminance levels, and reporting whether illuminance is above, below, or on target.</description>
+    <code>0x0401</code>
+    <define>ILLUM_LEVEL_SENSING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LEVEL_STATUS" type="ENUM8" min="0x00" max="0xFE" writable="false" reportable="true" optional="false">level status</attribute>
+    <attribute side="server" code="0x0001" define="SENSING_LIGHT_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="true">light sensor type</attribute>
+    <!-- LIGHT_SENSOR_TYPE -->
+    <attribute side="server" code="0x0010" define="ILLUMINANCE_TARGET_LEVEL" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="false">illuminance level target</attribute>
+  </cluster>
+  <cluster>
+    <name>Temperature Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.</description>
+    <code>0x0402</code>
+    <define>TEMP_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TEMP_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TEMP_MIN_MEASURED_VALUE" type="INT16S" min="0x954D" max="0x7FFE" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TEMP_MAX_MEASURED_VALUE" type="INT16S" min="0x954E" max="0x7FFF" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Pressure Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.</description>
+    <code>0x0403</code>
+    <define>PRESSURE_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="INT16S" min="0x8001" max="0x7FFE" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="INT16S" min="0x8002" max="0x7FFF" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="true">scaled value</attribute>
+    <attribute side="server" code="0x0011" define="PRESSURE_MIN_SCALED_VALUE" type="INT16S" min="0x8001" max="0x7FFE" writable="false" optional="true">min scaled value</attribute>
+    <attribute side="server" code="0x0012" define="PRESSURE_MAX_SCALED_VALUE" type="INT16S" min="0x8002" max="0x7FFF" writable="false" optional="true">max scaled value</attribute>
+    <attribute side="server" code="0x0013" define="PRESSURE_SCALED_TOLERANCE" type="INT16S" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">scaled tolerance</attribute>
+    <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="INT8S" min="0x81" max="0x7F" writable="false" optional="true">scale</attribute>
+  </cluster>
+  <cluster>
+    <name>Flow Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of flow, and reporting flow rates.</description>
+    <code>0x0404</code>
+    <define>FLOW_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="FLOW_MEASURED_VALUE" type="INT16U" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FLOW_MIN_MEASURED_VALUE" type="INT16U" min="0x0000" max="0xfffd" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FLOW_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xfffe" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FLOW_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Relative Humidity Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.</description>
+    <code>0x0405</code>
+    <define>RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY_MEASURED_VALUE" type="INT16U" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="RELATIVE_HUMIDITY_MIN_MEASURED_VALUE" type="INT16U" min="0x0000" max="0x270F" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="RELATIVE_HUMIDITY_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0x2710" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Occupancy Sensing</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring occupancy sensing, and reporting occupancy status.</description>
+    <code>0x0406</code>
+    <define>OCCUPANCY_SENSING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="OCCUPANCY" type="BITMAP8" min="0x00" max="0x01" writable="false" reportable="true" optional="false">occupancy</attribute>
+    <attribute side="server" code="0x0001" define="OCCUPANCY_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">occupancy sensor type</attribute>
+    <attribute side="server" code="0x0010" define="PIR_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">PIR occupied to unoccupied delay</attribute>
+    <attribute side="server" code="0x0011" define="PIR_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">PIR unoccupied to occupied delay</attribute>
+    <attribute side="server" code="0x0012" define="PIR_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">PIR unoccupied to occupied threshold</attribute>
+    <attribute side="server" code="0x0020" define="ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">ultrasonic occupied to unoccupied delay</attribute>
+    <attribute side="server" code="0x0021" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">ultrasonic unoccupied to occupied delay</attribute>
+    <attribute side="server" code="0x0022" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">ultrasonic unoccupied to occupied threshold</attribute>
+  </cluster>
+  <cluster>
+    <name>Carbon Monoxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of carbon monoxide concentration and reporting concentration measurements.</description>
+    <code>0x040C</code>
+    <define>CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Carbon Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the carbon diaoxide concentration and reporting concentration measurements.</description>
+    <code>0x040D</code>
+    <define>CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ethylene Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ethylene concentration and reporting concentration measurements.</description>
+    <code>0x040E</code>
+    <define>ETHYLENE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ETHYLENE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ethylene Oxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ethylene Oxide concentration and reporting concentration measurements.</description>
+    <code>0x040F</code>
+    <define>ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Hydrogen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Hydrogen concentration and reporting concentration measurements.</description>
+    <code>0x0410</code>
+    <define>HYDROGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HYDROGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Hydrogen Sulphide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Hydrogen Sulphide concentration and reporting concentration measurements.</description>
+    <code>0x0411</code>
+    <define>HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Nitric Oxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Nitric Oxide concentration and reporting concentration measurements.</description>
+    <code>0x0412</code>
+    <define>NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Nitrogen Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Nitrogen Dioxide concentration and reporting concentration measurements.</description>
+    <code>0x0413</code>
+    <define>NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Oxygen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Oxygen concentration and reporting concentration measurements.</description>
+    <code>0x0414</code>
+    <define>OXYGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="OXYGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="OXYGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="OXYGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="OXYGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ozone Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ozone concentration and reporting concentration measurements.</description>
+    <code>0x0415</code>
+    <define>OZONE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="OZONE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="OZONE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="OZONE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="OZONE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sulfur Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sulphur Dioxide concentration and reporting concentration measurements.</description>
+    <code>0x0416</code>
+    <define>SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Dissolved Oxygen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Dissolved Oxygen concentration and reporting concentration measurements.</description>
+    <code>0x0417</code>
+    <define>DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromate Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromate concentration, and reporting concentration measurements.</description>
+    <code>0x0418</code>
+    <define>BROMATE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="BROMATE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMATE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMATE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMATE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chloramines Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chloramines concentration and reporting concentration measurements.</description>
+    <code>0x0419</code>
+    <define>CHLORAMINES_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chlorine Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chlorine concentration and reporting concentration measurements.</description>
+    <code>0x041A</code>
+    <define>CHLORINE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CHLORINE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORINE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORINE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORINE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Fecal coliform and E. Coli Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Fecal coliform and E. Coli concentration and reporting concentration measurements.</description>
+    <code>0x041B</code>
+    <define>FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Fluoride Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Fluoride concentration and reporting concentration measurements.</description>
+    <code>0x041C</code>
+    <define>FLUORIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FLUORIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Haloacetic Acids Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Haloacetic Acids concentration and reporting concentration measurements.</description>
+    <code>0x041D</code>
+    <define>HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Total Trihalomethanes Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Total Trihalomethanes concentration and reporting concentration measurements.</description>
+    <code>0x041E</code>
+    <define>TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Total Coliform Bacteria Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Total Coliform Bacteria concentration and reporting concentration measurements.</description>
+    <code>0x041F</code>
+    <define>TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Turbidity Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Turbidity concentration and reporting concentration measurements.</description>
+    <code>0x0420</code>
+    <define>TURBIDITY_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TURBIDITY_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Copper Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Copper concentration and reporting concentration measurements.</description>
+    <code>0x0421</code>
+    <define>COPPER_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="COPPER_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="COPPER_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="COPPER_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="COPPER_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Lead Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Lead concentration and reporting concentration measurements.</description>
+    <code>0x0422</code>
+    <define>LEAD_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LEAD_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="LEAD_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="LEAD_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="LEAD_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Manganese Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Manganese concentration and reporting concentration measurements.</description>
+    <code>0x0423</code>
+    <define>MANGANESE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="MANGANESE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="MANGANESE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="MANGANESE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="MANGANESE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sulfate Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sulfate concentration and reporting concentration measurements.</description>
+    <code>0x0424</code>
+    <define>SULFATE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SULFATE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SULFATE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SULFATE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SULFATE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromodichloromethane Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromodichloromethane concentration and reporting concentration measurements.</description>
+    <code>0x0425</code>
+    <define>BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromoform Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromoform concentration and reporting concentration measurements.</description>
+    <code>0x0426</code>
+    <define>BROMOFORM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMOFORM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chlorodibromomethane Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chlorodibromomethane concentration and reporting concentration measurements.</description>
+    <code>0x0427</code>
+    <define>CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chloroform Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chloroform concentration and reporting concentration measurements.</description>
+    <code>0x0428</code>
+    <define>CHLOROFORM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sodium Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sodium concentration and reporting concentration measurements.</description>
+    <code>0x0429</code>
+    <define>SODIUM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SODIUM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SODIUM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SODIUM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SODIUM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>IAS Zone</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS security zone devices.</description>
+    <code>0x0500</code>
+    <define>IAS_ZONE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ZONE_STATE" type="ENUM8" writable="false" default="0x00" optional="false">zone state</attribute>
+    <attribute side="server" code="0x0001" define="ZONE_TYPE" type="ENUM16" writable="false" optional="false">zone type</attribute>
+    <attribute side="server" code="0x0002" define="ZONE_STATUS" type="BITMAP16" writable="false" default="0x0000" optional="false">zone status</attribute>
+    <attribute side="server" code="0x0010" define="IAS_CIE_ADDRESS" type="IEEE_ADDRESS" writable="true" optional="false">IAS CIE address</attribute>
+    <attribute side="server" code="0x0011" define="ZONE_ID" type="INT8U" writable="false" default="0xff" optional="false">Zone ID</attribute>
+    <attribute side="server" code="0x0012" define="NUMBER_OF_ZONE_SENSITIVITY_LEVELS_SUPPORTED" type="INT8U" writable="false" default="0x02" optional="true">Number of Zone Sensitivity Levels Supported</attribute>
+    <attribute side="server" code="0x0013" define="CURRENT_ZONE_SENSITIVITY_LEVEL" type="INT8U" writable="true" default="0x00" optional="true">Current Zone Sensitivity Level</attribute>
+    <command source="client" code="0x00" name="ZoneEnrollResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for zoneEnrollResponse
+      </description>
+      <arg name="enrollResponseCode" type="IasEnrollResponseCode"/>
+      <arg name="zoneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="InitiateNormalOperationMode" optional="true">
+      <description>
+        Used to tell the IAS Zone server to commence normal operation mode
+      </description>
+    </command>
+    <command source="client" code="0x02" name="InitiateTestMode" optional="true">
+      <description>
+        Certain IAS Zone servers may have operational configurations that could be configured OTA or locally on the device. This command enables them to be remotely placed into a test mode so that the user or installer may configure their field of view, sensitivity, and other operational parameters.
+      </description>
+      <arg name="testModeDuration" type="INT8U"/>
+      <arg name="currentZoneSensitivityLevel" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="ZoneStatusChangeNotification" optional="false" cli="zcl ias-zone sc">
+      <description>
+        Command description for zoneStatusChangeNotification
+      </description>
+      <arg name="zoneStatus" type="IasZoneStatus"/>
+      <arg name="extendedStatus" type="BITMAP8"/>
+      <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="delay" type="INT16U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x01" name="ZoneEnrollRequest" optional="false" cli="zcl ias-zone enroll">
+      <description>
+        Command description for zoneEnrollRequest
+      </description>
+      <arg name="zoneType" type="IasZoneType"/>
+      <arg name="manufacturerCode" type="INT16U"/>
+    </command>
+    <command source="server" code="0x02" name="InitiateNormalOperationModeResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Confirms that the IAS Zone server has commenced normal operation mode.
+      </description>
+    </command>
+    <command source="server" code="0x03" name="InitiateTestModeResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Confirms that the IAS Zone server has commenced test mode and that the IAS Zone client should treat any Zone Status Change Notification commands received from the sending IAS Zone server as being in response to test events.
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>IAS ACE</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS Ancillary Control Equipment.</description>
+    <code>0x0501</code>
+    <define>IAS_ACE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="Arm" optional="false" cli="zcl ias-ace a">
+      <description>
+        Command description for Arm
+      </description>
+      <arg name="armMode" type="IasAceArmMode"/>
+      <arg name="armDisarmCode" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="Bypass" optional="false" cli="zcl ias-ace b">
+      <description>
+        Command description for Bypass
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneIds" type="INT8U" array="true" countArg="numberOfZones"/>
+      <arg name="armDisarmCode" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="client" code="0x02" name="Emergency" optional="false" cli="zcl ias-ace e">
+      <description>
+        Command description for Emergency
+      </description>
+    </command>
+    <command source="client" code="0x03" name="Fire" optional="false" cli="zcl ias-ace f">
+      <description>
+        Command description for Fire
+      </description>
+    </command>
+    <command source="client" code="0x04" name="Panic" optional="false" cli="zcl ias-ace p">
+      <description>
+        Command description for Panic
+      </description>
+    </command>
+    <command source="client" code="0x05" name="GetZoneIdMap" optional="false" cli="zcl ias-ace getzm">
+      <description>
+        Command description for GetZoneIdMap
+      </description>
+    </command>
+    <command source="client" code="0x06" name="GetZoneInformation" optional="false" cli="zcl ias-ace getzi">
+      <description>
+        Command description for GetZoneInformation
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="GetPanelStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to request an update to the status of the ACE server
+      </description>
+    </command>
+    <command source="client" code="0x08" name="GetBypassedZoneList" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to retrieve the bypassed zones
+        </description>
+    </command>
+    <command source="client" code="0x09" name="GetZoneStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to request an update to the zone status of the ACE server
+      </description>
+      <arg name="startingZoneId" type="INT8U"/>
+      <arg name="maxNumberOfZoneIds" type="INT8U"/>
+      <arg name="zoneStatusMaskFlag" type="BOOLEAN"/>
+      <arg name="zoneStatusMask" type="BITMAP16"/>
+    </command>
+    <command source="server" code="0x00" name="ArmResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ArmResponse
+      </description>
+      <arg name="armNotification" type="IasAceArmNotification"/>
+    </command>
+    <command source="server" code="0x01" name="GetZoneIdMapResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetZoneIdMapResponse
+      </description>
+      <arg name="section0" type="BITMAP16"/>
+      <arg name="section1" type="BITMAP16"/>
+      <arg name="section2" type="BITMAP16"/>
+      <arg name="section3" type="BITMAP16"/>
+      <arg name="section4" type="BITMAP16"/>
+      <arg name="section5" type="BITMAP16"/>
+      <arg name="section6" type="BITMAP16"/>
+      <arg name="section7" type="BITMAP16"/>
+      <arg name="section8" type="BITMAP16"/>
+      <arg name="section9" type="BITMAP16"/>
+      <arg name="section10" type="BITMAP16"/>
+      <arg name="section11" type="BITMAP16"/>
+      <arg name="section12" type="BITMAP16"/>
+      <arg name="section13" type="BITMAP16"/>
+      <arg name="section14" type="BITMAP16"/>
+      <arg name="section15" type="BITMAP16"/>
+    </command>
+    <command source="server" code="0x02" name="GetZoneInformationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetZoneInformationResponse
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+      <arg name="zoneType" type="IasZoneType"/>
+      <arg name="ieeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="zoneLabel" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x03" name="ZoneStatusChanged" optional="false">
+      <description>
+        This command updates ACE clients in the system of changes to zone status recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+      <arg name="zoneStatus" type="ENUM16"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification" introducedIn="ha-1.2.1-05-3520-30"/>
+      <arg name="zoneLabel" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x04" name="PanelStatusChanged" optional="false">
+      <description>
+        This command updates ACE clients in the system of changes to panel status recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="panelStatus" type="IasAcePanelStatus"/>
+      <arg name="secondsRemaining" type="INT8U"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification" introducedIn="ha-1.2.1-05-3520-30"/>
+      <arg name="alarmStatus" type="IasAceAlarmStatus" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x05" name="GetPanelStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        Command updates requesting IAS ACE clients in the system of changes to the security panel status recorded by the ACE server.
+      </description>
+      <arg name="panelStatus" type="IasAcePanelStatus"/>
+      <arg name="secondsRemaining" type="INT8U"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification"/>
+      <arg name="alarmStatus" type="IasAceAlarmStatus"/>
+    </command>
+    <command source="server" code="0x06" name="SetBypassedZoneList" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+       Sets the list of bypassed zones on the IAS ACE client
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneIds" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="BypassResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        Provides the response of the security panel to the request from the IAS ACE client to bypass zones via a Bypass command.
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="bypassResult" type="IasAceBypassResult" array="true"/>
+    </command>
+    <command source="server" code="0x08" name="GetZoneStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        This command updates requesting IAS ACE clients in the system of changes to the IAS Zone server statuses recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="zoneStatusComplete" type="BOOLEAN"/>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneStatusResult" type="IasAceZoneStatusResult" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>IAS WD</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS Warning Devices.</description>
+    <code>0x0502</code>
+    <define>IAS_WD_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="quarter" init="false">true</server>
+    <attribute side="server" code="0x0000" define="MAX_DURATION" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="240" optional="false">max duration</attribute>
+    <command source="client" code="0x00" name="StartWarning" optional="false">
+      <description>
+        Command description for StartWarning
+      </description>
+      <arg name="warningInfo" type="WarningInfo"/>
+      <arg name="warningDuration" type="INT16U"/>
+      <arg name="strobeDutyCycle" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="strobeLevel" type="ENUM8" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="Squawk" optional="false">
+      <description>
+        Command description for Squawk
+      </description>
+      <arg name="squawkInfo" type="SquawkInfo"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Door Lock</name>
+    <domain>Closures</domain>
+    <description>Provides an interface into a generic way to secure a door. </description>
+    <code>0x0101</code>
+    <define>DOOR_LOCK_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LOCK_STATE" type="ENUM8" writable="false" reportable="true" optional="false">lock state</attribute>
+    <attribute side="server" code="0x0001" define="LOCK_TYPE" type="ENUM8" writable="false" optional="false">lock type</attribute>
+    <attribute side="server" code="0x0002" define="ACTUATOR_ENABLED" type="BOOLEAN" writable="false" optional="false">actuator enabled</attribute>
+    <attribute side="server" code="0x0003" define="DOOR_STATE" type="ENUM8" writable="false" reportable="true" optional="true">door state</attribute>
+    <attribute side="server" code="0x0004" define="DOOR_OPEN_EVENTS" type="INT32U" writable="true" optional="true">door open events</attribute>
+    <attribute side="server" code="0x0005" define="DOOR_CLOSED_EVENTS" type="INT32U" writable="true" optional="true">door closed events</attribute>
+    <attribute side="server" code="0x0006" define="OPEN_PERIOD" type="INT16U" writable="true" optional="true">open period</attribute>
+    <attribute side="server" code="0x0010" define="NUM_LOCK_RECORDS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num lock records supported</attribute>
+    <attribute side="server" code="0x0011" define="NUM_TOTAL_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num total users supported</attribute>
+    <attribute side="server" code="0x0012" define="NUM_PIN_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num PIN users supported</attribute>
+    <attribute side="server" code="0x0013" define="NUM_RFID_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num RFID users supported</attribute>
+    <attribute side="server" code="0x0014" define="NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num weekday schedules supported per user</attribute>
+    <attribute side="server" code="0x0015" define="NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num yearday schedules supported per user</attribute>
+    <attribute side="server" code="0x0016" define="NUM_HOLIDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num holiday schedules supported per user</attribute>
+    <attribute side="server" code="0x0017" define="MAX_PIN_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x08" optional="true" introducedIn="ha-1.2-05-3520-29">max pin length</attribute>
+    <attribute side="server" code="0x0018" define="MIN_PIN_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x04" optional="true" introducedIn="ha-1.2-05-3520-29">min pin length</attribute>
+    <attribute side="server" code="0x0019" define="MAX_RFID_CODE_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x14" optional="true" introducedIn="ha-1.2-05-3520-29">max rfid code length</attribute>
+    <attribute side="server" code="0x001A" define="MIN_RFID_CODE_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x08" optional="true" introducedIn="ha-1.2-05-3520-29">min rfid code length</attribute>
+    <attribute side="server" code="0x0020" define="ENABLE_LOGGING" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable logging</attribute>
+    <attribute side="server" code="0x0021" define="LANGUAGE" type="CHAR_STRING" length="2" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">language</attribute>
+    <attribute side="server" code="0x0022" define="LED_SETTINGS" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">led settings</attribute>
+    <attribute side="server" code="0x0023" define="AUTO_RELOCK_TIME" type="INT32U" min="0x00" max="0xFFFFFFFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">auto relock time</attribute>
+    <attribute side="server" code="0x0024" define="SOUND_VOLUME" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">sound volume</attribute>
+    <attribute side="server" code="0x0025" define="OPERATING_MODE" type="ENUM8" min="0x00" max="0x05" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">operating mode</attribute>
+    <attribute side="server" code="0x0026" define="SUPPORTED_OPERATING_MODES" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" default="0x01" optional="true" introducedIn="ha-1.2-05-3520-29">supported operating modes</attribute>
+    <attribute side="server" code="0x0027" define="DEFAULT_CONFIGURATION_REGISTER" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">default configuration register</attribute>
+    <attribute side="server" code="0x0028" define="ENABLE_LOCAL_PROGRAMMING" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x01" optional="true" introducedIn="ha-1.2-05-3520-29">enable local programming</attribute>
+    <attribute side="server" code="0x0029" define="ENABLE_ONE_TOUCH_LOCKING" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable one touch locking</attribute>
+    <attribute side="server" code="0x002A" define="ENABLE_INSIDE_STATUS_LED" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable inside status led</attribute>
+    <attribute side="server" code="0x002B" define="ENABLE_PRIVACY_MODE_BUTTON" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable privacy mode button</attribute>
+    <attribute side="server" code="0x0030" define="WRONG_CODE_ENTRY_LIMIT" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">wrong code entry limit</attribute>
+    <attribute side="server" code="0x0031" define="USER_CODE_TEMPORARY_DISABLE_TIME" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">user code temporary disable time</attribute>
+    <attribute side="server" code="0x0032" define="SEND_PIN_OVER_THE_AIR" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">send pin over the air</attribute>
+    <attribute side="server" code="0x0033" define="REQUIRE_PIN_FOR_RF_OPERATION" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">require pin for rf operation</attribute>
+    <attribute side="server" code="0x0034" define="ZIGBEE_SECURITY_LEVEL" type="ENUM8" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">zigbee security level</attribute>
+    <attribute side="server" code="0x0040" define="DOOR_LOCK_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">alarm mask</attribute>
+    <attribute side="server" code="0x0041" define="KEYPAD_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">keypad operation event mask</attribute>
+    <attribute side="server" code="0x0042" define="RF_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">RF operation event mask</attribute>
+    <attribute side="server" code="0x0043" define="MANUAL_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">manual operation event mask</attribute>
+    <attribute side="server" code="0X0044" define="RFID_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rfid operation event mask</attribute>
+    <attribute side="server" code="0x0045" define="KEYPAD_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">keypad programming event mask</attribute>
+    <attribute side="server" code="0X0046" define="RF_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rf programming event mask</attribute>
+    <attribute side="server" code="0X0047" define="RFID_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rfid programming event mask</attribute>
+    <command source="client" code="0x00" name="LockDoor" optional="false" cli="zcl lock lock">
+      <description>
+        Locks the door
+      </description>
+      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="UnlockDoor" optional="false" cli="zcl lock unlock">
+      <description>
+        Unlocks the door
+      </description>
+      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x02" name="Toggle" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Toggles the door lock from its current state to the opposite state locked or unlocked.
+       </description>
+      <arg name="pin" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x03" name="UnlockWithTimeout" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Unlock the door with a timeout. When the timeout expires, the door will automatically re-lock.
+       </description>
+      <arg name="timeoutInSeconds" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x04" name="GetLogRecord" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve a log record at a specified index.
+       </description>
+      <arg name="logIndex" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="SetPin" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the PIN for a specified user id.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x06" name="GetPin" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve PIN information for a user with a specific user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="ClearPin" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear the PIN for a user with a specific user ID
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="ClearAllPins" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear all PIN codes on the lock for all users.
+       </description>
+    </command>
+    <command source="client" code="0x09" name="SetUserStatus" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the status value for a specified user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0A" name="GetUserStatus" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve the status byte for a specific user.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0B" name="SetWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the schedule of days during the week that the associated user based on the user ID will have access to the lock and will be able to operate it.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="daysMask" type="DoorLockDayOfWeek"/>
+      <arg name="startHour" type="INT8U"/>
+      <arg name="startMinute" type="INT8U"/>
+      <arg name="endHour" type="INT8U"/>
+      <arg name="endMinute" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0C" name="GetWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve a weekday schedule for doorlock user activation for a specific schedule id and user id.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0D" name="ClearWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear a weekday schedule for doorlock user activation for a specific schedule id and user id.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0E" name="SetYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set a door lock user id activation schedule according to a specific absolute local start and end time
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="localStartTime" type="INT32U"/>
+      <arg name="localEndTime" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0F" name="GetYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve a yearday schedule for a specific scheduleId and userId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x10" name="ClearYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear a yearday schedule for a specific scheduleId and userId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x11" name="SetHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the holiday schedule for a specific user
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U"/>
+      <arg name="localEndTime" type="INT32U"/>
+      <arg name="operatingModeDuringHoliday" type="ENUM8"/>
+    </command>
+    <command source="client" code="0x12" name="GetHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve a holiday schedule for a specific scheduleId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x13" name="ClearHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear a holiday schedule for a specific scheduleId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x14" name="SetUserType" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the type value for a user based on user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userType" type="DoorLockUserType"/>
+    </command>
+    <command source="client" code="0x15" name="GetUserType" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve the type for a specific user based on the user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x16" name="SetRfid" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the PIN for a specified user id.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="id" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x17" name="GetRfid" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve RFID ID information for a user with a specific user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x18" name="ClearRfid" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear the RFID ID for a user with a specific user ID
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x19" name="ClearAllRfids" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear all RFID ID codes on the lock for all users.
+       </description>
+    </command>
+    <command source="server" code="0x00" name="LockDoorResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Indicates lock success or failure
+      </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="UnlockDoorResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Indicates unlock success or failure
+      </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x02" name="ToggleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Response provided to the toggle command, indicates whether the toggle was successful or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x03" name="UnlockWithTimeoutResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Response provided to unlock with specific timeout. This command indicates whether the unlock command was successful or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x04" name="GetLogRecordResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the specific log record requested.
+       </description>
+      <arg name="logEntryId" type="INT16U"/>
+      <arg name="timestamp" type="INT32U"/>
+      <arg name="eventType" type="ENUM8"/>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventIdOrAlarmCode" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x05" name="SetPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Indicates whether the setting of the PIN was successful or not.
+       </description>
+      <arg name="status" type="DoorLockSetPinOrIdStatus"/>
+    </command>
+    <command source="server" code="0x06" name="GetPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the PIN requested according to the user ID passed.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x07" name="ClearPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the PIN was cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x08" name="ClearAllPinsResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the PINs were cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x09" name="SetUserStatusResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the user status was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0A" name="GetUserStatusResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the user status.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0B" name="SetWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the status of setting the weekday schedule
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0C" name="GetWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the weekday schedule requested.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="daysMask" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="startHour" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="startMinute" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="endHour" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="endMinute" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x0D" name="ClearWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the status of clearing the weekday schedule
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0E" name="SetYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the yearday schedule was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0F" name="GetYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the yearday schedule requested
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="localEndTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x10" name="ClearYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the yearday schedule was removed or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x11" name="SetHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the holiday schedule was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x12" name="GetHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the holiday schedule requested
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="localEndTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="operatingModeDuringHoliday" type="ENUM8" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x13" name="ClearHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the holiday schedule was removed or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x14" name="SetUserTypeResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         returns success or failure depending on whether the user type was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x15" name="GetUserTypeResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the user type for the user ID requested.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userType" type="DoorLockUserType"/>
+    </command>
+    <command source="server" code="0x16" name="SetRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+          Indicates whether the setting of the RFID ID was successful or not.
+        </description>
+      <arg name="status" type="DoorLockSetPinOrIdStatus"/>
+    </command>
+    <command source="server" code="0x17" name="GetRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the RFID ID requested according to the user ID passed.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="rfid" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x18" name="ClearRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the RFID ID was cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x19" name="ClearAllRfidsResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the RFID IDs were cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x20" name="OperationEventNotification" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Indicates that an operation event has taken place. Includes the associated event information.
+       </description>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventCode" type="DoorLockOperationEventCode"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="timeStamp" type="INT32U"/>
+      <arg name="data" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x21" name="ProgrammingEventNotification" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Indicates that a programming event has taken place. Includes the associated programming event information.
+       </description>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventCode" type="DoorLockProgrammingEventCode"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="timeStamp" type="INT32U"/>
+      <arg name="data" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Window Covering</name>
+    <domain>Closures</domain>
+    <description>Provides an interface for controlling and adjusting automatic window coverings. </description>
+    <code>0x0102</code>
+    <define>WINDOW_COVERING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="COVERING_TYPE" type="ENUM8" min="0x00" max="0x09" writable="false" default="0x00" optional="false">window covering type</attribute>
+    <attribute side="server" code="0x0001" define="LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">physical closed limit - lift</attribute>
+    <attribute side="server" code="0x0002" define="LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">physical closed limit - tilt</attribute>
+    <attribute side="server" code="0x0003" define="CURRENT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">current position - lift</attribute>
+    <attribute side="server" code="0x0004" define="CURRENT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">current position - tilt</attribute>
+    <attribute side="server" code="0x0005" define="NUMBER_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of actuations - lift</attribute>
+    <attribute side="server" code="0x0006" define="NUMBER_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of actuations - tilt</attribute>
+    <attribute side="server" code="0x0007" define="CONFIG_STATUS" type="BITMAP8" min="0x00" max="0x7F" writable="false" default="0x03" optional="false">config status</attribute>
+    <attribute side="server" code="0x0008" define="CURRENT_LIFT_PERCENTAGE" type="INT8U" min="0x00" max="0x64" writable="false" default="0x00" optional="true">current position lift percentage</attribute>
+    <attribute side="server" code="0x0009" define="CURRENT_TILT_PERCENTAGE" type="INT8U" min="0x00" max="0x64" writable="false" default="0x00" optional="true">current position tilt percentage</attribute>
+    <attribute side="server" code="0x0010" define="OPEN_LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">installed open limit - lift</attribute>
+    <attribute side="server" code="0x0011" define="CLOSED_LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0xFFFF" optional="false">installed closed limit - lift</attribute>
+    <attribute side="server" code="0x0012" define="OPEN_LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">installed open limit - tilt</attribute>
+    <attribute side="server" code="0x0013" define="CLOSED_LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0xFFFF" optional="false">installed closed limit - tilt</attribute>
+    <attribute side="server" code="0x0014" define="VELOCITY_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">velocity - lift</attribute>
+    <attribute side="server" code="0x0015" define="ACCELERATION_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">acceleration time - lift</attribute>
+    <attribute side="server" code="0x0016" define="DECELERATION_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">deceleration time - lift</attribute>
+    <attribute side="server" code="0x0017" define="MODE" type="BITMAP8" min="0x00" max="0xE0" writable="true" default="0x14" optional="false">mode</attribute>
+    <attribute side="server" code="0x0018" define="SETPOINTS_LIFT" type="OCTET_STRING" length="254" writable="true" default="1,0x0000" optional="true">intermediate setpoints - lift</attribute>
+    <attribute side="server" code="0x0019" define="SETPOINTS_TILT" type="OCTET_STRING" length="254" writable="true" default="1,0x0000" optional="true">intermediate setpoints - tilt</attribute>
+    <command source="client" code="0x00" name="WindowCoveringUpOpen" optional="false" cli="zcl window-covering up">
+      <description>
+        Moves window covering to InstalledOpenLimit - Lift and InstalledOpenLimit - Tilt
+      </description>
+    </command>
+    <command source="client" code="0x01" name="WindowCoveringDownClose" optional="false" cli="zcl window-covering down">
+      <description>
+        Moves window covering to InstalledClosedLimit - Lift and InstalledCloseLimit - Tilt
+      </description>
+    </command>
+    <command source="client" code="0x02" name="WindowCoveringStop" optional="false" cli="zcl window-covering stop">
+      <description>
+        Stop any adjusting of window covering
+      </description>
+    </command>
+    <command source="client" code="0x04" name="WindowCoveringGoToLiftValue" optional="true" cli="zcl window-covering go-to-lift-value">
+      <description>
+        Goto lift value specified
+      </description>
+      <arg name="liftValue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="WindowCoveringGoToLiftPercentage" optional="true" cli="zcl window-covering go-to-lift-percent">
+      <description>
+        Goto lift percentage specified
+      </description>
+      <arg name="percentageLiftValue" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="WindowCoveringGoToTiltValue" optional="true" cli="zcl window-covering go-to-tilt-value">
+      <description>
+        Goto tilt value specified
+      </description>
+      <arg name="tiltValue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="WindowCoveringGoToTiltPercentage" optional="true" cli="zcl window-covering go-to-tilt-percentage">
+      <description>
+        Goto tilt percentage specified
+      </description>
+      <arg name="percentageTiltValue" type="INT8U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Barrier Control</name>
+    <domain>Closures</domain>
+    <description>This cluster provides control of a barrier (garage door).</description>
+    <code>0x0103</code>
+    <define>BARRIER_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0001" define="BARRIER_MOVING_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">barrier moving state</attribute>
+    <attribute side="server" code="0x0002" define="BARRIER_SAFETY_STATUS" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" optional="false">barrier safety status</attribute>
+    <attribute side="server" code="0x0003" define="BARRIER_CAPABILITIES" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">barrier capabilities</attribute>
+    <attribute side="server" code="0x0004" define="BARRIER_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier open events</attribute>
+    <attribute side="server" code="0x0005" define="BARRIER_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier close events</attribute>
+    <attribute side="server" code="0x0006" define="BARRIER_COMMAND_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command open events</attribute>
+    <attribute side="server" code="0x0007" define="BARRIER_COMMAND_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command close events</attribute>
+    <attribute side="server" code="0x0008" define="BARRIER_OPEN_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier open period</attribute>
+    <attribute side="server" code="0x0009" define="BARRIER_CLOSE_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier close period</attribute>
+    <attribute side="server" code="0x000A" define="BARRIER_POSITION" type="INT8U" min="0x0000" max="0xFF" writable="false" optional="false">barrier position</attribute>
+    <command source="client" code="0x00" name="BarrierControlGoToPercent" optional="false" cli="zcl barrier-control go-to-percent">
+      <description>
+        Command to instruct a barrier to go to a percent open state.
+      </description>
+      <arg name="percentOpen" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="BarrierControlStop" optional="false" cli="zcl barrier-control stop">
+      <description>
+        Command that instructs the barrier to stop moving.
+      </description>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Control</name>
+    <domain>General</domain>
+    <description>This cluster provides an interface to remotely control and to program household appliances.</description>
+    <code>0x001B</code>
+    <define>APPLIANCE_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="START_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">start time</attribute>
+    <attribute side="server" code="0x0001" define="FINISH_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">finish time</attribute>
+    <attribute side="server" code="0x0002" define="REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="true">remaining time</attribute>
+    <command source="client" code="0x00" name="ExecutionOfACommand" optional="false">
+      <description>
+        This basic message is used to remotely control and to program household appliances.
+      </description>
+      <arg name="commandId" type="CommandIdentification"/>
+    </command>
+    <command source="client" code="0x01" name="SignalState" optional="false">
+      <description>
+        This basic message is used to retrieve Household Appliances status.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="WriteFunctions" optional="true">
+      <description>
+        This basic message is used to set appliance functions, i.e. information regarding the execution of an appliance cycle.  Condition parameters such as start time or finish time information could be provided through this command.
+      </description>
+      <arg name="functionId" type="INT16U"/>
+      <arg name="functionDataType" type="ENUM8"/>
+      <arg name="functionData" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="OverloadPauseResume" optional="true">
+      <description>
+        This command shall be used to resume the normal behavior of a household appliance being in pause mode after receiving a Overload Pause command.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="OverloadPause" optional="true">
+      <description>
+        This command shall be used to pause the household appliance as a consequence of an imminent overload event.
+      </description>
+    </command>
+    <command source="client" code="0x05" name="OverloadWarning" optional="true">
+      <description>
+        This basic message is used to send warnings the household appliance as a consequence of a possible overload event, or the notification of the end of the warning state.
+      </description>
+      <arg name="warningEvent" type="WarningEvent"/>
+    </command>
+    <command source="server" code="0x00" name="SignalStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command shall be used to return household appliance status, according to Appliance Status Values and Remote Enable Flags Values.
+      </description>
+      <arg name="applianceStatus" type="ApplianceStatus"/>
+      <arg name="remoteEnableFlagsAndDeviceStatus2" type="RemoteEnableFlagsAndDeviceStatus2"/>
+      <arg name="applianceStatus2" type="INT24U"/>
+      <!-- optional -->
+    </command>
+    <command source="server" code="0x01" name="SignalStateNotification" optional="false">
+      <description>
+        This command shall be used to return household appliance status, automatically when appliance status changes.
+      </description>
+      <arg name="applianceStatus" type="ApplianceStatus"/>
+      <arg name="remoteEnableFlagsAndDeviceStatus2" type="RemoteEnableFlagsAndDeviceStatus2"/>
+      <arg name="applianceStatus2" type="INT24U"/>
+      <!-- optional -->
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Power Profile</name>
+    <domain>General</domain>
+    <description>This cluster provides an interface for transferring power profile information from a device (e.g. Whitegood) to a controller (e.g. the Home Gateway).  The Power Profile transferred can be solicited by client side (request command) or can be notified directly from the device (server side).</description>
+    <code>0x001A</code>
+    <define>POWER_PROFILE_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="TOTAL_PROFILE_NUM" type="INT8U" min="0x01" max="0xFE" writable="false" optional="false">total profile num</attribute>
+    <attribute side="server" code="0x0001" define="MULTIPLE_SCHEDULING" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">multiple scheduling</attribute>
+    <attribute side="server" code="0x0002" define="ENERGY_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x01" optional="false">energy formatting</attribute>
+    <attribute side="server" code="0x0003" define="ENERGY_REMOTE" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">energy remote</attribute>
+    <attribute side="server" code="0x0004" define="SCHEDULE_MODE" type="BITMAP8" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="false">schedule mode</attribute>
+    <command source="client" code="0x00" name="PowerProfileRequest" optional="false" cli="zcl power-profile profile">
+      <description>
+        The PowerProfileRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the Power Profile of a server device.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="PowerProfileStateRequest" optional="false" cli="zcl power-profile state">
+      <description>
+        The PowerProfileStateRequest Command is generated in order to retrieve the identifiers of current Power Profiles.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="GetPowerProfilePriceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The GetPowerProfilePriceResponse command allows a device (client) to communicate the cost associated to the selected Power Profile to another device (server) requesting it.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="GetOverallSchedulePriceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The GetOverallSchedulePriceResponse command allows a device (client) to communicate the overall cost associated to all Power Profiles scheduled to another device (server) requesting it.
+      </description>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="client" code="0x04" name="EnergyPhasesScheduleNotification" optional="false" cli="zcl power-profile energy-phases-schedule">
+      <description>
+        The EnergyPhasesScheduleNotification Command is generated by a device supporting the client side of the Power Profile cluster in order to schedule the start of the selected Power Profile and its phases.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="client" code="0x05" name="EnergyPhasesScheduleResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command is generated by the client side of Power Profile cluster as a reply to the EnergyPhasesScheduleRequest command.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="client" code="0x06" name="PowerProfileScheduleConstraintsRequest" optional="false" cli="zcl power-profile schedule-constraints">
+      <description>
+        The PowerProfileScheduleConstraintsRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the constraints -if set- of Power Profile of a client device, in order to set the proper boundaries for the scheduling when calculating the schedules.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="EnergyPhasesScheduleStateRequest" optional="false" cli="zcl power-profile energy-phases-schedule-states">
+      <description>
+        The EnergyPhasesScheduleStateRequest  Command is generated by a device supporting the client side of the Power Profile cluster to check the states of the scheduling of a power profile, which is supported in the device implementing the server side of Power Profile cluster.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x08" name="GetPowerProfilePriceExtendedResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Get Power Profile Price Extended Response command allows a device (client) to communicate the cost associated to all Power Profiles scheduled to another device (server) requesting it according to the specific options contained in the Get Power Profile Price Extended Response.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="PowerProfileNotification" optional="false">
+      <description>
+        The PowerProfileNotification Command is generated by a device supporting the server side of the Power Profile cluster in order to send the information of the specific parameters (such as Peak power and others) belonging to each phase.
+      </description>
+      <arg name="totalProfileNum" type="INT8U"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfTransferredPhases" type="INT8U"/>
+      <arg name="transferredPhases" type="TransferredPhase" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="PowerProfileResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server side of Power Profile cluster as a reply to the PowerProfileRequest command.
+      </description>
+      <arg name="totalProfileNum" type="INT8U"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfTransferredPhases" type="INT8U"/>
+      <arg name="transferredPhases" type="TransferredPhase" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="PowerProfileStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The PowerProfileStateResponse command allows a device (server) to communicate its current Power Profile(s) to another device (client) that previously requested them.
+      </description>
+      <arg name="powerProfileCount" type="INT8U"/>
+      <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="GetPowerProfilePrice" optional="true">
+      <description>
+        The GetPowerProfilePrice Command is generated by the server (e.g. White goods) in order to retrieve the cost associated to a specific Power profile.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x04" name="PowerProfilesStateNotification" optional="false">
+      <description>
+        The PowerProfileStateNotification Command is generated by the server (e.g. White goods) in order to update the state of the power profile and the current energy phase.
+      </description>
+      <arg name="powerProfileCount" type="INT8U"/>
+      <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="GetOverallSchedulePrice" optional="true">
+      <description>
+        The GetOverallSchedulePrice Command is generated by the server (e.g. White goods) in order to retrieve the overall cost associated to all the Power Profiles scheduled by the scheduler (the device supporting the Power Profile cluster client side) for the next 24 hours.
+      </description>
+    </command>
+    <command source="server" code="0x06" name="EnergyPhasesScheduleRequest" optional="false">
+      <description>
+        The EnergyPhasesScheduleRequest Command is generated by the server (e.g. White goods) in order to retrieve from the scheduler (e.g. Home Gateway) the schedule (if available) associated to the specific Power Profile carried in the payload.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x07" name="EnergyPhasesScheduleStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The EnergyPhasesScheduleStateResponse Command is generated by the server (e.g. White goods) in order to reply to a EnergyPhasesScheduleStateRequest command about the scheduling states that are set in the server side.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="server" code="0x08" name="EnergyPhasesScheduleStateNotification" optional="false">
+      <description>
+        The EnergyPhasesScheduleStateNotification Command is generated by the server (e.g. White goods) in order to notify (un-solicited command) a client side about the scheduling states that are set in the server side.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="server" code="0x09" name="PowerProfileScheduleConstraintsNotification" optional="false">
+      <description>
+        The PowerProfileScheduleConstraintsNotification Command is generated by a device supporting the server side of the Power Profile cluster to notify the client side of this cluster about the imposed constraints and let the scheduler (i.e. the entity supporting the Power Profile cluster client side) to set the proper boundaries for the scheduling.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="startAfter" type="INT16U"/>
+      <arg name="stopBefore" type="INT16U"/>
+    </command>
+    <command source="server" code="0x0A" name="PowerProfileScheduleConstraintsResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The PowerProfileScheduleConstraintsResponse Command is generated by a device supporting the server side of the Power Profile cluster to reply to a client side of this cluster which sent a PowerProfileScheduleConstraintsRequest.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="startAfter" type="INT16U"/>
+      <arg name="stopBefore" type="INT16U"/>
+    </command>
+    <command source="server" code="0x0B" name="GetPowerProfilePriceExtended" optional="true">
+      <description>
+        The Get Power Profile Price Extended command is generated by the server (e.g., White Goods) in order to retrieve the cost associated to a specific Power profile considering specific conditions described in the option field (e.g., a specific time).
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="powerProfileStartTime" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Poll Control</name>
+    <domain>General</domain>
+    <description>This cluster provides a mechanism for the management of an end device's MAC Data Poll rate.  For the purposes of this cluster, the term "poll" always refers to the sending of a MAC Data Poll from the end device to the end device's parent.</description>
+    <code>0x0020</code>
+    <define>POLL_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="CHECK_IN_INTERVAL" type="INT32U" min="0x00000000" max="0x006E0000" writable="true" default="0x00003840" optional="false">check-in interval</attribute>
+    <attribute side="server" code="0x0001" define="LONG_POLL_INTERVAL" type="INT32U" min="0x00000004" max="0x006E0000" writable="false" default="0x00000014" optional="false">long poll interval</attribute>
+    <attribute side="server" code="0x0002" define="SHORT_POLL_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="false" default="0x0002" optional="false">short poll interval</attribute>
+    <attribute side="server" code="0x0003" define="FAST_POLL_TIMEOUT" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0028" optional="false">fast poll timeout</attribute>
+    <attribute side="server" code="0x0004" define="CHECK_IN_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">check in interval min</attribute>
+    <attribute side="server" code="0x0005" define="LONG_POLL_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">long poll interval min</attribute>
+    <attribute side="server" code="0x0006" define="FAST_POLL_TIMEOUT_MAX" type="INT16U" writable="false" default="0x0000" optional="true">fast poll timeout max</attribute>
+    <command source="server" code="0x00" name="CheckIn" optional="false">
+      <description>
+        The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on the server's Check-in Interval attribute.
+      </description>
+    </command>
+    <command source="client" code="0x00" name="CheckInResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Check-in Response is sent in response to the receipt of a Check-in command.
+      </description>
+      <arg name="startFastPolling" type="BOOLEAN"/>
+      <arg name="fastPollTimeout" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="FastPollStop" optional="false" cli="zcl poll-control stop">
+      <description>
+        The Fast Poll Stop command is used to stop the fast poll mode initiated by the Check-in response.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="SetLongPollInterval" optional="true" cli="zcl poll-control long">
+      <description>
+        The Set Long Poll Interval command is used to set the read only Long Poll Interval Attribute.
+      </description>
+      <arg name="newLongPollInterval" type="INT32U"/>
+    </command>
+    <command source="client" code="0x03" name="SetShortPollInterval" optional="true" cli="zcl poll-control short">
+      <description>
+        The Set Short Poll Interval command is used to set the read only Short Poll Interval Attribute.
+      </description>
+      <arg name="newShortPollInterval" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Identification</name>
+    <domain>Home Automation</domain>
+    <description>Attributes and commands for determining basic information about a device and setting user device information.</description>
+    <code>0x0B00</code>
+    <define>APPLIANCE_IDENTIFICATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="BASIC_IDENTIFICATION" type="INT56U" writable="false" optional="false">basic identification</attribute>
+    <attribute side="server" code="0x0010" define="APPLIANCE_COMPANY_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">company name</attribute>
+    <attribute side="server" code="0x0011" define="COMPANY_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">company id</attribute>
+    <attribute side="server" code="0x0012" define="BRAND_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">brand name</attribute>
+    <attribute side="server" code="0x0013" define="BRAND_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">brand id</attribute>
+    <attribute side="server" code="0x0014" define="APPLIANCE_MODEL" type="OCTET_STRING" length="16" writable="false" optional="true">model</attribute>
+    <attribute side="server" code="0x0015" define="APPLIANCE_PART_NUMBER" type="OCTET_STRING" length="16" writable="false" optional="true">part number</attribute>
+    <attribute side="server" code="0x0016" define="APPLIANCE_PRODUCT_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">product revision</attribute>
+    <attribute side="server" code="0x0017" define="APPLIANCE_SOFTWARE_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">software revision</attribute>
+    <attribute side="server" code="0x0018" define="PRODUCT_TYPE_NAME" type="OCTET_STRING" length="2" writable="false" optional="true">product type name</attribute>
+    <attribute side="server" code="0x0019" define="PRODUCT_TYPE_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">product type id</attribute>
+    <attribute side="server" code="0x001A" define="CECED_SPECIFICATION_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">ceced specification version</attribute>
+  </cluster>
+  <!-- METER IDENTIFICATION -->
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Meter Identification</name>
+    <domain>Home Automation</domain>
+    <description>This cluster provides Attributes and commands for determining advanced information about utility metering device.</description>
+    <code>0x0B01</code>
+    <define>METER_IDENTIFICATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="METER_COMPANY_NAME" type="CHAR_STRING" length="16" writable="false" optional="false">company name</attribute>
+    <attribute side="server" code="0x0001" define="METER_TYPE_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">meter type id</attribute>
+    <attribute side="server" code="0x0004" define="DATA_QUALITY_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">data quality id</attribute>
+    <attribute side="server" code="0x0005" define="CUSTOMER_NAME" type="CHAR_STRING" length="16" writable="true" optional="true">customer name</attribute>
+    <attribute side="server" code="0x0006" define="METER_MODEL" type="OCTET_STRING" length="16" writable="false" optional="true">model</attribute>
+    <attribute side="server" code="0x0007" define="METER_PART_NUMBER" type="OCTET_STRING" length="16" writable="false" optional="true">part number</attribute>
+    <attribute side="server" code="0x0008" define="METER_PRODUCT_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">product revision</attribute>
+    <attribute side="server" code="0x000A" define="METER_SOFTWARE_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">software revision</attribute>
+    <attribute side="server" code="0x000B" define="UTILITY_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">utility name</attribute>
+    <attribute side="server" code="0x000C" define="POD" type="CHAR_STRING" length="16" writable="false" optional="false">pod</attribute>
+    <attribute side="server" code="0x000D" define="AVAILABLE_POWER" type="INT24S" min="0x000000" max="0xFFFFFF" writable="false" optional="false">available power</attribute>
+    <attribute side="server" code="0x000E" define="POWER_THRESHOLD" type="INT24S" min="0x000000" max="0xFFFFFF" writable="false" optional="false">power threshold</attribute>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Events and Alert</name>
+    <domain>Home Automation</domain>
+    <description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning.</description>
+    <code>0x0B02</code>
+    <define>APPLIANCE_EVENTS_AND_ALERT_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <command source="client" code="0x00" name="GetAlerts" optional="false">
+      <description>
+        This basic message is used to retrieve Household Appliance current alerts.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="GetAlertsResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This message is used to return household appliance current alerts.
+      </description>
+      <arg name="alertsCount" type="AlertCount"/>
+      <arg name="alertStructures" type="AlertStructure" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="AlertsNotification" optional="false">
+      <description>
+        This message is used to notify the current modification of warning and/or fault conditions.
+      </description>
+      <arg name="alertsCount" type="AlertCount"/>
+      <arg name="alertStructures" type="AlertStructure" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="EventsNotification" optional="false">
+      <description>
+        This message is used to notify an event occurred during the normal working of the appliance.
+      </description>
+      <arg name="eventHeader" type="INT8U"/>
+      <arg name="eventId" type="EventIdentification"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Statistics</name>
+    <domain>Home Automation</domain>
+    <description>
+      This cluster provides a mechanism for the transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs. In case of statistic information that will not fit the single ZigBee payload, the Partition cluster should be used.
+    </description>
+    <code>0x0B03</code>
+    <define>APPLIANCE_STATISTICS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="LOG_MAX_SIZE" type="INT32U" writable="false" default="0x0000003C" optional="false">log max size</attribute>
+    <attribute side="server" code="0x0001" define="LOG_QUEUE_MAX_SIZE" type="INT8U" writable="false" default="0x01" optional="false">log queue max size</attribute>
+    <command source="server" code="0x00" name="LogNotification" optional="false">
+      <description>
+        The Appliance Statistics Cluster server occasionally sends out a Log Notification command to the devices to which it needs to log information related to statistics (e.g., home gateways) which implement the client side of Appliance Statistics Cluster.
+      </description>
+      <arg name="timeStamp" type="TIME_OF_DAY"/>
+      <arg name="logId" type="INT32U"/>
+      <arg name="logLength" type="INT32U"/>
+      <arg name="logPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="LogResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Appliance Statistics Cluster server sends out a Log Response command to respond to a Log Request command generated by the client side of the Appliance Statistics cluster.
+      </description>
+      <arg name="timeStamp" type="TIME_OF_DAY"/>
+      <arg name="logId" type="INT32U"/>
+      <arg name="logLength" type="INT32U"/>
+      <arg name="logPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="LogQueueResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Log Queue Response command is generated as a response to a LogQueueRequest command in order to notify the client side of the Appliance statistics cluster about the logs stored in the server side (queue) that can be retrieved by the client side of this cluster through a LogRequest command.
+      </description>
+      <arg name="logQueueSize" type="INT8U"/>
+      <arg name="logIds" type="INT32U" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="StatisticsAvailable" optional="false">
+      <description>
+        The Appliance Statistics Cluster server sends out a Statistic Available command to notify the client side of the Appliance Statistics cluster that there are statistics that can be retrieved by using the Log Request command.
+      </description>
+      <arg name="logQueueSize" type="INT8U"/>
+      <arg name="logIds" type="INT32U" array="true"/>
+    </command>
+    <command source="client" code="0x00" name="LogRequest" optional="false">
+      <description>
+        The Log request command is sent from a device supporting the client side of the Appliance Statistics cluster (e.g., Home Gateway) to retrieve the log from the device supporting the server side (e.g., appliance).
+      </description>
+      <arg name="logId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x01" name="LogQueueRequest" optional="false">
+      <description>
+        The Log Queue Request command is send from a device supporting the client side of the Appliance Statistics cluster (e.g. Home Gateway) to retrieve the information about the logs inserted in the queue, from the device supporting the server side (e.g. appliance).
+      </description>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Electrical Measurement</name>
+    <domain>Home Automation</domain>
+    <description>Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..</description>
+    <code>0x0B04</code>
+    <define>ELECTRICAL_MEASUREMENT_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="MEASUREMENT_TYPE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x000000" optional="true">measurement type</attribute>
+    <attribute side="server" code="0x0100" define="DC_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage</attribute>
+    <attribute side="server" code="0x0101" define="DC_VOLTAGE_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage min</attribute>
+    <attribute side="server" code="0x0102" define="DC_VOLTAGE_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage max</attribute>
+    <attribute side="server" code="0x0103" define="DC_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current</attribute>
+    <attribute side="server" code="0x0104" define="DC_CURRENT_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current min</attribute>
+    <attribute side="server" code="0x0105" define="DC_CURRENT_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current max</attribute>
+    <attribute side="server" code="0x0106" define="DC_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power</attribute>
+    <attribute side="server" code="0x0107" define="DC_POWER_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power min</attribute>
+    <attribute side="server" code="0x0108" define="DC_POWER_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power max</attribute>
+    <attribute side="server" code="0x0200" define="DC_VOLTAGE_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc voltage multiplier</attribute>
+    <attribute side="server" code="0x0201" define="DC_VOLTAGE_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc voltage divisor</attribute>
+    <attribute side="server" code="0x0202" define="DC_CURRENT_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc current multiplier</attribute>
+    <attribute side="server" code="0x0203" define="DC_CURRENT_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc current divisor</attribute>
+    <attribute side="server" code="0x0204" define="DC_POWER_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc power multiplier</attribute>
+    <attribute side="server" code="0x0205" define="DC_POWER_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc power divisor</attribute>
+    <attribute side="server" code="0x0300" define="AC_FREQUENCY" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency</attribute>
+    <attribute side="server" code="0x0301" define="AC_FREQUENCY_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency min</attribute>
+    <attribute side="server" code="0x0302" define="AC_FREQUENCY_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency max</attribute>
+    <attribute side="server" code="0x0303" define="NEUTRAL_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x0000" optional="true">neutral current</attribute>
+    <attribute side="server" code="0x0304" define="TOTAL_ACTIVE_POWER" type="INT32S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">total active power</attribute>
+    <attribute side="server" code="0x0305" define="TOTAL_REACTIVE_POWER" type="INT32S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">total reactive power</attribute>
+    <attribute side="server" code="0x0306" define="TOTAL_APPARENT_POWER" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">total apparent power</attribute>
+    <attribute side="server" code="0x0307" define="MEASURED_1ST_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 1st harmonic current</attribute>
+    <attribute side="server" code="0x0308" define="MEASURED_3RD_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 3rd harmonic current</attribute>
+    <attribute side="server" code="0x0309" define="MEASURED_5TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 5th harmonic current</attribute>
+    <attribute side="server" code="0x030A" define="MEASURED_7TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 7th harmonic current</attribute>
+    <attribute side="server" code="0x030B" define="MEASURED_9TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 9th harmonic current</attribute>
+    <attribute side="server" code="0x030C" define="MEASURED_11TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 11th harmonic current</attribute>
+    <attribute side="server" code="0x030D" define="MEASURED_PHASE_1ST_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 1st harmonic current</attribute>
+    <attribute side="server" code="0x030E" define="MEASURED_PHASE_3RD_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 3rd harmonic current</attribute>
+    <attribute side="server" code="0x030F" define="MEASURED_PHASE_5TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 5th harmonic current</attribute>
+    <attribute side="server" code="0x0310" define="MEASURED_PHASE_7TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 7th harmonic current</attribute>
+    <attribute side="server" code="0x0311" define="MEASURED_PHASE_9TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 9th harmonic current</attribute>
+    <attribute side="server" code="0x0312" define="MEASURED_PHASE_11TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 11th harmonic current</attribute>
+    <attribute side="server" code="0x0400" define="AC_FREQUENCY_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac frequency multiplier</attribute>
+    <attribute side="server" code="0x0401" define="AC_FREQUENCY_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac frequency divisor</attribute>
+    <attribute side="server" code="0x0402" define="POWER_MULTIPLIER" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">power multiplier</attribute>
+    <attribute side="server" code="0x0403" define="POWER_DIVISOR" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">power divisor</attribute>
+    <attribute side="server" code="0x0404" define="HARMONIC_CURRENT_MULTIPLIER" type="INT8S" min="-127" max="127" writable="false" default="0x00" optional="true">harmonic current multiplier</attribute>
+    <attribute side="server" code="0x0405" define="PHASE_HARMONIC_CURRENT_MULTIPLIER" type="INT8S" min="-127" max="127" writable="false" default="0x00" optional="true">phase harmonic current multiplier</attribute>
+    <attribute side="server" code="0x0500" define="INSTANTANEOUS_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous voltage</attribute>
+    <attribute side="server" code="0x0501" define="INSTANTANEOUS_LINE_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">instantaneous line current</attribute>
+    <attribute side="server" code="0x0502" define="INSTANTANEOUS_ACTIVE_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous active current</attribute>
+    <attribute side="server" code="0x0503" define="INSTANTANEOUS_REACTIVE_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous reactive current</attribute>
+    <attribute side="server" code="0x0504" define="INSTANTANEOUS_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous power</attribute>
+    <attribute side="server" code="0x0505" define="RMS_VOLTAGE" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms voltage</attribute>
+    <attribute side="server" code="0x0506" define="RMS_VOLTAGE_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x8000" optional="true">rms voltage min</attribute>
+    <attribute side="server" code="0x0507" define="RMS_VOLTAGE_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x8000" optional="true">rms voltage max</attribute>
+    <attribute side="server" code="0x0508" define="RMS_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current</attribute>
+    <attribute side="server" code="0x0509" define="RMS_CURRENT_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current min</attribute>
+    <attribute side="server" code="0x050A" define="RMS_CURRENT_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current max</attribute>
+    <attribute side="server" code="0x050B" define="ACTIVE_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power</attribute>
+    <attribute side="server" code="0x050C" define="ACTIVE_POWER_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min</attribute>
+    <attribute side="server" code="0x050D" define="ACTIVE_POWER_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max</attribute>
+    <attribute side="server" code="0x050E" define="REACTIVE_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power</attribute>
+    <attribute side="server" code="0x050F" define="APPARENT_POWER" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">apparent power</attribute>
+    <attribute side="server" code="0x0510" define="AC_POWER_FACTOR" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor</attribute>
+    <attribute side="server" code="0x0511" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">average rms voltage measurement period</attribute>
+    <attribute side="server" code="0x0513" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">average rms under voltage counter</attribute>
+    <attribute side="server" code="0x0514" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms extreme over voltage period</attribute>
+    <attribute side="server" code="0x0515" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms extreme under voltage period</attribute>
+    <attribute side="server" code="0x0516" define="RMS_VOLTAGE_SAG_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms voltage sag period</attribute>
+    <attribute side="server" code="0x0517" define="RMS_VOLTAGE_SWELL_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms voltage swell period</attribute>
+    <attribute side="server" code="0x0600" define="AC_VOLTAGE_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac voltage multiplier</attribute>
+    <attribute side="server" code="0x0601" define="AC_VOLTAGE_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac voltage divisor</attribute>
+    <attribute side="server" code="0x0602" define="AC_CURRENT_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac current multiplier</attribute>
+    <attribute side="server" code="0x0603" define="AC_CURRENT_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac current divisor</attribute>
+    <attribute side="server" code="0x0604" define="AC_POWER_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac power multiplier</attribute>
+    <attribute side="server" code="0x0605" define="AC_POWER_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac power divisor</attribute>
+    <attribute side="server" code="0x0700" define="DC_OVERLOAD_ALARMS_MASK" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">overload alarms mask</attribute>
+    <attribute side="server" code="0x0701" define="DC_VOLTAGE_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">voltage overload</attribute>
+    <attribute side="server" code="0x0702" define="DC_CURRENT_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">current overload</attribute>
+    <attribute side="server" code="0x0800" define="AC_OVERLOAD_ALARMS_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">ac overload alarms mask</attribute>
+    <attribute side="server" code="0x0801" define="AC_VOLTAGE_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac voltage overload</attribute>
+    <attribute side="server" code="0x0802" define="AC_CURRENT_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac current overload</attribute>
+    <attribute side="server" code="0x0803" define="AC_POWER_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac active power overload</attribute>
+    <attribute side="server" code="0x0804" define="AC_REACTIVE_POWER_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac reactive power overload</attribute>
+    <attribute side="server" code="0x0805" define="AVERAGE_RMS_OVER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">average rms over voltage</attribute>
+    <attribute side="server" code="0x0806" define="AVERAGE_RMS_UNDER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">average rms under voltage</attribute>
+    <attribute side="server" code="0x0807" define="RMS_EXTREME_OVER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms extreme over voltage</attribute>
+    <attribute side="server" code="0x0808" define="RMS_EXTREME_UNDER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms extreme under voltage</attribute>
+    <attribute side="server" code="0x0809" define="RMS_VOLTAGE_SAG" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms voltage sag</attribute>
+    <attribute side="server" code="0x080A" define="RMS_VOLTAGE_SWELL" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms voltage swell</attribute>
+    <attribute side="server" code="0x0901" define="LINE_CURRENT_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">line current phase b</attribute>
+    <attribute side="server" code="0x0902" define="ACTIVE_CURRENT_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active current phase b</attribute>
+    <attribute side="server" code="0x0903" define="REACTIVE_CURRENT_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive current phase b</attribute>
+    <attribute side="server" code="0x0905" define="RMS_VOLTAGE_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage phase b</attribute>
+    <attribute side="server" code="0x0906" define="RMS_VOLTAGE_MIN_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage min phase b</attribute>
+    <attribute side="server" code="0x0907" define="RMS_VOLTAGE_MAX_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage max phase b</attribute>
+    <attribute side="server" code="0x0908" define="RMS_CURRENT_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current phase b</attribute>
+    <attribute side="server" code="0x0909" define="RMS_CURRENT_MIN_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current min phase b</attribute>
+    <attribute side="server" code="0x090A" define="RMS_CURRENT_MAX_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current max phase b</attribute>
+    <attribute side="server" code="0x090B" define="ACTIVE_POWER_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power phase b</attribute>
+    <attribute side="server" code="0x090C" define="ACTIVE_POWER_MIN_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min phase b</attribute>
+    <attribute side="server" code="0x090D" define="ACTIVE_POWER_MAX_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max phase b</attribute>
+    <attribute side="server" code="0x090E" define="REACTIVE_POWER_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power phase b</attribute>
+    <attribute side="server" code="0x090F" define="APPARENT_POWER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">apparent power phase b</attribute>
+    <attribute side="server" code="0x0910" define="POWER_FACTOR_PHASE_B" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor phase b</attribute>
+    <attribute side="server" code="0x0911" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms voltage measurement period phase b</attribute>
+    <attribute side="server" code="0x0912" define="AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms over voltage counter phase b</attribute>
+    <attribute side="server" code="0x0913" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms under voltage counter phase b</attribute>
+    <attribute side="server" code="0x0914" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme over voltage period phase b</attribute>
+    <attribute side="server" code="0x0915" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme under voltage period phase b</attribute>
+    <attribute side="server" code="0x0916" define="RMS_VOLTAGE_SAG_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage sag period phase b</attribute>
+    <attribute side="server" code="0x0917" define="RMS_VOLTAGE_SWELL_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage swell period phase b</attribute>
+    <attribute side="server" code="0x0A01" define="LINE_CURRENT_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">line current phase c</attribute>
+    <attribute side="server" code="0x0A02" define="ACTIVE_CURRENT_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active current phase c</attribute>
+    <attribute side="server" code="0x0A03" define="REACTIVE_CURRENT_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive current phase c</attribute>
+    <attribute side="server" code="0x0A05" define="RMS_VOLTAGE_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage phase c</attribute>
+    <attribute side="server" code="0x0A06" define="RMS_VOLTAGE_MIN_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage min phase c</attribute>
+    <attribute side="server" code="0x0A07" define="RMS_VOLTAGE_MAX_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage max phase c</attribute>
+    <attribute side="server" code="0x0A08" define="RMS_CURRENT_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current phase b</attribute>
+    <attribute side="server" code="0x0A09" define="RMS_CURRENT_MIN_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current min phase c</attribute>
+    <attribute side="server" code="0x0A0A" define="RMS_CURRENT_MAX_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current max phase c</attribute>
+    <attribute side="server" code="0x0A0B" define="ACTIVE_POWER_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power phase c</attribute>
+    <attribute side="server" code="0x0A0C" define="ACTIVE_POWER_MIN_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min phase c</attribute>
+    <attribute side="server" code="0x0A0D" define="ACTIVE_POWER_MAX_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max phase c</attribute>
+    <attribute side="server" code="0x0A0E" define="REACTIVE_POWER_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power phase c</attribute>
+    <attribute side="server" code="0x0A0F" define="APPARENT_POWER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">apparent power phase c</attribute>
+    <attribute side="server" code="0x0A10" define="POWER_FACTOR_PHASE_C" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor phase c</attribute>
+    <attribute side="server" code="0x0A11" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms voltage measurement period phase c</attribute>
+    <attribute side="server" code="0x0A12" define="AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms over voltage counter phase c</attribute>
+    <attribute side="server" code="0x0A13" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms under voltage counter phase c</attribute>
+    <attribute side="server" code="0x0A14" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme over voltage period phase c</attribute>
+    <attribute side="server" code="0x0A15" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme under voltage period phase c</attribute>
+    <attribute side="server" code="0x0A16" define="RMS_VOLTAGE_SAG_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage sag period phase c</attribute>
+    <attribute side="server" code="0x0A17" define="RMS_VOLTAGE_SWELL_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage swell period phase c</attribute>
+    <command source="server" code="0x00" name="GetProfileInfoResponseCommand" optional="true" disableDefaultResponse="true">
+      <description>
+        A function which returns the power profiling information requested in the GetProfileInfo command. The power profiling information consists of a list of attributes which are profiled along with the period used to profile them.
+      </description>
+      <arg name="profileCount" type="INT8U"/>
+      <arg name="profileIntervalPeriod" type="ENUM8"/>
+      <arg name="maxNumberOfIntervals" type="INT8U"/>
+      <arg name="listOfAttributes" type="INT16U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="GetMeasurementProfileResponseCommand" optional="true" disableDefaultResponse="true">
+      <description>
+        A function which returns the electricity measurement profile. The electricity measurement profile includes information regarding the amount of time used to capture data related to the flow of electricity as well as the intervals thes
+      </description>
+      <arg name="startTime" type="INT32U"/>
+      <arg name="status" type="ENUM8"/>
+      <arg name="profileIntervalPeriod" type="ENUM8"/>
+      <arg name="numberOfIntervalsDelivered" type="INT8U"/>
+      <arg name="attributeId" type="INT16U"/>
+      <arg name="intervals" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x00" name="GetProfileInfoCommand" optional="true">
+      <description>
+        A function which retrieves the power profiling information from the electrical measurement server.
+      </description>
+    </command>
+    <command source="client" code="0x01" name="GetMeasurementProfileCommand" optional="true">
+      <description>
+        A function which retrieves an electricity measurement profile from the electricity measurement server for a specific attribute Id requested.
+      </description>
+      <arg name="attributeId" type="INT16U"/>
+      <arg name="startTime" type="INT32U"/>
+      <arg name="numberOfIntervals" type="ENUM8"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Diagnostics</name>
+    <domain>Home Automation</domain>
+    <description>Attributes related to the gathering of diagnostic information from a stack.</description>
+    <code>0x0B05</code>
+    <define>DIAGNOSTICS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="NUMBER_OF_RESETS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of resets</attribute>
+    <attribute side="server" code="0x0001" define="PERSISTENT_MEMORY_WRITES" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">persistent memory writes</attribute>
+    <attribute side="server" code="0x0100" define="MAC_RX_BCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac rx broadcast</attribute>
+    <attribute side="server" code="0x0101" define="MAC_TX_BCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac tx broadcast</attribute>
+    <attribute side="server" code="0x0102" define="MAC_RX_UCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac rx unicast</attribute>
+    <attribute side="server" code="0x0103" define="MAC_TX_UCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac tx unicast</attribute>
+    <attribute side="server" code="0x0104" define="MAC_TX_UCAST_RETRY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">mac tx unicast retry</attribute>
+    <attribute side="server" code="0x0105" define="MAC_TX_UCAST_FAIL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">mac tx unicast fail</attribute>
+    <attribute side="server" code="0x0106" define="APS_RX_BCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps rx broadcast</attribute>
+    <attribute side="server" code="0x0107" define="APS_TX_BCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx broadcast</attribute>
+    <attribute side="server" code="0x0108" define="APS_RX_UCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps rx unicast</attribute>
+    <attribute side="server" code="0x0109" define="APS_UCAST_SUCCESS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps unicast success</attribute>
+    <attribute side="server" code="0x010A" define="APS_TX_UCAST_RETRY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx unicast retries</attribute>
+    <attribute side="server" code="0x010B" define="APS_TX_UCAST_FAIL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx unicast failures</attribute>
+    <attribute side="server" code="0x010C" define="ROUTE_DISC_INITIATED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">route discovery initiated</attribute>
+    <attribute side="server" code="0x010D" define="NEIGHBOR_ADDED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor added</attribute>
+    <attribute side="server" code="0x010E" define="NEIGHBOR_REMOVED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor moved</attribute>
+    <attribute side="server" code="0x010F" define="NEIGHBOR_STALE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor stale</attribute>
+    <attribute side="server" code="0x0110" define="JOIN_INDICATION" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">join indication</attribute>
+    <attribute side="server" code="0x0111" define="CHILD_MOVED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">child moved</attribute>
+    <attribute side="server" code="0x0112" define="NWK_FC_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">network frame control failure</attribute>
+    <attribute side="server" code="0x0113" define="APS_FC_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps frame control failure</attribute>
+    <attribute side="server" code="0x0114" define="APS_UNAUTHORIZED_KEY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps unauthorized key</attribute>
+    <attribute side="server" code="0x0115" define="NWK_DECRYPT_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">network decryption failure</attribute>
+    <attribute side="server" code="0x0116" define="APS_DECRYPT_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps decryption failure</attribute>
+    <attribute side="server" code="0x0117" define="PACKET_BUFFER_ALLOC_FAILURES" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">packet buffer allocation failures</attribute>
+    <attribute side="server" code="0x0118" define="RELAYED_UNICAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">relayed unicasts</attribute>
+    <attribute side="server" code="0x0119" define="PHY_TO_MAC_QUEUE_LIMIT_REACHED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">phy to mac queue limit reached</attribute>
+    <attribute side="server" code="0x011A" define="PACKET_VALIDATE_DROP_COUNT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">packet validate drop count</attribute>
+    <attribute side="server" code="0x011B" define="AVERAGE_MAC_RETRY_PER_APS_MSG_SENT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">average mac retry per aps message sent</attribute>
+    <attribute side="server" code="0x011C" define="LAST_MESSAGE_LQI" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x0000" optional="true">last message lqi</attribute>
+    <attribute side="server" code="0x011D" define="LAST_MESSAGE_RSSI" type="INT8S" min="0x00" max="0xFF" writable="false" default="0x0000" optional="true">last message rssi</attribute>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ha.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ha.xml
@@ -1,0 +1,2537 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="Closures" spec="zcl-6.0-15-02018-001"/>
+  <domain name="HVAC" spec="zcl-6.0-15-02018-001"/>
+  <domain name="Lighting" spec="zcl6-errata-14-0129-15">
+    <older spec="zcl-6.0-15-02018-001" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <domain name="Measurement &amp; Sensing" spec="zcl-6.0-15-02018-001"/>
+  <domain name="Security &amp; Safety" spec="zcl-6.0-15-02018-001"/>
+  <domain name="HA" spec="ha-1.2.1-05-3520-30" dependsOn="zcl-1.0-07-5123-03" certifiable="true">
+    <older spec="ha-1.2-05-3520-29" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+    <older spec="ha-1.1-05-3520-27" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  </domain>
+  <cluster>
+    <name>Shade Configuration</name>
+    <domain>Closures</domain>
+    <description>Attributes and commands for configuring a shade.</description>
+    <code>0x0100</code>
+    <define>SHADE_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="SHADE_CONFIG_PHYSICAL_CLOSED_LIMIT" type="INT16U" min="0x0001" max="0xFFFE" writable="false" optional="true">physical closed limit</attribute>
+    <!-- PHYSICAL_CLOSED_LIMIT -->
+    <attribute side="server" code="0x0001" define="SHADE_CONFIG_MOTOR_STEP_SIZE" type="INT8U" min="0x00" max="0xFE" writable="false" optional="true">motor step size</attribute>
+    <!-- MOTOR_STEP_SIZE -->
+    <attribute side="server" code="0x0002" define="SHADE_CONFIG_STATUS" type="BITMAP8" min="0x00" max="0x0F" writable="true" default="0x00" optional="false">status</attribute>
+    <!-- STATUS -->
+    <attribute side="server" code="0x0010" define="SHADE_CONFIG_CLOSED_LIMIT" type="INT16U" min="0x0001" max="0xFFFE" writable="true" default="0x0001" optional="false">closed limit</attribute>
+    <!-- CLOSED_LIMIT -->
+    <attribute side="server" code="0x0011" define="SHADE_CONFIG_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">mode</attribute>
+    <!-- MODE -->
+  </cluster>
+  <cluster>
+    <name>Pump Configuration and Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring and controlling pumps.</description>
+    <code>0x0200</code>
+    <define>PUMP_CONFIG_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="false">max pressure</attribute>
+    <attribute side="server" code="0x0001" define="MAX_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="false">max speed</attribute>
+    <attribute side="server" code="0x0002" define="MAX_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="false">max flow</attribute>
+    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">min const pressure</attribute>
+    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">max const pressure</attribute>
+    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">min comp pressure</attribute>
+    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="INT16S" min="0x8001" max="0x7FFF" writable="false" optional="true">max comp pressure</attribute>
+    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">min const speed</attribute>
+    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">max const speed</attribute>
+    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">min const flow</attribute>
+    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">max const flow</attribute>
+    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">min const temp</attribute>
+    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">max const temp</attribute>
+    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="BITMAP16" writable="false" reportable="true" optional="true">pump status</attribute>
+    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective operation mode</attribute>
+    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">effective control mode</attribute>
+    <attribute side="server" code="0x0013" define="CAPACITY" type="INT16S" min="0x0000" max="0x7FFF" writable="false" reportable="true" optional="false">capacity</attribute>
+    <attribute side="server" code="0x0014" define="SPEED" type="INT16U" min="0x0000" max="0xFFFE" writable="false" optional="true">speed</attribute>
+    <attribute side="server" code="0x0015" define="LIFETIME_RUNNING_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">lifetime running hours</attribute>
+    <attribute side="server" code="0x0016" define="PUMP_POWER" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" optional="true">power</attribute>
+    <attribute side="server" code="0x0017" define="LIFETIME_ENERGY_CONSUMED" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0x00000000" optional="true">lifetime energy consumed</attribute>
+    <attribute side="server" code="0x0020" define="OPERATION_MODE" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="false">operation mode</attribute>
+    <attribute side="server" code="0x0021" define="CONTROL_MODE" type="ENUM8" min="0x00" max="0xFe" writable="true" default="0x00" optional="true">control mode</attribute>
+    <attribute side="server" code="0x0022" define="PUMP_ALARM_MASK" type="BITMAP16" writable="false" optional="true">alarm mask</attribute>
+    <!-- ALARM_MASK -->
+  </cluster>
+  <cluster>
+    <name>Thermostat</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring and controlling the functionality of a thermostat.</description>
+    <code>0x0201</code>
+    <define>THERMOSTAT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" reportable="true" optional="false">local temperature</attribute>
+    <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" optional="true">outdoor temperature</attribute>
+    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="BITMAP8" min="0x00" max="0x01" writable="false" default="0x01" optional="true">occupancy</attribute>
+    <!-- OCCUPANCY -->
+    <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x02BC" optional="true">abs min heat setpoint limit</attribute>
+    <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0BB8" optional="true">abs max heat setpoint limit</attribute>
+    <attribute side="server" code="0x0005" define="ABS_MIN_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0640" optional="true">abs min cool setpoint limit</attribute>
+    <attribute side="server" code="0x0006" define="ABS_MAX_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x0C80" optional="true">abs max cool setpoint limit</attribute>
+    <attribute side="server" code="0x0007" define="PI_COOLING_DEMAND" type="INT8U" min="0x00" max="0x64" writable="false" reportable="true" optional="true">pi cooling demand</attribute>
+    <attribute side="server" code="0x0008" define="PI_HEATING_DEMAND" type="INT8U" min="0x00" max="0x64" writable="false" reportable="true" optional="true">pi heating demand</attribute>
+    <attribute side="server" code="0x0009" define="HVAC_SYSTEM_TYPE_CONFIGURATION" type="BITMAP8" min="0x00" max="0xFF" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">HVAC system type configuration</attribute>
+    <attribute side="server" code="0x0010" define="LOCAL_TEMPERATURE_CALIBRATION" type="INT8S" min="0xE7" max="0x19" writable="true" default="0x00" optional="true">local temperature calibration</attribute>
+    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="INT16S" writable="true" default="0x0A28" optional="false">occupied cooling setpoint</attribute>
+    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="INT16S" writable="true" default="0x07D0" optional="false">occupied heating setpoint</attribute>
+    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="INT16S" writable="true" default="0x0A28" optional="true">unoccupied cooling setpoint</attribute>
+    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="INT16S" writable="true" default="0x07D0" optional="true">unoccupied heating setpoint</attribute>
+    <attribute side="server" code="0x0015" define="MIN_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x02BC" optional="true">min heat setpoint limit</attribute>
+    <attribute side="server" code="0x0016" define="MAX_HEAT_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0BB8" optional="true">max heat setpoint limit</attribute>
+    <attribute side="server" code="0x0017" define="MIN_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0640" optional="true">min cool setpoint limit</attribute>
+    <attribute side="server" code="0x0018" define="MAX_COOL_SETPOINT_LIMIT" type="INT16S" min="0x954D" max="0x7FFF" writable="true" default="0x0C80" optional="true">max cool setpoint limit</attribute>
+    <attribute side="server" code="0x0019" define="MIN_SETPOINT_DEAD_BAND" type="INT8S" min="0x0A" max="0x19" writable="true" default="0x19" optional="true">min setpoint dead band</attribute>
+    <attribute side="server" code="0x001A" define="REMOTE_SENSING" type="BITMAP8" min="0x00" max="0x07" writable="true" default="0x00" optional="true">remote sensing</attribute>
+    <attribute side="server" code="0x001B" define="CONTROL_SEQUENCE_OF_OPERATION" type="ENUM8" min="0x00" max="0x05" writable="true" default="0x04" optional="false">control sequence of operation</attribute>
+    <attribute side="server" code="0x001C" define="SYSTEM_MODE" type="ENUM8" min="0x00" max="0x07" writable="true" default="0x01" optional="false">system mode</attribute>
+    <attribute side="server" code="0x001D" define="THERMOSTAT_ALARM_MASK" type="BITMAP8" min="0x00" max="0x07" writable="false" default="0x00" optional="true">alarm mask</attribute>
+    <!-- ALARM_MASK -->
+    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ENUM8" min="0x00" max="0x04" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">thermostat running mode</attribute>
+    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="ENUM8" min="0x00" max="0x06" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">start of week</attribute>
+    <attribute side="server" code="0x0021" define="NUMBER_OF_WEEKLY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">number of weekly transitions</attribute>
+    <attribute side="server" code="0x0022" define="NUMBER_OF_DAILY_TRANSITIONS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">number of daily transitions</attribute>
+    <attribute side="server" code="0x0023" define="TEMPERATURE_SETPOINT_HOLD" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">temperature setpoint hold</attribute>
+    <attribute side="server" code="0x0024" define="TEMPERATURE_SETPOINT_HOLD_DURATION" type="INT16U" min="0x0000" max="0x05A0" writable="true" default="0xFFFF" optional="true" introducedIn="ha-1.2-05-3520-29">temperature setpoint hold duration</attribute>
+    <attribute side="server" code="0x0025" define="THERMOSTAT_PROGRAMMING_OPERATION_MODE" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">thermostat programming operation mode</attribute>
+    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="BITMAP16" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">hvac relay state</attribute>
+    <attribute side="server" code="0x0030" define="SETPOINT_CHANGE_SOURCE" type="ENUM8" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change source</attribute>
+    <attribute side="server" code="0x0031" define="SETPOINT_CHANGE_AMOUNT" type="INT16S" writable="false" default="0x8000" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change amount</attribute>
+    <attribute side="server" code="0x0032" define="SETPOINT_CHANGE_SOURCE_TIMESTAMP" type="UTC_TIME" writable="false" optional="true" introducedIn="ha-1.2-05-3520-29">setpoint change source timestamp</attribute>
+    <attribute side="server" code="0x0040" define="AC_TYPE" type="ENUM8" min="0x00" max="0x04" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">ac type</attribute>
+    <attribute side="server" code="0x0041" define="AC_CAPACITY" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">ac capacity</attribute>
+    <attribute side="server" code="0x0042" define="AC_REFRIGERANT_TYPE" type="ENUM8" min="0x00" max="0x03" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">ac refrigerant type</attribute>
+    <attribute side="server" code="0x0043" define="AC_COMPRESSOR" type="ENUM8" min="0x00" max="0x03" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">ac compressor</attribute>
+    <attribute side="server" code="0x0044" define="AC_ERROR_CODE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="true" default="0x00000000" optional="true" introducedIn="ha-1.2-05-3520-29">ac error code</attribute>
+    <attribute side="server" code="0x0045" define="AC_LOUVER_POSITION" type="ENUM8" min="0x00" max="0x05" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">ac louver position</attribute>
+    <attribute side="server" code="0x0046" define="AC_COIL_TEMPERATURE" type="INT16S" min="0x954D" max="0x7FFF" writable="false" default="0x8000" optional="true" introducedIn="ha-1.2-05-3520-29">ac coil temperature</attribute>
+    <attribute side="server" code="0x0047" define="AC_CAPACITY_FORMAT" type="ENUM8" min="0x00" max="0xFF" writable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">ac capacity format</attribute>
+    <command source="client" code="0x00" name="SetpointRaiseLower" optional="false" cli="zcl tstat set">
+      <description>
+        Command description for SetpointRaiseLower
+      </description>
+      <arg name="mode" type="SetpointAdjustMode"/>
+      <arg name="amount" type="INT8S"/>
+    </command>
+    <command source="client" code="0x01" name="SetWeeklySchedule" optional="false" cli="zcl tstat sws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        Command description for SetWeeklySchedule
+      </description>
+      <arg name="numberOfTransitionsForSequence" type="ENUM8"/>
+      <arg name="dayOfWeekForSequence" type="DayOfWeek"/>
+      <arg name="modeForSequence" type="ModeForSequence"/>
+      <arg name="payload" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="GetWeeklySchedule" optional="false" cli="zcl tstat gws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        Command description for GetWeeklySchedule
+      </description>
+      <arg name="daysToReturn" type="DayOfWeek"/>
+      <arg name="modeToReturn" type="ModeForSequence"/>
+    </command>
+    <command source="client" code="0x03" name="ClearWeeklySchedule" optional="false" cli="zcl tstat cws" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Clear Weekly Schedule command is used to clear the weekly schedule.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="GetRelayStatusLog" optional="false" cli="zcl tstat grs" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Get Relay Status Log command is used to query the thermostat internal relay status log.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="CurrentWeeklySchedule" optional="false" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        The Current Weekly Schedule Command is sent from the server in response to the Get Weekly Schedule Command.
+      </description>
+      <arg name="numberOfTransitionsForSequence" type="ENUM8"/>
+      <arg name="dayOfWeekForSequence" type="DayOfWeek"/>
+      <arg name="modeForSequence" type="ModeForSequence"/>
+      <arg name="payload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="RelayStatusLog" optional="false" introducedIn="ha-1.2-05-3520-29">
+      <description>
+        This command is sent from the thermostat cluster server in response to the Get  Relay Status Log.
+      </description>
+      <arg name="timeOfDay" type="INT16U"/>
+      <arg name="relayStatus" type="BITMAP16"/>
+      <arg name="localTemperature" type="INT16S"/>
+      <arg name="humidityInPercentage" type="INT8U"/>
+      <arg name="setpoint" type="INT16S"/>
+      <arg name="unreadEntries" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Fan Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for controlling a fan in a heating/cooling system.</description>
+    <code>0x0202</code>
+    <define>FAN_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="FAN_CONTROL_FAN_MODE" type="ENUM8" min="0x00" max="0x06" writable="true" default="0x05" optional="false">fan mode</attribute>
+    <!-- FAN_MODE -->
+    <attribute side="server" code="0x0001" define="FAN_CONTROL_FAN_MODE_SEQUENCE" type="ENUM8" min="0x00" max="0x04" writable="true" default="0x02" optional="false">fan mode sequence</attribute>
+    <!-- FAN_MODE_SEQUENCE -->
+  </cluster>
+  <cluster>
+    <name>Dehumidification Control</name>
+    <domain>HVAC</domain>
+    <description>An interface for controlling dehumidification.</description>
+    <code>0x0203</code>
+    <define>DEHUMID_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY" type="INT8U" min="0x00" max="0x64" writable="false" optional="true">relative humidity</attribute>
+    <attribute side="server" code="0x0001" define="DEHUMIDIFICATION_COOLING" type="INT8U" min="0x00" writable="false" optional="false">dehumidification cooling</attribute>
+    <attribute side="server" code="0x0010" define="RH_DEHUMIDIFICATION_SETPOINT" type="INT8U" min="0x1E" max="0x64" writable="true" default="0x32" optional="false">RH dehumidification setpoint</attribute>
+    <attribute side="server" code="0x0011" define="RELATIVE_HUMIDITY_MODE" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">relative humidity mode</attribute>
+    <attribute side="server" code="0x0012" define="DEHUMIDIFICATION_LOCKOUT" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x01" optional="true">dehumidification lockout</attribute>
+    <attribute side="server" code="0x0013" define="DEHUMIDIFICATION_HYSTERESIS" type="INT8U" min="0x02" max="0x14" writable="true" default="0x02" optional="false">dehumidification hysteresis</attribute>
+    <attribute side="server" code="0x0014" define="DEHUMIDIFICATION_MAX_COOL" type="INT8U" min="0x14" max="0x64" writable="true" default="0x14" optional="false">dehumidification max cool</attribute>
+    <attribute side="server" code="0x0015" define="RELATIVE_HUMIDITY_DISPLAY" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">relative humidity display</attribute>
+  </cluster>
+  <cluster>
+    <name>Thermostat User Interface Configuration</name>
+    <domain>HVAC</domain>
+    <description>An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).</description>
+    <code>0x0204</code>
+    <define>THERMOSTAT_UI_CONFIG_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <attribute side="server" code="0x0000" define="TEMPERATURE_DISPLAY_MODE" type="ENUM8" min="0x00" max="0x01" writable="true" default="0x00" optional="false">temperature display mode</attribute>
+    <attribute side="server" code="0x0001" define="KEYPAD_LOCKOUT" type="ENUM8" min="0x00" max="0x05" writable="true" default="0x00" optional="false">keypad lockout</attribute>
+    <attribute side="server" code="0x0002" define="SCHEDULE_PROGRAMMING_VISIBILITY" type="ENUM8" min="0x00" max="0x01" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">schedule programming visibility</attribute>
+  </cluster>
+  <cluster>
+    <name>Color Control</name>
+    <domain>Lighting</domain>
+    <description>Attributes and commands for controlling the color properties of a color-capable light.</description>
+    <code>0x0300</code>
+    <define>COLOR_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="INT8U" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">current hue</attribute>
+    <!-- CURRENT_HUE -->
+    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="INT8U" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">current saturation</attribute>
+    <!-- CURRENT_SATURATION -->
+    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="false" default="0x0000" optional="true">remaining time</attribute>
+    <!-- REMAINING_TIME -->
+    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x616B" optional="false">current x</attribute>
+    <!-- CURRENT_X -->
+    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x607D" optional="false">current y</attribute>
+    <!-- CURRENT_Y -->
+    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="ENUM8" min="0x00" max="0x04" writable="false" optional="true">drift compensation</attribute>
+    <!-- DRIFT_COMPENSATION -->
+    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="CHAR_STRING" length="254" writable="false" optional="true">compensation text</attribute>
+    <!-- COMPENSATION_TEXT -->
+    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="INT16U" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x00FA" optional="true">color temperature</attribute>
+    <!-- COLOR_TEMPERATURE -->
+    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ENUM8" min="0x00" max="0x02" writable="false" default="0x01" optional="true">color mode</attribute>
+    <!-- COLOR_MODE -->
+    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x00" optional="false" introducedIn="zcl-6.0-15-02017-001">color control options</attribute>
+    <!-- COLOR_CONTROL_OPTIONS -->
+    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="INT8U" min="0x00" max="0x06" writable="false" optional="true">number of primaries</attribute>
+    <!-- NUMBER_OF_PRIMARIES -->
+    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 1 x</attribute>
+    <!-- PRIMARY_1_X -->
+    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 1 y</attribute>
+    <!-- PRIMARY_1_Y -->
+    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 1 intensity</attribute>
+    <!-- PRIMARY_1_INTENSITY -->
+    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 2 x</attribute>
+    <!-- PRIMARY_2_X -->
+    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 2 y</attribute>
+    <!-- PRIMARY_2_Y -->
+    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 2 intensity</attribute>
+    <!-- PRIMARY_2_INTENSITY -->
+    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 3 x</attribute>
+    <!-- PRIMARY_3_X -->
+    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 3 y</attribute>
+    <!-- PRIMARY_3_Y -->
+    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 3 intensity</attribute>
+    <!-- PRIMARY_3_INTENSITY -->
+    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 4 x</attribute>
+    <!-- PRIMARY_4_X -->
+    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 4 y</attribute>
+    <!-- PRIMARY_4_Y -->
+    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 4 intensity</attribute>
+    <!-- PRIMARY_4_INTENSITY -->
+    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 5 x</attribute>
+    <!-- PRIMARY_5_X -->
+    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 5 y</attribute>
+    <!-- PRIMARY_5_Y -->
+    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 5 intensity</attribute>
+    <!-- PRIMARY_5_INTENSITY -->
+    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 6 x</attribute>
+    <!-- PRIMARY_6_X -->
+    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="false" optional="true">primary 6 y</attribute>
+    <!-- PRIMARY_6_Y -->
+    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">primary 6 intensity</attribute>
+    <!-- PRIMARY_6_INTENSITY -->
+    <attribute side="server" code="0x0030" define="COLOR_CONTROL_WHITE_POINT_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">white point x</attribute>
+    <!-- WHITE_POINT_X -->
+    <attribute side="server" code="0x0031" define="COLOR_CONTROL_WHITE_POINT_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">white point y</attribute>
+    <!-- WHITE_POINT_Y -->
+    <attribute side="server" code="0x0032" define="COLOR_CONTROL_COLOR_POINT_R_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point r x</attribute>
+    <!-- COLOR_POINT_R_X -->
+    <attribute side="server" code="0x0033" define="COLOR_CONTROL_COLOR_POINT_R_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point r y</attribute>
+    <!-- COLOR_POINT_R_Y -->
+    <attribute side="server" code="0x0034" define="COLOR_CONTROL_COLOR_POINT_R_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point r intensity</attribute>
+    <!-- COLOR_POINT_R_INTENSITY -->
+    <attribute side="server" code="0x0036" define="COLOR_CONTROL_COLOR_POINT_G_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point g x</attribute>
+    <!-- COLOR_POINT_G_X -->
+    <attribute side="server" code="0x0037" define="COLOR_CONTROL_COLOR_POINT_G_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point g y</attribute>
+    <!-- COLOR_POINT_G_Y -->
+    <attribute side="server" code="0x0038" define="COLOR_CONTROL_COLOR_POINT_G_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point g intensity</attribute>
+    <!-- COLOR_POINT_G_INTENSITY -->
+    <attribute side="server" code="0x003A" define="COLOR_CONTROL_COLOR_POINT_B_X" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point b x</attribute>
+    <!-- COLOR_POINT_B_X -->
+    <attribute side="server" code="0x003B" define="COLOR_CONTROL_COLOR_POINT_B_Y" type="INT16U" min="0x0000" max="0xFEFF" writable="true" optional="true">color point b y</attribute>
+    <!-- COLOR_POINT_B_Y -->
+    <attribute side="server" code="0x003C" define="COLOR_CONTROL_COLOR_POINT_B_INTENSITY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">color point b intensity</attribute>
+    <!-- COLOR_POINT_B_INTENSITY -->
+    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false" introducedIn="l&amp;o-1.0-15-0014-04">couple color temp to level min-mireds</attribute>
+    <attribute side="server" code="0x4010" define="START_UP_COLOR_TEMPERATURE_MIREDS" type="INT16U" min="0x0000" max="0xFFFF" writable="true" optional="false" introducedIn="l&amp;o-1.0-15-0014-04">start up color temperature mireds</attribute>
+    <command source="client" code="0x00" name="MoveToHue" optional="true" cli="zcl color-control movetohue">
+      <description>
+        Move to specified hue.
+      </description>
+      <arg name="hue" type="INT8U"/>
+      <arg name="direction" type="HueDirection"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x01" name="MoveHue" optional="true" cli="zcl color-control movehue">
+      <description>
+        Move hue up or down at specified rate.
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT8U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x02" name="StepHue" optional="true" cli="zcl color-control stephue">
+      <description>
+        Step hue up or down by specified size at specified rate.
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT8U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x03" name="MoveToSaturation" optional="true" cli="zcl color-control movetosat">
+      <description>
+        Move to specified saturation.
+      </description>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x04" name="MoveSaturation" optional="true" cli="zcl color-control movesat">
+      <description>
+        Move saturation up or down at specified rate.
+      </description>
+      <arg name="moveMode" type="SaturationMoveMode"/>
+      <arg name="rate" type="INT8U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x05" name="StepSaturation" optional="true" cli="zcl color-control stepsat">
+      <description>
+        Step saturation up or down by specified size at specified rate.
+      </description>
+      <arg name="stepMode" type="SaturationStepMode"/>
+      <arg name="stepSize" type="INT8U"/>
+      <arg name="transitionTime" type="INT8U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x06" name="MoveToHueAndSaturation" optional="true" cli="zcl color-control movetohueandsat">
+      <description>
+        Move to hue and saturation.
+      </description>
+      <arg name="hue" type="INT8U"/>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x07" name="MoveToColor" optional="false" cli="zcl color-control movetocolor">
+      <description>
+        Move to specified color.
+      </description>
+      <arg name="colorX" type="INT16U"/>
+      <arg name="colorY" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x08" name="MoveColor" optional="false" cli="zcl color-control movecolor">
+      <description>
+        Moves the color.
+      </description>
+      <arg name="rateX" type="INT16S"/>
+      <arg name="rateY" type="INT16S"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x09" name="StepColor" optional="false" cli="zcl color-control stepcolor">
+      <description>
+        Steps the lighting to a specific color.
+      </description>
+      <arg name="stepX" type="INT16S"/>
+      <arg name="stepY" type="INT16S"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x0A" name="MoveToColorTemperature" optional="true" cli="zcl color-control movetocolortemp">
+      <description>
+        Move to a specific color temperature.
+      </description>
+      <arg name="colorTemperature" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Ballast Configuration</name>
+    <domain>Lighting</domain>
+    <description>Attributes and commands for configuring a lighting ballast.</description>
+    <code>0x0301</code>
+    <define>BALLAST_CONFIGURATION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0x01" optional="true">physical min level</attribute>
+    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="false" default="0xFE" optional="true">physical max level</attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BITMAP8" min="0x00" max="0x03" writable="false" default="0x00" optional="false">ballast status</attribute>
+    <attribute side="server" code="0x0010" define="MIN_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">min level</attribute>
+    <attribute side="server" code="0x0011" define="MAX_LEVEL" type="INT8U" min="0x01" max="0xFE" writable="true" default="0xFE" optional="true">max level</attribute>
+    <attribute side="server" code="0x0012" define="POWER_ON_LEVEL" type="INT8U" min="0x00" max="0xFE" writable="true" default="0xFE" optional="true">power on level</attribute>
+    <attribute side="server" code="0x0013" define="POWER_ON_FADE_TIME" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">power on fade time</attribute>
+    <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="INT8U" min="0x00" max="0xFE" writable="true" optional="true">intrinsic ballast factor</attribute>
+    <attribute side="server" code="0x0015" define="BALLAST_FACTOR_ADJUSTMENT" type="INT8U" min="0x64" writable="true" default="0xFF" optional="true">ballast factor adjustment</attribute>
+    <attribute side="server" code="0x0020" define="LAMP_QUALITY" type="INT8U" min="0x00" max="0xFE" writable="false" optional="true">lamp quality</attribute>
+    <attribute side="server" code="0x0030" define="LAMP_TYPE" type="CHAR_STRING" length="16" writable="true" optional="true">lamp type</attribute>
+    <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="CHAR_STRING" length="16" writable="true" optional="true">lamp manufacturer</attribute>
+    <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0xFFFFFF" optional="true">lamp rated hours</attribute>
+    <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0x000000" optional="true">lamp burn hours</attribute>
+    <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="BITMAP8" min="0x00" max="0x01" writable="true" default="0x00" optional="true">lamp alarm mode</attribute>
+    <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="INT24U" min="0x000000" max="0xFFFFFE" writable="true" default="0xFFFFFF" optional="true">lamp burn hours trip point</attribute>
+  </cluster>
+  <cluster>
+    <name>Illuminance Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.</description>
+    <code>0x0400</code>
+    <define>ILLUM_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="ILLUM_MEASURED_VALUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ILLUM_MIN_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xFFFD" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ILLUM_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xFFFE" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ILLUM_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+    <attribute side="server" code="0x0004" define="MEASUREMENT_LIGHT_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true">light sensor type</attribute>
+    <!-- LIGHT_SENSOR_TYPE -->
+  </cluster>
+  <cluster>
+    <name>Illuminance Level Sensing</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the sensing of illuminance levels, and reporting whether illuminance is above, below, or on target.</description>
+    <code>0x0401</code>
+    <define>ILLUM_LEVEL_SENSING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="LEVEL_STATUS" type="ENUM8" min="0x00" max="0xFE" writable="false" reportable="true" optional="false">level status</attribute>
+    <attribute side="server" code="0x0001" define="SENSING_LIGHT_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="true">light sensor type</attribute>
+    <!-- LIGHT_SENSOR_TYPE -->
+    <attribute side="server" code="0x0010" define="ILLUMINANCE_TARGET_LEVEL" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="false">illuminance level target</attribute>
+  </cluster>
+  <cluster>
+    <name>Temperature Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.</description>
+    <code>0x0402</code>
+    <define>TEMP_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="TEMP_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" default="0x8000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TEMP_MIN_MEASURED_VALUE" type="INT16S" min="0x954D" max="0x7FFE" writable="false" default="0x8000" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TEMP_MAX_MEASURED_VALUE" type="INT16S" min="0x954E" max="0x7FFF" writable="false" default="0x8000" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Pressure Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.</description>
+    <code>0x0403</code>
+    <define>PRESSURE_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="INT16S" min="0x8001" max="0x7FFE" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="INT16S" min="0x8002" max="0x7FFF" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="INT16S" writable="false" reportable="true" default="0x0000" optional="true">scaled value</attribute>
+    <attribute side="server" code="0x0011" define="PRESSURE_MIN_SCALED_VALUE" type="INT16S" min="0x8001" max="0x7FFE" writable="false" optional="true">min scaled value</attribute>
+    <attribute side="server" code="0x0012" define="PRESSURE_MAX_SCALED_VALUE" type="INT16S" min="0x8002" max="0x7FFF" writable="false" optional="true">max scaled value</attribute>
+    <attribute side="server" code="0x0013" define="PRESSURE_SCALED_TOLERANCE" type="INT16S" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">scaled tolerance</attribute>
+    <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="INT8S" min="0x81" max="0x7F" writable="false" optional="true">scale</attribute>
+  </cluster>
+  <cluster>
+    <name>Flow Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of flow, and reporting flow rates.</description>
+    <code>0x0404</code>
+    <define>FLOW_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="FLOW_MEASURED_VALUE" type="INT16U" writable="false" reportable="true" default="0x0000" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FLOW_MIN_MEASURED_VALUE" type="INT16U" min="0x0000" max="0xfffd" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FLOW_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0xfffe" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FLOW_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Relative Humidity Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.</description>
+    <code>0x0405</code>
+    <define>RELATIVE_HUMIDITY_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY_MEASURED_VALUE" type="INT16U" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="RELATIVE_HUMIDITY_MIN_MEASURED_VALUE" type="INT16U" min="0x0000" max="0x270F" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="RELATIVE_HUMIDITY_MAX_MEASURED_VALUE" type="INT16U" min="0x0001" max="0x2710" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="INT16U" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Occupancy Sensing</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring occupancy sensing, and reporting occupancy status.</description>
+    <code>0x0406</code>
+    <define>OCCUPANCY_SENSING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="OCCUPANCY" type="BITMAP8" min="0x00" max="0x01" writable="false" reportable="true" optional="false">occupancy</attribute>
+    <attribute side="server" code="0x0001" define="OCCUPANCY_SENSOR_TYPE" type="ENUM8" min="0x00" max="0xFE" writable="false" optional="false">occupancy sensor type</attribute>
+    <attribute side="server" code="0x0002" define="OCCUPANCY_SENSOR_TYPE_BITMAP" type="BITMAP8" min="0x00" max="0x07" writable="false" optional="false">occupancy sensor type bitmap</attribute>
+    <attribute side="server" code="0x0010" define="PIR_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">PIR occupied to unoccupied delay</attribute>
+    <attribute side="server" code="0x0011" define="PIR_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">PIR unoccupied to occupied delay</attribute>
+    <attribute side="server" code="0x0012" define="PIR_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">PIR unoccupied to occupied threshold</attribute>
+    <attribute side="server" code="0x0020" define="ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">ultrasonic occupied to unoccupied delay</attribute>
+    <attribute side="server" code="0x0021" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">ultrasonic unoccupied to occupied delay</attribute>
+    <attribute side="server" code="0x0022" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">ultrasonic unoccupied to occupied threshold</attribute>
+    <attribute side="server" code="0x0030" define="PHYSICAL_CONTACT_OCCUPIED_TO_UNOCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">physical contact occupied to unoccupied delay</attribute>
+    <attribute side="server" code="0x0031" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_DELAY" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">physical contact unoccupied to occupied delay</attribute>
+    <attribute side="server" code="0x0032" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="INT8U" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">physical contact unoccupied to occupied threshold</attribute>
+  </cluster>
+  <cluster>
+    <name>Carbon Monoxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of carbon monoxide concentration and reporting concentration measurements.</description>
+    <code>0x040C</code>
+    <define>CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CARBON_MONOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Carbon Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the carbon diaoxide concentration and reporting concentration measurements.</description>
+    <code>0x040D</code>
+    <define>CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CARBON_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ethylene Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ethylene concentration and reporting concentration measurements.</description>
+    <code>0x040E</code>
+    <define>ETHYLENE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ETHYLENE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ETHYLENE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ethylene Oxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ethylene Oxide concentration and reporting concentration measurements.</description>
+    <code>0x040F</code>
+    <define>ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="ETHYLENE_OXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Hydrogen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Hydrogen concentration and reporting concentration measurements.</description>
+    <code>0x0410</code>
+    <define>HYDROGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HYDROGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HYDROGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Hydrogen Sulphide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Hydrogen Sulphide concentration and reporting concentration measurements.</description>
+    <code>0x0411</code>
+    <define>HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HYDROGEN_SULPHIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Nitric Oxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Nitric Oxide concentration and reporting concentration measurements.</description>
+    <code>0x0412</code>
+    <define>NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="NITRIC_OXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Nitrogen Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Nitrogen Dioxide concentration and reporting concentration measurements.</description>
+    <code>0x0413</code>
+    <define>NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="NITROGEN_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Oxygen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Oxygen concentration and reporting concentration measurements.</description>
+    <code>0x0414</code>
+    <define>OXYGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="OXYGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="OXYGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="OXYGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="OXYGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Ozone Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Ozone concentration and reporting concentration measurements.</description>
+    <code>0x0415</code>
+    <define>OZONE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="OZONE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="OZONE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="OZONE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="OZONE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sulfur Dioxide Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sulphur Dioxide concentration and reporting concentration measurements.</description>
+    <code>0x0416</code>
+    <define>SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SULFUR_DIOXIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Dissolved Oxygen Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Dissolved Oxygen concentration and reporting concentration measurements.</description>
+    <code>0x0417</code>
+    <define>DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="DISSOLVED_OXYGEN_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromate Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromate concentration, and reporting concentration measurements.</description>
+    <code>0x0418</code>
+    <define>BROMATE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="BROMATE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMATE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMATE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMATE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chloramines Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chloramines concentration and reporting concentration measurements.</description>
+    <code>0x0419</code>
+    <define>CHLORAMINES_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORAMINES_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chlorine Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chlorine concentration and reporting concentration measurements.</description>
+    <code>0x041A</code>
+    <define>CHLORINE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CHLORINE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORINE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORINE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORINE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Fecal coliform and E. Coli Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Fecal coliform and E. Coli concentration and reporting concentration measurements.</description>
+    <code>0x041B</code>
+    <define>FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FECAL_COLIFORM_AND_E_COLI_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Fluoride Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Fluoride concentration and reporting concentration measurements.</description>
+    <code>0x041C</code>
+    <define>FLUORIDE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="FLUORIDE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="FLUORIDE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Haloacetic Acids Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Haloacetic Acids concentration and reporting concentration measurements.</description>
+    <code>0x041D</code>
+    <define>HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="HALOACETIC_ACIDS_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Total Trihalomethanes Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Total Trihalomethanes concentration and reporting concentration measurements.</description>
+    <code>0x041E</code>
+    <define>TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TOTAL_TRIHALOMETHANES_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Total Coliform Bacteria Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Total Coliform Bacteria concentration and reporting concentration measurements.</description>
+    <code>0x041F</code>
+    <define>TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TOTAL_COLIFORM_BACTERIA_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Turbidity Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Turbidity concentration and reporting concentration measurements.</description>
+    <code>0x0420</code>
+    <define>TURBIDITY_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="TURBIDITY_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="TURBIDITY_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Copper Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Copper concentration and reporting concentration measurements.</description>
+    <code>0x0421</code>
+    <define>COPPER_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="COPPER_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="COPPER_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="COPPER_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="COPPER_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Lead Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Lead concentration and reporting concentration measurements.</description>
+    <code>0x0422</code>
+    <define>LEAD_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="LEAD_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="LEAD_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="LEAD_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="LEAD_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Manganese Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Manganese concentration and reporting concentration measurements.</description>
+    <code>0x0423</code>
+    <define>MANGANESE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="MANGANESE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="MANGANESE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="MANGANESE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="MANGANESE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sulfate Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sulfate concentration and reporting concentration measurements.</description>
+    <code>0x0424</code>
+    <define>SULFATE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="SULFATE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SULFATE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SULFATE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SULFATE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromodichloromethane Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromodichloromethane concentration and reporting concentration measurements.</description>
+    <code>0x0425</code>
+    <define>BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMODICHLOROMETHANE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Bromoform Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Bromoform concentration and reporting concentration measurements.</description>
+    <code>0x0426</code>
+    <define>BROMOFORM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="BROMOFORM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="BROMOFORM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chlorodibromomethane Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chlorodibromomethane concentration and reporting concentration measurements.</description>
+    <code>0x0427</code>
+    <define>CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLORODIBROMOMETHANE_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Chloroform Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Chloroform concentration and reporting concentration measurements.</description>
+    <code>0x0428</code>
+    <define>CHLOROFORM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="CHLOROFORM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>Sodium Concentration Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the Sodium concentration and reporting concentration measurements.</description>
+    <code>0x0429</code>
+    <define>SODIUM_CONCENTRATION_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="half" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="SODIUM_CONCENTRATION_MEASUREMENT_MEASURED_VALUE" type="FLOAT_SINGLE" writable="false" reportable="true" optional="false">measured value</attribute>
+    <!-- MEASURED_VALUE -->
+    <attribute side="server" code="0x0001" define="SODIUM_CONCENTRATION_MEASUREMENT_MIN_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">min measured value</attribute>
+    <!-- MIN_MEASURED_VALUE -->
+    <attribute side="server" code="0x0002" define="SODIUM_CONCENTRATION_MEASUREMENT_MAX_MEASURED_VALUE" type="FLOAT_SINGLE" min="0x0000" max="0x3F800000" writable="false" optional="false">max measured value</attribute>
+    <!-- MAX_MEASURED_VALUE -->
+    <attribute side="server" code="0x0003" define="SODIUM_CONCENTRATION_MEASUREMENT_TOLERANCE" type="FLOAT_SINGLE" min="0x0000" max="0x0800" writable="false" optional="true">tolerance</attribute>
+    <!-- TOLERANCE -->
+  </cluster>
+  <cluster>
+    <name>IAS Zone</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS security zone devices.</description>
+    <code>0x0500</code>
+    <define>IAS_ZONE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="ZONE_STATE" type="ENUM8" writable="false" default="0x00" optional="false">zone state</attribute>
+    <attribute side="server" code="0x0001" define="ZONE_TYPE" type="ENUM16" writable="false" optional="false">zone type</attribute>
+    <attribute side="server" code="0x0002" define="ZONE_STATUS" type="BITMAP16" writable="false" default="0x0000" optional="false">zone status</attribute>
+    <attribute side="server" code="0x0010" define="IAS_CIE_ADDRESS" type="IEEE_ADDRESS" writable="true" optional="false">IAS CIE address</attribute>
+    <attribute side="server" code="0x0011" define="ZONE_ID" type="INT8U" writable="false" default="0xff" optional="false">Zone ID</attribute>
+    <attribute side="server" code="0x0012" define="NUMBER_OF_ZONE_SENSITIVITY_LEVELS_SUPPORTED" type="INT8U" writable="false" default="0x02" optional="true">Number of Zone Sensitivity Levels Supported</attribute>
+    <attribute side="server" code="0x0013" define="CURRENT_ZONE_SENSITIVITY_LEVEL" type="INT8U" writable="true" default="0x00" optional="true">Current Zone Sensitivity Level</attribute>
+    <command source="client" code="0x00" name="ZoneEnrollResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for zoneEnrollResponse
+      </description>
+      <arg name="enrollResponseCode" type="IasEnrollResponseCode"/>
+      <arg name="zoneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="InitiateNormalOperationMode" optional="true">
+      <description>
+        Used to tell the IAS Zone server to commence normal operation mode
+      </description>
+    </command>
+    <command source="client" code="0x02" name="InitiateTestMode" optional="true">
+      <description>
+        Certain IAS Zone servers may have operational configurations that could be configured OTA or locally on the device. This command enables them to be remotely placed into a test mode so that the user or installer may configure their field of view, sensitivity, and other operational parameters.
+      </description>
+      <arg name="testModeDuration" type="INT8U"/>
+      <arg name="currentZoneSensitivityLevel" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="ZoneStatusChangeNotification" optional="false" cli="zcl ias-zone sc">
+      <description>
+        Command description for zoneStatusChangeNotification
+      </description>
+      <arg name="zoneStatus" type="IasZoneStatus"/>
+      <arg name="extendedStatus" type="BITMAP8"/>
+      <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="delay" type="INT16U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x01" name="ZoneEnrollRequest" optional="false" cli="zcl ias-zone enroll">
+      <description>
+        Command description for zoneEnrollRequest
+      </description>
+      <arg name="zoneType" type="IasZoneType"/>
+      <arg name="manufacturerCode" type="INT16U"/>
+    </command>
+    <command source="server" code="0x02" name="InitiateNormalOperationModeResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Confirms that the IAS Zone server has commenced normal operation mode.
+      </description>
+    </command>
+    <command source="server" code="0x03" name="InitiateTestModeResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Confirms that the IAS Zone server has commenced test mode and that the IAS Zone client should treat any Zone Status Change Notification commands received from the sending IAS Zone server as being in response to test events.
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>IAS ACE</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS Ancillary Control Equipment.</description>
+    <code>0x0501</code>
+    <define>IAS_ACE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="Arm" optional="false" cli="zcl ias-ace a">
+      <description>
+        Command description for Arm
+      </description>
+      <arg name="armMode" type="IasAceArmMode"/>
+      <arg name="armDisarmCode" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="zoneId" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="Bypass" optional="false" cli="zcl ias-ace b">
+      <description>
+        Command description for Bypass
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneIds" type="INT8U" array="true" countArg="numberOfZones"/>
+      <arg name="armDisarmCode" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="client" code="0x02" name="Emergency" optional="false" cli="zcl ias-ace e">
+      <description>
+        Command description for Emergency
+      </description>
+    </command>
+    <command source="client" code="0x03" name="Fire" optional="false" cli="zcl ias-ace f">
+      <description>
+        Command description for Fire
+      </description>
+    </command>
+    <command source="client" code="0x04" name="Panic" optional="false" cli="zcl ias-ace p">
+      <description>
+        Command description for Panic
+      </description>
+    </command>
+    <command source="client" code="0x05" name="GetZoneIdMap" optional="false" cli="zcl ias-ace getzm">
+      <description>
+        Command description for GetZoneIdMap
+      </description>
+    </command>
+    <command source="client" code="0x06" name="GetZoneInformation" optional="false" cli="zcl ias-ace getzi">
+      <description>
+        Command description for GetZoneInformation
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="GetPanelStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to request an update to the status of the ACE server
+      </description>
+    </command>
+    <command source="client" code="0x08" name="GetBypassedZoneList" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to retrieve the bypassed zones
+        </description>
+    </command>
+    <command source="client" code="0x09" name="GetZoneStatus" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+        Used by the ACE client to request an update to the zone status of the ACE server
+      </description>
+      <arg name="startingZoneId" type="INT8U"/>
+      <arg name="maxNumberOfZoneIds" type="INT8U"/>
+      <arg name="zoneStatusMaskFlag" type="BOOLEAN"/>
+      <arg name="zoneStatusMask" type="BITMAP16"/>
+    </command>
+    <command source="server" code="0x00" name="ArmResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for ArmResponse
+      </description>
+      <arg name="armNotification" type="IasAceArmNotification"/>
+    </command>
+    <command source="server" code="0x01" name="GetZoneIdMapResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetZoneIdMapResponse
+      </description>
+      <arg name="section0" type="BITMAP16"/>
+      <arg name="section1" type="BITMAP16"/>
+      <arg name="section2" type="BITMAP16"/>
+      <arg name="section3" type="BITMAP16"/>
+      <arg name="section4" type="BITMAP16"/>
+      <arg name="section5" type="BITMAP16"/>
+      <arg name="section6" type="BITMAP16"/>
+      <arg name="section7" type="BITMAP16"/>
+      <arg name="section8" type="BITMAP16"/>
+      <arg name="section9" type="BITMAP16"/>
+      <arg name="section10" type="BITMAP16"/>
+      <arg name="section11" type="BITMAP16"/>
+      <arg name="section12" type="BITMAP16"/>
+      <arg name="section13" type="BITMAP16"/>
+      <arg name="section14" type="BITMAP16"/>
+      <arg name="section15" type="BITMAP16"/>
+    </command>
+    <command source="server" code="0x02" name="GetZoneInformationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GetZoneInformationResponse
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+      <arg name="zoneType" type="IasZoneType"/>
+      <arg name="ieeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="zoneLabel" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x03" name="ZoneStatusChanged" optional="false">
+      <description>
+        This command updates ACE clients in the system of changes to zone status recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="zoneId" type="INT8U"/>
+      <arg name="zoneStatus" type="ENUM16"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification" introducedIn="ha-1.2.1-05-3520-30"/>
+      <arg name="zoneLabel" type="CHAR_STRING" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x04" name="PanelStatusChanged" optional="false">
+      <description>
+        This command updates ACE clients in the system of changes to panel status recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="panelStatus" type="IasAcePanelStatus"/>
+      <arg name="secondsRemaining" type="INT8U"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification" introducedIn="ha-1.2.1-05-3520-30"/>
+      <arg name="alarmStatus" type="IasAceAlarmStatus" introducedIn="ha-1.2.1-05-3520-30"/>
+    </command>
+    <command source="server" code="0x05" name="GetPanelStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        Command updates requesting IAS ACE clients in the system of changes to the security panel status recorded by the ACE server.
+      </description>
+      <arg name="panelStatus" type="IasAcePanelStatus"/>
+      <arg name="secondsRemaining" type="INT8U"/>
+      <arg name="audibleNotification" type="IasAceAudibleNotification"/>
+      <arg name="alarmStatus" type="IasAceAlarmStatus"/>
+    </command>
+    <command source="server" code="0x06" name="SetBypassedZoneList" optional="false" introducedIn="ha-1.2.1-05-3520-30">
+      <description>
+       Sets the list of bypassed zones on the IAS ACE client
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneIds" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="BypassResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        Provides the response of the security panel to the request from the IAS ACE client to bypass zones via a Bypass command.
+      </description>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="bypassResult" type="IasAceBypassResult" array="true"/>
+    </command>
+    <command source="server" code="0x08" name="GetZoneStatusResponse" optional="false" introducedIn="ha-1.2.1-05-3520-30" disableDefaultResponse="true">
+      <description>
+        This command updates requesting IAS ACE clients in the system of changes to the IAS Zone server statuses recorded by the ACE server (e.g., IAS CIE device).
+      </description>
+      <arg name="zoneStatusComplete" type="BOOLEAN"/>
+      <arg name="numberOfZones" type="INT8U"/>
+      <arg name="zoneStatusResult" type="IasAceZoneStatusResult" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>IAS WD</name>
+    <domain>Security &amp; Safety</domain>
+    <description>Attributes and commands for IAS Warning Devices.</description>
+    <code>0x0502</code>
+    <define>IAS_WD_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" tickFrequency="quarter" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="MAX_DURATION" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="240" optional="false">max duration</attribute>
+    <command source="client" code="0x00" name="StartWarning" optional="false">
+      <description>
+        Command description for StartWarning
+      </description>
+      <arg name="warningInfo" type="WarningInfo"/>
+      <arg name="warningDuration" type="INT16U"/>
+      <arg name="strobeDutyCycle" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="strobeLevel" type="ENUM8" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="Squawk" optional="false">
+      <description>
+        Command description for Squawk
+      </description>
+      <arg name="squawkInfo" type="SquawkInfo"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Door Lock</name>
+    <domain>Closures</domain>
+    <description>Provides an interface into a generic way to secure a door. </description>
+    <code>0x0101</code>
+    <define>DOOR_LOCK_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="LOCK_STATE" type="ENUM8" writable="false" reportable="true" optional="false">lock state</attribute>
+    <attribute side="server" code="0x0001" define="LOCK_TYPE" type="ENUM8" writable="false" optional="false">lock type</attribute>
+    <attribute side="server" code="0x0002" define="ACTUATOR_ENABLED" type="BOOLEAN" writable="false" optional="false">actuator enabled</attribute>
+    <attribute side="server" code="0x0003" define="DOOR_STATE" type="ENUM8" writable="false" reportable="true" optional="true">door state</attribute>
+    <attribute side="server" code="0x0004" define="DOOR_OPEN_EVENTS" type="INT32U" writable="true" optional="true">door open events</attribute>
+    <attribute side="server" code="0x0005" define="DOOR_CLOSED_EVENTS" type="INT32U" writable="true" optional="true">door closed events</attribute>
+    <attribute side="server" code="0x0006" define="OPEN_PERIOD" type="INT16U" writable="true" optional="true">open period</attribute>
+    <attribute side="server" code="0x0010" define="NUM_LOCK_RECORDS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num lock records supported</attribute>
+    <attribute side="server" code="0x0011" define="NUM_TOTAL_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num total users supported</attribute>
+    <attribute side="server" code="0x0012" define="NUM_PIN_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num PIN users supported</attribute>
+    <attribute side="server" code="0x0013" define="NUM_RFID_USERS_SUPPORTED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">num RFID users supported</attribute>
+    <attribute side="server" code="0x0014" define="NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num weekday schedules supported per user</attribute>
+    <attribute side="server" code="0x0015" define="NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num yearday schedules supported per user</attribute>
+    <attribute side="server" code="0x0016" define="NUM_HOLIDAY_SCHEDULES_SUPPORTED_PER_USER" type="INT8U" min="0x0000" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">num holiday schedules supported per user</attribute>
+    <attribute side="server" code="0x0017" define="MAX_PIN_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x08" optional="true" introducedIn="ha-1.2-05-3520-29">max pin length</attribute>
+    <attribute side="server" code="0x0018" define="MIN_PIN_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x04" optional="true" introducedIn="ha-1.2-05-3520-29">min pin length</attribute>
+    <attribute side="server" code="0x0019" define="MAX_RFID_CODE_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x14" optional="true" introducedIn="ha-1.2-05-3520-29">max rfid code length</attribute>
+    <attribute side="server" code="0x001A" define="MIN_RFID_CODE_LENGTH" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x08" optional="true" introducedIn="ha-1.2-05-3520-29">min rfid code length</attribute>
+    <attribute side="server" code="0x0020" define="ENABLE_LOGGING" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable logging</attribute>
+    <attribute side="server" code="0x0021" define="LANGUAGE" type="CHAR_STRING" length="2" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">language</attribute>
+    <attribute side="server" code="0x0022" define="LED_SETTINGS" type="INT8U" min="0x00" max="0x02" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">led settings</attribute>
+    <attribute side="server" code="0x0023" define="AUTO_RELOCK_TIME" type="INT32U" min="0x00" max="0xFFFFFFFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">auto relock time</attribute>
+    <attribute side="server" code="0x0024" define="SOUND_VOLUME" type="INT8U" min="0x00" max="0x02" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">sound volume</attribute>
+    <attribute side="server" code="0x0025" define="OPERATING_MODE" type="ENUM8" min="0x00" max="0x05" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">operating mode</attribute>
+    <attribute side="server" code="0x0026" define="SUPPORTED_OPERATING_MODES" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" default="0x01" optional="true" introducedIn="ha-1.2-05-3520-29">supported operating modes</attribute>
+    <attribute side="server" code="0x0027" define="DEFAULT_CONFIGURATION_REGISTER" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">default configuration register</attribute>
+    <attribute side="server" code="0x0028" define="ENABLE_LOCAL_PROGRAMMING" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x01" optional="true" introducedIn="ha-1.2-05-3520-29">enable local programming</attribute>
+    <attribute side="server" code="0x0029" define="ENABLE_ONE_TOUCH_LOCKING" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable one touch locking</attribute>
+    <attribute side="server" code="0x002A" define="ENABLE_INSIDE_STATUS_LED" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable inside status led</attribute>
+    <attribute side="server" code="0x002B" define="ENABLE_PRIVACY_MODE_BUTTON" type="BOOLEAN" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">enable privacy mode button</attribute>
+    <attribute side="server" code="0x0030" define="WRONG_CODE_ENTRY_LIMIT" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">wrong code entry limit</attribute>
+    <attribute side="server" code="0x0031" define="USER_CODE_TEMPORARY_DISABLE_TIME" type="INT8U" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">user code temporary disable time</attribute>
+    <attribute side="server" code="0x0032" define="SEND_PIN_OVER_THE_AIR" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">send pin over the air</attribute>
+    <attribute side="server" code="0x0033" define="REQUIRE_PIN_FOR_RF_OPERATION" type="BOOLEAN" min="0x00" max="0x01" writable="true" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">require pin for rf operation</attribute>
+    <attribute side="server" code="0x0034" define="ZIGBEE_SECURITY_LEVEL" type="ENUM8" min="0x00" max="0xFF" writable="false" reportable="true" default="0x00" optional="true" introducedIn="ha-1.2-05-3520-29">zigbee security level</attribute>
+    <attribute side="server" code="0x0040" define="DOOR_LOCK_ALARM_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">alarm mask</attribute>
+    <attribute side="server" code="0x0041" define="KEYPAD_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">keypad operation event mask</attribute>
+    <attribute side="server" code="0x0042" define="RF_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">RF operation event mask</attribute>
+    <attribute side="server" code="0x0043" define="MANUAL_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">manual operation event mask</attribute>
+    <attribute side="server" code="0X0044" define="RFID_OPERATION_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rfid operation event mask</attribute>
+    <attribute side="server" code="0x0045" define="KEYPAD_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">keypad programming event mask</attribute>
+    <attribute side="server" code="0X0046" define="RF_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rf programming event mask</attribute>
+    <attribute side="server" code="0X0047" define="RFID_PROGRAMMING_EVENT_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" reportable="true" default="0x0000" optional="true" introducedIn="ha-1.2-05-3520-29">rfid programming event mask</attribute>
+    <command source="client" code="0x00" name="LockDoor" optional="false" cli="zcl lock lock">
+      <description>
+        Locks the door
+      </description>
+      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x01" name="UnlockDoor" optional="false" cli="zcl lock unlock">
+      <description>
+        Unlocks the door
+      </description>
+      <arg name="PIN" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x02" name="Toggle" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Toggles the door lock from its current state to the opposite state locked or unlocked.
+       </description>
+      <arg name="pin" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x03" name="UnlockWithTimeout" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock unlock-with-timeout">
+      <description>
+         Unlock the door with a timeout. When the timeout expires, the door will automatically re-lock.
+       </description>
+      <arg name="timeoutInSeconds" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="client" code="0x04" name="GetLogRecord" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-log-record">
+      <description>
+         Retrieve a log record at a specified index.
+       </description>
+      <arg name="logIndex" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="SetPin" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-pin">
+      <description>
+         Set the PIN for a specified user id.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x06" name="GetPin" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-pin">
+      <description>
+         Retrieve PIN information for a user with a specific user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="ClearPin" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-pin">
+      <description>
+         Clear the PIN for a user with a specific user ID
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="ClearAllPins" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Clear all PIN codes on the lock for all users.
+       </description>
+    </command>
+    <command source="client" code="0x09" name="SetUserStatus" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Set the status value for a specified user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0A" name="GetUserStatus" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Retrieve the status byte for a specific user.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0B" name="SetWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-weekday-schedule">
+      <description>
+         Set the schedule of days during the week that the associated user based on the user ID will have access to the lock and will be able to operate it.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="daysMask" type="DoorLockDayOfWeek"/>
+      <arg name="startHour" type="INT8U"/>
+      <arg name="startMinute" type="INT8U"/>
+      <arg name="endHour" type="INT8U"/>
+      <arg name="endMinute" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0C" name="GetWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-weekday-schedule">
+      <description>
+         Retrieve a weekday schedule for doorlock user activation for a specific schedule id and user id.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0D" name="ClearWeekdaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-weekday-schedule">
+      <description>
+         Clear a weekday schedule for doorlock user activation for a specific schedule id and user id.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0E" name="SetYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-yearday-schedule">
+      <description>
+         Set a door lock user id activation schedule according to a specific absolute local start and end time
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="localStartTime" type="INT32U"/>
+      <arg name="localEndTime" type="INT32U"/>
+    </command>
+    <command source="client" code="0x0F" name="GetYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-yearday-schedule">
+      <description>
+         Retrieve a yearday schedule for a specific scheduleId and userId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x10" name="ClearYeardaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-yearday-schedule">
+      <description>
+         Clear a yearday schedule for a specific scheduleId and userId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x11" name="SetHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-holiday-schedule">
+      <description>
+         Set the holiday schedule for a specific user
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U"/>
+      <arg name="localEndTime" type="INT32U"/>
+      <arg name="operatingModeDuringHoliday" type="ENUM8"/>
+    </command>
+    <command source="client" code="0x12" name="GetHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-holiday-schedule">
+      <description>
+         Retrieve a holiday schedule for a specific scheduleId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x13" name="ClearHolidaySchedule" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-holiday-schedule">
+      <description>
+         Clear a holiday schedule for a specific scheduleId
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x14" name="SetUserType" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-user-type">
+      <description>
+         Set the type value for a user based on user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userType" type="DoorLockUserType"/>
+    </command>
+    <command source="client" code="0x15" name="GetUserType" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-user-type">
+      <description>
+         Retrieve the type for a specific user based on the user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x16" name="SetRfid" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock set-rfid">
+      <description>
+         Set the PIN for a specified user id.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="id" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x17" name="GetRfid" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock get-rfid">
+      <description>
+         Retrieve RFID ID information for a user with a specific user ID.
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x18" name="ClearRfid" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-rfid">
+      <description>
+         Clear the RFID ID for a user with a specific user ID
+       </description>
+      <arg name="userId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x19" name="ClearAllRfids" optional="true" introducedIn="ha-1.2-05-3520-29" cli="zcl lock clear-all-rfids">
+      <description>
+         Clear all RFID ID codes on the lock for all users.
+       </description>
+    </command>
+    <command source="server" code="0x00" name="LockDoorResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Indicates lock success or failure
+      </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="UnlockDoorResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Indicates unlock success or failure
+      </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x02" name="ToggleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Response provided to the toggle command, indicates whether the toggle was successful or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x03" name="UnlockWithTimeoutResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Response provided to unlock with specific timeout. This command indicates whether the unlock command was successful or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x04" name="GetLogRecordResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the specific log record requested.
+       </description>
+      <arg name="logEntryId" type="INT16U"/>
+      <arg name="timestamp" type="INT32U"/>
+      <arg name="eventType" type="ENUM8"/>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventIdOrAlarmCode" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x05" name="SetPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Indicates whether the setting of the PIN was successful or not.
+       </description>
+      <arg name="status" type="DoorLockSetPinOrIdStatus"/>
+    </command>
+    <command source="server" code="0x06" name="GetPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the PIN requested according to the user ID passed.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="pin" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x07" name="ClearPinResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the PIN was cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x08" name="ClearAllPinsResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the PINs were cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x09" name="SetUserStatusResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the user status was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0A" name="GetUserStatusResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the user status.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0B" name="SetWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the status of setting the weekday schedule
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0C" name="GetWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the weekday schedule requested.
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="daysMask" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="startHour" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="startMinute" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="endHour" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="endMinute" type="INT8U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x0D" name="ClearWeekdayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the status of clearing the weekday schedule
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0E" name="SetYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the yearday schedule was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x0F" name="GetYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the yearday schedule requested
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="localEndTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x10" name="ClearYeardayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the yearday schedule was removed or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x11" name="SetHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the holiday schedule was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x12" name="GetHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the holiday schedule requested
+       </description>
+      <arg name="scheduleId" type="INT8U"/>
+      <arg name="status" type="INT8U"/>
+      <arg name="localStartTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="localEndTime" type="INT32U" introducedIn="ha-1.2-05-3520-29"/>
+      <arg name="operatingModeDuringHoliday" type="ENUM8" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x13" name="ClearHolidayScheduleResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the holiday schedule was removed or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x14" name="SetUserTypeResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         returns success or failure depending on whether the user type was set or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x15" name="GetUserTypeResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the user type for the user ID requested.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userType" type="DoorLockUserType"/>
+    </command>
+    <command source="server" code="0x16" name="SetRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+          Indicates whether the setting of the RFID ID was successful or not.
+        </description>
+      <arg name="status" type="DoorLockSetPinOrIdStatus"/>
+    </command>
+    <command source="server" code="0x17" name="GetRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns the RFID ID requested according to the user ID passed.
+       </description>
+      <arg name="userId" type="INT16U"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="rfid" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x18" name="ClearRfidResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the RFID ID was cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x19" name="ClearAllRfidsResponse" optional="true" introducedIn="ha-1.2-05-3520-29" disableDefaultResponse="true">
+      <description>
+         Returns success or failure depending on whether the RFID IDs were cleared or not.
+       </description>
+      <arg name="status" type="INT8U"/>
+    </command>
+    <command source="server" code="0x20" name="OperationEventNotification" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Indicates that an operation event has taken place. Includes the associated event information.
+       </description>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventCode" type="DoorLockOperationEventCode"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="timeStamp" type="INT32U"/>
+      <arg name="data" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+    <command source="server" code="0x21" name="ProgrammingEventNotification" optional="true" introducedIn="ha-1.2-05-3520-29">
+      <description>
+         Indicates that a programming event has taken place. Includes the associated programming event information.
+       </description>
+      <arg name="source" type="INT8U"/>
+      <arg name="eventCode" type="DoorLockProgrammingEventCode"/>
+      <arg name="userId" type="INT16U"/>
+      <arg name="pin" type="CHAR_STRING"/>
+      <arg name="userType" type="DoorLockUserType"/>
+      <arg name="userStatus" type="DoorLockUserStatus"/>
+      <arg name="timeStamp" type="INT32U"/>
+      <arg name="data" type="CHAR_STRING" introducedIn="ha-1.2-05-3520-29"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Window Covering</name>
+    <domain>Closures</domain>
+    <description>Provides an interface for controlling and adjusting automatic window coverings. </description>
+    <code>0x0102</code>
+    <define>WINDOW_COVERING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="COVERING_TYPE" type="ENUM8" min="0x00" max="0x09" writable="false" default="0x00" optional="false">window covering type</attribute>
+    <attribute side="server" code="0x0001" define="LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">physical closed limit - lift</attribute>
+    <attribute side="server" code="0x0002" define="LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">physical closed limit - tilt</attribute>
+    <attribute side="server" code="0x0003" define="CURRENT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">current position - lift</attribute>
+    <attribute side="server" code="0x0004" define="CURRENT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">current position - tilt</attribute>
+    <attribute side="server" code="0x0005" define="NUMBER_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of actuations - lift</attribute>
+    <attribute side="server" code="0x0006" define="NUMBER_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of actuations - tilt</attribute>
+    <attribute side="server" code="0x0007" define="CONFIG_STATUS" type="BITMAP8" min="0x00" max="0x7F" writable="false" default="0x03" optional="false">config status</attribute>
+    <attribute side="server" code="0x0008" define="CURRENT_LIFT_PERCENTAGE" type="INT8U" min="0x00" max="0x64" writable="false" default="0xFF" optional="true">current position lift percentage</attribute>
+    <attribute side="server" code="0x0009" define="CURRENT_TILT_PERCENTAGE" type="INT8U" min="0x00" max="0x64" writable="false" default="0xFF" optional="true">current position tilt percentage</attribute>
+    <attribute side="server" code="0x0010" define="OPEN_LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">installed open limit - lift</attribute>
+    <attribute side="server" code="0x0011" define="CLOSED_LIMIT_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0xFFFF" optional="false">installed closed limit - lift</attribute>
+    <attribute side="server" code="0x0012" define="OPEN_LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">installed open limit - tilt</attribute>
+    <attribute side="server" code="0x0013" define="CLOSED_LIMIT_TILT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0xFFFF" optional="false">installed closed limit - tilt</attribute>
+    <attribute side="server" code="0x0014" define="VELOCITY_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">velocity - lift</attribute>
+    <attribute side="server" code="0x0015" define="ACCELERATION_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">acceleration time - lift</attribute>
+    <attribute side="server" code="0x0016" define="DECELERATION_LIFT" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">deceleration time - lift</attribute>
+    <attribute side="server" code="0x0017" define="MODE" type="BITMAP8" min="0x00" max="0xE0" writable="true" default="0x14" optional="false">mode</attribute>
+    <attribute side="server" code="0x0018" define="SETPOINTS_LIFT" type="OCTET_STRING" length="254" writable="true" default="1,0x0000" optional="true">intermediate setpoints - lift</attribute>
+    <attribute side="server" code="0x0019" define="SETPOINTS_TILT" type="OCTET_STRING" length="254" writable="true" default="1,0x0000" optional="true">intermediate setpoints - tilt</attribute>
+    <command source="client" code="0x00" name="WindowCoveringUpOpen" optional="false" cli="zcl window-covering up">
+      <description>
+        Moves window covering to InstalledOpenLimit - Lift and InstalledOpenLimit - Tilt
+      </description>
+    </command>
+    <command source="client" code="0x01" name="WindowCoveringDownClose" optional="false" cli="zcl window-covering down">
+      <description>
+        Moves window covering to InstalledClosedLimit - Lift and InstalledCloseLimit - Tilt
+      </description>
+    </command>
+    <command source="client" code="0x02" name="WindowCoveringStop" optional="false" cli="zcl window-covering stop">
+      <description>
+        Stop any adjusting of window covering
+      </description>
+    </command>
+    <command source="client" code="0x04" name="WindowCoveringGoToLiftValue" optional="true" cli="zcl window-covering go-to-lift-value">
+      <description>
+        Goto lift value specified
+      </description>
+      <arg name="liftValue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x05" name="WindowCoveringGoToLiftPercentage" optional="true" cli="zcl window-covering go-to-lift-percent">
+      <description>
+        Goto lift percentage specified
+      </description>
+      <arg name="percentageLiftValue" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="WindowCoveringGoToTiltValue" optional="true" cli="zcl window-covering go-to-tilt-value">
+      <description>
+        Goto tilt value specified
+      </description>
+      <arg name="tiltValue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="WindowCoveringGoToTiltPercentage" optional="true" cli="zcl window-covering go-to-tilt-percentage">
+      <description>
+        Goto tilt percentage specified
+      </description>
+      <arg name="percentageTiltValue" type="INT8U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Barrier Control</name>
+    <domain>Closures</domain>
+    <description>This cluster provides control of a barrier (garage door).</description>
+    <code>0x0103</code>
+    <define>BARRIER_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0001" define="BARRIER_MOVING_STATE" type="ENUM8" min="0x00" max="0xFF" writable="false" optional="false">barrier moving state</attribute>
+    <attribute side="server" code="0x0002" define="BARRIER_SAFETY_STATUS" type="BITMAP16" min="0x0000" max="0xFFFF" writable="false" optional="false">barrier safety status</attribute>
+    <attribute side="server" code="0x0003" define="BARRIER_CAPABILITIES" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">barrier capabilities</attribute>
+    <attribute side="server" code="0x0004" define="BARRIER_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier open events</attribute>
+    <attribute side="server" code="0x0005" define="BARRIER_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier close events</attribute>
+    <attribute side="server" code="0x0006" define="BARRIER_COMMAND_OPEN_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command open events</attribute>
+    <attribute side="server" code="0x0007" define="BARRIER_COMMAND_CLOSE_EVENTS" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0000" optional="true">barrier command close events</attribute>
+    <attribute side="server" code="0x0008" define="BARRIER_OPEN_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier open period</attribute>
+    <attribute side="server" code="0x0009" define="BARRIER_CLOSE_PERIOD" type="INT16U" min="0x0000" max="0xFFFE" writable="true" optional="true">barrier close period</attribute>
+    <attribute side="server" code="0x000A" define="BARRIER_POSITION" type="INT8U" min="0x0000" max="0xFF" writable="false" optional="false">barrier position</attribute>
+    <command source="client" code="0x00" name="BarrierControlGoToPercent" optional="false" cli="zcl barrier-control go-to-percent">
+      <description>
+        Command to instruct a barrier to go to a percent open state.
+      </description>
+      <arg name="percentOpen" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="BarrierControlStop" optional="false" cli="zcl barrier-control stop">
+      <description>
+        Command that instructs the barrier to stop moving.
+      </description>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Control</name>
+    <domain>General</domain>
+    <description>This cluster provides an interface to remotely control and to program household appliances.</description>
+    <code>0x001B</code>
+    <define>APPLIANCE_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="START_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">start time</attribute>
+    <attribute side="server" code="0x0001" define="FINISH_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="false">finish time</attribute>
+    <attribute side="server" code="0x0002" define="REMAINING_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" reportable="true" default="0x0000" optional="true">remaining time</attribute>
+    <command source="client" code="0x00" name="ExecutionOfACommand" optional="false">
+      <description>
+        This basic message is used to remotely control and to program household appliances.
+      </description>
+      <arg name="commandId" type="CommandIdentification"/>
+    </command>
+    <command source="client" code="0x01" name="SignalState" optional="false">
+      <description>
+        This basic message is used to retrieve Household Appliances status.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="WriteFunctions" optional="true">
+      <description>
+        This basic message is used to set appliance functions, i.e. information regarding the execution of an appliance cycle.  Condition parameters such as start time or finish time information could be provided through this command.
+      </description>
+      <arg name="functionId" type="INT16U"/>
+      <arg name="functionDataType" type="ENUM8"/>
+      <arg name="functionData" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="OverloadPauseResume" optional="true">
+      <description>
+        This command shall be used to resume the normal behavior of a household appliance being in pause mode after receiving a Overload Pause command.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="OverloadPause" optional="true">
+      <description>
+        This command shall be used to pause the household appliance as a consequence of an imminent overload event.
+      </description>
+    </command>
+    <command source="client" code="0x05" name="OverloadWarning" optional="true">
+      <description>
+        This basic message is used to send warnings the household appliance as a consequence of a possible overload event, or the notification of the end of the warning state.
+      </description>
+      <arg name="warningEvent" type="WarningEvent"/>
+    </command>
+    <command source="server" code="0x00" name="SignalStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command shall be used to return household appliance status, according to Appliance Status Values and Remote Enable Flags Values.
+      </description>
+      <arg name="applianceStatus" type="ApplianceStatus"/>
+      <arg name="remoteEnableFlagsAndDeviceStatus2" type="RemoteEnableFlagsAndDeviceStatus2"/>
+      <arg name="applianceStatus2" type="INT24U"/>
+      <!-- optional -->
+    </command>
+    <command source="server" code="0x01" name="SignalStateNotification" optional="false">
+      <description>
+        This command shall be used to return household appliance status, automatically when appliance status changes.
+      </description>
+      <arg name="applianceStatus" type="ApplianceStatus"/>
+      <arg name="remoteEnableFlagsAndDeviceStatus2" type="RemoteEnableFlagsAndDeviceStatus2"/>
+      <arg name="applianceStatus2" type="INT24U"/>
+      <!-- optional -->
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Power Profile</name>
+    <domain>General</domain>
+    <description>This cluster provides an interface for transferring power profile information from a device (e.g. Whitegood) to a controller (e.g. the Home Gateway).  The Power Profile transferred can be solicited by client side (request command) or can be notified directly from the device (server side).</description>
+    <code>0x001A</code>
+    <define>POWER_PROFILE_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="TOTAL_PROFILE_NUM" type="INT8U" min="0x01" max="0xFE" writable="false" optional="false">total profile num</attribute>
+    <attribute side="server" code="0x0001" define="MULTIPLE_SCHEDULING" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">multiple scheduling</attribute>
+    <attribute side="server" code="0x0002" define="ENERGY_FORMATTING" type="BITMAP8" min="0x00" max="0xFF" writable="false" default="0x01" optional="false">energy formatting</attribute>
+    <attribute side="server" code="0x0003" define="ENERGY_REMOTE" type="BOOLEAN" min="0x00" max="0x01" writable="false" reportable="true" default="0x00" optional="false">energy remote</attribute>
+    <attribute side="server" code="0x0004" define="SCHEDULE_MODE" type="BITMAP8" min="0x00" max="0xFF" writable="true" reportable="true" default="0x00" optional="false">schedule mode</attribute>
+    <command source="client" code="0x00" name="PowerProfileRequest" optional="false" cli="zcl power-profile profile">
+      <description>
+        The PowerProfileRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the Power Profile of a server device.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="PowerProfileStateRequest" optional="false" cli="zcl power-profile state">
+      <description>
+        The PowerProfileStateRequest Command is generated in order to retrieve the identifiers of current Power Profiles.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="GetPowerProfilePriceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The GetPowerProfilePriceResponse command allows a device (client) to communicate the cost associated to the selected Power Profile to another device (server) requesting it.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="client" code="0x03" name="GetOverallSchedulePriceResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The GetOverallSchedulePriceResponse command allows a device (client) to communicate the overall cost associated to all Power Profiles scheduled to another device (server) requesting it.
+      </description>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="client" code="0x04" name="EnergyPhasesScheduleNotification" optional="false" cli="zcl power-profile energy-phases-schedule">
+      <description>
+        The EnergyPhasesScheduleNotification Command is generated by a device supporting the client side of the Power Profile cluster in order to schedule the start of the selected Power Profile and its phases.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="client" code="0x05" name="EnergyPhasesScheduleResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command is generated by the client side of Power Profile cluster as a reply to the EnergyPhasesScheduleRequest command.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="client" code="0x06" name="PowerProfileScheduleConstraintsRequest" optional="false" cli="zcl power-profile schedule-constraints">
+      <description>
+        The PowerProfileScheduleConstraintsRequest Command is generated by a device supporting the client side of the Power Profile cluster in order to request the constraints -if set- of Power Profile of a client device, in order to set the proper boundaries for the scheduling when calculating the schedules.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x07" name="EnergyPhasesScheduleStateRequest" optional="false" cli="zcl power-profile energy-phases-schedule-states">
+      <description>
+        The EnergyPhasesScheduleStateRequest  Command is generated by a device supporting the client side of the Power Profile cluster to check the states of the scheduling of a power profile, which is supported in the device implementing the server side of Power Profile cluster.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x08" name="GetPowerProfilePriceExtendedResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Get Power Profile Price Extended Response command allows a device (client) to communicate the cost associated to all Power Profiles scheduled to another device (server) requesting it according to the specific options contained in the Get Power Profile Price Extended Response.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="currency" type="INT16U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+    </command>
+    <command source="server" code="0x00" name="PowerProfileNotification" optional="false">
+      <description>
+        The PowerProfileNotification Command is generated by a device supporting the server side of the Power Profile cluster in order to send the information of the specific parameters (such as Peak power and others) belonging to each phase.
+      </description>
+      <arg name="totalProfileNum" type="INT8U"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfTransferredPhases" type="INT8U"/>
+      <arg name="transferredPhases" type="TransferredPhase" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="PowerProfileResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server side of Power Profile cluster as a reply to the PowerProfileRequest command.
+      </description>
+      <arg name="totalProfileNum" type="INT8U"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfTransferredPhases" type="INT8U"/>
+      <arg name="transferredPhases" type="TransferredPhase" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="PowerProfileStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The PowerProfileStateResponse command allows a device (server) to communicate its current Power Profile(s) to another device (client) that previously requested them.
+      </description>
+      <arg name="powerProfileCount" type="INT8U"/>
+      <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="GetPowerProfilePrice" optional="true">
+      <description>
+        The GetPowerProfilePrice Command is generated by the server (e.g. White goods) in order to retrieve the cost associated to a specific Power profile.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x04" name="PowerProfilesStateNotification" optional="false">
+      <description>
+        The PowerProfileStateNotification Command is generated by the server (e.g. White goods) in order to update the state of the power profile and the current energy phase.
+      </description>
+      <arg name="powerProfileCount" type="INT8U"/>
+      <arg name="powerProfileRecords" type="PowerProfileRecord" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="GetOverallSchedulePrice" optional="true">
+      <description>
+        The GetOverallSchedulePrice Command is generated by the server (e.g. White goods) in order to retrieve the overall cost associated to all the Power Profiles scheduled by the scheduler (the device supporting the Power Profile cluster client side) for the next 24 hours.
+      </description>
+    </command>
+    <command source="server" code="0x06" name="EnergyPhasesScheduleRequest" optional="false">
+      <description>
+        The EnergyPhasesScheduleRequest Command is generated by the server (e.g. White goods) in order to retrieve from the scheduler (e.g. Home Gateway) the schedule (if available) associated to the specific Power Profile carried in the payload.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x07" name="EnergyPhasesScheduleStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The EnergyPhasesScheduleStateResponse Command is generated by the server (e.g. White goods) in order to reply to a EnergyPhasesScheduleStateRequest command about the scheduling states that are set in the server side.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="server" code="0x08" name="EnergyPhasesScheduleStateNotification" optional="false">
+      <description>
+        The EnergyPhasesScheduleStateNotification Command is generated by the server (e.g. White goods) in order to notify (un-solicited command) a client side about the scheduling states that are set in the server side.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="numOfScheduledPhases" type="INT8U"/>
+      <arg name="scheduledPhases" type="ScheduledPhase" array="true"/>
+    </command>
+    <command source="server" code="0x09" name="PowerProfileScheduleConstraintsNotification" optional="false">
+      <description>
+        The PowerProfileScheduleConstraintsNotification Command is generated by a device supporting the server side of the Power Profile cluster to notify the client side of this cluster about the imposed constraints and let the scheduler (i.e. the entity supporting the Power Profile cluster client side) to set the proper boundaries for the scheduling.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="startAfter" type="INT16U"/>
+      <arg name="stopBefore" type="INT16U"/>
+    </command>
+    <command source="server" code="0x0A" name="PowerProfileScheduleConstraintsResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The PowerProfileScheduleConstraintsResponse Command is generated by a device supporting the server side of the Power Profile cluster to reply to a client side of this cluster which sent a PowerProfileScheduleConstraintsRequest.
+      </description>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="startAfter" type="INT16U"/>
+      <arg name="stopBefore" type="INT16U"/>
+    </command>
+    <command source="server" code="0x0B" name="GetPowerProfilePriceExtended" optional="true">
+      <description>
+        The Get Power Profile Price Extended command is generated by the server (e.g., White Goods) in order to retrieve the cost associated to a specific Power profile considering specific conditions described in the option field (e.g., a specific time).
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="powerProfileId" type="INT8U"/>
+      <arg name="powerProfileStartTime" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Poll Control</name>
+    <domain>General</domain>
+    <description>This cluster provides a mechanism for the management of an end device's MAC Data Poll rate.  For the purposes of this cluster, the term "poll" always refers to the sending of a MAC Data Poll from the end device to the end device's parent.</description>
+    <code>0x0020</code>
+    <define>POLL_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="CHECK_IN_INTERVAL" type="INT32U" min="0x00000000" max="0x006E0000" writable="true" default="0x00003840" optional="false">check-in interval</attribute>
+    <attribute side="server" code="0x0001" define="LONG_POLL_INTERVAL" type="INT32U" min="0x00000004" max="0x006E0000" writable="false" default="0x00000014" optional="false">long poll interval</attribute>
+    <attribute side="server" code="0x0002" define="SHORT_POLL_INTERVAL" type="INT16U" min="0x0001" max="0xFFFF" writable="false" default="0x0002" optional="false">short poll interval</attribute>
+    <attribute side="server" code="0x0003" define="FAST_POLL_TIMEOUT" type="INT16U" min="0x0001" max="0xFFFF" writable="true" default="0x0028" optional="false">fast poll timeout</attribute>
+    <attribute side="server" code="0x0004" define="CHECK_IN_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">check in interval min</attribute>
+    <attribute side="server" code="0x0005" define="LONG_POLL_INTERVAL_MIN" type="INT32U" writable="false" default="0x00000000" optional="true">long poll interval min</attribute>
+    <attribute side="server" code="0x0006" define="FAST_POLL_TIMEOUT_MAX" type="INT16U" writable="false" default="0x0000" optional="true">fast poll timeout max</attribute>
+    <command source="server" code="0x00" name="CheckIn" optional="false">
+      <description>
+        The Poll Control Cluster server sends out a Check-in command to the devices to which it is paired based on the server's Check-in Interval attribute.
+      </description>
+    </command>
+    <command source="client" code="0x00" name="CheckInResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Check-in Response is sent in response to the receipt of a Check-in command.
+      </description>
+      <arg name="startFastPolling" type="BOOLEAN"/>
+      <arg name="fastPollTimeout" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="FastPollStop" optional="false" cli="zcl poll-control stop">
+      <description>
+        The Fast Poll Stop command is used to stop the fast poll mode initiated by the Check-in response.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="SetLongPollInterval" optional="true" cli="zcl poll-control long">
+      <description>
+        The Set Long Poll Interval command is used to set the read only Long Poll Interval Attribute.
+      </description>
+      <arg name="newLongPollInterval" type="INT32U"/>
+    </command>
+    <command source="client" code="0x03" name="SetShortPollInterval" optional="true" cli="zcl poll-control short">
+      <description>
+        The Set Short Poll Interval command is used to set the read only Short Poll Interval Attribute.
+      </description>
+      <arg name="newShortPollInterval" type="INT16U"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Identification</name>
+    <domain>Home Automation</domain>
+    <description>Attributes and commands for determining basic information about a device and setting user device information.</description>
+    <code>0x0B00</code>
+    <define>APPLIANCE_IDENTIFICATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="BASIC_IDENTIFICATION" type="INT56U" writable="false" optional="false">basic identification</attribute>
+    <attribute side="server" code="0x0010" define="APPLIANCE_COMPANY_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">company name</attribute>
+    <attribute side="server" code="0x0011" define="COMPANY_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">company id</attribute>
+    <attribute side="server" code="0x0012" define="BRAND_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">brand name</attribute>
+    <attribute side="server" code="0x0013" define="BRAND_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">brand id</attribute>
+    <attribute side="server" code="0x0014" define="APPLIANCE_MODEL" type="OCTET_STRING" length="16" writable="false" optional="true">model</attribute>
+    <attribute side="server" code="0x0015" define="APPLIANCE_PART_NUMBER" type="OCTET_STRING" length="16" writable="false" optional="true">part number</attribute>
+    <attribute side="server" code="0x0016" define="APPLIANCE_PRODUCT_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">product revision</attribute>
+    <attribute side="server" code="0x0017" define="APPLIANCE_SOFTWARE_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">software revision</attribute>
+    <attribute side="server" code="0x0018" define="PRODUCT_TYPE_NAME" type="OCTET_STRING" length="2" writable="false" optional="true">product type name</attribute>
+    <attribute side="server" code="0x0019" define="PRODUCT_TYPE_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">product type id</attribute>
+    <attribute side="server" code="0x001A" define="CECED_SPECIFICATION_VERSION" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">ceced specification version</attribute>
+  </cluster>
+  <!-- METER IDENTIFICATION -->
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Meter Identification</name>
+    <domain>Home Automation</domain>
+    <description>This cluster provides Attributes and commands for determining advanced information about utility metering device.</description>
+    <code>0x0B01</code>
+    <define>METER_IDENTIFICATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="2"/>
+    <attribute side="server" code="0x0000" define="METER_COMPANY_NAME" type="CHAR_STRING" length="16" writable="false" optional="false">company name</attribute>
+    <attribute side="server" code="0x0001" define="METER_TYPE_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">meter type id</attribute>
+    <attribute side="server" code="0x0004" define="DATA_QUALITY_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">data quality id</attribute>
+    <attribute side="server" code="0x0005" define="CUSTOMER_NAME" type="CHAR_STRING" length="16" writable="true" optional="true">customer name</attribute>
+    <attribute side="server" code="0x0006" define="METER_MODEL" type="OCTET_STRING" length="16" writable="false" optional="true">model</attribute>
+    <attribute side="server" code="0x0007" define="METER_PART_NUMBER" type="OCTET_STRING" length="16" writable="false" optional="true">part number</attribute>
+    <attribute side="server" code="0x0008" define="METER_PRODUCT_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">product revision</attribute>
+    <attribute side="server" code="0x000A" define="METER_SOFTWARE_REVISION" type="OCTET_STRING" length="6" writable="false" optional="true">software revision</attribute>
+    <attribute side="server" code="0x000B" define="UTILITY_NAME" type="CHAR_STRING" length="16" writable="false" optional="true">utility name</attribute>
+    <attribute side="server" code="0x000C" define="POD" type="CHAR_STRING" length="16" writable="false" optional="false">pod</attribute>
+    <attribute side="server" code="0x000D" define="AVAILABLE_POWER" type="INT24S" min="0x000000" max="0xFFFFFF" writable="false" optional="false">available power</attribute>
+    <attribute side="server" code="0x000E" define="POWER_THRESHOLD" type="INT24S" min="0x000000" max="0xFFFFFF" writable="false" optional="false">power threshold</attribute>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Events and Alert</name>
+    <domain>Home Automation</domain>
+    <description>Attributes and commands for transmitting or notifying the occurrence of an event, such as "temperature reached" and of an alert such as alarm, fault or warning.</description>
+    <code>0x0B02</code>
+    <define>APPLIANCE_EVENTS_AND_ALERT_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <command source="client" code="0x00" name="GetAlerts" optional="false">
+      <description>
+        This basic message is used to retrieve Household Appliance current alerts.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="GetAlertsResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        This message is used to return household appliance current alerts.
+      </description>
+      <arg name="alertsCount" type="AlertCount"/>
+      <arg name="alertStructures" type="AlertStructure" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="AlertsNotification" optional="false">
+      <description>
+        This message is used to notify the current modification of warning and/or fault conditions.
+      </description>
+      <arg name="alertsCount" type="AlertCount"/>
+      <arg name="alertStructures" type="AlertStructure" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="EventsNotification" optional="false">
+      <description>
+        This message is used to notify an event occurred during the normal working of the appliance.
+      </description>
+      <arg name="eventHeader" type="INT8U"/>
+      <arg name="eventId" type="EventIdentification"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Appliance Statistics</name>
+    <domain>Home Automation</domain>
+    <description>
+      This cluster provides a mechanism for the transmitting appliance statistics to a collection unit (gateway). The statistics can be in format of data logs. In case of statistic information that will not fit the single ZigBee payload, the Partition cluster should be used.
+    </description>
+    <code>0x0B03</code>
+    <define>APPLIANCE_STATISTICS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="LOG_MAX_SIZE" type="INT32U" writable="false" default="0x0000003C" optional="false">log max size</attribute>
+    <attribute side="server" code="0x0001" define="LOG_QUEUE_MAX_SIZE" type="INT8U" writable="false" default="0x01" optional="false">log queue max size</attribute>
+    <command source="server" code="0x00" name="LogNotification" optional="false">
+      <description>
+        The Appliance Statistics Cluster server occasionally sends out a Log Notification command to the devices to which it needs to log information related to statistics (e.g., home gateways) which implement the client side of Appliance Statistics Cluster.
+      </description>
+      <arg name="timeStamp" type="TIME_OF_DAY"/>
+      <arg name="logId" type="INT32U"/>
+      <arg name="logLength" type="INT32U"/>
+      <arg name="logPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="LogResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Appliance Statistics Cluster server sends out a Log Response command to respond to a Log Request command generated by the client side of the Appliance Statistics cluster.
+      </description>
+      <arg name="timeStamp" type="TIME_OF_DAY"/>
+      <arg name="logId" type="INT32U"/>
+      <arg name="logLength" type="INT32U"/>
+      <arg name="logPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="LogQueueResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        The Log Queue Response command is generated as a response to a LogQueueRequest command in order to notify the client side of the Appliance statistics cluster about the logs stored in the server side (queue) that can be retrieved by the client side of this cluster through a LogRequest command.
+      </description>
+      <arg name="logQueueSize" type="INT8U"/>
+      <arg name="logIds" type="INT32U" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="StatisticsAvailable" optional="false">
+      <description>
+        The Appliance Statistics Cluster server sends out a Statistic Available command to notify the client side of the Appliance Statistics cluster that there are statistics that can be retrieved by using the Log Request command.
+      </description>
+      <arg name="logQueueSize" type="INT8U"/>
+      <arg name="logIds" type="INT32U" array="true"/>
+    </command>
+    <command source="client" code="0x00" name="LogRequest" optional="false">
+      <description>
+        The Log request command is sent from a device supporting the client side of the Appliance Statistics cluster (e.g., Home Gateway) to retrieve the log from the device supporting the server side (e.g., appliance).
+      </description>
+      <arg name="logId" type="INT32U"/>
+    </command>
+    <command source="client" code="0x01" name="LogQueueRequest" optional="false">
+      <description>
+        The Log Queue Request command is send from a device supporting the client side of the Appliance Statistics cluster (e.g. Home Gateway) to retrieve the information about the logs inserted in the queue, from the device supporting the server side (e.g. appliance).
+      </description>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Electrical Measurement</name>
+    <domain>Home Automation</domain>
+    <description>Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..</description>
+    <code>0x0B04</code>
+    <define>ELECTRICAL_MEASUREMENT_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="MEASUREMENT_TYPE" type="BITMAP32" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x000000" optional="true">measurement type</attribute>
+    <attribute side="server" code="0x0100" define="DC_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage</attribute>
+    <attribute side="server" code="0x0101" define="DC_VOLTAGE_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage min</attribute>
+    <attribute side="server" code="0x0102" define="DC_VOLTAGE_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc voltage max</attribute>
+    <attribute side="server" code="0x0103" define="DC_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current</attribute>
+    <attribute side="server" code="0x0104" define="DC_CURRENT_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current min</attribute>
+    <attribute side="server" code="0x0105" define="DC_CURRENT_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc current max</attribute>
+    <attribute side="server" code="0x0106" define="DC_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power</attribute>
+    <attribute side="server" code="0x0107" define="DC_POWER_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power min</attribute>
+    <attribute side="server" code="0x0108" define="DC_POWER_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0x8000" optional="true">dc power max</attribute>
+    <attribute side="server" code="0x0200" define="DC_VOLTAGE_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc voltage multiplier</attribute>
+    <attribute side="server" code="0x0201" define="DC_VOLTAGE_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc voltage divisor</attribute>
+    <attribute side="server" code="0x0202" define="DC_CURRENT_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc current multiplier</attribute>
+    <attribute side="server" code="0x0203" define="DC_CURRENT_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc current divisor</attribute>
+    <attribute side="server" code="0x0204" define="DC_POWER_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc power multiplier</attribute>
+    <attribute side="server" code="0x0205" define="DC_POWER_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">dc power divisor</attribute>
+    <attribute side="server" code="0x0300" define="AC_FREQUENCY" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency</attribute>
+    <attribute side="server" code="0x0301" define="AC_FREQUENCY_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency min</attribute>
+    <attribute side="server" code="0x0302" define="AC_FREQUENCY_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">ac frequency max</attribute>
+    <attribute side="server" code="0x0303" define="NEUTRAL_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x0000" optional="true">neutral current</attribute>
+    <attribute side="server" code="0x0304" define="TOTAL_ACTIVE_POWER" type="INT32S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">total active power</attribute>
+    <attribute side="server" code="0x0305" define="TOTAL_REACTIVE_POWER" type="INT32S" min="0x800001" max="0x7FFFFF" writable="false" default="0x000000" optional="true">total reactive power</attribute>
+    <attribute side="server" code="0x0306" define="TOTAL_APPARENT_POWER" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">total apparent power</attribute>
+    <attribute side="server" code="0x0307" define="MEASURED_1ST_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 1st harmonic current</attribute>
+    <attribute side="server" code="0x0308" define="MEASURED_3RD_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 3rd harmonic current</attribute>
+    <attribute side="server" code="0x0309" define="MEASURED_5TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 5th harmonic current</attribute>
+    <attribute side="server" code="0x030A" define="MEASURED_7TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 7th harmonic current</attribute>
+    <attribute side="server" code="0x030B" define="MEASURED_9TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 9th harmonic current</attribute>
+    <attribute side="server" code="0x030C" define="MEASURED_11TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured 11th harmonic current</attribute>
+    <attribute side="server" code="0x030D" define="MEASURED_PHASE_1ST_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 1st harmonic current</attribute>
+    <attribute side="server" code="0x030E" define="MEASURED_PHASE_3RD_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 3rd harmonic current</attribute>
+    <attribute side="server" code="0x030F" define="MEASURED_PHASE_5TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 5th harmonic current</attribute>
+    <attribute side="server" code="0x0310" define="MEASURED_PHASE_7TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 7th harmonic current</attribute>
+    <attribute side="server" code="0x0311" define="MEASURED_PHASE_9TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 9th harmonic current</attribute>
+    <attribute side="server" code="0x0312" define="MEASURED_PHASE_11TH_HARMONIC_CURRENT" type="INT16S" min="-32768" max="323767" writable="false" default="0x8000" optional="true">measured phase 11th harmonic current</attribute>
+    <attribute side="server" code="0x0400" define="AC_FREQUENCY_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac frequency multiplier</attribute>
+    <attribute side="server" code="0x0401" define="AC_FREQUENCY_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac frequency divisor</attribute>
+    <attribute side="server" code="0x0402" define="POWER_MULTIPLIER" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">power multiplier</attribute>
+    <attribute side="server" code="0x0403" define="POWER_DIVISOR" type="INT32U" min="0" max="0xFFFFFF" writable="false" default="0x000001" optional="true">power divisor</attribute>
+    <attribute side="server" code="0x0404" define="HARMONIC_CURRENT_MULTIPLIER" type="INT8S" min="-127" max="127" writable="false" default="0x00" optional="true">harmonic current multiplier</attribute>
+    <attribute side="server" code="0x0405" define="PHASE_HARMONIC_CURRENT_MULTIPLIER" type="INT8S" min="-127" max="127" writable="false" default="0x00" optional="true">phase harmonic current multiplier</attribute>
+    <attribute side="server" code="0x0500" define="INSTANTANEOUS_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous voltage</attribute>
+    <attribute side="server" code="0x0501" define="INSTANTANEOUS_LINE_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">instantaneous line current</attribute>
+    <attribute side="server" code="0x0502" define="INSTANTANEOUS_ACTIVE_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous active current</attribute>
+    <attribute side="server" code="0x0503" define="INSTANTANEOUS_REACTIVE_CURRENT" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous reactive current</attribute>
+    <attribute side="server" code="0x0504" define="INSTANTANEOUS_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">instantaneous power</attribute>
+    <attribute side="server" code="0x0505" define="RMS_VOLTAGE" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms voltage</attribute>
+    <attribute side="server" code="0x0506" define="RMS_VOLTAGE_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x8000" optional="true">rms voltage min</attribute>
+    <attribute side="server" code="0x0507" define="RMS_VOLTAGE_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0x8000" optional="true">rms voltage max</attribute>
+    <attribute side="server" code="0x0508" define="RMS_CURRENT" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current</attribute>
+    <attribute side="server" code="0x0509" define="RMS_CURRENT_MIN" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current min</attribute>
+    <attribute side="server" code="0x050A" define="RMS_CURRENT_MAX" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">rms current max</attribute>
+    <attribute side="server" code="0x050B" define="ACTIVE_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power</attribute>
+    <attribute side="server" code="0x050C" define="ACTIVE_POWER_MIN" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min</attribute>
+    <attribute side="server" code="0x050D" define="ACTIVE_POWER_MAX" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max</attribute>
+    <attribute side="server" code="0x050E" define="REACTIVE_POWER" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power</attribute>
+    <attribute side="server" code="0x050F" define="APPARENT_POWER" type="INT16U" min="0" max="0xFFFF" writable="false" default="0xffff" optional="true">apparent power</attribute>
+    <attribute side="server" code="0x0510" define="AC_POWER_FACTOR" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor</attribute>
+    <attribute side="server" code="0x0511" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">average rms voltage measurement period</attribute>
+    <attribute side="server" code="0x0513" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">average rms under voltage counter</attribute>
+    <attribute side="server" code="0x0514" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms extreme over voltage period</attribute>
+    <attribute side="server" code="0x0515" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms extreme under voltage period</attribute>
+    <attribute side="server" code="0x0516" define="RMS_VOLTAGE_SAG_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms voltage sag period</attribute>
+    <attribute side="server" code="0x0517" define="RMS_VOLTAGE_SWELL_PERIOD" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">rms voltage swell period</attribute>
+    <attribute side="server" code="0x0600" define="AC_VOLTAGE_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac voltage multiplier</attribute>
+    <attribute side="server" code="0x0601" define="AC_VOLTAGE_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac voltage divisor</attribute>
+    <attribute side="server" code="0x0602" define="AC_CURRENT_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac current multiplier</attribute>
+    <attribute side="server" code="0x0603" define="AC_CURRENT_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac current divisor</attribute>
+    <attribute side="server" code="0x0604" define="AC_POWER_MULTIPLIER" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac power multiplier</attribute>
+    <attribute side="server" code="0x0605" define="AC_POWER_DIVISOR" type="INT16U" min="1" max="0xFFFF" writable="false" default="0x01" optional="true">ac power divisor</attribute>
+    <attribute side="server" code="0x0700" define="DC_OVERLOAD_ALARMS_MASK" type="BITMAP8" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">overload alarms mask</attribute>
+    <attribute side="server" code="0x0701" define="DC_VOLTAGE_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">voltage overload</attribute>
+    <attribute side="server" code="0x0702" define="DC_CURRENT_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">current overload</attribute>
+    <attribute side="server" code="0x0800" define="AC_OVERLOAD_ALARMS_MASK" type="BITMAP16" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">ac overload alarms mask</attribute>
+    <attribute side="server" code="0x0801" define="AC_VOLTAGE_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac voltage overload</attribute>
+    <attribute side="server" code="0x0802" define="AC_CURRENT_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac current overload</attribute>
+    <attribute side="server" code="0x0803" define="AC_POWER_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac active power overload</attribute>
+    <attribute side="server" code="0x0804" define="AC_REACTIVE_POWER_OVERLOAD" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">ac reactive power overload</attribute>
+    <attribute side="server" code="0x0805" define="AVERAGE_RMS_OVER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">average rms over voltage</attribute>
+    <attribute side="server" code="0x0806" define="AVERAGE_RMS_UNDER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">average rms under voltage</attribute>
+    <attribute side="server" code="0x0807" define="RMS_EXTREME_OVER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms extreme over voltage</attribute>
+    <attribute side="server" code="0x0808" define="RMS_EXTREME_UNDER_VOLTAGE" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms extreme under voltage</attribute>
+    <attribute side="server" code="0x0809" define="RMS_VOLTAGE_SAG" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms voltage sag</attribute>
+    <attribute side="server" code="0x080A" define="RMS_VOLTAGE_SWELL" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">rms voltage swell</attribute>
+    <attribute side="server" code="0x0901" define="LINE_CURRENT_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">line current phase b</attribute>
+    <attribute side="server" code="0x0902" define="ACTIVE_CURRENT_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active current phase b</attribute>
+    <attribute side="server" code="0x0903" define="REACTIVE_CURRENT_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive current phase b</attribute>
+    <attribute side="server" code="0x0905" define="RMS_VOLTAGE_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage phase b</attribute>
+    <attribute side="server" code="0x0906" define="RMS_VOLTAGE_MIN_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage min phase b</attribute>
+    <attribute side="server" code="0x0907" define="RMS_VOLTAGE_MAX_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage max phase b</attribute>
+    <attribute side="server" code="0x0908" define="RMS_CURRENT_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current phase b</attribute>
+    <attribute side="server" code="0x0909" define="RMS_CURRENT_MIN_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current min phase b</attribute>
+    <attribute side="server" code="0x090A" define="RMS_CURRENT_MAX_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current max phase b</attribute>
+    <attribute side="server" code="0x090B" define="ACTIVE_POWER_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power phase b</attribute>
+    <attribute side="server" code="0x090C" define="ACTIVE_POWER_MIN_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min phase b</attribute>
+    <attribute side="server" code="0x090D" define="ACTIVE_POWER_MAX_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max phase b</attribute>
+    <attribute side="server" code="0x090E" define="REACTIVE_POWER_PHASE_B" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power phase b</attribute>
+    <attribute side="server" code="0x090F" define="APPARENT_POWER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">apparent power phase b</attribute>
+    <attribute side="server" code="0x0910" define="POWER_FACTOR_PHASE_B" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor phase b</attribute>
+    <attribute side="server" code="0x0911" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms voltage measurement period phase b</attribute>
+    <attribute side="server" code="0x0912" define="AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms over voltage counter phase b</attribute>
+    <attribute side="server" code="0x0913" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms under voltage counter phase b</attribute>
+    <attribute side="server" code="0x0914" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme over voltage period phase b</attribute>
+    <attribute side="server" code="0x0915" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme under voltage period phase b</attribute>
+    <attribute side="server" code="0x0916" define="RMS_VOLTAGE_SAG_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage sag period phase b</attribute>
+    <attribute side="server" code="0x0917" define="RMS_VOLTAGE_SWELL_PERIOD_PHASE_B" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage swell period phase b</attribute>
+    <attribute side="server" code="0x0A01" define="LINE_CURRENT_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">line current phase c</attribute>
+    <attribute side="server" code="0x0A02" define="ACTIVE_CURRENT_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active current phase c</attribute>
+    <attribute side="server" code="0x0A03" define="REACTIVE_CURRENT_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive current phase c</attribute>
+    <attribute side="server" code="0x0A05" define="RMS_VOLTAGE_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage phase c</attribute>
+    <attribute side="server" code="0x0A06" define="RMS_VOLTAGE_MIN_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage min phase c</attribute>
+    <attribute side="server" code="0x0A07" define="RMS_VOLTAGE_MAX_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms voltage max phase c</attribute>
+    <attribute side="server" code="0x0A08" define="RMS_CURRENT_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current phase b</attribute>
+    <attribute side="server" code="0x0A09" define="RMS_CURRENT_MIN_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current min phase c</attribute>
+    <attribute side="server" code="0x0A0A" define="RMS_CURRENT_MAX_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">rms current max phase c</attribute>
+    <attribute side="server" code="0x0A0B" define="ACTIVE_POWER_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power phase c</attribute>
+    <attribute side="server" code="0x0A0C" define="ACTIVE_POWER_MIN_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power min phase c</attribute>
+    <attribute side="server" code="0x0A0D" define="ACTIVE_POWER_MAX_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">active power max phase c</attribute>
+    <attribute side="server" code="0x0A0E" define="REACTIVE_POWER_PHASE_C" type="INT16S" min="-32768" max="32767" writable="false" default="0xffff" optional="true">reactive power phase c</attribute>
+    <attribute side="server" code="0x0A0F" define="APPARENT_POWER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0xffff" optional="true">apparent power phase c</attribute>
+    <attribute side="server" code="0x0A10" define="POWER_FACTOR_PHASE_C" type="INT8S" min="-100" max="100" writable="false" default="0x00" optional="true">power factor phase c</attribute>
+    <attribute side="server" code="0x0A11" define="AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms voltage measurement period phase c</attribute>
+    <attribute side="server" code="0x0A12" define="AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms over voltage counter phase c</attribute>
+    <attribute side="server" code="0x0A13" define="AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">average rms under voltage counter phase c</attribute>
+    <attribute side="server" code="0x0A14" define="RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme over voltage period phase c</attribute>
+    <attribute side="server" code="0x0A15" define="RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms extreme under voltage period phase c</attribute>
+    <attribute side="server" code="0x0A16" define="RMS_VOLTAGE_SAG_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage sag period phase c</attribute>
+    <attribute side="server" code="0x0A17" define="RMS_VOLTAGE_SWELL_PERIOD_PHASE_C" type="INT16U" min="0x0000" max="0xffff" writable="false" default="0x0000" optional="true">rms voltage swell period phase c</attribute>
+    <command source="server" code="0x00" name="GetProfileInfoResponseCommand" optional="true" disableDefaultResponse="true">
+      <description>
+        A function which returns the power profiling information requested in the GetProfileInfo command. The power profiling information consists of a list of attributes which are profiled along with the period used to profile them.
+      </description>
+      <arg name="profileCount" type="INT8U"/>
+      <arg name="profileIntervalPeriod" type="ENUM8"/>
+      <arg name="maxNumberOfIntervals" type="INT8U"/>
+      <arg name="listOfAttributes" type="INT16U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="GetMeasurementProfileResponseCommand" optional="true" disableDefaultResponse="true">
+      <description>
+        A function which returns the electricity measurement profile. The electricity measurement profile includes information regarding the amount of time used to capture data related to the flow of electricity as well as the intervals thes
+      </description>
+      <arg name="startTime" type="INT32U"/>
+      <arg name="status" type="ENUM8"/>
+      <arg name="profileIntervalPeriod" type="ENUM8"/>
+      <arg name="numberOfIntervalsDelivered" type="INT8U"/>
+      <arg name="attributeId" type="INT16U"/>
+      <arg name="intervals" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x00" name="GetProfileInfoCommand" optional="true">
+      <description>
+        A function which retrieves the power profiling information from the electrical measurement server.
+      </description>
+    </command>
+    <command source="client" code="0x01" name="GetMeasurementProfileCommand" optional="true">
+      <description>
+        A function which retrieves an electricity measurement profile from the electricity measurement server for a specific attribute Id requested.
+      </description>
+      <arg name="attributeId" type="INT16U"/>
+      <arg name="startTime" type="INT32U"/>
+      <arg name="numberOfIntervals" type="ENUM8"/>
+    </command>
+  </cluster>
+  <cluster introducedIn="ha-1.2-05-3520-29">
+    <name>Diagnostics</name>
+    <domain>Home Automation</domain>
+    <description>Attributes related to the gathering of diagnostic information from a stack.</description>
+    <code>0x0B05</code>
+    <define>DIAGNOSTICS_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="NUMBER_OF_RESETS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">number of resets</attribute>
+    <attribute side="server" code="0x0001" define="PERSISTENT_MEMORY_WRITES" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">persistent memory writes</attribute>
+    <attribute side="server" code="0x0100" define="MAC_RX_BCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac rx broadcast</attribute>
+    <attribute side="server" code="0x0101" define="MAC_TX_BCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac tx broadcast</attribute>
+    <attribute side="server" code="0x0102" define="MAC_RX_UCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac rx unicast</attribute>
+    <attribute side="server" code="0x0103" define="MAC_TX_UCAST" type="INT32U" min="0x0000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">mac tx unicast</attribute>
+    <attribute side="server" code="0x0104" define="MAC_TX_UCAST_RETRY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">mac tx unicast retry</attribute>
+    <attribute side="server" code="0x0105" define="MAC_TX_UCAST_FAIL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">mac tx unicast fail</attribute>
+    <attribute side="server" code="0x0106" define="APS_RX_BCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps rx broadcast</attribute>
+    <attribute side="server" code="0x0107" define="APS_TX_BCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx broadcast</attribute>
+    <attribute side="server" code="0x0108" define="APS_RX_UCAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps rx unicast</attribute>
+    <attribute side="server" code="0x0109" define="APS_UCAST_SUCCESS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps unicast success</attribute>
+    <attribute side="server" code="0x010A" define="APS_TX_UCAST_RETRY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx unicast retries</attribute>
+    <attribute side="server" code="0x010B" define="APS_TX_UCAST_FAIL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps tx unicast failures</attribute>
+    <attribute side="server" code="0x010C" define="ROUTE_DISC_INITIATED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">route discovery initiated</attribute>
+    <attribute side="server" code="0x010D" define="NEIGHBOR_ADDED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor added</attribute>
+    <attribute side="server" code="0x010E" define="NEIGHBOR_REMOVED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor moved</attribute>
+    <attribute side="server" code="0x010F" define="NEIGHBOR_STALE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">neighbor stale</attribute>
+    <attribute side="server" code="0x0110" define="JOIN_INDICATION" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">join indication</attribute>
+    <attribute side="server" code="0x0111" define="CHILD_MOVED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">child moved</attribute>
+    <attribute side="server" code="0x0112" define="NWK_FC_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">network frame control failure</attribute>
+    <attribute side="server" code="0x0113" define="APS_FC_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps frame control failure</attribute>
+    <attribute side="server" code="0x0114" define="APS_UNAUTHORIZED_KEY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps unauthorized key</attribute>
+    <attribute side="server" code="0x0115" define="NWK_DECRYPT_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">network decryption failure</attribute>
+    <attribute side="server" code="0x0116" define="APS_DECRYPT_FAILURE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">aps decryption failure</attribute>
+    <attribute side="server" code="0x0117" define="PACKET_BUFFER_ALLOC_FAILURES" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">packet buffer allocation failures</attribute>
+    <attribute side="server" code="0x0118" define="RELAYED_UNICAST" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">relayed unicasts</attribute>
+    <attribute side="server" code="0x0119" define="PHY_TO_MAC_QUEUE_LIMIT_REACHED" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">phy to mac queue limit reached</attribute>
+    <attribute side="server" code="0x011A" define="PACKET_VALIDATE_DROP_COUNT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">packet validate drop count</attribute>
+    <attribute side="server" code="0x011B" define="AVERAGE_MAC_RETRY_PER_APS_MSG_SENT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">average mac retry per aps message sent</attribute>
+    <attribute side="server" code="0x011C" define="LAST_MESSAGE_LQI" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x0000" optional="true">last message lqi</attribute>
+    <attribute side="server" code="0x011D" define="LAST_MESSAGE_RSSI" type="INT8S" min="0x00" max="0xFF" writable="false" default="0x0000" optional="true">last message rssi</attribute>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/hc-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/hc-devices.xml
@@ -1,0 +1,545 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>HC-datacollectionunit</name>
+    <domain>HC</domain>
+    <typeName>HC Data Collection Unit</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-genericmultifunctiondevice</name>
+    <domain>HC</domain>
+    <typeName>HC Generic Multifunction Healthcare Device</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x0f00</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-pulseoximeter</name>
+    <domain>HC</domain>
+    <typeName>HC Pulse Oximeter</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1004</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-ecg</name>
+    <domain>HC</domain>
+    <typeName>HC ECG</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1006</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-bloodpressuremeter</name>
+    <domain>HC</domain>
+    <typeName>HC Blood Pressure Meter</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1007</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-thermometer</name>
+    <domain>HC</domain>
+    <typeName>HC Thermometer</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-weightscale</name>
+    <domain>HC</domain>
+    <typeName>HC Weight Scale</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x100f</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-glucosemeter</name>
+    <domain>HC</domain>
+    <typeName>HC Glucose Meter</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1011</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-inr</name>
+    <domain>HC</domain>
+    <typeName>HC INR</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1012</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-insulinpump</name>
+    <domain>HC</domain>
+    <typeName>HC Insulin Pump</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1013</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-peakflowmeter</name>
+    <domain>HC</domain>
+    <typeName>HC Peak Flow Meter</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1015</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-cardiovascularfitnessandactivitymonitor</name>
+    <domain>HC</domain>
+    <typeName>HC Cardiovascular Fitness and Activity Monitor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1029</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-strengthfitnessequipment</name>
+    <domain>HC</domain>
+    <typeName>HC Strength and Fitness Equipment</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x102a</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-physicalactivitymonitor</name>
+    <domain>HC</domain>
+    <typeName>HC Physical Activity Monitor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x102b</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-stepcounter</name>
+    <domain>HC</domain>
+    <typeName>HC Step Counter</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1068</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-ilah</name>
+    <domain>HC</domain>
+    <typeName>HC ILAH</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1047</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-adherencemonitor</name>
+    <domain>HC</domain>
+    <typeName>HC Adherence Monitor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1048</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-fallsensor</name>
+    <domain>HC</domain>
+    <typeName>HC Fall Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1075</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-perssensor</name>
+    <domain>HC</domain>
+    <typeName>HC PERS Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1076</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-smokesensor</name>
+    <domain>HC</domain>
+    <typeName>HC Smoke Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1077</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-cosensor</name>
+    <domain>HC</domain>
+    <typeName>HC CO Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1078</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-watersensor</name>
+    <domain>HC</domain>
+    <typeName>HC Water Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1079</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-gassensor</name>
+    <domain>HC</domain>
+    <typeName>HC Gas Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107a</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-motionsensor</name>
+    <domain>HC</domain>
+    <typeName>HC Motion Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107b</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-propertyexitsensor</name>
+    <domain>HC</domain>
+    <typeName>HC Property Exit Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107c</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-enuresissensor</name>
+    <domain>HC</domain>
+    <typeName>HC Enuresis Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107d</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-contactclosuresensor</name>
+    <domain>HC</domain>
+    <typeName>HC Contact Closure Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107e</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-usagesensor</name>
+    <domain>HC</domain>
+    <typeName>HC Usage Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x107f</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-switchusesensor</name>
+    <domain>HC</domain>
+    <typeName>HC Switch Use Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1080</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-dosagesensor</name>
+    <domain>HC</domain>
+    <typeName>HC Dosage Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1081</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>HC-temperaturesensor</name>
+    <domain>HC</domain>
+    <typeName>HC Temperature Sensor</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0108</profileId>
+    <deviceId editable="false">0x1082</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Generic Tunnel</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">11073 Protocol Tunnel</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="false">Time</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/hc.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/hc.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="HC" spec="hc-1.0-07-5360-15" dependsOn="zcl-1.0-07-5123-03"/>
+  <enum name="11073ConnectRequestConnectControl" type="ENUM8">
+    <item name="Preemptible" value="0x01"/>
+  </enum>
+  <enum name="11073TunnelConnectionStatus" type="ENUM8">
+    <item name="Disconnected" value="0x00"/>
+    <item name="Connected" value="0x01"/>
+    <item name="NotAuthorized" value="0x02"/>
+    <item name="ReconnectRequest" value="0x03"/>
+    <item name="AlreadyConnected" value="0x04"/>
+  </enum>
+  <cluster>
+    <name>11073 Protocol Tunnel</name>
+    <domain>HC</domain>
+    <description>Attributes and commands for the 11073 protocol tunnel used for ZigBee Health Care.</description>
+    <code>0x0614</code>
+    <define>11073_PROTOCOL_TUNNEL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="DEVICE_ID_LIST" type="INT16U" writable="false" optional="true" array="true">device id list</attribute>
+    <attribute side="server" code="0x0001" define="MANAGER_TARGET" type="IEEE_ADDRESS" min="0x0000000000000000" max="0xffffffffffffffff" writable="false" optional="true">manager target</attribute>
+    <attribute side="server" code="0x0002" define="MANAGER_ENDPOINT" type="INT8U" min="0x01" max="0xff" writable="false" optional="true">manager endpoint</attribute>
+    <attribute side="server" code="0x0003" define="CONNECTED" type="BOOLEAN" writable="false" optional="true">connected</attribute>
+    <attribute side="server" code="0x0004" define="PREEMPTIBLE" type="BOOLEAN" writable="false" optional="true">preemptible</attribute>
+    <attribute side="server" code="0x0005" define="IDLE_TIMEOUT" type="INT16U" min="0x01" max="0xffff" writable="false" optional="true">idle timeout</attribute>
+    <command source="client" code="0x00" name="TransferAPDU" optional="false">
+      <description>
+        This command is generated when an 11073 network layer wishes to transfer an 11073 APDU across a ZigBee tunnel to another 11073 network layer.
+      </description>
+      <arg name="apdu" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x01" name="ConnectRequest" optional="true">
+      <description>
+        This command is generated when an Health Care client wishes to connect to a Health Care server for the purposes of transmitting 11073 APDUs across the 11073 tunnel.
+      </description>
+      <arg name="connectControl" type="11073ConnectRequestConnectControl"/>
+      <arg name="idleTimeout" type="INT16U"/>
+      <arg name="managerTarget" type="IEEE_ADDRESS"/>
+      <arg name="managerEndpoint" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="DisconnectRequest" optional="true">
+      <description>
+        This command is generated when an Health Care client wishes to disconnect from a Health Care server.
+      </description>
+      <arg name="managerIEEEAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command source="client" code="0x03" name="ConnectStatusNotification" optional="true">
+      <description>
+        Generated in response to requests related to connection or any event that causes the tunnel to become disconnected.
+      </description>
+      <arg name="connectStatus" type="11073TunnelConnectionStatus"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/lo-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/lo-devices.xml
@@ -1,0 +1,1725 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>LO-onofflight</name>
+    <domain>LO</domain>
+    <typeName>LO On/Off Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0100</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="false"/>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-dimmablelight</name>
+    <domain>LO</domain>
+    <typeName>LO Dimmable Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0101</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-colordimmablelight</name>
+    <domain>LO</domain>
+    <typeName>LO Color Dimmable Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0102</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-onofflightswitch</name>
+    <domain>LO</domain>
+    <typeName>LO On/Off Light Switch</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0103</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off Switch Configuration" client="false" server="true" clientLocked="true" serverLocked="false">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-dimmerswitch</name>
+    <domain>LO</domain>
+    <typeName>LO Dimmer Switch</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0104</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off Switch Configuration" client="false" server="true" clientLocked="true" serverLocked="false">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-colordimmerswitch</name>
+    <domain>LO</domain>
+    <typeName>LO Color Dimmer Switch</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0105</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off Switch Configuration" client="false" server="true" clientLocked="true" serverLocked="false">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-lightsensor</name>
+    <domain>LO</domain>
+    <typeName>LO Light Sensor</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0106</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Illuminance Measurement" client="false" server="true" clientLocked="false" serverLocked="true">
+        <requireAttribute>ILLUM_MEASURED_VALUE</requireAttribute>
+        <requireAttribute>ILLUM_MIN_MEASURED_VALUE</requireAttribute>
+        <requireAttribute>ILLUM_MAX_MEASURED_VALUE</requireAttribute>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-occupancysensor</name>
+    <domain>LO</domain>
+    <typeName>LO Occupancy Sensor</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0107</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Occupancy Sensing" client="false" server="true" clientLocked="false" serverLocked="true">
+        <requireAttribute>OCCUPANCY</requireAttribute>
+        <requireAttribute>OCCUPANCY_SENSOR_TYPE</requireAttribute>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-onoffballast</name>
+    <domain>LO</domain>
+    <typeName>LO On/Off Balast</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0108</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Power Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Device Temperature Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_TEMPERATURE</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Ballast Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>BALLAST_STATUS</requireAttribute>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Illuminance Level Sensing" client="true" server="true" clientLocked="false" serverLocked="false">
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Illuminance Measurement" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-dimmableballast</name>
+    <domain>LO</domain>
+    <typeName>LO Dimmable Balast</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0109</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Power Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Device Temperature Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_TEMPERATURE</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Ballast Configuration" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>BALLAST_STATUS</requireAttribute>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="false" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Illuminance Level Sensing" client="true" server="true" clientLocked="false" serverLocked="false">
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Illuminance Measurement" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-onoffpluginunit</name>
+    <domain>LO</domain>
+    <typeName>LO On/Off Plug-in Unit</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x010A</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-dimmablepluginunit</name>
+    <domain>LO</domain>
+    <typeName>LO Dimmable Plug-in Unit</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x010B</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="false" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-colortemperaturelight</name>
+    <domain>LO</domain>
+    <typeName>LO Color Temperature Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x010C</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS</requireAttribute>
+        <requireAttribute>START_UP_COLOR_TEMPERATURE_MIREDS</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="true" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-extendedcolorlight</name>
+    <domain>LO</domain>
+    <typeName>LO Extended Color Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x010D</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireAttribute>START_UP_ON_OFF</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>OPTIONS</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>START_UP_CURRENT_LEVEL</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_OPTIONS</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS</requireAttribute>
+        <requireAttribute>START_UP_COLOR_TEMPERATURE_MIREDS</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+      </include>
+      <include cluster="ZLL Commissioning" client="false" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-lightlevelsensor</name>
+    <domain>LO</domain>
+    <typeName>LO Light Level Sensor</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x010E</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Illuminance Level Sensing" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>LEVEL_STATUS</requireAttribute>
+        <requireAttribute>ILLUMINANCE_TARGET_LEVEL</requireAttribute>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-colorcontroller</name>
+    <domain>LO</domain>
+    <typeName>LO Color Controller</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0800</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-colorscenecontroller</name>
+    <domain>LO</domain>
+    <typeName>LO Color Scene Controller</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0810</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-noncolorcontroller</name>
+    <domain>LO</domain>
+    <typeName>LO Non Color Controller</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0820</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-noncolorscenecontroller</name>
+    <domain>LO</domain>
+    <typeName>LO Non Color Scene Controller</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0830</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-controlbridge</name>
+    <domain>LO</domain>
+    <typeName>LO Control Bridge</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0840</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="true" clientLocked="false" serverLocked="false"/>
+      <include cluster="Illuminance Measurement" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Illuminance Level Sensing" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Occupancy Sensing" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>LO-onoffsensor</name>
+    <domain>LO</domain>
+    <typeName>LO On/off Sensor</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0850</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_CLASS</requireAttribute>
+        <requireAttribute>GENERIC_DEVICE_TYPE</requireAttribute>
+        <requireAttribute>PRODUCT_CODE</requireAttribute>
+        <requireAttribute>PRODUCT_URL</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="Identify" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true">
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Level Control" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Over the Air Bootloading" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="Color Control" client="true" server="false" clientLocked="false" serverLocked="true">
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="false" serverLocked="false">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ota-dotdot.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ota-dotdot.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="SE" spec="se-1.2b-15-0131-02" dependsOn="zcl-1.0-07-5123-04" certifiable="false">
+  </domain>
+  <cluster>
+    <name>Over the Air Bootloading</name>
+    <domain>General</domain>
+    <description>This cluster contains commands and attributes that act as an interface for Thread Over-the-air bootloading.</description>
+    <code>0x2000</code>
+    <define>OTA_BOOTLOAD_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <generateCmdHandlers>false</generateCmdHandlers>
+    <attribute side="client" type="IEEE_ADDRESS" code="0x0000" writable="false" optional="false" default="0xffffffffffffffff" define="UPGRADE_SERVER_ID">OTA Upgrade Server ID</attribute>
+    <!-- Although the File Offset attribute is optional, it is mandatory for our implementation of the OTA client plugin. -->
+    <attribute side="client" type="INT32U" code="0x0001" writable="false" optional="false" default="0xffffffff" define="FILE_OFFSET">Offset (address) into the file</attribute>
+    <attribute side="client" type="INT32U" code="0x0002" writable="false" optional="true" default="0xffffffff" define="CURRENT_FILE_VERSION">OTA Current File Version</attribute>
+    <attribute side="client" type="INT16U" code="0x0003" writable="false" optional="true" default="0xffff" define="CURRENT_ZIGBEE_STACK_VERSION">OTA Current ZigBee Stack Version</attribute>
+    <attribute side="client" type="INT32U" code="0x0004" writable="false" optional="true" default="0xffffffff" define="DOWNLOADED_FILE_VERSION">OTA Downloaded File Version</attribute>
+    <attribute side="client" type="INT16U" code="0x0005" writable="false" optional="true" default="0xffff" define="DOWNLOADED_ZIGBEE_STACK_VERSION">OTA Downloaded ZigBee Stack Version</attribute>
+    <attribute side="client" type="ENUM8" code="0x0006" writable="false" optional="false" default="0x00" define="IMAGE_UPGRADE_STATUS">OTA Upgrade Status</attribute>
+    <attribute side="client" type="INT16U" code="0x0007" writable="false" optional="true" define="MANUFACTURER_ID">Manufacturer ID</attribute>
+    <attribute side="client" type="INT16U" code="0x0008" writable="false" optional="true" define="IMAGE_TYPE_ID">Image Type ID</attribute>
+    <attribute side="client" type="INT16U" code="0x0009" writable="false" optional="true" define="MINIMUM_BLOCK_REQUEST_PERIOD" introducedIn="ha-1.2-05-3520-29">Minimum Block Request Period</attribute>
+    <attribute side="client" type="INT32U" code="0x000A" writable="false" optional="true" define="IMAGE_STAMP" introducedIn="ha-1.2-05-3520-29">Image Stamp</attribute>
+    <attribute side="client" type="ENUM8" code="0x000B" writable="false" optional="true" default="0x00" define="UPGRADE_ACTIVATION_POLICY" introducedIn="se-1.2b-15-0131-02">Upgrade Activation Policy</attribute>
+    <attribute side="client" type="ENUM8" code="0x000C" writable="false" optional="true" default="0x00" define="UPGRADE_TIMEOUT_POLICY" introducedIn="se-1.2b-15-0131-02">Upgrade Timeout Policy</attribute>
+    <command code="0x0" name="ImageNotify" source="server">
+      <description>
+        This command is generated when the upgrade server wishes to notify the clients of the available OTA upgrade image.  The command can be sent as unicast which provides a way for the server to force the upgrade on the client.  The command can also be sent as broadcast or multicast to certain class of clients (for example, the ones that have matching manufacturing and device ids).
+      </description>
+      <arg name="payloadType" type="ENUM8"/>
+      <arg name="queryJitter" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="newFileVersion" type="INT32U"/>
+    </command>
+    <command code="0x1" name="QueryNextImageRequest" source="client">
+      <description>
+      This command is generated upon receipt of an Image Notify command to indicate that the client is looking for the next firmware image to upgrade to.  The client may also choose to send the command periodically to the server.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="currentFileVersion" type="INT32U"/>
+      <arg name="hardwareVersion" type="INT16U"/>
+    </command>
+    <command code="0x2" name="QueryNextImageResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated upon receipt of an QueryNextImageRequest command to response whether the server has a valid OTA upgrade image for the client or not.  If the server has the file, information regarding the file and OTA upgrade process will be included in the command.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="imageSize" type="INT32U"/>
+      <arg name="fileUri" type="CHAR_STRING"/>
+    </command>
+    <command code="0x3" name="ImageBlockRequest" source="client">
+      <description>
+        This command is generated by the client to request blocks of OTA upgrade file data.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="maxDataSize" type="INT8U"/>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command code="0x4" name="ImagePageRequest" source="client" optional="true">
+      <description>
+        This command is generated by the client to request pages of OTA upgrade file data. A page would contain multiple blocks of data.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="maxDataSize" type="INT8U"/>
+      <arg name="pageSize" type="INT16U"/>
+      <arg name="responseSpacing" type="INT16U"/>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command code="0x5" name="ImageBlockResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server in response to the block or page request command.  If the server has the data available, it will reply back with a SUCCESS status.  For other error cases, it may reply with status WAIT_FOR_DATA (server does not have the data available yet) or ABORT (invalid requested parameters or other failure cases).
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="dataSize" type="INT8U"/>
+      <arg name="imageData" type="INT8U" array="true"/>
+    </command>
+    <command code="0x6" name="UpgradeEndRequest" source="client">
+      <description>
+        This command is generated by the client to notify the server of the end of the upgrade process.  The process may end with success or error status.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+    </command>
+    <command code="0x7" name="UpgradeEndResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server in response to the upgrade request in order to let the client know when to upgrade to running new firmware image.
+      </description>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="currentTime" type="INT32U"/>
+      <arg name="upgradeTime" type="INT32U"/>
+    </command>
+    <command code="0x8" name="QuerySpecificFileRequest" source="client" optional="true">
+      <description>
+        This command is generated by the client to request a file that is specific to itself.  The intention is to provide a way for the client to request non-OTA upgrade file.
+      </description>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="currentZigbeeStackVersion" type="INT16U"/>
+    </command>
+    <command code="0x9" name="QuerySpecificFileResponse" source="server" disableDefaultResponse="true" optional="true">
+      <description>
+        This command is generated upon receipt of an QuerySpecificFileRequest command to response whether the server has a valid file for the client or not.  If the server has the file, information regarding the file and OTA process will be included in the command.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="imageSize" type="INT32U"/>
+      <arg name="fileUri" type="CHAR_STRING"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ota.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ota.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="SE" spec="se-1.2b-15-0131-02" dependsOn="zcl-1.0-07-5123-04" certifiable="false">
+  </domain>
+  <cluster>
+    <name>Over the Air Bootloading</name>
+    <domain>General</domain>
+    <description>This cluster contains commands and attributes that act as an interface for ZigBee Over-the-air bootloading.</description>
+    <code>0x0019</code>
+    <define>OTA_BOOTLOAD_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <generateCmdHandlers>false</generateCmdHandlers>
+    <globalAttribute side="either" code="0xFFFD" value="4"/>
+    <attribute side="client" type="IEEE_ADDRESS" code="0x0000" writable="false" optional="false" default="0xffffffffffffffff" define="UPGRADE_SERVER_ID">OTA Upgrade Server ID</attribute>
+    <!-- Although the File Offset attribute is optional, it is mandatory for our implementation of the OTA client plugin. -->
+    <attribute side="client" type="INT32U" code="0x0001" writable="false" optional="false" default="0xffffffff" define="FILE_OFFSET">Offset (address) into the file</attribute>
+    <attribute side="client" type="INT32U" code="0x0002" writable="false" optional="true" default="0xffffffff" define="CURRENT_FILE_VERSION">OTA Current File Version</attribute>
+    <attribute side="client" type="INT16U" code="0x0003" writable="false" optional="true" default="0xffff" define="CURRENT_ZIGBEE_STACK_VERSION">OTA Current ZigBee Stack Version</attribute>
+    <attribute side="client" type="INT32U" code="0x0004" writable="false" optional="true" default="0xffffffff" define="DOWNLOADED_FILE_VERSION">OTA Downloaded File Version</attribute>
+    <attribute side="client" type="INT16U" code="0x0005" writable="false" optional="true" default="0xffff" define="DOWNLOADED_ZIGBEE_STACK_VERSION">OTA Downloaded ZigBee Stack Version</attribute>
+    <attribute side="client" type="ENUM8" code="0x0006" writable="false" optional="false" default="0x00" define="IMAGE_UPGRADE_STATUS">OTA Upgrade Status</attribute>
+    <attribute side="client" type="INT16U" code="0x0007" writable="false" optional="true" define="MANUFACTURER_ID">Manufacturer ID</attribute>
+    <attribute side="client" type="INT16U" code="0x0008" writable="false" optional="true" define="IMAGE_TYPE_ID">Image Type ID</attribute>
+    <attribute side="client" type="INT16U" code="0x0009" writable="false" optional="true" define="MINIMUM_BLOCK_REQUEST_PERIOD" introducedIn="ha-1.2-05-3520-29">Minimum Block Request Period</attribute>
+    <attribute side="client" type="INT32U" code="0x000A" writable="false" optional="true" define="IMAGE_STAMP" introducedIn="ha-1.2-05-3520-29">Image Stamp</attribute>
+    <attribute side="client" type="ENUM8" code="0x000B" writable="false" optional="true" default="0x00" define="UPGRADE_ACTIVATION_POLICY" introducedIn="se-1.2b-15-0131-02">Upgrade Activation Policy</attribute>
+    <attribute side="client" type="ENUM8" code="0x000C" writable="false" optional="true" default="0x00" define="UPGRADE_TIMEOUT_POLICY" introducedIn="se-1.2b-15-0131-02">Upgrade Timeout Policy</attribute>
+    <command code="0x0" name="ImageNotify" source="server">
+      <description>
+        This command is generated when the upgrade server wishes to notify the clients of the available OTA upgrade image.  The command can be sent as unicast which provides a way for the server to force the upgrade on the client.  The command can also be sent as broadcast or multicast to certain class of clients (for example, the ones that have matching manufacturing and device ids).
+      </description>
+      <arg name="payloadType" type="ENUM8"/>
+      <arg name="queryJitter" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="newFileVersion" type="INT32U"/>
+    </command>
+    <command code="0x1" name="QueryNextImageRequest" source="client">
+      <description>
+      This command is generated upon receipt of an Image Notify command to indicate that the client is looking for the next firmware image to upgrade to.  The client may also choose to send the command periodically to the server.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="currentFileVersion" type="INT32U"/>
+      <arg name="hardwareVersion" type="INT16U"/>
+    </command>
+    <command code="0x2" name="QueryNextImageResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated upon receipt of an QueryNextImageRequest command to response whether the server has a valid OTA upgrade image for the client or not.  If the server has the file, information regarding the file and OTA upgrade process will be included in the command.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="imageSize" type="INT32U"/>
+    </command>
+    <command code="0x3" name="ImageBlockRequest" source="client">
+      <description>
+        This command is generated by the client to request blocks of OTA upgrade file data.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="maxDataSize" type="INT8U"/>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command code="0x4" name="ImagePageRequest" source="client" optional="true">
+      <description>
+        This command is generated by the client to request pages of OTA upgrade file data. A page would contain multiple blocks of data.
+      </description>
+      <arg name="fieldControl" type="INT8U"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="maxDataSize" type="INT8U"/>
+      <arg name="pageSize" type="INT16U"/>
+      <arg name="responseSpacing" type="INT16U"/>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+    </command>
+    <command code="0x5" name="ImageBlockResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server in response to the block or page request command.  If the server has the data available, it will reply back with a SUCCESS status.  For other error cases, it may reply with status WAIT_FOR_DATA (server does not have the data available yet) or ABORT (invalid requested parameters or other failure cases).
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="fileOffset" type="INT32U"/>
+      <arg name="dataSize" type="INT8U"/>
+      <arg name="imageData" type="INT8U" array="true"/>
+    </command>
+    <command code="0x6" name="UpgradeEndRequest" source="client">
+      <description>
+        This command is generated by the client to notify the server of the end of the upgrade process.  The process may end with success or error status.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+    </command>
+    <command code="0x7" name="UpgradeEndResponse" source="server" disableDefaultResponse="true">
+      <description>
+        This command is generated by the server in response to the upgrade request in order to let the client know when to upgrade to running new firmware image.
+      </description>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="currentTime" type="UTC_TIME"/>
+      <arg name="upgradeTime" type="UTC_TIME"/>
+    </command>
+    <command code="0x8" name="QuerySpecificFileRequest" source="client" optional="true">
+      <description>
+        This command is generated by the client to request a file that is specific to itself.  The intention is to provide a way for the client to request non-OTA upgrade file.
+      </description>
+      <arg name="requestNodeAddress" type="IEEE_ADDRESS"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="currentZigbeeStackVersion" type="INT16U"/>
+    </command>
+    <command code="0x9" name="QuerySpecificFileResponse" source="server" disableDefaultResponse="true" optional="true">
+      <description>
+        This command is generated upon receipt of an QuerySpecificFileRequest command to response whether the server has a valid file for the client or not.  If the server has the file, information regarding the file and OTA process will be included in the command.
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="imageType" type="INT16U"/>
+      <arg name="fileVersion" type="INT32U"/>
+      <arg name="imageSize" type="INT32U"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/profiles.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/profiles.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<map>
+  <mapping code="0x0000" translation="ZigBee device profile"/>
+  <mapping code="0x0101" translation="Industrial plant monitoring"/>
+  <mapping code="0x0103" translation="Test profile 1"/>
+  <mapping code="0x0104" translation="Home automation"/>
+  <mapping code="0x0105" translation="Commercial building automation"/>
+  <mapping code="0x0106" translation="Wireless sensor networks"/>
+  <mapping code="0x0107" translation="Telecom Applications"/>
+  <mapping code="0x0108" translation="Personal, Home &amp; Hospital Care"/>
+  <mapping code="0x0109" translation="Smart Energy"/>
+  <mapping code="0x7F01" translation="Test profile 2"/>
+  <mapping code="0x7F02" translation="Gateway Specification profile"/>
+  <mapping code="0xA1E0" translation="Green Power"/>
+</map>

--- a/src/app/zap-templates/zcl/data-model/silabs/relay-control.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/relay-control.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <cluster>
+    <name>Relay Control</name>
+    <domain>Ember</domain>
+    <description>Commands to turn on and off the stack's relay capabilities, and to determine whether or not relay is enabled.</description>
+    <code>0xC00D</code>
+    <define>RELAY_CONTROL_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <command source="client" code="0x00" name="SetRelayState" optional="false">
+      <description>
+        Sets the on-off state of stack relay.
+      </description>
+      <arg name="isEnabled" type="BOOLEAN"/>
+      <arg name="magicNumber" type="INT32U"/>
+    </command>
+    <command source="client" code="0x01" name="GetRelayState" optional="false">
+      <description>
+        Client-to-server query that provides the on-off state of stack relay.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="GetRelayStateResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Response to GetRelayState query.
+      </description>
+      <arg name="isEnabled" type="BOOLEAN"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/sample-extensions.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/sample-extensions.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!-- 
+     This xml file contains a sample extension to the Application Framework's
+     cluster definitions. There are 4 ways to add manufacturer specific
+     extensions within ZigBee.  
+     
+     1. Private Profile: 
+        You can create your own private ZigBee profile.
+        We do not provide an example of this here since private profiles 
+        may or may not even use the cluster library or something like it. If
+        you create your own custom profile you can basically do whatever you
+        want after the APS frame in the ZigBee packet. If you choose to use
+        the ZigBee cluster library within your private profile the Application
+        Framework will be useful to you. If you do not, it will not be useful
+        to you as all of the code in the Application Framework centers around
+        support for the ZigBee Cluster Library (ZCL).
+      
+    2. Manufacturer Specific Clusters:
+       You can add manufacturer specific clusters to a standard profile.
+       We provide an example of this below. In order to do this you must
+       satisfy two obligations:
+         
+         1. The cluster id MUST be in the manufacturer specific range,
+            0xfc00 - 0xffff.
+         2. The cluster definition must include a manufacturer code 
+            which will be applied to ALL attributes and 
+            commands within that cluster and must be provided when sending 
+            and receiving commands and interacting with attributes. 
+     
+     3. Manufacturer Specific Commands in Standard ZigBee Custer:
+        You can add your own commands to any standard ZigBee cluster with 
+        the following requirements:
+        
+        1. Your manufacturer specific commands may use any command id 
+          within the command id range, 0x00 - 0xff. 
+        2. You must also provide a manufacturer code for the command so 
+           that it can be distinguished from other commands in the cluster 
+           and handled appropriately.
+     
+     4. Manufacturer Specific Attributes in Standard ZigBee Cluster:
+        You can add your own attributes to any standard ZigBee cluster with 
+        the following requirements:
+        
+        1. Your manufacturer specific attributes may use any attribute id 
+           within the attribute id range, 0x0000 - 0xffff. 
+        2. You must also provide a manufacturer code for the attribute so 
+           that it can be distinguished from other attributes in the cluster 
+           and handled appropriately.
+        
+     This sample provides an example of how to:
+       1. Extend the ZCL with a manufacturer specific cluster 
+       2. Extend the standard ZCL on/off cluster with manufacturer specific
+          attributes.
+       3. Extend the standard ZCL on/off cluster with manufacturer specific
+          commands.
+     
+     Manufacturer Code:
+     In all cases below, we have used Ember's manufacturerCode 0x1002 since
+     the cluster, attributes and the commands were created by Ember 
+     as an example of how the Application Framework can be 
+     extended to support manufacturer specific commands and attributes.
+     
+     XML Validation:
+     You may validate any xml file that you create against the 
+     AppBuilder XSD located in tool/appbuilder/appbuilder.xsd
+     
+-->
+<configurator>
+  <domain name="Ember"/>
+  <!-- Use manufacturerCode to indicate that this is a manufacturer specific
+       cluster. -->
+  <cluster manufacturerCode="0x1002">
+    <name>Sample Mfg Specific Cluster</name>
+    <domain>Ember</domain>
+    <description>This cluster provides an example of how the Application 
+      Framework can be extended to include manufacturer specific clusters.
+      </description>
+    <!-- Cluster Id must be within the mfg spec range 0xfc00 - 0xffff -->
+    <code>0xFC00</code>
+    <define>SAMPLE_MFG_SPECIFIC_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="ATTRIBUTE_ONE" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">ember sample attribute</attribute>
+    <attribute side="server" code="0x0001" define="ATTRIBUTE_TWO" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x00" optional="true">ember sample attribute 2</attribute>
+    <command source="client" code="0x00" name="CommandOne" optional="true">
+      <description>
+        A sample manufacturer specific command within the sample manufacturer specific
+        cluster.
+      </description>
+      <arg name="argOne" type="INT8U"/>
+    </command>
+  </cluster>
+  <cluster manufacturerCode="0x1049">
+    <name>Sample Mfg Specific Cluster 2</name>
+    <domain>Ember</domain>
+    <description>This cluster provides an example of how the Application 
+      Framework can be extended to include manufacturer specific clusters.
+      </description>
+    <!-- Cluster Id must be within the mfg spec range 0xfc00 - 0xffff -->
+    <code>0xFC00</code>
+    <define>SAMPLE_MFG_SPECIFIC_CLUSTER_2</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="ATTRIBUTE_THREE" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">ember sample attribute 2</attribute>
+    <attribute side="server" code="0x0001" define="ATTRIBUTE_FOUR" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true">ember sample attribute 2</attribute>
+    <command source="client" code="0x00" name="CommandTwo" optional="true">
+      <description>
+        A sample manufacturer specific command within the sample manufacturer specific
+        cluster.
+      </description>
+      <arg name="argOne" type="INT8U"/>
+    </command>
+  </cluster>
+  <!-- Use the cluster extension Extend the on/off cluster -->
+  <clusterExtension code="0x0006">
+    <attribute side="server" code="0x0000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" manufacturerCode="0x1002">Sample Mfg Specific Attribute: 0x0000 0x1002</attribute>
+    <attribute side="server" code="0x0000" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_2" type="INT8U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" manufacturerCode="0x1049">Sample Mfg Specific Attribute: 0x0000 0x1049</attribute>
+    <attribute side="server" code="0x0001" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_3" type="INT8U" min="0x0000" max="0xFFFF" writable="true" default="0x00" optional="true" manufacturerCode="0x1002">Sample Mfg Specific Attribute: 0x0001 0x1002</attribute>
+    <attribute side="server" code="0x0001" define="SAMPLE_MFG_SPECIFIC_TRANSITION_TIME_4" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" manufacturerCode="0x1049">Sample Mfg Specific Attribute: 0x0001 0x1040</attribute>
+    <command source="client" code="0x00" name="SampleMfgSpecificOffWithTransition" optional="true" manufacturerCode="0x1002">
+      <description>Client command that turns the device off with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+    <command source="client" code="0x01" name="SampleMfgSpecificOnWithTransition" optional="true" manufacturerCode="0x1002">
+      <description>Client command that turns the device on with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+    <command source="client" code="0x02" name="SampleMfgSpecificToggleWithTransition" optional="true" manufacturerCode="0x1002">
+      <description>Client command that toggles the device with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+    <command source="client" code="0x01" name="SampleMfgSpecificOnWithTransition2" optional="true" manufacturerCode="0x1049">
+      <description>Client command that turns the device on with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+    <command source="client" code="0x02" name="SampleMfgSpecificToggleWithTransition2" optional="true" manufacturerCode="0x1049">
+      <description>Client command that toggles the device with a transition given
+        by the transition time in the Ember Sample transition time attribute.</description>
+    </command>
+  </clusterExtension>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/schema/zcl-validation.js
+++ b/src/app/zap-templates/zcl/data-model/silabs/schema/zcl-validation.js
@@ -1,0 +1,30 @@
+/**
+ *
+ *    Copyright (c) 2020 Silicon Labs
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+const libxmljs = require('libxmljs')
+
+// validateZclFile will have validationSchema be bound to it.
+function validateZclFile(validationSchemaBuffer, zclFileBuffer) {
+  let zclFile = libxmljs.parseXml(zclFileBuffer.toString())
+  let xsdDoc = libxmljs.parseXml(validationSchemaBuffer.toString())
+  let validationStatus = zclFile.validate(xsdDoc)
+  let validationErrors = zclFile.validationErrors
+  let returnValue = { isValid: validationStatus, errors: validationErrors }
+  return returnValue
+}
+
+exports.validateZclFile = validateZclFile

--- a/src/app/zap-templates/zcl/data-model/silabs/schema/zcl-validation.js
+++ b/src/app/zap-templates/zcl/data-model/silabs/schema/zcl-validation.js
@@ -18,13 +18,13 @@
 const libxmljs = require('libxmljs')
 
 // validateZclFile will have validationSchema be bound to it.
-function validateZclFile(validationSchemaBuffer, zclFileBuffer) {
-  let zclFile = libxmljs.parseXml(zclFileBuffer.toString())
-  let xsdDoc = libxmljs.parseXml(validationSchemaBuffer.toString())
+function validateZclFile(validationSchemaBuffer, zclFileBuffer)
+{
+  let zclFile          = libxmljs.parseXml(zclFileBuffer.toString())
+  let xsdDoc           = libxmljs.parseXml(validationSchemaBuffer.toString())
   let validationStatus = zclFile.validate(xsdDoc)
   let validationErrors = zclFile.validationErrors
-  let returnValue = { isValid: validationStatus, errors: validationErrors }
-  return returnValue
+  let returnValue      = { isValid : validationStatus, errors : validationErrors } return returnValue
 }
 
 exports.validateZclFile = validateZclFile

--- a/src/app/zap-templates/zcl/data-model/silabs/schema/zcl.xsd
+++ b/src/app/zap-templates/zcl/data-model/silabs/schema/zcl.xsd
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+    <xs:annotation>
+      <xs:documentation>This schema describes the format of the XML files, that describe the ZCL specification.
+It does not describe over-the-air format of the packet.
+
+Copyright 2012, Silicon Laboratories Inc.</xs:documentation></xs:annotation>
+    <xs:element name="cli">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="group" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="command" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="description" />
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:string" />
+      <xs:attribute name="name" use="required" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="configurator">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice>
+          <xs:element ref="callback" />
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="deviceType" />
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element minOccurs="0" ref="global" />
+          <xs:element minOccurs="0" maxOccurs="unbounded" ref="domain" />
+        </xs:choice>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="atomic" />
+          <xs:element ref="bitmap" />
+          <xs:element ref="cluster" />
+          <xs:element ref="clusterExtension" />
+          <xs:element ref="enum" />
+          <xs:element ref="struct" />
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="deviceType">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="name" />
+        <xs:element ref="domain" />
+        <xs:element ref="typeName" />
+        <xs:element ref="zigbeeType" />
+        <xs:element ref="profileId" />
+        <xs:element ref="deviceId" />
+        <xs:element minOccurs="0" ref="channels" />
+        <xs:element ref="clusters" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="typeName" type="xs:string" />
+  <xs:element name="zigbeeType">
+    <xs:complexType mixed="true">
+      <xs:attribute name="editable" use="optional" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="profileId">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="editable" use="required" type="xs:boolean" />
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="deviceId">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="editable" use="required" type="xs:boolean" />
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="channels">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="channel" />
+      </xs:sequence>
+      <xs:attribute name="editable" use="required" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="channel">
+    <xs:simpleType>
+      <xs:restriction base="xs:integer">
+        <xs:minInclusive value="11"></xs:minInclusive>
+        <xs:maxInclusive value="26"></xs:maxInclusive>
+        <xs:whiteSpace value="collapse"></xs:whiteSpace>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+  <xs:element name="clusters">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="include" />
+      </xs:sequence>
+      <xs:attribute name="lockOthers" use="required" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="include">
+    <xs:complexType mixed="true">
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="requireAttribute" />
+        <xs:element ref="requireCommand" />
+      </xs:choice>
+      <xs:attribute name="client" use="required" type="xs:boolean" />
+      <xs:attribute name="clientLocked" use="required" type="xs:boolean" />
+      <xs:attribute name="cluster" />
+      <xs:attribute name="server" use="required" type="xs:boolean" />
+      <xs:attribute name="serverLocked" use="required" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="requireAttribute" type="zclAttributeDefine" />
+  <xs:element name="requireCommand" type="zclCommandName" />
+  <xs:element name="global">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="command" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attribute" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="atomic">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="type" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="type">
+    <xs:complexType>
+      <xs:attribute name="id" use="required" type="xs:string" />
+      <xs:attribute name="name" use="required" type="xs:string" />
+      <xs:attribute name="description" use="required" type="xs:string" />
+      <xs:attribute name="size" type="xs:integer" />
+      <xs:attribute name="discrete" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="bitmap">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="field" />
+      </xs:sequence>
+      <xs:attribute name="name" use="required" type="xs:string" />
+      <xs:attribute name="type" use="required" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="field">
+    <xs:complexType>
+      <xs:attribute name="mask" use="required" type="xs:string" />
+      <xs:attribute name="name" use="required" type="xs:string" />
+      <xs:attribute name="introducedIn" type="zclSpecVersion" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="globalAttribute">
+    <xs:complexType>
+      <xs:attribute name="side" use="required" type="zclSideWithEither" />
+      <xs:attribute name="code" use="required" type="xs:string" />
+      <xs:attribute name="value" use="required" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cluster">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="name" />
+        <xs:element ref="domain" />
+        <xs:element ref="description" />
+        <xs:element ref="code" />
+        <xs:element ref="define" />
+        <xs:element ref="client" />
+        <xs:element ref="server" />
+        <xs:element minOccurs="0" ref="generateCmdHandlers" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="globalAttribute" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="attribute" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="command" />
+      </xs:sequence>
+      <xs:attribute name="introducedIn" type="xs:string" />
+      <xs:attribute name="manufacturerCode" type="zclCode" />
+      <xs:attribute name="singleton" type="xs:boolean" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="code" type="zclCode" />
+  <xs:element name="define" type="xs:string" />
+  <xs:element name="client">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:boolean">
+          <xs:attribute name="init" use="required" type="xs:boolean" />
+          <xs:attribute name="tick" use="required" type="xs:boolean" />
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="server">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:boolean">
+          <xs:attribute name="init" use="required" type="xs:boolean" />
+          <xs:attribute name="tick" use="required" type="xs:boolean" />
+          <xs:attribute name="tickFrequency" type="xs:string" />
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="generateCmdHandlers" type="xs:boolean" />
+  <xs:element name="clusterExtension">
+    <xs:complexType>
+    	<xs:sequence>
+    		<xs:element minOccurs="0" maxOccurs="unbounded"
+    			ref="attribute" />
+    		<xs:element minOccurs="0" maxOccurs="unbounded"
+    			ref="command" />
+    	</xs:sequence>
+    	<xs:attribute name="code" use="required" type="xs:string" />
+    	<xs:attribute name="introducedIn" type="zclSpecVersion"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="enum">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="item" />
+      </xs:sequence>
+      <xs:attribute name="description" />
+      <xs:attribute name="name" use="required" type="xs:string" />
+      <xs:attribute name="type" use="required" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="struct">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="item" />
+      </xs:sequence>
+      <xs:attribute name="length" type="xs:integer" />
+      <xs:attribute name="name" use="required" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="callback">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="function" />
+      </xs:sequence>
+      <xs:attribute name="postfix" type="xs:string" />
+      <xs:attribute name="prefix" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="function">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" ref="description" />
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="arg" />
+        <xs:element minOccurs="0" ref="codeForStub" />
+      </xs:sequence>
+      <xs:attribute name="category" type="xs:string" />
+      <xs:attribute name="cluster" />
+      <xs:attribute name="consumed" type="xs:boolean" />
+      <xs:attribute name="id" use="required" type="xs:string" />
+      <xs:attribute name="name" use="required" />
+      <xs:attribute name="platformType" type="xs:string" />
+      <xs:attribute name="returnType" use="required" type="xs:string" />
+      <xs:attribute name="side" type="zclSide" />
+      <xs:attribute name="stackMacro" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="codeForStub" type="xs:string" />
+  <xs:element name="name" type="xs:string" />
+  <xs:element name="domain">
+    <xs:complexType mixed="true">
+    	<xs:sequence>
+    		<xs:element minOccurs="0" maxOccurs="unbounded" ref="older" />
+    	</xs:sequence>
+    	<xs:attribute name="dependsOn" type="zclSpecVersion" />
+    	<xs:attribute name="name" />
+    	<xs:attribute name="spec" type="zclSpecVersion" />
+    	<xs:attribute name="certifiable" type="xs:boolean"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="older">
+    <xs:complexType>
+    	<xs:attribute name="dependsOn" use="optional" type="xs:string" />
+    	<xs:attribute name="spec" use="required" type="xs:string" />
+    	<xs:attribute name="certifiable" type="xs:boolean"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="command">
+    <xs:complexType>
+    	<xs:sequence>
+    		<xs:element ref="description" />
+    		<xs:element minOccurs="0" maxOccurs="unbounded" ref="arg" />
+    	</xs:sequence>
+    	<xs:attribute name="cli" />
+    	<xs:attribute name="cliFunctionName" type="xs:string" />
+    	<xs:attribute name="code" type="xs:string" />
+    	<xs:attribute name="disableDefaultResponse" type="xs:boolean" />
+    	<xs:attribute name="functionName" type="xs:string" />
+    	<xs:attribute name="group" type="xs:string" />
+    	<xs:attribute name="introducedIn" type="zclSpecVersion" />
+    	<xs:attribute name="noDefaultImplementation" type="xs:boolean"></xs:attribute>
+    	<xs:attribute name="manufacturerCode" type="xs:string" />
+    	<xs:attribute name="name" type="xs:string" />
+    	<xs:attribute name="optional" type="xs:boolean" />
+    	<xs:attribute name="source" type="xs:string" />
+    	<xs:attribute name="restriction" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="item">
+    <xs:complexType>
+    	<xs:attribute name="introducedIn" type="zclSpecVersion" />
+    	<xs:attribute name="name" use="required" type="xs:string" />
+    	<xs:attribute name="type" type="xs:string" />
+    	<xs:attribute name="value" type="xs:string" />
+    	<xs:attribute name="array" type="xs:boolean"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="attribute">
+    <xs:complexType mixed="true">
+    	<xs:attribute name="code" use="required" type="zclCode" />
+    	<xs:attribute name="default" />
+    	<xs:attribute name="define" use="required"
+    		type="zclAttributeDefine" />
+    	<xs:attribute name="introducedIn" type="zclSpecVersion" />
+    	<xs:attribute name="length" type="xs:integer" />
+    	<xs:attribute name="manufacturerCode" type="zclCode" />
+    	<xs:attribute name="max" type="xs:anySimpleType" />
+    	<xs:attribute name="min" type="xs:anySimpleType" />
+    	<xs:attribute name="optional" use="required" type="xs:boolean" />
+    	<xs:attribute name="side" use="required" type="zclSide" />
+    	<xs:attribute name="type" use="required" type="xs:string" />
+    	<xs:attribute name="readable" type="xs:boolean" />
+    	<xs:attribute name="writable" type="xs:boolean" />
+    	<xs:attribute name="reportable" type="xs:boolean" />
+    	<xs:attribute name="array" type="xs:boolean"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="description">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="arg" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arg">
+        <xs:annotation>
+        	<xs:documentation>An optional attribute, that specifies the length argument.
+
+This is used in cases where a length argument is preceding the actual array.
+
+In those cases, an array becomes a known length, and you can have variable length arguments after it.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+        <xs:attribute name="arrayLength" type="xs:boolean" />
+    	<xs:attribute name="array" type="xs:boolean" />
+    	<xs:attribute name="default" type="xs:string" />
+    	<xs:attribute name="description" type="xs:string" />
+    	<xs:attribute name="introducedIn" type="zclSpecVersion" />
+    	<xs:attribute name="removedIn" type="zclSpecVersion"></xs:attribute>
+    	<xs:attribute name="name" use="required" />
+    	<xs:attribute name="type" use="required" />
+    	<xs:attribute name="length" type="xs:int"></xs:attribute>
+    	<xs:attribute name="presentIf" type="xs:string" />
+    	<xs:attribute name="optional" type="xs:integer" />
+    	<xs:attribute name="countArg" type="xs:string" use="optional"></xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:simpleType name="zclAttributeDefine">
+    <xs:restriction base="xs:string"></xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zclCommandName">
+    <xs:restriction base="xs:string"></xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zclSpecVersion">
+    <xs:restriction base="xs:string"></xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zclCode">
+    <xs:restriction base="xs:string"></xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zclSide">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="client"></xs:enumeration>
+      <xs:enumeration value="server"></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="zclSideWithEither">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="client"></xs:enumeration>
+      <xs:enumeration value="server"></xs:enumeration>
+      <xs:enumeration value="either"></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="mapping">
+    <xs:complexType>
+      <xs:attribute name="code" type="xs:string" />
+      <xs:attribute name="translation" type="xs:string" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="map">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="mapping" />
+        </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/app/zap-templates/zcl/data-model/silabs/silabs.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/silabs.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!-- 
+     This xml file contains a sample extension to the Application Framework's
+     cluster definitions. There are 4 ways to add manufacturer specific
+     extensions within ZigBee.  
+     
+     1. Private Profile: 
+        You can create your own private ZigBee profile.
+        We do not provide an example of this here since private profiles 
+        may or may not even use the cluster library or something like it. If
+        you create your own custom profile you can basically do whatever you
+        want after the APS frame in the ZigBee packet. If you choose to use
+        the ZigBee cluster library within your private profile the Application
+        Framework will be useful to you. If you do not, it will not be useful
+        to you as all of the code in the Application Framework centers around
+        support for the ZigBee Cluster Library (ZCL).
+      
+    2. Manufacturer Specific Clusters:
+       You can add manufacturer specific clusters to a standard profile.
+       We provide an example of this below. In order to do this you must
+       satisfy two obligations:
+         
+         1. The cluster id MUST be in the manufacturer specific range,
+            0xfc00 - 0xffff.
+         2. The cluster definition must include a manufacturer code 
+            which will be applied to ALL attributes and 
+            commands within that cluster and must be provided when sending 
+            and receiving commands and interacting with attributes. 
+     
+     3. Manufacturer Specific Commands in Standard ZigBee Custer:
+        You can add your own commands to any standard ZigBee cluster with 
+        the following requirements:
+        
+        1. Your manufacturer specific commands may use any command id 
+          within the command id range, 0x00 - 0xff. 
+        2. You must also provide a manufacturer code for the command so 
+           that it can be distinguished from other commands in the cluster 
+           and handled appropriately.
+     
+     4. Manufacturer Specific Attributes in Standard ZigBee Cluster:
+        You can add your own attributes to any standard ZigBee cluster with 
+        the following requirements:
+        
+        1. Your manufacturer specific attributes may use any attribute id 
+           within the attribute id range, 0x0000 - 0xffff. 
+        2. You must also provide a manufacturer code for the attribute so 
+           that it can be distinguished from other attributes in the cluster 
+           and handled appropriately.
+        
+     This sample provides an example of how to:
+       1. Extend the ZCL with a manufacturer specific cluster 
+       2. Extend the standard ZCL on/off cluster with manufacturer specific
+          attributes.
+       3. Extend the standard ZCL on/off cluster with manufacturer specific
+          commands.
+     
+     Manufacturer Code:
+     In all cases below, we have used Ember's manufacturerCode 0x1002 since
+     the cluster, attributes and the commands were created by Ember 
+     as an example of how the Application Framework can be 
+     extended to support manufacturer specific commands and attributes.
+     
+     XML Validation:
+     You may validate any xml file that you create against the 
+     AppBuilder XSD located in tool/appbuilder/appbuilder.xsd
+     
+-->
+<configurator>
+  <domain name="Ember"/>
+  <!-- Use manufacturerCode to indicate that this is a manufacturer specific
+       cluster. -->
+  <cluster manufacturerCode="0x1002">
+    <name>Configuration Cluster</name>
+    <domain>Ember</domain>
+    <description>This cluster allows for the OTA configuration of firmware
+	  parameters.  
+      </description>
+    <code>0xFC01</code>
+    <define>OTA_CONFIGURATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="TOKENS_LOCKED" type="BOOLEAN" writable="false" default="0x00" optional="false">Prevents OTA writing of tokens.</attribute>
+    <command source="client" code="0x00" name="SetToken" optional="false" cli="zcl ota-config setToken">
+      <description>
+        Command to write a token value over the air.
+      </description>
+      <arg name="token" type="INT16U"/>
+      <arg name="data" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x01" name="LockTokens" optional="false" cli="zcl ota-config lock">
+      <description>
+        Command to lock the token values.
+      </description>
+    </command>
+    <command source="client" code="0x02" name="ReadTokens" optional="false" cli="zcl ota-config read">
+      <description>
+        Command to read a token value.
+      </description>
+      <arg name="token" type="INT16U"/>
+    </command>
+    <command source="client" code="0x03" name="UnlockTokens" optional="false" cli="zcl ota-config unlock">
+      <description>
+        Command to unlock tokens with a device-specific password (if allowed).
+      </description>
+      <arg name="data" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x00" name="ReturnToken" optional="false">
+      <description>
+        Response to a token value read.
+      </description>
+      <arg name="token" type="INT16U"/>
+      <arg name="data" type="OCTET_STRING"/>
+    </command>
+  </cluster>
+  <cluster manufacturerCode="0x1002">
+    <name>MFGLIB Cluster</name>
+    <domain>Ember</domain>
+    <description>This cluster provides commands to kick off MFGLIB actions 
+	  over the air.  
+      </description>
+    <code>0xFC02</code>
+    <define>MFGLIB_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="PACKETS_RECEIVED" type="INT16U" writable="false" default="0x00" optional="false">Number of packets received while in MFGLIB mode.</attribute>
+    <attribute side="server" code="0x0001" define="SAVED_RSSI" type="INT8S" writable="false" default="0x00" optional="false">RSSI of the first received packet.</attribute>
+    <attribute side="server" code="0x0002" define="SAVED_LQI" type="INT8U" writable="false" default="0x00" optional="false">LQI of the first received packet.</attribute>
+    <command source="client" code="0x00" name="stream" optional="false" cli="zcl mfglib stream">
+      <description>
+        Command to put the device into streaming mode.
+      </description>
+      <arg name="channel" type="INT8U"/>
+      <arg name="power" type="INT8S"/>
+      <arg name="time" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="tone" optional="false" cli="zcl mfglib tone">
+      <description>
+        Command to put the device into tone mode.
+      </description>
+      <arg name="channel" type="INT8U"/>
+      <arg name="power" type="INT8S"/>
+      <arg name="time" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="rxMode" optional="false" cli="zcl mfglib rx-mode">
+      <description>
+        Command to put the device into RX mode.
+      </description>
+      <arg name="channel" type="INT8U"/>
+      <arg name="power" type="INT8S"/>
+      <arg name="time" type="INT16U"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/sleeping-mesh.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/sleeping-mesh.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <!-- See bug 13487 (BITMAP48 data types). -->
+  <enum name="SmStatus" type="ENUM8">
+    <item name="NotConfigured" value="0x00"/>
+    <item name="NormalOperation" value="0x01"/>
+    <item name="Installation" value="0x02"/>
+    <item name="Maintenance" value="0x03"/>
+  </enum>
+  <bitmap name="SmHour" type="BITMAP48">
+    <field name="Hour0" mask="0x000000000002"/>
+    <field name="Hour1" mask="0x00000000000C"/>
+    <field name="Hour2" mask="0x000000000020"/>
+    <field name="Hour3" mask="0x0000000000C0"/>
+    <field name="Hour4" mask="0x000000000200"/>
+    <field name="Hour5" mask="0x000000000C00"/>
+    <field name="Hour6" mask="0x000000002000"/>
+    <field name="Hour7" mask="0x00000000C000"/>
+    <field name="Hour8" mask="0x000000020000"/>
+    <field name="Hour9" mask="0x0000000C0000"/>
+    <field name="Hour10" mask="0x000000200000"/>
+    <field name="Hour11" mask="0x000000C00000"/>
+    <field name="Hour12" mask="0x000002000000"/>
+    <field name="Hour13" mask="0x00000C000000"/>
+    <field name="Hour14" mask="0x000020000000"/>
+    <field name="Hour15" mask="0x0000C0000000"/>
+    <field name="Hour16" mask="0x000200000000"/>
+    <field name="Hour17" mask="0x000C00000000"/>
+    <field name="Hour18" mask="0x002000000000"/>
+    <field name="Hour19" mask="0x00C000000000"/>
+    <field name="Hour20" mask="0x020000000000"/>
+    <field name="Hour21" mask="0x0C0000000000"/>
+    <field name="Hour22" mask="0x200000000000"/>
+    <field name="Hour23" mask="0xC00000000000"/>
+  </bitmap>
+  <enum name="SmSchedulingType" type="ENUM8">
+    <item name="UseOfWakeupPeriod" value="0x00"/>
+    <item name="UseOfWakeupHoursScheduling" value="0x01"/>
+  </enum>
+  <cluster>
+    <name>Sleeping Mesh Configuration</name>
+    <domain>SM</domain>
+    <description>This cluster provides an interface for configuring and managing a sleeping mesh.  The sleeping mesh is defined as a ZigBee Network where a number of devices supporting router features are able to sleep using an application layer mechanism to synchronize the wakeup and sleep.</description>
+    <code>0xXXXX</code>
+    <define>SM_SLEEPING_MESH_CONFIGURATION_CLUSTER</define>
+    <client init="false" tick="false">true</client>
+    <server init="false" tick="false">true</server>
+    <attribute side="server" code="0x0000" define="SM_STATUS" type="ENUM8" writable="false" default="0x00" optional="true">status</attribute>
+    <attribute side="server" code="0x0001" define="SM_AWAKE_DURATION" type="INT16U" min="0x0000" max="0xFFFE" writable="false" default="0x003C" optional="true">awake duration</attribute>
+    <attribute side="server" code="0x0002" define="SM_WAKE_UP_PERIOD" type="INT32U" min="0x00000000" max="0xFFFFFFFE" writable="false" default="" optional="true">wake up period</attribute>
+    <attribute side="server" code="0x0003" define="SM_NEXT_WAKE_UP_UTC_TIME" type="UTC_TIME" min="0x00000000" max="0xFFFFFFFE" writable="false" default="0xFFFFFFFF" optional="true">next wake up utc time</attribute>
+    <attribute side="server" code="0x0004" define="SM_TX_JITTER" type="INT16U" min="0x0000" max="0xFFFE" writable="false" default="0x00000000" optional="true">tx jitter</attribute>
+    <attribute side="server" code="0x0005" define="SM_WAKE_UP_HOUR_WORK_DAY" type="BITMAP48" min="0x000000000000" max="0xFFFFFFFFFFFE" writable="false" default="" optional="true">wake up hour work day</attribute>
+    <attribute side="server" code="0x0006" define="SM_WAKE_UP_HOUR_HOLY_DAY" type="BITMAP48" min="0x000000000000" max="0xFFFFFFFFFFFE" writable="false" default="" optional="true">wake up hour holy day</attribute>
+    <attribute side="server" code="0x0007" define="SM_SCHEDULING_TYPE" type="ENUM8" writable="false" default="" optional="true">scheduling type</attribute>
+    <attribute side="server" code="0x0008" define="SM_SLEEPING_CONFIGURATION_ID" type="INT16U" min="0x0000" max="0xFFFE" writable="false" default="0x00" optional="true">sleeping configuration id</attribute>
+    <command source="client" code="0x00" name="SmSleepingMeshConfiguration" optional="false">
+      <description>
+        The Sleeping Mesh Configuration command is used to configure the device to operate in a sleeping mesh.  The configuration parameters allow the devices in the network to understand how to share a wakeup window and to operate in that period of time like an always-on ZigBee network.
+      </description>
+      <arg name="sleepingConfigurationId" type="INT16U"/>
+      <arg name="schedulingType" type="SmSchedulingType"/>
+      <arg name="status" type="SmStatus"/>
+      <arg name="awakeDuration" type="INT16U"/>
+      <arg name="wakeUpPeriod" type="INT32U"/>
+      <arg name="nextWakeUpUtcTime" type="UTC_TIME"/>
+      <arg name="txJitter" type="INT16U"/>
+      <arg name="timestamp" type="UTC_TIME"/>
+      <arg name="wakeUpHourWorkDay" type="SmHour"/>
+      <arg name="wakeUpHourHolyDay" type="SmHour"/>
+    </command>
+    <command source="server" code="0x00" name="SmGetSleepingMeshConfiguration" optional="false">
+      <description>
+        This command initiates a Sleeping Mesh Configuration command for the current sleeping configuration available for this device.
+      </description>
+      <arg name="sleepingConfigurationId" type="INT16U"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ta-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ta-devices.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>TA-zigbeesimcard</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee SIM Card (ZSIM)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">ISO 7816 Protocol Tunnel</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Information</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Payment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Billing</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Sharing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Voice over ZigBee</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Rate Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Chatting</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">RSSI Location</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeemobileterminal</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Mobile Terminal (ZMT)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0001</deviceId>
+    <clusters lockOthers="true">
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Information</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Payment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Billing</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Sharing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Rate Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Voice over ZigBee</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Gaming</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Chatting</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">ISO 7816 Protocol Tunnel</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">RSSI Location</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-configurationtool</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Configuration Tool</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0005</deviceId>
+    <clusters lockOthers="true">
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Information</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Data Rate Control</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Data Sharing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Payment</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Billing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Voice over ZigBee</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="true">RSSI Location</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="true">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-rangeextender</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Range Extender</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0008</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeeaccesspoint</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Access Point (ZAP)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0100</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Payment</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Billing</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeeinformationnode</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Information Node (ZIN)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0101</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="false" serverLocked="true">Information</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Billing</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeeinformationterminal</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Information Terminal (ZIT)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0102</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Information</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-pointofsale</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Point of Sale</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0200</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Payment</include>
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASKE</include>-->
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-ticketingmachine</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Ticketing Machine</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0201</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Payment</include>
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASKE</include>-->
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-paycontroller</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Pay Controller</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0202</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASKE</include>-->
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Payment</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-billingunit</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Billing Unit</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0203</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASKE</include>-->
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASAC</include>-->
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Billing</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-chargingunit</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Charging Unit</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0204</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Information</include>
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASKE</include>-->
+      <!--<include client="true"  server="true"  clientLocked="true"  serverLocked="true" >ASAC</include>-->
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Billing</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeeflashcard</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Flash Card</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0300</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">On/Off</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Sharing</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Data Rate Control</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Information</include>
+      <include client="false" server="false" clientLocked="false" serverLocked="false">Partition</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeepcsmartcardreader</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee PC Smart Card Reader</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0301</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">ISO 7816 Protocol Tunnel</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeeheadset</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Headset</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0400</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Voice over ZigBee</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeemicrophone</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Microphone</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0401</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">Voice over ZigBee</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-zigbeespeaker</name>
+    <domain>Telecom Applications</domain>
+    <typeName>ZigBee Speaker</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0402</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Voice over ZigBee</include>
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASKE</include>-->
+      <!--<include client="false" server="false" clientLocked="false" serverLocked="false">ASAC</include>-->
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-rssianchornode</name>
+    <domain>Telecom Applications</domain>
+    <typeName>RSSI Anchor Node (RAN)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0500</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">RSSI Location</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-rssilocationnode</name>
+    <domain>Telecom Applications</domain>
+    <typeName>RSSI Location Node (RLN)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0501</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">RSSI Location</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-rssilocationgateway</name>
+    <domain>Telecom Applications</domain>
+    <typeName>RSSI Location Gateway (RLG)</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0502</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="false" clientLocked="true" serverLocked="true">RSSI Location</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-chattingunit</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Chatting Unit</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0600</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="true" server="true" clientLocked="true" serverLocked="true">Chatting</include>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>TA-chattingstation</name>
+    <domain>Telecom Applications</domain>
+    <typeName>Chatting Station</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0107</profileId>
+    <deviceId editable="false">0x0601</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Groups</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Commissioning</include>
+      <include client="false" server="false" clientLocked="true" serverLocked="false">Identify</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Chatting</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/ta.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/ta.xml
@@ -1,0 +1,886 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="Telecom Applications" spec="ta-1.0-07-5307-07" dependsOn="zcl-1.0-07-5123-03"/>
+  <domain name="Protocol Interfaces" spec="ta-1.0-07-5307-07" dependsOn="zcl-1.0-07-5123-03"/>
+  <domain name="Telecommunication" spec="ta-1.0-07-5307-07" dependsOn="zcl-1.0-07-5123-03"/>
+  <domain name="Financial" spec="ta-1.0-07-5307-07" dependsOn="zcl-1.0-07-5123-03"/>
+  <cluster>
+    <name>Partition</name>
+    <domain>General</domain>
+    <description>Commands and attributes for enabling partitioning of large frame to be carried from other clusters of ZigBee devices.</description>
+    <code>0x0016</code>
+    <define>PARTITION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="PARTITION_MAXIMUM_INCOMING_TRANSFER_SIZE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0500" optional="false">maximum incoming transfer size</attribute>
+    <attribute side="server" code="0x0001" define="PARTITION_MAXIMUM_OUTGOING_TRANSFER_SIZE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0500" optional="false">maximum outgoing transfer size</attribute>
+    <attribute side="server" code="0x0002" define="PARTIONED_FRAME_SIZE" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x50" optional="false">partioned frame size</attribute>
+    <attribute side="server" code="0x0003" define="LARGE_FRAME_SIZE" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0500" optional="false">large frame size</attribute>
+    <attribute side="server" code="0x0004" define="NUMBER_OF_ACK_FRAME" type="INT8U" min="0x00" max="0xFF" writable="true" default="0x64" optional="false">number of ack frame</attribute>
+    <attribute side="server" code="0x0005" define="NACK_TIMEOUT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">nack timeout</attribute>
+    <attribute side="server" code="0x0006" define="INTERFRAME_DELAY" type="INT8U" min="0x00" max="0xFF" writable="true" optional="false">interframe delay</attribute>
+    <attribute side="server" code="0x0007" define="NUMBER_OF_SEND_RETRIES" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x03" optional="false">number of send retries</attribute>
+    <attribute side="server" code="0x0008" define="SENDER_TIMEOUT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">sender timeout</attribute>
+    <attribute side="server" code="0x0009" define="RECEIVER_TIMEOUT" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">receiver timeout</attribute>
+    <command source="client" code="0x00" name="TransferPartitionedFrame" optional="false">
+      <description>The TransferPartitionedFrame command is used to send a partitioned frame to another Partition cluster.</description>
+      <arg name="fragmentationOptions" type="BITMAP8"/>
+      <!-- Partition Indicator can be one or two bytes depending on the bits in
+           Fragmentation Options.  call-command-handler can't generate code for
+           something that complicated, so instead just send a buffer and leave
+           parsing to the user.
+      -->
+      <!--<arg name="partitionIndicator"   type="INT8U/INT16U" />-->
+      <!--<arg name="partitionedFrame"     type="OCTET_STRING" />-->
+      <arg name="partitionedIndicatorAndFrame" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="ReadHandshakeParam" optional="false">
+      <description>The ReadHandshakeParam command is used in order to read the appropriate set of parameters for each transaction to be performed by the Partition Cluster.</description>
+      <arg name="partitionedClusterId" type="CLUSTER_ID"/>
+      <arg name="attributeList" type="ATTRIBUTE_ID" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="WriteHandshakeParam" optional="false">
+      <description>The WriteHandshakeParam command is used during the handshake phase in order to write the appropriate parameters for each transaction to be performed by the Partition Cluster.</description>
+      <arg name="partitionedClusterId" type="CLUSTER_ID"/>
+      <arg name="writeAttributeRecords" type="WriteAttributeRecord" array="true"/>
+    </command>
+    <command source="server" code="0x00" name="MultipleAck" optional="false">
+      <description>MultipleACK command.</description>
+      <arg name="ackOptions" type="BITMAP8"/>
+      <!-- First Frame ID and the list of NACK IDs can be one or two bytes
+           depending on the bits in ACK Options.  call-command-handler can't
+           generate code for something that complicated, so instead just send a
+           buffer and leave parsing to the user.
+      -->
+      <!--<arg name="firstFrameId" type="INT8U/INT16U" />-->
+      <!--<arg name="nackList"     type="INT8U/INT16U" array="true" />-->
+      <arg name="firstFrameIdAndNackList" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="ReadHandshakeParamResponse" optional="false" disableDefaultResponse="true">
+      <description>The ReadHandshakeParamResponse command is used in order to response to the corresponding ReadHandshakeParam command in order to communicate the appropriate set of parameters configured for each transaction to be performed by the Partition Cluster.</description>
+      <arg name="partitionedClusterId" type="CLUSTER_ID"/>
+      <arg name="readAttributeStatusRecords" type="ReadAttributeStatusRecord" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>ISO 7816 Protocol Tunnel</name>
+    <domain>Protocol Interfaces</domain>
+    <description>Commands and attributes for mobile office solutions including ZigBee devices.</description>
+    <code>0x0615</code>
+    <define>ISO7816_PROTOCOL_TUNNEL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="ISO7816_PROTOCOL_TUNNEL_STATUS" type="INT8U" min="0x00" max="0x01" writable="false" default="0x00" optional="false">status</attribute>
+    <command source="either" code="0x00" name="TransferApdu" optional="false">
+      <description>
+        Command description for TransferApdu
+      </description>
+      <arg name="apdu" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x01" name="InsertSmartCard" optional="false">
+      <description>
+        Command description for InsertSmartCard
+      </description>
+    </command>
+    <command source="client" code="0x02" name="ExtractSmartCard" optional="false">
+      <description>
+        Command description for ExtractSmartCard
+      </description>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Information</name>
+    <domain>Telecommunication</domain>
+    <description>Provides commands and attributes for information delivery service on ZigBee networks.</description>
+    <code>0x0900</code>
+    <define>INFORMATION_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="NODE_DESCRIPTION" type="CHAR_STRING" length="16" writable="false" optional="false">node description</attribute>
+    <attribute side="server" code="0x0001" define="DELIVERY_ENABLE" type="BOOLEAN" min="0x00" max="0x01" writable="false" optional="false">delivery enable</attribute>
+    <attribute side="server" code="0x0002" define="PUSH_INFORMATION_TIMER" type="INT32U" writable="false" optional="true">push information timer</attribute>
+    <attribute side="server" code="0x0003" define="ENABLE_SECURE_CONFIGURATION" type="BOOLEAN" min="0x00" max="0x01" writable="false" optional="false">enable secure configuration</attribute>
+    <attribute side="server" code="0x0010" define="NUMBER_OF_CONTENTS" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">number of contents</attribute>
+    <attribute side="server" code="0x0011" define="CONTENT_ROOT_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="true">content root id</attribute>
+    <command source="client" code="0x00" name="RequestInformation" optional="false">
+      <description>
+        Command description for RequestInformation
+      </description>
+      <arg name="inquiryId" type="ENUM8"/>
+      <arg name="dataTypeId" type="BITMAP8"/>
+      <!-- Request Information Payload varies depending on Data Type ID.
+           call-command-handler can't generate code for something that
+           complicated, so instead just send a buffer and leave parsing to the
+           user.
+      -->
+      <arg name="requestInformationPayload" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="PushInformationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for PushInformationResponse
+      </description>
+      <arg name="notificationList" type="Notification" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="SendPreference" optional="true">
+      <description>
+        Command description for SendPreference
+      </description>
+      <arg name="preferenceType" type="INT16U"/>
+      <!-- Request Information Payload varies depending on Preference Type.
+           call-command-handler can't generate code for something that
+           complicated, so instead just send a buffer and leave parsing to the
+           user.
+      -->
+      <arg name="preferencePayload" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x03" name="RequestPreferenceResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for RequestPreferenceResponse
+      </description>
+      <arg name="statusFeedback" type="Status"/>
+      <arg name="preferenceType" type="INT16U"/>
+      <!-- Preference Payload varies depending on Preference Type.
+           call-command-handler can't generate code for something that
+           complicated, so instead just send a buffer and leave parsing to the
+           user.
+      -->
+      <arg name="preferencePayload" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x04" name="Update" optional="true">
+      <description>
+        Command description for Update
+      </description>
+      <arg name="accessControl" type="ENUM8"/>
+      <arg name="option" type="BITMAP8"/>
+      <arg name="contents" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x05" name="Delete" optional="true">
+      <description>
+        Command description for Delete
+      </description>
+      <arg name="deletionOptions" type="BITMAP8"/>
+      <arg name="contentIds" type="INT16U" array="true"/>
+    </command>
+    <command source="client" code="0x06" name="ConfigureNodeDescription" optional="true">
+      <description>
+        Command description for ConfigureNodeDescription
+      </description>
+      <arg name="description" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x07" name="ConfigureDeliveryEnable" optional="true">
+      <description>
+        Command description for ConfigureDeliveryEnable
+      </description>
+      <arg name="enable" type="BOOLEAN"/>
+    </command>
+    <command source="client" code="0x08" name="ConfigurePushInformationTimer" optional="true">
+      <description>
+        Command description for ConfigurePushInformationTimer
+      </description>
+      <arg name="timer" type="INT32U"/>
+    </command>
+    <command source="client" code="0x09" name="ConfigureSetRootId" optional="true">
+      <description>
+        Command description for ConfigureSetRootId
+      </description>
+      <arg name="rootId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="RequestInformationResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for RequestInformationResponse
+      </description>
+      <arg name="number" type="INT8U"/>
+      <!-- Each Status field will be followed by a Single Content or Content ID,
+           which are variable length.  call-command-handler can't generate code
+           for something that complicated, so instead just send a buffer and
+           leave parsing to the user.
+      -->
+      <arg name="buffer" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="PushInformation" optional="false">
+      <description>
+        Command description for PushInformation
+      </description>
+      <arg name="contents" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="SendPreferenceResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for SendPreferenceResponse
+      </description>
+      <arg name="statusFeedbackList" type="Status" array="true"/>
+    </command>
+    <command source="server" code="0x03" name="ServerRequestPreference" optional="true">
+      <description>
+        Command description for ServerRequestPreference
+      </description>
+    </command>
+    <command source="server" code="0x04" name="RequestPreferenceConfirmation" optional="true">
+      <description>
+        Command description for RequestPreferenceConfirmation
+      </description>
+      <arg name="statusFeedbackList" type="Status" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="UpdateResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for UpdateResponse
+      </description>
+      <arg name="notificationList" type="Notification" array="true"/>
+    </command>
+    <command source="server" code="0x06" name="DeleteResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for DeleteResponse
+      </description>
+      <arg name="notificationList" type="Notification" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Data Sharing</name>
+    <domain>Telecommunication</domain>
+    <description>Commands and attributes for small data sharing among ZigBee devices.</description>
+    <code>0x0901</code>
+    <define>DATA_SHARING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="DEVICE_NAME" type="CHAR_STRING" length="16" writable="false" optional="false">device name</attribute>
+    <attribute side="server" code="0x0001" define="DEVICE_DESCRIPTION" type="CHAR_STRING" length="16" writable="false" optional="true">device description</attribute>
+    <command source="client" code="0x00" name="ReadFileRequest" optional="false">
+      <description>
+        Command description for ReadFileRequest
+      </description>
+      <arg name="fileIndex" type="INT16U"/>
+      <!-- File Start Position and Requested Octet Count are optional fields and
+           may not be present.  call-command-handler can't generate code for
+           something that complicated, so instead just send a buffer and leave
+           parsing to the user.
+      -->
+      <!--<arg name="fileStartPosition"   type="INT32U" />-->
+      <!--<arg name="requestedOctetCount" type="INT32U" />-->
+      <arg name="fileStartPositionAndRequestedOctetCount" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="ReadRecordRequest" optional="true">
+      <description>
+        Command description for ReadRecordRequest
+      </description>
+      <arg name="fileIndex" type="INT16U"/>
+      <!-- File Start Record and Requested Record Count are optional fields and
+           may not be present.  call-command-handler can't generate code for
+           something that complicated, so instead just send a buffer and leave
+           parsing to the user.
+      -->
+      <!--<arg name="fileStartRecord"      type="INT16U" />-->
+      <!--<arg name="requestedRecordCount" type="INT16U" />-->
+      <arg name="fileStartRecordAndRequestedRecordCount" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="WriteFileResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for WriteFileResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+      <!-- File Index will not exist if status is SUCCESS.  call-command-handler
+           can't generate code for something that complicated, so instead just
+           send a buffer and leave parsing to the user.
+      -->
+      <!--<arg name="fileIndex" type="INT16U" />-->
+      <arg name="fileIndex" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x00" name="WriteFileRequest" optional="true">
+      <description>
+        Command description for WriteFileRequest
+      </description>
+      <arg name="writeOptions" type="BITMAP8"/>
+      <!-- Partition Indicator can be one or two bytes depending on the bits in
+           Fragmentation Options.  call-command-handler can't generate code for
+           something that complicated, so instead just send a buffer and leave
+           parsing to the user.
+      -->
+      <!--<arg name="fileSize"     type="INT8U/INT16U" />-->
+      <arg name="fileSize" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x01" name="ModifyFileRequest" optional="true">
+      <description>
+        Command description for ModifyFileRequest
+      </description>
+      <arg name="fileIndex" type="INT16U"/>
+      <arg name="fileStartPosition" type="INT32U"/>
+      <arg name="octetCount" type="INT32U"/>
+    </command>
+    <command source="server" code="0x02" name="ModifyRecordRequest" optional="true">
+      <description>
+        Command description for ModifyRecordRequest
+      </description>
+      <arg name="fileIndex" type="INT16U"/>
+      <arg name="fileStartRecord" type="INT16U"/>
+      <arg name="recordCount" type="INT16U"/>
+    </command>
+    <command source="server" code="0x03" name="FileTransmission" optional="false">
+      <description>
+        Command description for FileTransmission
+      </description>
+      <arg name="transmitOptions" type="BITMAP8"/>
+      <!-- File Index, File Start Position, File Length, and File Data may not
+           be present.  call-command-handler can't generate code for something
+           that complicated, so instead just send a buffer and leave parsing to
+           the user.
+      -->
+      <!--<arg name="fileIndex"         type="INT16U" />-->
+      <!--<arg name="fileStartPosition" type="INT32U" />-->
+      <!--<arg name="fileLength"        type="INT32U" />-->
+      <!--<arg name="fileData"          type="OCTET" array="true" />-->
+      <arg name="buffer" type="INT8U" array="true"/>
+    </command>
+    <command source="server" code="0x04" name="RecordTransmission" optional="true">
+      <description>
+        Command description for RecordTransmission
+      </description>
+      <arg name="transmitOptions" type="BITMAP8"/>
+      <!-- File Index, File Start Record, Record Count, and Record File Data may
+           not be present.  call-command-handler can't generate code for
+           something that complicated, so instead just send a buffer and leave
+           parsing to the user.
+      -->
+      <!--<arg name="fileIndex"       type="INT16U" />-->
+      <!--<arg name="fileStartRecord" type="INT16U" />-->
+      <!--<arg name="recordCount"     type="INT16U" />-->
+      <!--<arg name="recordFileData"  type="CHAR" array="true" />-->
+      <arg name="buffer" type="INT8U" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Gaming</name>
+    <domain>Telecommunication</domain>
+    <description>Attributes and commands to support gaming functions of ZigBee-enabled mobile terminals.</description>
+    <code>0x0902</code>
+    <define>GAMING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="PLAYER_NAME" type="CHAR_STRING" length="16" writable="false" optional="false">player name</attribute>
+    <attribute side="server" code="0x0001" define="NB_OF_GAMES" type="INT8U" min="0x00" max="0xFE" writable="false" optional="false">nb of games</attribute>
+    <attribute side="server" code="0x0002" define="LIST_OF_GAMES" type="CHAR_STRING" length="16" writable="false" optional="false">list of games</attribute>
+    <attribute side="server" code="0x0003" define="ANNOUNCEMENT_INTERVAL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">announcement interval</attribute>
+    <attribute side="server" code="0x0010" define="GAME_ID" type="INT16U" min="0x0001" max="0x00FE" writable="false" optional="false">game id</attribute>
+    <attribute side="server" code="0x0011" define="NAME_OF_GAME" type="CHAR_STRING" length="16" writable="false" optional="false">name of game</attribute>
+    <attribute side="server" code="0x0012" define="GAME_MASTER" type="BOOLEAN" writable="false" optional="false">game master</attribute>
+    <attribute side="server" code="0x0013" define="GAMING_STATUS" type="BITMAP8" min="0x00" max="0xFF" writable="false" optional="false">status</attribute>
+    <attribute side="server" code="0x0014" define="CURRENT_NB_OF_PLAYERS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="false">current nb of players</attribute>
+    <attribute side="server" code="0x0015" define="LIST_OF_CURRENT_PLAYERS" type="CHAR_STRING" length="16" writable="false" optional="false">list of current players</attribute>
+    <attribute side="server" code="0x0016" define="MAX_NB_OF_PLAYERS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="false">max nb of players</attribute>
+    <attribute side="server" code="0x0017" define="MIN_NB_OF_PLAYERS" type="INT8U" min="0x00" max="0xFF" writable="false" optional="false">min nb of players</attribute>
+    <attribute side="server" code="0x0018" define="CURRENT_GAME_LEVEL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">current game level</attribute>
+    <attribute side="server" code="0x0019" define="SCORE_OF_THIS_PLAYER" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">score of this player</attribute>
+    <attribute side="server" code="0x001A" define="TIMER1" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">timer1</attribute>
+    <attribute side="server" code="0x001B" define="TIMER2" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">timer2</attribute>
+    <attribute side="server" code="0x001C" define="TIMER3" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">timer3</attribute>
+    <attribute side="server" code="0x001D" define="COUNTER1" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">counter1</attribute>
+    <attribute side="server" code="0x001E" define="COUNTER2" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">counter2</attribute>
+    <attribute side="server" code="0x001F" define="DOWNLOADABLE" type="BOOLEAN" min="0x00" max="0x01" writable="false" optional="true">downloadable</attribute>
+    <command source="client" code="0x00" name="SearchGame" optional="false">
+      <description>
+        Command description for SearchGame
+      </description>
+      <arg name="specificGame" type="ENUM8"/>
+      <arg name="gameId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="JoinGame" optional="false">
+      <description>
+        Command description for JoinGame
+      </description>
+      <arg name="gameId" type="INT16U"/>
+      <arg name="joinAsMaster" type="BOOLEAN"/>
+      <arg name="nameOfGame" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x02" name="StartGame" optional="false">
+      <description>
+        Command description for StartGame
+      </description>
+    </command>
+    <command source="client" code="0x03" name="PauseGame" optional="false">
+      <description>
+        Command description for PauseGame
+      </description>
+    </command>
+    <command source="client" code="0x04" name="ResumeGame" optional="false">
+      <description>
+        Command description for ResumeGame
+      </description>
+    </command>
+    <command source="client" code="0x05" name="QuitGame" optional="false">
+      <description>
+        Command description for QuitGame
+      </description>
+    </command>
+    <command source="client" code="0x06" name="EndGame" optional="false">
+      <description>
+        Command description for EndGame
+      </description>
+    </command>
+    <command source="client" code="0x07" name="StartOver" optional="false">
+      <description>
+        Command description for StartOver
+      </description>
+    </command>
+    <command source="client" code="0x08" name="ActionControl" optional="false">
+      <description>
+        Command description for ActionControl
+      </description>
+      <arg name="actions" type="BITMAP32"/>
+    </command>
+    <command source="client" code="0x09" name="DownloadGame" optional="true">
+      <description>
+        Command description for DownloadGame
+      </description>
+    </command>
+    <command source="server" code="0x00" name="GameAnnouncement" optional="false">
+      <description>
+        Command description for GameAnnouncement
+      </description>
+      <arg name="gameId" type="INT16U"/>
+      <arg name="gameMaster" type="BOOLEAN"/>
+      <arg name="listOfGame" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x01" name="GeneralResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for GeneralResponse
+      </description>
+      <arg name="commandId" type="INT8U"/>
+      <arg name="status" type="BITMAP8"/>
+      <arg name="message" type="CHAR_STRING"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Data Rate Control</name>
+    <domain>Telecommunication</domain>
+    <description>This cluster seeks to give applications a means to managing data rate. It provides commands and attributes which form this interface.</description>
+    <code>0x0903</code>
+    <define>DATA_RATE_CONTROL_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="AVERAGE_LATENCY_REQUIREMENT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">average latency requirement</attribute>
+    <attribute side="server" code="0x0001" define="MAX_LATENCY_REQUIREMENT" type="INT8U" min="0x00" max="0xFF" writable="false" optional="true">max latency requirement</attribute>
+    <attribute side="server" code="0x0002" define="BANDWIDTH_REQUIREMENT" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">bandwidth requirement</attribute>
+    <command source="client" code="0x00" name="PathCreation" optional="true">
+      <description>
+        Command description for PathCreation
+      </description>
+      <arg name="originatorAddress" type="DATA16"/>
+      <arg name="destinationAddress" type="DATA16"/>
+      <arg name="dataRate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x01" name="DataRateNotification" optional="true">
+      <description>
+        Command description for DataRateNotification
+      </description>
+      <arg name="originatorAddress" type="DATA16"/>
+      <arg name="destinationAddress" type="DATA16"/>
+      <arg name="dataRate" type="INT8U"/>
+    </command>
+    <command source="client" code="0x02" name="PathDeletion" optional="true">
+      <description>
+        Command description for PathDeletion
+      </description>
+      <arg name="originatorAddress" type="DATA16"/>
+      <arg name="destinationAddress" type="DATA16"/>
+    </command>
+    <command source="server" code="0x00" name="DataRateControl" optional="false">
+      <description>
+        Command description for DataRateControl
+      </description>
+      <arg name="originatorAddress" type="DATA16"/>
+      <arg name="destinationAddress" type="DATA16"/>
+      <arg name="dataRate" type="INT8U"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Voice over ZigBee</name>
+    <domain>Telecommunication</domain>
+    <description>This cluster seeks to provide an interface to a voice over ZigBee protocol.</description>
+    <code>0x0904</code>
+    <define>VOICE_OVER_ZIGBEE_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="CODEC_TYPE" type="ENUM8" min="0x01" max="0x04" writable="true" optional="false">codec type</attribute>
+    <attribute side="server" code="0x0001" define="SAMPLING_FREQUENCY" type="ENUM8" min="0x01" max="0x03" writable="true" optional="false">sampling frequency</attribute>
+    <attribute side="server" code="0x0002" define="CODEC_RATE" type="ENUM8" min="0x01" max="0x0A" writable="true" optional="false">codec rate</attribute>
+    <attribute side="server" code="0x0003" define="ESTABLISHMENT_TIMEOUT" type="INT8U" min="0x01" max="0xFF" optional="false">establishment timeout</attribute>
+    <attribute side="server" code="0x0004" define="CODEC_TYPE_SUB1" type="ENUM8" writable="true" optional="true">codec type sub 1</attribute>
+    <attribute side="server" code="0x0005" define="CODEC_TYPE_SUB2" type="ENUM8" writable="true" optional="true">codec type sub 2</attribute>
+    <attribute side="server" code="0x0006" define="CODEC_TYPE_SUB3" type="ENUM8" writable="true" optional="true">codec type sub 3</attribute>
+    <attribute side="server" code="0x0007" define="COMPRESSION_TYPE" type="ENUM8" min="0x01" max="0x02" optional="true">compression type</attribute>
+    <attribute side="server" code="0x0008" define="COMPRESSION_RATE" type="ENUM8" optional="true">compression rate</attribute>
+    <attribute side="server" code="0x0009" define="OPTION_FLAGS" type="BITMAP8" min="0x00" max="0xFF" writable="true" optional="true">option flags</attribute>
+    <attribute side="server" code="0x000A" define="THRESHOLD" type="INT8U" min="0x00" max="0xFF" writable="true" optional="true">threshold</attribute>
+    <command source="client" code="0x00" name="EstablishmentRequest" optional="false">
+      <description>
+        Command description for EstablishmentRequest
+      </description>
+      <arg name="flag" type="BITMAP8"/>
+      <arg name="codecType" type="ENUM8"/>
+      <arg name="sampFreq" type="ENUM8"/>
+      <arg name="codecRate" type="ENUM8"/>
+      <arg name="serviceType" type="ENUM8"/>
+      <!-- Codec Type S1, Codec Type S2, Codec Type S3, Comp. Type., and Comp.
+           Rate may not be present.  call-command-handler can't generate code
+           for something that complicated, so instead just send a buffer and
+           leave parsing to the user.
+      -->
+      <!--<arg name="codecTypeS1" type="ENUM8" />-->
+      <!--<arg name="codecTypeS2" type="ENUM8" />-->
+      <!--<arg name="codecTypeS3" type="ENUM8" />-->
+      <!--<arg name="compType"    type="ENUM8" />-->
+      <!--<arg name="compRate"    type="ENUM8" />-->
+      <arg name="buffer" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x01" name="VoiceTransmission" optional="false">
+      <description>
+        Command description for VoiceTransmission
+      </description>
+      <arg name="voiceData" type="INT8U" array="true"/>
+    </command>
+    <command source="client" code="0x02" name="VoiceTransmissionCompletion" optional="true">
+      <description>
+        Command description for VoiceTransmissionCompletion
+      </description>
+    </command>
+    <command source="client" code="0x03" name="ControlResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for ControlResponse
+      </description>
+      <arg name="ackNack" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x00" name="EstablishmentResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for EstablishmentResponse
+      </description>
+      <arg name="ackNack" type="ENUM8"/>
+      <arg name="codecType" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x01" name="VoiceTransmissionResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for VoiceTransmissionResponse
+      </description>
+      <arg name="sequenceNumber" type="INT8U"/>
+      <arg name="errorFlag" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x02" name="Control" optional="true">
+      <description>
+        Command description for Control
+      </description>
+      <arg name="controlType" type="ENUM8"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Chatting</name>
+    <domain>Telecommunication</domain>
+    <description>Commands and attributes for sending chat messages among ZigBee devices.</description>
+    <code>0x0905</code>
+    <define>CHATTING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="U_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">u id</attribute>
+    <attribute side="server" code="0x0001" define="NICKNAME" type="CHAR_STRING" length="16" writable="false" optional="false">nickname</attribute>
+    <attribute side="server" code="0x0010" define="C_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">c iD</attribute>
+    <attribute side="server" code="0x0011" define="NAME" type="CHAR_STRING" length="16" writable="false" optional="false">name</attribute>
+    <attribute side="server" code="0x0020" define="ENABLE_ADD_CHAT" type="BOOLEAN" min="0x00" max="0x01" writable="false" optional="true">enable add chat</attribute>
+    <command source="client" code="0x00" name="JoinChatRequest" optional="false">
+      <description>
+        Command description for JoinChatRequest
+      </description>
+      <arg name="uid" type="INT16U"/>
+      <arg name="nickname" type="CHAR_STRING"/>
+      <arg name="cid" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="LeaveChatRequest" optional="false">
+      <description>
+        Command description for LeaveChatRequest
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="SearchChatRequest" optional="false">
+      <description>
+        Command description for SearchChatRequest
+      </description>
+    </command>
+    <command source="client" code="0x03" name="SwitchChairmanResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for SwitchChairmanResponse
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="StartChatRequest" optional="true">
+      <description>
+        Command description for StartChatRequest
+      </description>
+      <arg name="name" type="CHAR_STRING"/>
+      <arg name="uid" type="INT16U"/>
+      <arg name="nickname" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x05" name="ChatMessage" optional="false">
+      <description>
+        Command description for ChatMessage
+      </description>
+      <arg name="destinationUid" type="INT16U"/>
+      <arg name="sourceUid" type="INT16U"/>
+      <arg name="cid" type="INT16U"/>
+      <arg name="nickname" type="CHAR_STRING"/>
+      <arg name="message" type="CHAR_STRING"/>
+    </command>
+    <command source="client" code="0x06" name="GetNodeInformationRequest" optional="true">
+      <description>
+        Command description for GetNodeInformationRequest
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="StartChatResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for StartChatResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+      <arg name="cid" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="JoinChatResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for JoinChatResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+      <arg name="cid" type="INT16U"/>
+      <arg name="chatParticipantList" type="ChatParticipant" array="true"/>
+    </command>
+    <command source="server" code="0x02" name="UserLeft" optional="false">
+      <description>
+        Command description for UserLeft
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+      <arg name="nickname" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x03" name="UserJoined" optional="false">
+      <description>
+        Command description for UserJoined
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+      <arg name="nickname" type="CHAR_STRING"/>
+    </command>
+    <command source="server" code="0x04" name="SearchChatResponse" optional="false" disableDefaultResponse="true">
+      <description>
+        Command description for SearchChatResponse
+      </description>
+      <arg name="options" type="BITMAP8"/>
+      <arg name="chatRoomList" type="ChatRoom" array="true"/>
+    </command>
+    <command source="server" code="0x05" name="SwitchChairmanRequest" optional="true">
+      <description>
+        Command description for SwitchChairmanRequest
+      </description>
+      <arg name="cid" type="INT16U"/>
+    </command>
+    <command source="server" code="0x06" name="SwitchChairmanConfirm" optional="true">
+      <description>
+        Command description for SwitchChairmanConfirm
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="nodeInformationList" type="NodeInformation" array="true"/>
+    </command>
+    <command source="server" code="0x07" name="SwitchChairmanNotification" optional="true">
+      <description>
+        Command description for SwitchChairmanNotification
+      </description>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+      <arg name="address" type="DATA16"/>
+      <arg name="endpoint" type="INT8U"/>
+    </command>
+    <command source="server" code="0x08" name="GetNodeInformationResponse" optional="true" disableDefaultResponse="true">
+      <description>
+        Command description for GetNodeInformationResponse
+      </description>
+      <arg name="status" type="ENUM8"/>
+      <arg name="cid" type="INT16U"/>
+      <arg name="uid" type="INT16U"/>
+      <!-- Address, Endpoint, and Nickname will not be present if status is
+           SUCCESS.  call-command-handler can't generate code for something that
+           complicated, so instead just send a buffer and leave parsing to the
+           user.
+      -->
+      <!--<arg name="address"                    type="DATA16" />-->
+      <!--<arg name="endpoint"                   type="INT8U" />-->
+      <!--<arg name="nickname"                   type="CHAR_STRING" />-->
+      <arg name="addressEndpointAndNickname" type="INT8U" array="true"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Payment</name>
+    <domain>Financial</domain>
+    <description>Commands and attributes for payment scenarios including ZigBee devices.</description>
+    <code>0x0A01</code>
+    <define>PAYMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="PAYMENT_USER_ID" type="OCTET_STRING" length="64" writable="false" optional="false">user id</attribute>
+    <attribute side="server" code="0x0001" define="USER_TYPE" type="INT16U" writable="false" optional="true">user type</attribute>
+    <attribute side="server" code="0x0010" define="PAYMENT_SERVICE_ID" type="INT16U" writable="false" optional="false">service id</attribute>
+    <attribute side="server" code="0x0011" define="PAYMENT_SERVICE_PROVIDER_ID" type="INT16U" writable="false" optional="false">service provider id</attribute>
+    <attribute side="server" code="0x0012" define="TOTEM_ID" type="INT16U" writable="false" optional="true">totem id</attribute>
+    <attribute side="server" code="0x0020" define="CURRENCY" type="INT32U" writable="false" optional="false">currency</attribute>
+    <attribute side="server" code="0x0021" define="PRICE_TRAILING_DIGIT" type="INT8U" writable="false" optional="false">price trailing digit</attribute>
+    <attribute side="server" code="0x0022" define="PRICE" type="INT32U" writable="false" optional="false">price</attribute>
+    <attribute side="server" code="0x0030" define="GOOD_ID" type="OCTET_STRING" length="64" writable="false" optional="false">good id</attribute>
+    <attribute side="server" code="0x0031" define="SERIAL_NUMBER" type="OCTET_STRING" length="64" writable="false" optional="false">serial number</attribute>
+    <attribute side="server" code="0x0032" define="PAYMENT_TIMESTAMP" type="OCTET_STRING" length="64" writable="false" optional="false">timestamp</attribute>
+    <attribute side="server" code="0x0033" define="TRANS_ID" type="INT16U" writable="true" optional="true">trans id</attribute>
+    <attribute side="server" code="0x0034" define="TRANS_STATUS" type="ENUM8" writable="true" optional="true">trans status</attribute>
+    <attribute side="server" code="0x0035" define="PAYMENT_STATUS" type="ENUM8" writable="false" optional="false">status</attribute>
+    <command source="client" code="0x00" name="BuyRequest" optional="true">
+      <description>
+        Command description for BuyRequest
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="userType" type="INT16U"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="goodId" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x01" name="AcceptPayment" optional="true">
+      <description>
+        Command description for AcceptPayment
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="userType" type="INT16U"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="goodId" type="OCTET_STRING"/>
+    </command>
+    <command source="client" code="0x02" name="PaymentConfirm" optional="true">
+      <description>
+        Command description for PaymentConfirm
+      </description>
+      <arg name="serialNumber" type="OCTET_STRING"/>
+      <arg name="transId" type="INT16U"/>
+      <arg name="transStatus" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x00" name="BuyConfirm" optional="false">
+      <description>
+        Command description for BuyConfirm
+      </description>
+      <arg name="serialNumber" type="OCTET_STRING"/>
+      <arg name="currency" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="timestamp" type="OCTET_STRING"/>
+      <arg name="transId" type="INT16U"/>
+      <arg name="transStatus" type="ENUM8"/>
+    </command>
+    <command source="server" code="0x01" name="ReceiptDelivery" optional="false">
+      <description>
+        Command description for ReceiptDelivery
+      </description>
+      <arg name="serialNumber" type="OCTET_STRING"/>
+      <arg name="currency" type="INT32U"/>
+      <arg name="priceTrailingDigit" type="INT8U"/>
+      <arg name="price" type="INT32U"/>
+      <arg name="timestamp" type="OCTET_STRING"/>
+    </command>
+    <command source="server" code="0x02" name="TransactionEnd" optional="false">
+      <description>
+        Command description for TransactionEnd
+      </description>
+      <arg name="serialNumber" type="OCTET_STRING"/>
+      <arg name="status" type="ENUM8"/>
+    </command>
+  </cluster>
+  <cluster>
+    <name>Billing</name>
+    <domain>Financial</domain>
+    <description>Attributes and commands to enable billing of users for provided services through the use of a billing platform.</description>
+    <code>0x0A02</code>
+    <define>BILLING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <attribute side="server" code="0x0000" define="USER_ID" type="OCTET_STRING" length="64" writable="false" optional="false">user id</attribute>
+    <attribute side="server" code="0x0010" define="SERVICE_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">service id</attribute>
+    <attribute side="server" code="0x0011" define="SERVICE_PROVIDER_ID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">service provider id</attribute>
+    <attribute side="server" code="0x0012" define="SESSION_INTERVAL" type="INT16U" min="0x0000" max="0xFFFF" writable="false" optional="false">session interval</attribute>
+    <attribute side="server" code="0x0020" define="TIMESTAMP" type="OCTET_STRING" length="64" writable="false" optional="false">timestamp</attribute>
+    <attribute side="server" code="0x0021" define="DURATION" type="INT16U" writable="true" optional="true">duration</attribute>
+    <command source="client" code="0x00" name="Subscribe" optional="true">
+      <description>
+        Command description for Subscribe
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x01" name="Unsubscribe" optional="true">
+      <description>
+        Command description for Unsubscribe
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x02" name="StartBillingSession" optional="true">
+      <description>
+        Command description for StartBillingSession
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x03" name="StopBillingSession" optional="true">
+      <description>
+        Command description for StopBillingSession
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x04" name="BillStatusNotification" optional="true">
+      <description>
+        Command description for BillStatusNotification
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="status" type="ENUM8"/>
+    </command>
+    <command source="client" code="0x05" name="SessionKeepAlive" optional="true">
+      <description>
+        Command description for SessionKeepAlive
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x00" name="CheckBillStatus" optional="false">
+      <description>
+        Command description for CheckBillStatus
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x01" name="SendBillRecord" optional="false">
+      <description>
+        Command description for SendBillRecord
+      </description>
+      <arg name="userId" type="OCTET_STRING"/>
+      <arg name="serviceId" type="INT16U"/>
+      <arg name="serviceProviderId" type="INT16U"/>
+      <arg name="timestamp" type="OCTET_STRING"/>
+      <arg name="duration" type="INT16U"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/types.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/types.xml
@@ -1,0 +1,1069 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <atomic>
+    <type id="0x00" name="no_data" size="0" description="No data"/>
+    <type id="0x08" name="data8" size="1" description="8-bit data" discrete="true" />
+    <type id="0x09" name="data16" size="2" description="16-bit data" discrete="true" />
+    <type id="0x0A" name="data24" size="3" description="24-bit data" discrete="true" />
+    <type id="0x0B" name="data32" size="4" description="32-bit data" discrete="true" />
+    <type id="0x0C" name="data40" size="5" description="40-bit data" discrete="true" />
+    <type id="0x0D" name="data48" size="6" description="48-bit data" discrete="true" />
+    <type id="0x0E" name="data56" size="7" description="56-bit data" discrete="true" />
+    <type id="0x0F" name="data64" size="8" description="64-bit data" discrete="true" />
+    <type id="0x10" name="boolean" size="1" description="Boolean" discrete="true" />
+    <type id="0x18" name="bitmap8" size="1" description="8-bit bitmap" discrete="true" />
+    <type id="0x19" name="bitmap16" size="2" description="16-bit bitmap" discrete="true" />
+    <type id="0x1A" name="bitmap24" size="3" description="24-bit bitmap" discrete="true" />
+    <type id="0x1B" name="bitmap32" size="4" description="32-bit bitmap" discrete="true" />
+    <type id="0x1C" name="bitmap40" size="5" description="40-bit bitmap" discrete="true" />
+    <type id="0x1D" name="bitmap48" size="6" description="48-bit bitmap" discrete="true" />
+    <type id="0x1E" name="bitmap56" size="7" description="56-bit bitmap" discrete="true" />
+    <type id="0x1F" name="bitmap64" size="8" description="64-bit bitmap" discrete="true" />
+    <type id="0x20" name="int8u" size="1" description="Unsigned 8-bit integer"/>
+    <type id="0x21" name="int16u" size="2" description="Unsigned 16-bit integer"/>
+    <type id="0x22" name="int24u" size="3" description="Unsigned 24-bit integer"/>
+    <type id="0x23" name="int32u" size="4" description="Unsigned 32-bit integer"/>
+    <type id="0x24" name="int40u" size="5" description="Unsigned 40-bit integer"/>
+    <type id="0x25" name="int48u" size="6" description="Unsigned 48-bit integer"/>
+    <type id="0x26" name="int56u" size="7" description="Unsigned 56-bit integer"/>
+    <type id="0x27" name="int64u" size="8" description="Unsigned 64-bit integer"/>
+    <type id="0x28" name="int8s" size="1" description="Signed 8-bit integer"/>
+    <type id="0x29" name="int16s" size="2" description="Signed 16-bit integer"/>
+    <type id="0x2A" name="int24s" size="3" description="Signed 24-bit integer"/>
+    <type id="0x2B" name="int32s" size="4" description="Signed 32-bit integer"/>
+    <type id="0x2C" name="int40s" size="5" description="Signed 40-bit integer"/>
+    <type id="0x2D" name="int48s" size="6" description="Signed 48-bit integer"/>
+    <type id="0x2E" name="int56s" size="7" description="Signed 56-bit integer"/>
+    <type id="0x2F" name="int64s" size="8" description="Signed 64-bit integer"/>
+    <type id="0x30" name="enum8" size="1" description="8-bit enumeration" discrete="true" />
+    <type id="0x31" name="enum16" size="2" description="16-bit enumeration" discrete="true" />
+    <type id="0x38" name="float_semi" size="2" description="Semi-precision"/>
+    <type id="0x39" name="float_single" size="4" description="Single precision"/>
+    <type id="0x3A" name="float_double" size="8" description="Double precision"/>
+    <type id="0x41" name="octet_string" description="Octet string" discrete="true" />
+    <type id="0x42" name="char_string" description="Character string" discrete="true" />
+    <type id="0x43" name="long_octet_string" description="Long octet string" discrete="true" />
+    <type id="0x44" name="long_char_string" description="Long character string" discrete="true" />
+    <type id="0x48" name="array" description="Array" discrete="true" />
+    <type id="0x4C" name="struct" description="Structure" discrete="true" />
+    <type id="0x50" name="set" description="Set" discrete="true" />
+    <type id="0x51" name="bag" description="Bag" discrete="true" />
+    <type id="0xE0" name="time_of_day" size="4" description="Time of day"/>
+    <type id="0xE1" name="date" size="4" description="Date"/>
+    <type id="0xE2" name="utc_time" size="4" description="UTC Time"/>
+    <type id="0xE8" name="cluster_id" size="2" description="Cluster ID" discrete="true" />
+    <type id="0xE9" name="attribute_id" size="2" description="Attribute ID" discrete="true" />
+    <type id="0xEA" name="bacnet_oid" size="4" description="BACnet OID" discrete="true" />
+    <type id="0xF0" name="ieee_address" size="8" description="IEEE address" discrete="true" />
+    <type id="0xF1" name="security_key" size="16" description="128-bit security key" discrete="true" />
+    <type id="0xFF" name="unknown" size="0" description="Unknown"/>
+  </atomic>
+  <bitmap name="ShadeClosureStatus" type="BITMAP8">
+    <field name="operational" mask="0x1"/>
+    <field name="adjusting" mask="0x2"/>
+    <field name="opening" mask="0x4"/>
+    <field name="motorOpening" mask="0x8"/>
+  </bitmap>
+  <bitmap name="AlarmMask" type="BITMAP8">
+    <field name="GeneralHwFault" mask="0x1"/>
+    <field name="GeneralSwFault" mask="0x2"/>
+  </bitmap>
+  <bitmap name="RestartOptions" type="BITMAP8">
+    <field name="StartMode1" mask="0x1"/>
+    <field name="StartupMode2" mask="0x2"/>
+    <field name="StartupMode3" mask="0x4"/>
+    <field name="Immediate" mask="0x8"/>
+  </bitmap>
+  <bitmap name="ResetOptions" type="BITMAP8">
+    <field name="ResetCurrent" mask="0x1"/>
+    <field name="ResetAll" mask="0x2"/>
+    <field name="EraseIndex" mask="0x4"/>
+  </bitmap>
+  <enum name="CommissioningStartupControl" type="ENUM8">
+    <item name="NoAction" value="0x00"/>
+    <item name="FormNetwork" value="0x01"/>
+    <item name="RejoinNetwork" value="0x02"/>
+    <item name="StartFromScratch" value="0x03"/>
+  </enum>
+  <enum name="EzModeCommissioningClusterType" type="ENUM8">
+    <item name="Server" value="0x00"/>
+    <item name="Client" value="0x01"/>
+  </enum>
+  <bitmap name="MainsAlarmMask" type="BITMAP8">
+    <field name="VoltageTooLow" mask="0x1"/>
+    <field name="VoltageTooHigh" mask="0x2"/>
+    <field name="MainsPowerSupplyLost" mask="0x4"/>
+  </bitmap>
+  <bitmap name="BatteryAlarmMask" type="BITMAP8">
+    <field name="VoltageTooLow" mask="0x1"/>
+  </bitmap>
+  <bitmap name="DeviceTempAlarmMask" type="BITMAP8">
+    <field name="TooLow" mask="0x1"/>
+    <field name="TooHigh" mask="0x2"/>
+  </bitmap>
+  <bitmap name="TimeStatusMask" type="BITMAP8">
+    <field name="MasterClock" mask="0x1"/>
+    <field name="Synchronized" mask="0x2"/>
+    <field name="MasterZoneDst" mask="0x4"/>
+    <field name="Superseding" mask="0x8"/>
+  </bitmap>
+  <bitmap name="LocationType" type="BITMAP8">
+    <field name="absolute" mask="0x1"/>
+    <field name="2-D" mask="0x2"/>
+    <field name="coordinateSystem" mask="0xc"/>
+  </bitmap>
+  <bitmap name="GetLocationDataFlags" type="BITMAP8">
+    <field name="absoluteOnly" mask="0x1"/>
+    <field name="recalculate" mask="0x2"/>
+    <field name="broadcast" mask="0x4"/>
+    <field name="broadcastResponse" mask="0x8"/>
+    <field name="compactResponse" mask="0x10"/>
+  </bitmap>
+  <bitmap name="PumpStatus" type="BITMAP16">
+    <field name="deviceFault" mask="0x1"/>
+    <field name="supplyfault" mask="0x2"/>
+    <field name="speedLow" mask="0x4"/>
+    <field name="speedHigh" mask="0x8"/>
+    <field name="localOverride" mask="0x10"/>
+    <field name="running" mask="0x20"/>
+    <field name="remotePressure" mask="0x40"/>
+    <field name="remoteFlow" mask="0x80"/>
+    <field name="remoteTemperature" mask="0x100"/>
+  </bitmap>
+  <bitmap name="PumpAlarmMask" type="BITMAP16">
+    <field name="SupplyVoltageTooLow" mask="0x1"/>
+    <field name="SupplyVoltageTooHigh" mask="0x2"/>
+    <field name="PowerMissingPhase" mask="0x4"/>
+    <field name="SystemPressureTooLow" mask="0x8"/>
+    <field name="SystemPressureTooHigh" mask="0x10"/>
+    <field name="DryRunning" mask="0x20"/>
+    <field name="MotorTemperatureTooHigh" mask="0x40"/>
+    <field name="PumpMotorHasFatalFailure" mask="0x80"/>
+    <field name="ElectronicTemperatureTooHigh" mask="0x100"/>
+    <field name="PumpBlocked" mask="0x200"/>
+    <field name="SensorFailure" mask="0x400"/>
+    <field name="ElectronicNonFatalFailure" mask="0x800"/>
+    <field name="ElectronicFatalFailure" mask="0x1000"/>
+    <field name="GeneralFault" mask="0x2000"/>
+  </bitmap>
+  <bitmap name="ThermostatOccupancy" type="BITMAP8">
+    <field name="occupied" mask="0x1"/>
+  </bitmap>
+  <bitmap name="ThermostatSensing" type="BITMAP8">
+    <field name="localTempSensedRemotely" mask="0x1"/>
+    <field name="outdoorTempSensedRemotely" mask="0x2"/>
+    <field name="occupancySensedRemotely" mask="0x4"/>
+  </bitmap>
+  <bitmap name="ThermostatAlarmMask" type="BITMAP8">
+    <field name="initializationFailure" mask="0x1"/>
+    <field name="hardwareFailure" mask="0x2"/>
+    <field name="selfcalibrationFailure" mask="0x4"/>
+  </bitmap>
+  <bitmap name="BallastStatus" type="BITMAP8">
+    <field name="NonOperational" mask="0x1"/>
+    <field name="LampNotInSocket" mask="0x2"/>
+  </bitmap>
+  <bitmap name="LampAlarmMode" type="BITMAP8">
+    <field name="lampBurnHours" mask="0x1"/>
+  </bitmap>
+  <bitmap name="Occupancy" type="BITMAP8">
+    <field name="occupied" mask="0x1"/>
+  </bitmap>
+  <bitmap name="IasZoneStatus" type="BITMAP16">
+    <field name="alarm1" mask="0x1"/>
+    <field name="alarm2" mask="0x2"/>
+    <field name="tamper" mask="0x4"/>
+    <field name="battery" mask="0x8"/>
+    <field name="supervisionReports" mask="0x10"/>
+    <field name="restoreReports" mask="0x20"/>
+    <field name="trouble" mask="0x40"/>
+    <field name="AC" mask="0x80"/>
+    <field name="test" mask="0x100"/>
+    <field name="batteryDefect" mask="0x200"/>
+  </bitmap>
+  <bitmap name="WarningInfo" type="BITMAP8">
+    <field name="mode" mask="0xf0"/>
+    <field name="strobe" mask="0x0c"/>
+    <field name="sirenLevel" mask="0x03"/>
+  </bitmap>
+  <bitmap name="SquawkInfo" type="BITMAP8">
+    <field name="mode" mask="0xf0"/>
+    <field name="strobe" mask="0x08"/>
+    <field name="level" mask="0x03"/>
+  </bitmap>
+  <enum name="OperatingMode" type="ENUM8">
+    <item name="normal" value="0x0"/>
+    <item name="configure" value="0x1"/>
+  </enum>
+  <enum name="Status" type="INT8U" description="Status codes used in the ZigBee Cluster Library">
+    <item name="SUCCESS" value="0x00"/>
+    <item name="FAILURE" value="0x01"/>
+    <item name="NOT_AUTHORIZED" value="0x7E"/>
+    <!-- item name="reserved" value="0x7F"/ -->
+    <item name="MALFORMED_COMMAND" value="0x80"/>
+    <item name="UNSUP_COMMAND" value="0x81"/>
+    <!-- renamed from UNSUP_CLUSTER_COMMAND -->
+    <item name="UNSUP_GENERAL_COMMAND" value="0x82"/>
+    <!-- DEPRECATED use UNSUP_COMMAND -->
+    <item name="UNSUP_MANUF_CLUSTER_COMMAND" value="0x83"/>
+    <!-- DEPRECATED use UNSUP_COMMAND -->
+    <item name="UNSUP_MANUF_GENERAL_COMMAND" value="0x84"/>
+    <!-- DEPRECATED use UNSUP_COMMAND -->
+    <item name="INVALID_FIELD" value="0x85"/>
+    <item name="UNSUPPORTED_ATTRIBUTE" value="0x86"/>
+    <item name="INVALID_VALUE" value="0x87"/>
+    <item name="READ_ONLY" value="0x88"/>
+    <item name="INSUFFICIENT_SPACE" value="0x89"/>
+    <item name="DUPLICATE_EXISTS" value="0x8A"/>
+    <!-- DEPRECATED use SUCCESS -->
+    <item name="NOT_FOUND" value="0x8B"/>
+    <item name="UNREPORTABLE_ATTRIBUTE" value="0x8C"/>
+    <item name="INVALID_DATA_TYPE" value="0x8D"/>
+    <item name="INVALID_SELECTOR" value="0x8E"/>
+    <item name="WRITE_ONLY" value="0x8F"/>
+    <!-- DEPRECATED use NOT_AUTHORIZED -->
+    <item name="INCONSISTENT_STARTUP_STATE" value="0x90"/>
+    <!-- DEPRECATED use FAILURE -->
+    <item name="DEFINED_OUT_OF_BAND" value="0x91"/>
+    <!-- DEPRECATED use FAILURE -->
+    <!-- item name="reserved" value="0x92"/ -->
+    <item name="ACTION_DENIED" value="0x93"/>
+    <!-- DEPRECATED use FAILURE -->
+    <item name="TIMEOUT" value="0x94"/>
+    <item name="ABORT" value="0x95"/>
+    <item name="INVALID_IMAGE" value="0x96"/>
+    <item name="WAIT_FOR_DATA" value="0x97"/>
+    <item name="NO_IMAGE_AVAILABLE" value="0x98"/>
+    <item name="REQUIRE_MORE_IMAGE" value="0x99"/>
+    <item name="NOTIFICATION_PENDING" value="0x9A"/>
+    <item name="HARDWARE_FAILURE" value="0xC0"/>
+    <!-- DEPRECATED use FAILURE -->
+    <item name="SOFTWARE_FAILURE" value="0xC1"/>
+    <!-- DEPRECATED use FAILURE -->
+    <!-- item name="reserved" value="0xC2"/ -->
+    <item name="UNSUPPORTED_CLUSTER" value="0xC3"/>
+    <item name="LIMIT_REACHED" value="0xC4"/>
+    <!-- DEPRECATED use SUCCESS -->
+  </enum>
+  <enum name="PowerSource" type="ENUM8">
+    <item name="Unknown" value="0x0"/>
+    <item name="SinglePhaseMains" value="0x1"/>
+    <item name="ThreePhaseMains" value="0x2"/>
+    <item name="Battery" value="0x3"/>
+    <item name="DcSource" value="0x4"/>
+    <item name="EmergencyMainsConstantPower" value="0x5"/>
+    <item name="EmergencyMainsTransferSwitch" value="0x6"/>
+    <item name="BatteryBackup" value="0x80"/>
+  </enum>
+  <enum name="PhysicalEnvironment" type="ENUM8">
+    <item name="Unspecified" value="0x0"/>
+    <item name="FirstProfileSpecifiedValue" value="0x1"/>
+    <item name="LastProfileSpecifiedValue" value="0x7f"/>
+    <item name="Unknown" value="0xff"/>
+  </enum>
+  <enum name="BatterySize" type="ENUM8">
+    <item name="NoBattery" value="0x0"/>
+    <item name="BuiltIn" value="0x1"/>
+    <item name="Other" value="0x2"/>
+    <item name="AA" value="0x3"/>
+    <item name="AAA" value="0x4"/>
+    <item name="C" value="0x5"/>
+    <item name="D" value="0x6"/>
+    <item name="Unknown" value="0xff"/>
+  </enum>
+  <enum name="SwitchType" type="ENUM8">
+    <item name="Toggle" value="0x00"/>
+    <item name="Momentary" value="0x01"/>
+    <item name="MultiFunction" value="0x02" introducedIn="ha-1.2-05-3520-29"/>
+  </enum>
+  <enum name="SwitchActions" type="ENUM8">
+    <item name="On" value="0x0"/>
+    <item name="Off" value="0x1"/>
+    <item name="Toggle" value="0x2"/>
+  </enum>
+  <enum name="MoveMode" type="ENUM8">
+    <item name="Up" value="0x0"/>
+    <item name="Down" value="0x1"/>
+  </enum>
+  <enum name="StepMode" type="ENUM8">
+    <item name="Up" value="0x0"/>
+    <item name="Down" value="0x1"/>
+  </enum>
+  <enum name="LocationMethod" type="ENUM8">
+    <item name="Lateration" value="0x0"/>
+    <item name="Signposting" value="0x1"/>
+    <item name="RfFingerprinting" value="0x2"/>
+    <item name="OutOfBand" value="0x3"/>
+  </enum>
+  <enum name="PumpOperationMode" type="ENUM8">
+    <item name="normal" value="0x0"/>
+    <item name="minimum" value="0x1"/>
+    <item name="maximum" value="0x2"/>
+    <item name="local" value="0x3"/>
+  </enum>
+  <enum name="PumpControlMode" type="ENUM8">
+    <item name="constantSpeed" value="0x0"/>
+    <item name="constantPressure" value="0x1"/>
+    <item name="proportionalPressure" value="0x2"/>
+    <item name="constantFlow" value="0x3"/>
+    <item name="constantTemperature" value="0x5"/>
+    <item name="automatic" value="0x7"/>
+  </enum>
+  <enum name="ThermostatControlSequence" type="ENUM8">
+    <item name="coolingOnly" value="0x0"/>
+    <item name="coolingWithReheat" value="0x1"/>
+    <item name="heatingOnly" value="0x2"/>
+    <item name="heatingWithReheat" value="0x3"/>
+    <item name="coolingAndHeating" value="0x4"/>
+    <item name="coolingAndHeatingWithReheat" value="0x5"/>
+  </enum>
+  <enum name="ThermostatSystemMode" type="ENUM8">
+    <item name="off" value="0x0"/>
+    <item name="auto" value="0x1"/>
+    <item name="cool" value="0x3"/>
+    <item name="heat" value="0x4"/>
+    <item name="emergencyHeating" value="0x5"/>
+    <item name="precooling" value="0x6"/>
+    <item name="fanOnly" value="0x7"/>
+  </enum>
+  <enum name="SetpointAdjustMode" type="ENUM8">
+    <item name="heatSetpoint" value="0x0"/>
+    <item name="coolSetpoint" value="0x1"/>
+    <item name="heatAndCoolSetpoints" value="0x2"/>
+  </enum>
+  <enum name="FanMode" type="ENUM8">
+    <item name="off" value="0x0"/>
+    <item name="low" value="0x1"/>
+    <item name="medium" value="0x2"/>
+    <item name="high" value="0x3"/>
+    <item name="on" value="0x4"/>
+    <item name="auto" value="0x5"/>
+    <item name="smart" value="0x6"/>
+  </enum>
+  <enum name="FanModeSequence" type="ENUM8">
+    <item name="LowMedHigh" value="0x0"/>
+    <item name="lowHigh" value="0x1"/>
+    <item name="LowMedHighAuto" value="0x2"/>
+    <item name="lowHighAuto" value="0x3"/>
+    <item name="onAuto" value="0x4"/>
+  </enum>
+  <enum name="RelativeHumidityMode" type="ENUM8">
+    <item name="measureLocally" value="0x0"/>
+    <item name="updatedOverTheNetwork" value="0x1"/>
+  </enum>
+  <enum name="DehumidifcationLockout" type="ENUM8">
+    <item name="notAllowed" value="0x0"/>
+    <item name="allowed" value="0x1"/>
+  </enum>
+  <enum name="RelativeHumidityDisplay" type="ENUM8">
+    <item name="notDisplayed" value="0x0"/>
+    <item name="displayed" value="0x1"/>
+  </enum>
+  <enum name="TemperatureDisplayMode" type="ENUM8">
+    <item name="celsius" value="0x0"/>
+    <item name="fahrenheit" value="0x1"/>
+  </enum>
+  <enum name="KeypadLockout" type="ENUM8">
+    <item name="noLockout" value="0x0"/>
+    <item name="levelOneLockout" value="0x1"/>
+    <item name="levelTwoLockout" value="0x2"/>
+    <item name="levelThreeLockout" value="0x3"/>
+    <item name="levelFourLockout" value="0x4"/>
+    <item name="levelfiveLockout" value="0x5"/>
+  </enum>
+  <enum name="HueDirection" type="ENUM8">
+    <item name="ShortestDistance" value="0x0"/>
+    <item name="LongestDistance" value="0x1"/>
+    <item name="Up" value="0x2"/>
+    <item name="Down" value="0x3"/>
+  </enum>
+  <enum name="HueMoveMode" type="ENUM8">
+    <item name="stop" value="0x0"/>
+    <item name="Up" value="0x1"/>
+    <item name="Down" value="0x3"/>
+  </enum>
+  <enum name="HueStepMode" type="ENUM8">
+    <item name="Up" value="0x1"/>
+    <item name="Down" value="0x3"/>
+  </enum>
+  <enum name="SaturationMoveMode" type="ENUM8">
+    <item name="stop" value="0x0"/>
+    <item name="Up" value="0x1"/>
+    <item name="Down" value="0x3"/>
+  </enum>
+  <enum name="SaturationStepMode" type="ENUM8">
+    <item name="Up" value="0x1"/>
+    <item name="Down" value="0x3"/>
+  </enum>
+  <enum name="ColorMode" type="ENUM8">
+    <item name="CurrentHueAndCurrentSaturation" value="0x00"/>
+    <item name="CurrentXAndCurrentY" value="0x01"/>
+    <item name="ColorTemperature" value="0x02"/>
+  </enum>
+  <enum name="ColorControlOptions" type="BITMAP8">
+    <item name="ExecuteIfOff" value="0x1"/>
+  </enum>
+  <enum name="MeasurementLightSensorType" type="ENUM8">
+    <item name="photodiode" value="0x0"/>
+    <item name="CMOS" value="0x1"/>
+  </enum>
+  <enum name="LevelStatus" type="ENUM8">
+    <item name="OnTarget" value="0x0"/>
+    <item name="BelowTarget" value="0x1"/>
+    <item name="AboveTarget" value="0x2"/>
+  </enum>
+  <enum name="SensingLightSensorType" type="ENUM8">
+    <item name="photodiode" value="0x0"/>
+    <item name="CMOS" value="0x1"/>
+  </enum>
+  <enum name="OccupancySensorType" type="ENUM8">
+    <item name="PIR" value="0x0"/>
+    <item name="Ultrasonic" value="0x1"/>
+    <item name="pirAndUltrasonic" value="0x2"/>
+    <item name="physicalContact" value="0x3"/>
+  </enum>
+  <bitmap name="OccupancySensorTypeBitmap" type="BITMAP8">
+    <field name="Pir" mask="0x01"/>
+    <field name="Ultrasonic" mask="0x02"/>
+    <field name="PhysicalContact" mask="0x04"/>
+  </bitmap>
+  <enum name="IasZoneState" type="ENUM8">
+    <item name="notEnrolled" value="0x0"/>
+    <item name="enrolled" value="0x1"/>
+  </enum>
+  <enum name="IasZoneType" type="ENUM16">
+    <item name="standardCie" value="0x0"/>
+    <item name="motionSensor" value="0xd"/>
+    <item name="contactSwitch" value="0x15"/>
+    <item name="fireSensor" value="0x28"/>
+    <item name="waterSensor" value="0x2a"/>
+    <item name="gasSensor" value="0x2b"/>
+    <item name="personalEmergencyDevice" value="0x2c"/>
+    <item name="vibrationMovementSensor" value="0x2d"/>
+    <item name="remoteControl" value="0x10f"/>
+    <item name="keyFob" value="0x115"/>
+    <item name="keypad" value="0x21d"/>
+    <item name="standardWarningDevice" value="0x225"/>
+    <item name="glassBreakSensor" value="0x226"/>
+    <item name="carbonMonoxideSensor" value="0x227"/>
+    <item name="securityRepeater" value="0x0229"/>
+    <!-- 0x8000 - 0xFFFE manufacturer specific types -->
+    <item name="invalidZoneType" value="0xFFFF"/>
+  </enum>
+  <enum name="IasEnrollResponseCode" type="ENUM8">
+    <item name="success" value="0x0"/>
+    <item name="notSupported" value="0x1"/>
+    <item name="noEnrollPermit" value="0x2"/>
+    <item name="tooManyZones" value="0x3"/>
+  </enum>
+  <enum name="IasAceArmMode" type="ENUM8">
+    <item name="disarm" value="0x0"/>
+    <item name="armDayHomeZonesOnly" value="0x1"/>
+    <item name="armNightSleepZonesOnly" value="0x2"/>
+    <item name="armAllZones" value="0x3"/>
+  </enum>
+  <enum name="IasAceArmNotification" type="ENUM8">
+    <item name="allZonesDisarmed" value="0x0"/>
+    <item name="onlyDayHomeZonesArmed" value="0x1"/>
+    <item name="onlyNightSleepZonesArmed" value="0x2"/>
+    <item name="allZonesArmed" value="0x3"/>
+    <item name="invalidArmDisarmCode" value="0x04"/>
+    <item name="notReadyToArm" value="0x05"/>
+    <item name="alreadyDisarmed" value="0x06"/>
+  </enum>
+  <enum name="IasAceAudibleNotification" type="ENUM8">
+    <item name="mute" value="0x0"/>
+    <item name="defaultSound" value="0x1"/>
+  </enum>
+  <enum name="IasAceAlarmStatus" type="ENUM8">
+    <item name="noAlarm" value="0x0"/>
+    <item name="burglar" value="0x1"/>
+    <item name="fire" value="0x2"/>
+    <item name="emergency" value="0x3"/>
+    <item name="policePanic" value="0x4"/>
+    <item name="firePanic" value="0x5"/>
+    <item name="emergencyPanic" value="0x6"/>
+  </enum>
+  <enum name="IasAcePanelStatus" type="ENUM8">
+    <item name="panelDisarmed" value="0x00"/>
+    <item name="armedStay" value="0x01"/>
+    <item name="armedNight" value="0x02"/>
+    <item name="armedAway" value="0x03"/>
+    <item name="exitDelay" value="0x04"/>
+    <item name="entryDelay" value="0x05"/>
+    <item name="notReadyToArm" value="0x06"/>
+    <item name="inAlarm" value="0x07"/>
+    <item name="armingStay" value="0x08"/>
+    <item name="armingNight" value="0x09"/>
+    <item name="armingAway" value="0x0A"/>
+  </enum>
+  <enum name="IasAceBypassResult" type="ENUM8">
+    <item name="zoneBypassed" value="0x0"/>
+    <item name="zoneNotBypassed" value="0x1"/>
+    <item name="notAllowed" value="0x2"/>
+    <item name="invalidZoneId" value="0x3"/>
+    <item name="unknownZoneId" value="0x4"/>
+    <item name="invalidArmDisarmCode" value="0x5"/>
+  </enum>
+  <struct name="IasAceZoneStatusResult">
+    <item name="zoneId" type="INT8U"/>
+    <item name="zoneStatus" type="IasZoneStatus"/>
+  </struct>
+  <enum name="WarningMode" type="ENUM8">
+    <item name="stop" value="0x0"/>
+    <item name="burglar" value="0x1"/>
+    <item name="fire" value="0x2"/>
+    <item name="emergency" value="0x3"/>
+    <item name="policePanic" value="0x4"/>
+    <item name="firePanic" value="0x5"/>
+    <item name="emergencyPanic" value="0x6"/>
+  </enum>
+  <enum name="WarningStobe" type="ENUM8">
+    <item name="noStrobe" value="0x0"/>
+    <item name="useStrobe" value="0x1"/>
+  </enum>
+  <enum name="SquawkMode" type="ENUM8">
+    <item name="systemIsArmed" value="0x0"/>
+    <item name="systemIsDisarmed" value="0x1"/>
+  </enum>
+  <enum name="SquawkStobe" type="ENUM8">
+    <item name="noStrobe" value="0x0"/>
+    <item name="useStrobe" value="0x1"/>
+  </enum>
+  <enum name="SquawkLevel" type="ENUM8">
+    <item name="lowLevel" value="0x0"/>
+    <item name="mediumLevel" value="0x1"/>
+    <item name="highLevel" value="0x2"/>
+    <item name="veryHighLevel" value="0x2"/>
+  </enum>
+  <enum name="AmiRegistrationState" type="ENUM8">
+    <item name="Unregistered" value="0x0"/>
+    <item name="JoiningNetwork" value="0x1"/>
+    <item name="JoinedNetwork" value="0x2"/>
+    <item name="SubmittedRegistrationRequest" value="0x3"/>
+    <item name="RegistrationRejected" value="0x4"/>
+    <item name="Registered" value="0x5"/>
+    <item name="RegisterationNotPossible" value="0x6"/>
+  </enum>
+  <enum name="AnonymousDataState" type="ENUM8">
+    <item name="NoSourceFound" value="0x0"/>
+    <item name="SourceFound" value="0x1"/>
+  </enum>
+  <enum name="AttributeWritePermission" type="ENUM8">
+    <item name="DenyWrite" value="0x00"/>
+    <item name="AllowWriteNormal" value="0x01"/>
+    <item name="AllowWriteOfReadOnly" value="0x02"/>
+    <item name="UnsupportedAttribute" value="0x86"/>
+    <item name="InvalidValue" value="0x87"/>
+    <item name="ReadOnly" value="0x88"/>
+    <item name="InvalidDataType" value="0x8D"/>
+  </enum>
+  <struct name="ReadAttributeStatusRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="status" type="Status"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeLocation" type="NO_DATA"/>
+  </struct>
+  <struct name="WriteAttributeRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeLocation" type="NO_DATA"/>
+  </struct>
+  <struct name="WriteAttributeStatusRecord">
+    <item name="status" type="Status"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+  </struct>
+  <struct name="ConfigureReportingRecord">
+    <item name="direction" type="INT8U"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="minimumReportingInterval" type="INT16U"/>
+    <item name="maximumReportingInterval" type="INT16U"/>
+    <item name="reportableChangeLocation" type="NO_DATA"/>
+    <item name="timeoutPeriod" type="INT16U"/>
+  </struct>
+  <struct name="ConfigureReportingStatusRecord">
+    <item name="status" type="Status"/>
+    <item name="direction" type="INT8U"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+  </struct>
+  <struct name="ReadReportingConfigurationRecord">
+    <item name="status" type="Status"/>
+    <item name="direction" type="INT8U"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="minimumReportingInterval" type="INT16U"/>
+    <item name="maximumReportingInterval" type="INT16U"/>
+    <item name="reportableChangeLocation" type="NO_DATA"/>
+    <item name="timeoutPeriod" type="INT16U"/>
+  </struct>
+  <enum name="ReportingDirection" type="ENUM8">
+    <item name="reported" value="0x00"/>
+    <item name="received" value="0x01"/>
+  </enum>
+  <struct name="ReadReportingConfigurationAttributeRecord">
+    <item name="direction" type="INT8U"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+  </struct>
+  <struct name="ReportAttributeRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeLocation" type="NO_DATA"/>
+  </struct>
+  <struct name="DiscoverAttributesInfoRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+  </struct>
+  <struct name="ExtendedDiscoverAttributesInfoRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeAccessControl" type="INT8U"/>
+  </struct>
+  <struct name="ReadStructuredAttributeRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="indicator" type="INT8U"/>
+    <item name="indicies" type="INT16U" array="true"/>
+  </struct>
+  <struct name="WriteStructuredAttributeRecord">
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="indicator" type="INT8U"/>
+    <item name="indicies" type="INT16U" array="true"/>
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeLocation" type="NO_DATA"/>
+  </struct>
+  <struct name="WriteStructuredAttributeStatusRecord">
+    <item name="status" type="Status"/>
+    <item name="attributeId" type="ATTRIBUTE_ID"/>
+    <item name="indicator" type="INT8U"/>
+    <item name="indicies" type="INT16U" array="true"/>
+  </struct>
+  <struct name="SceneExtensionAttributeInfo">
+    <item name="attributeType" type="INT8U"/>
+    <item name="attributeLocation" type="NO_DATA"/>
+  </struct>
+  <struct name="SceneExtensionFieldSet">
+    <item name="clusterId" type="CLUSTER_ID"/>
+    <item name="length" type="INT8U"/>
+    <item name="value" type="INT8U"/>
+  </struct>
+  <struct name="BlockThreshold">
+    <item name="blockThreshold" type="ENUM8"/>
+    <item name="priceControl" type="BITMAP8"/>
+    <item name="blockPeriodStartTime" type="UTC_TIME"/>
+    <item name="blockPeriodDurationMinutes" type="INT24U"/>
+    <item name="fuelType" type="ENUM8"/>
+    <item name="standingCharge" type="INT32U"/>
+  </struct>
+  <struct name="Notification">
+    <item name="contentId" type="INT16U"/>
+    <item name="statusFeedback" type="Status"/>
+  </struct>
+  <struct name="NeighborInfo">
+    <item name="neighbor" type="IEEE_ADDRESS"/>
+    <item name="x" type="INT16S"/>
+    <item name="y" type="INT16S"/>
+    <item name="z" type="INT16S"/>
+    <item name="rssi" type="INT8S"/>
+    <item name="numberRssiMeasurements" type="INT8U"/>
+  </struct>
+  <struct name="ChatParticipant">
+    <item name="uid" type="INT16U"/>
+    <item name="nickname" type="CHAR_STRING"/>
+  </struct>
+  <struct name="ChatRoom">
+    <item name="cid" type="INT16U"/>
+    <item name="name" type="CHAR_STRING"/>
+  </struct>
+  <struct name="NodeInformation">
+    <item name="uid" type="INT16U"/>
+    <item name="address" type="DATA16"/>
+    <item name="endpoint" type="INT8U"/>
+    <item name="nickname" type="CHAR_STRING"/>
+  </struct>
+  <bitmap name="EnergyFormatting" type="BITMAP8">
+    <field name="NumberOfDigitsToTheRightOfTheDecimalPoint" mask="0x07"/>
+    <field name="NumberOfDigitsToTheLeftOfTheDecimalPoint" mask="0x78"/>
+    <field name="SuppressLeadingZeros" mask="0x80"/>
+  </bitmap>
+  <struct name="ScheduledPhase">
+    <item name="energyPhaseId" type="INT8U"/>
+    <item name="scheduledTime" type="INT16U"/>
+  </struct>
+  <struct name="TransferredPhase">
+    <item name="energyPhaseId" type="INT8U"/>
+    <item name="macroPhaseId" type="INT8U"/>
+    <item name="expectedDuration" type="INT16U"/>
+    <item name="peakPower" type="INT16U"/>
+    <item name="energy" type="INT16U"/>
+    <item name="maxActivationDelay" type="INT16U"/>
+  </struct>
+  <struct name="PowerProfileRecord">
+    <item name="powerProfileId" type="INT8U"/>
+    <item name="energyPhaseId" type="INT8U"/>
+    <item name="powerProfileRemoteControl" type="BOOLEAN"/>
+    <item name="powerProfileState" type="ENUM8"/>
+  </struct>
+  <enum name="PowerProfileState" type="ENUM8">
+    <item name="PowerProfileWaitingToStart" value="0x01"/>
+    <item name="PowerProfileStarted" value="0x02"/>
+    <item name="EnergyPhaseRunning" value="0x03"/>
+    <item name="EnergyPhaseEnded" value="0x04"/>
+    <item name="EnergyPhaseWaitingToStart" value="0x05"/>
+    <item name="EnergyPhaseStarted" value="0x06"/>
+    <item name="PowerProfileEnded" value="0x07"/>
+    <item name="ProfileReadyForScheduling" value="0x08"/>
+    <item name="PowerProfileScheduled" value="0x09"/>
+  </enum>
+  <enum name="ApplianceStatus" type="ENUM8">
+    <item name="Off" value="0x01"/>
+    <item name="StandBy" value="0x02"/>
+    <item name="Programmed" value="0x03"/>
+    <item name="ProgrammedWaitingToStart" value="0x04"/>
+    <item name="Running" value="0x05"/>
+    <item name="Pause" value="0x06"/>
+    <item name="EndProgrammed" value="0x07"/>
+    <item name="Failure" value="0x08"/>
+    <item name="ProgrammeInterrupted" value="0x09"/>
+    <item name="Idle" value="0x0A"/>
+    <item name="RinseHold" value="0x0B"/>
+    <item name="Service" value="0x0C"/>
+    <item name="Superfreezing" value="0x0D"/>
+    <item name="Supercooling" value="0x0E"/>
+    <item name="Superheating" value="0x0F"/>
+  </enum>
+  <bitmap name="RemoteEnableFlagsAndDeviceStatus2" type="BITMAP8">
+    <field name="RemoteEnableFlags" mask="0x0F"/>
+    <field name="DeviceStatus2Structure" mask="0xF0"/>
+  </bitmap>
+  <enum name="RemoteEnableFlags" type="ENUM8">
+    <item name="Disabled" value="0x00"/>
+    <item name="TemporarilyLockedDisabled" value="0x07"/>
+    <item name="EnabledRemoteControl" value="0x0F"/>
+    <item name="EnabledRemoteAndEnergyControl" value="0x01"/>
+  </enum>
+  <enum name="DeviceStatus2Structure" type="ENUM8">
+    <item name="IrisSymptomCode" value="0x20"/>
+  </enum>
+  <bitmap name="StartTime" type="BITMAP16">
+    <field name="Minutes" mask="0x003F"/>
+    <field name="TimeEncoding" mask="0x00C0"/>
+    <field name="Hours" mask="0xFF00"/>
+  </bitmap>
+  <enum name="TimeEncoding" type="ENUM8">
+    <item name="Relative" value="0x00"/>
+    <item name="Absolute" value="0x40"/>
+  </enum>
+  <enum name="CommandIdentification" type="ENUM8">
+    <item name="Start" value="0x01"/>
+    <item name="Stop" value="0x02"/>
+    <item name="Pause" value="0x03"/>
+    <item name="StartSuperfreezing" value="0x04"/>
+    <item name="StopSuperfreezing" value="0x05"/>
+    <item name="StartSupercooling" value="0x06"/>
+    <item name="StopSupercooling" value="0x07"/>
+    <item name="DisableGas" value="0x08"/>
+    <item name="EnableGas" value="0x09"/>
+    <item name="EnableEnergyControl" value="0x0A"/>
+    <item name="DisableEnergyControl" value="0x0B"/>
+  </enum>
+  <enum name="WarningEvent" type="ENUM8">
+    <item name="Warning1OverallPowerAboveAvailablePowerLevel" value="0x00"/>
+    <item name="Warning2OverallPowerAbovePowerThresholdLevel" value="0x01"/>
+    <item name="Warning3OverallPowerBackBelowTheAvailablePowerLevel" value="0x02"/>
+    <item name="Warning4OverallPowerBackBelowThePowerThresholdLevel" value="0x03"/>
+    <item name="Warning5OverallPowerWillBePotentiallyAboveAvailablePowerLevelIfTheApplianceStarts" value="0x04"/>
+  </enum>
+  <enum name="DoorLockState" type="ENUM8">
+    <item name="NotFullyLocked" value="0x00"/>
+    <item name="Locked" value="0x01"/>
+    <item name="Unlocked" value="0x02"/>
+  </enum>
+  <enum name="DoorLockSoundVolume" type="ENUM8">
+    <item name="Silent" value="0x00"/>
+    <item name="Low" value="0x01"/>
+    <item name="High" value="0x02"/>
+  </enum>
+  <enum name="DoorLockType" type="ENUM8">
+    <item name="DeadBolt" value="0x00"/>
+    <item name="Magnetic" value="0x01"/>
+    <item name="Mortise" value="0x02"/>
+    <item name="Rim" value="0x03"/>
+    <item name="LatchBolt" value="0x04"/>
+    <item name="Cylindrical" value="0x05"/>
+    <item name="Tubular" value="0x06"/>
+    <item name="Interconnected" value="0x07"/>
+    <item name="DeadLatch" value="0x08"/>
+    <item name="Other" value="0x09"/>
+  </enum>
+  <enum name="DoorState" type="ENUM8">
+    <item name="Open" value="0x00"/>
+    <item name="Closed" value="0x01"/>
+    <item name="ErrorJammed" value="0x02"/>
+    <item name="ErrorForcedOpen" value="0x03"/>
+    <item name="ErrorUnspecified" value="0x04"/>
+  </enum>
+  <enum name="DoorLockOperatingMode" type="ENUM8">
+    <item name="NormalMode" value="0x00"/>
+    <item name="VacationMode" value="0x01"/>
+    <item name="PrivacyMode" value="0x02"/>
+    <item name="NoRfLockOrUnlock" value="0x03"/>
+    <item name="LocalProgrammingMode" value="0x04"/>
+    <item name="PassageMode" value="0x05"/>
+  </enum>
+  <enum name="DoorLockSecurityLevel" type="ENUM8">
+    <item name="NetworkSecurity" value="0x00"/>
+    <item name="ApsSecurity" value="0x01"/>
+  </enum>
+  <enum name="DoorLockUserStatus" type="ENUM8">
+    <item name="Available" value="0x00"/>
+    <item name="OccupiedEnabled" value="0x01"/>
+    <item name="OccupiedDisabled" value="0x03"/>
+    <item name="NotSupported" value="0xFF"/>
+  </enum>
+  <enum name="DoorLockUserType" type="ENUM8">
+    <item name="Unrestricted" value="0x00"/>
+    <item name="YearDayScheduleUser" value="0x01"/>
+    <item name="WeekDayScheduleUser" value="0x02"/>
+    <item name="MasterUser" value="0x03"/>
+    <item name="NonAccessUser" value="0x04"/>
+    <item name="NotSupported" value="0xFF"/>
+  </enum>
+  <bitmap name="DoorLockDayOfWeek" type="BITMAP8">
+    <field name="Sunday" mask="0x01"/>
+    <field name="Monday" mask="0x02"/>
+    <field name="Tuesday" mask="0x04"/>
+    <field name="Wednesday" mask="0x08"/>
+    <field name="Thursday" mask="0x10"/>
+    <field name="Friday" mask="0x20"/>
+    <field name="Saturday" mask="0x40"/>
+  </bitmap>
+  <enum name="DoorLockEventType" type="ENUM8">
+    <item name="Operation" value="0x00"/>
+    <item name="Programming" value="0x01"/>
+    <item name="Alarm" value="0x02"/>
+  </enum>
+  <enum name="DoorLockEventSource" type="ENUM8">
+    <item name="Keypad" value="0x00"/>
+    <item name="Rf" value="0x01"/>
+    <item name="Manual" value="0x02"/>
+    <item name="Rfid" value="0x03"/>
+    <item name="Indeterminate" value="0xFF"/>
+  </enum>
+  <enum name="DoorLockSetPinOrIdStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="GeneralFailure" value="0x01"/>
+    <item name="MemoryFull" value="0x02"/>
+    <item name="DuplicateCodeError" value="0x03"/>
+  </enum>
+  <enum name="DoorLockOperationEventCode" type="ENUM8">
+    <item name="UnknownOrMfgSpecific" value="0x00"/>
+    <item name="Lock" value="0x01"/>
+    <item name="Unlock" value="0x02"/>
+    <item name="LockInvalidPinOrId" value="0x03"/>
+    <item name="LockInvalidSchedule" value="0x04"/>
+    <item name="UnlockInvalidPinOrId" value="0x05"/>
+    <item name="UnlockInvalidSchedule" value="0x06"/>
+    <item name="OneTouchLock" value="0x07"/>
+    <item name="KeyLock" value="0x08"/>
+    <item name="KeyUnlock" value="0x09"/>
+    <item name="AutoLock" value="0x0A"/>
+    <item name="ScheduleLock" value="0x0B"/>
+    <item name="ScheduleUnlock" value="0x0C"/>
+    <item name="ManualLock" value="0x0D"/>
+    <item name="ManualUnlock" value="0x0E"/>
+  </enum>
+  <enum name="DoorLockProgrammingEventCode" type="ENUM8">
+    <item name="UnknownOrMfgSpecific" value="0x00"/>
+    <item name="MasterCodeChanged" value="0x01"/>
+    <item name="PinAdded" value="0x02"/>
+    <item name="PinDeleted" value="0x03"/>
+    <item name="PinChanged" value="0x04"/>
+    <item name="IdAdded" value="0x05"/>
+    <item name="IdDeleted" value="0x06"/>
+  </enum>
+  <enum name="ThermostatRunningMode" type="ENUM8">
+    <item name="Off" value="0x00"/>
+    <item name="Cool" value="0x03"/>
+    <item name="Heat" value="0x04"/>
+  </enum>
+  <enum name="StartOfWeek" type="ENUM8">
+    <item name="Sunday" value="0x00"/>
+    <item name="Monday" value="0x01"/>
+    <item name="Tuesday" value="0x02"/>
+    <item name="Wednesday" value="0x03"/>
+    <item name="Thursday" value="0x04"/>
+    <item name="Friday" value="0x05"/>
+    <item name="Saturday" value="0x06"/>
+  </enum>
+  <enum name="TemperatureSetpointHold" type="ENUM8">
+    <item name="SetpointHoldOff" value="0x00"/>
+    <item name="SetpointHoldOn" value="0x01"/>
+  </enum>
+  <bitmap name="ThermostatRunningState" type="BITMAP16">
+    <field name="HeatStateOn" mask="0x0001"/>
+    <field name="CoolStateOn" mask="0x0002"/>
+    <field name="FanStateOn" mask="0x0004"/>
+    <field name="HeatSecondStageStateOn" mask="0x0008"/>
+    <field name="CoolSecondStageStateOn" mask="0x0010"/>
+    <field name="FanSecondStageStateOn" mask="0x0020"/>
+    <field name="FanThirdStageStateOn" mask="0x0040"/>
+  </bitmap>
+  <bitmap name="DayOfWeek" type="BITMAP8">
+    <field name="Sunday" mask="0x01"/>
+    <field name="Monday" mask="0x02"/>
+    <field name="Tuesday" mask="0x04"/>
+    <field name="Wednesday" mask="0x08"/>
+    <field name="Thursday" mask="0x10"/>
+    <field name="Friday" mask="0x20"/>
+    <field name="Saturday" mask="0x40"/>
+    <field name="AwayOrVacation" mask="0x80"/>
+  </bitmap>
+  <bitmap name="ModeForSequence" type="BITMAP8">
+    <field name="HeatSetpointFieldPresent" mask="0x01"/>
+    <field name="CoolSetpointFieldPresent" mask="0x02"/>
+  </bitmap>
+  <enum name="ProductTypeId" type="ENUM16">
+    <item name="WhiteGoods" value="0x0000"/>
+    <item name="Dishwasher" value="0x5601"/>
+    <item name="TumbleDryer" value="0x5602"/>
+    <item name="WasherDryer" value="0x5603"/>
+    <item name="WashingMachine" value="0x5604"/>
+    <item name="Hobs" value="0x5E03"/>
+    <item name="InductionHobs" value="0x5E09"/>
+    <item name="Oven" value="0x5E01"/>
+    <item name="ElectricalOven" value="0x5E06"/>
+    <item name="RefrigeratorFreezer" value="0x6601"/>
+  </enum>
+  <enum name="CecedSpecificationVersion" type="ENUM8">
+    <item name="CompliantWithV10NotCertified" value="0x10"/>
+    <item name="CompliantWithV10Certified" value="0x1A"/>
+  </enum>
+  <enum name="MeterTypeId" type="ENUM16">
+    <item name="UtilityPrimaryMeter" value="0x0000"/>
+    <item name="UtilityProductionMeter" value="0x0001"/>
+    <item name="UtilitySecondaryMeter" value="0x0002"/>
+    <item name="PrivatePrimaryMeter" value="0x0100"/>
+    <item name="PrivateProductionMeter" value="0x0101"/>
+    <item name="PrivateSecondaryMeters" value="0x0102"/>
+    <item name="GenericMeter" value="0x0110"/>
+  </enum>
+  <enum name="DataQualityId" type="ENUM16">
+    <item name="AllDataCertified" value="0x0000"/>
+    <item name="OnlyInstantaneousPowerNotCertified" value="0x0001"/>
+    <item name="OnlyCumulatedConsumptionNotCertified" value="0x0002"/>
+    <item name="NotCertifiedData" value="0x0003"/>
+  </enum>
+  <!-- APPLIANCE EVENTS AND ALERT -->
+  <bitmap name="AlertStructure" type="BITMAP24">
+    <field name="AlertId" mask="0x0000FF"/>
+    <field name="Category" mask="0x000F00"/>
+    <field name="PresenceRecovery" mask="0x003000"/>
+  </bitmap>
+  <enum name="AlertStructureCategory" type="ENUM16">
+    <item name="Warning" value="0x0100"/>
+    <item name="Danger" value="0x0200"/>
+    <item name="Failure" value="0x0300"/>
+  </enum>
+  <enum name="AlertStructurePresenceRecovery" type="ENUM16">
+    <item name="Recovery" value="0x0000"/>
+    <item name="Presence" value="0x1000"/>
+  </enum>
+  <bitmap name="AlertCount" type="BITMAP8">
+    <field name="NumberOfAlerts" mask="0x0F"/>
+    <field name="TypeOfAlert" mask="0xF0"/>
+  </bitmap>
+  <enum name="AlertCountType" type="ENUM8">
+    <item name="Unstructured" value="0x00"/>
+  </enum>
+  <enum name="EventIdentification" type="ENUM8">
+    <item name="EndOfCycle" value="0x01"/>
+    <item name="TemperatureReached" value="0x04"/>
+    <item name="EndOfCooking" value="0x05"/>
+    <item name="SwitchingOff" value="0x06"/>
+    <item name="WrongData" value="0x07"/>
+  </enum>
+  <enum name="GenericDeviceClass" type="ENUM8">
+    <item name="Lighting" value="0x00"/>
+  </enum>
+  <!-- Lighting and Occupancy Types -->
+  <enum name="GenericDeviceType" type="ENUM8">
+    <item name="Incandescent" value="0x00"/>
+    <item name="SpotlightHalogen" value="0x01"/>
+    <item name="HalogenBulb" value="0x02"/>
+    <item name="CFL" value="0x03"/>
+    <item name="LinearFlourescent" value="0x04"/>
+    <item name="LedBulb" value="0x05"/>
+    <item name="SpotlightLed" value="0x06"/>
+    <item name="LedStrip" value="0x07"/>
+    <item name="LedTube" value="0x08"/>
+    <item name="GenericIndoorFixture" value="0x09"/>
+    <item name="GenericOutdoorFixture" value="0x0A"/>
+    <item name="PendantFixture" value="0x0B"/>
+    <item name="FloorStandingFixture" value="0x0C"/>
+    <!-- 0x0D-0xDF reserved -->
+    <item name="GenericController" value="0xE0"/>
+    <item name="WallSwitch" value="0xE1"/>
+    <item name="PortableRemoteController" value="0xE2"/>
+    <item name="MotionOrLightSensor" value="0xE3"/>
+    <!-- 0xE4-0xEF reserved -->
+    <item name="GenericActuator" value="0xF0"/>
+    <item name="PluginUnit" value="0xF1"/>
+    <item name="RetrofitActuator" value="0xF2"/>
+    <!-- 0xF5-0xFE reserved -->
+    <item name="Unspecified" value="0xFF"/>
+  </enum>
+  <enum name="ProductCode" type="ENUM8">
+    <item name="ManufacturerDefined" value="0x00"/>
+    <item name="IternationalArticleNumber" value="0x01"/>
+    <item name="GlobalTradeItemNumber" value="0x02"/>
+    <item name="UniversalProductCode" value="0x03"/>
+    <item name="StockKeepingUnit" value="0x04"/>
+    <!-- 0x05-0xFF reserved -->
+  </enum>
+  <enum name="StartUpOnOffValue" type="ENUM8">
+    <item name="SetToOff" value="0x00"/>
+    <item name="SetToOn" value="0x01"/>
+    <item name="SetToToggle" value="0x02"/>
+    <!-- 0x03-0xFF reserved -->
+    <item name="SetToPrevious" value="0xFF"/>
+  </enum>
+  <enum name="LevelControlOptions" type="BITMAP8">
+    <item name="ExecuteIfOff" value="0x1"/>
+    <item name="CoupleColorTempToLevel" value="0x02"/>
+  </enum>
+  <!-- Barrier Control Cluster -->
+  <bitmap name="BarrierControlCapabilities" type="BITMAP8">
+    <field name="partialBarrier" mask="0x01"/>
+  </bitmap>
+  <bitmap name="BarrierControlSafetyStatus" type="BITMAP16">
+    <field name="remoteLockout" mask="0x01"/>
+    <field name="temperDetected" mask="0x02"/>
+    <field name="failedCommunication" mask="0x04"/>
+    <field name="positionFailure" mask="0x08"/>
+  </bitmap>
+  <enum name="BarrierControlBarrierPosition" type="INT8U">
+    <item name="Closed" value="0"/>
+    <item name="Open" value="100"/>
+    <item name="Unknown" value="0xFF"/>
+  </enum>
+  <enum name="BarrierControlMovingState" type="ENUM8">
+    <item name="Stopped" value="0x00"/>
+    <item name="Closing" value="0x01"/>
+    <item name="Opening" value="0x02"/>
+  </enum>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/wwah-silabs-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/wwah-silabs-devices.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>SL-WWAH-door-lock</name>
+    <domain>WWAH</domain>
+    <typeName>SL WWAH Door Lock</typeName>
+    <zigbeeType>Coordinator</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Basic</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Power Configuration</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Identify</include>
+      <include client="true" server="false" clientLocked="false" serverLocked="false">Over the Air Bootloading</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Alarms</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Poll Control</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Door Lock</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Diagnostics</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">Time</include>
+      <include client="false" server="true" clientLocked="true" serverLocked="true">SL Works With All Hubs</include>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/wwah-silabs.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/wwah-silabs.xml
@@ -1,0 +1,352 @@
+<?xml version="1.0"?>
+<configurator>
+  <!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+  <domain name="Works With All Hubs"/>
+  <enum name="WwahIasZoneEnrollmentMode" type="ENUM8">
+    <item name="TripToPair" value="0x00"/>
+    <item name="AutoEnrollmentResponse" value="0x01"/>
+    <item name="Request" value="0x02"/>
+  </enum>
+  <enum name="WwahPowerNotificationReason" type="ENUM8">
+    <item name="Unknown" value="0x00"/>
+    <item name="Battery" value="0x01"/>
+    <item name="Brownout" value="0x02"/>
+    <item name="Watchdog" value="0x03"/>
+    <item name="ResetPin" value="0x04"/>
+    <item name="MemoryHardwareFault" value="0x05"/>
+    <item name="SofwareException" value="0x06"/>
+    <item name="OtaBootloadSuccess" value="0x07"/>
+    <item name="SoftwareReset" value="0x08"/>
+    <item name="PowerButton" value="0x09"/>
+    <item name="Temperature" value="0x0A"/>
+    <item name="BootloadFailure" value="0x0B"/>
+  </enum>
+  <struct name="WwahBeaconSurvey">
+    <item name="deviceShort" type="INT16U"/>
+    <item name="rssi" type="INT8U"/>
+    <item name="classificationMask" type="INT8U"/>
+  </struct>
+  <struct name="WwahClusterStatusToUseTC">
+    <item name="clusterId" type="CLUSTER_ID"/>
+    <item name="status" type="Status"/>
+  </struct>
+  <cluster manufacturerCode="0x1217" singleton="true">
+    <!-- Amazon -->
+    <name>SL Works With All Hubs</name>
+    <!-- Aligned with 17-01067-023-WWAH ZCL Cluster Definition -->
+    <domain>Works With All Hubs</domain>
+    <description>Silicon Labs proprietary attributes and commands for Works With All Hubs functional extensions.</description>
+    <code>0xFC57</code>
+    <!-- 0xFCxx for proprietary cluster ID; 0x57 for 'W' -->
+    <define>SL_WWAH_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <!-- attribute side="server" code="0x0000" define="NOT_DEFINED"></attribute -->
+    <!-- removed from spec Version 023 -->
+    <!-- attribute side="server" code="0x0001" define="NOT_DEFINED"></attribute -->
+    <!-- removed from spec Version 012 -->
+    <attribute side="server" code="0x0002" define="SL_DISABLE_OTA_DOWNGRADES" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">disable ota downgrades</attribute>
+    <attribute side="server" code="0x0003" define="SL_MGMT_LEAVE_WITHOUT_REJOIN_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="false">mgmt leave without rejoin enabled</attribute>
+    <attribute side="server" code="0x0004" define="SL_NWK_RETRY_COUNT" type="INT8U" min="0x03" max="0xFF" writable="false" default="0xFF" optional="false">network retry count</attribute>
+    <attribute side="server" code="0x0005" define="SL_MAC_RETRY_COUNT" type="INT8U" min="0x03" max="0xFF" writable="false" default="0xFF" optional="false">mac retry count</attribute>
+    <attribute side="server" code="0x0006" define="SL_ROUTER_CHECKIN_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">router checkin enabled</attribute>
+    <attribute side="server" code="0x0007" define="SL_TOUCHLINK_INTERPAN_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">touchlink interpan enabled</attribute>
+    <attribute side="server" code="0x0008" define="SL_WWAH_PARENT_CLASSIFICATION_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">wwah parent classification enabled</attribute>
+    <attribute side="server" code="0x0009" define="SL_WWAH_APP_EVENT_RETRY_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="false">wwah app event retry enabled</attribute>
+    <attribute side="server" code="0x000A" define="SL_WWAH_APP_EVENT_RETRY_QUEUE_SIZE" type="INT8U" min="0x0A" max="0xFF" writable="false" default="0x0A" optional="false">wwah app event retry queue size</attribute>
+    <attribute side="server" code="0x000B" define="SL_WWAH_REJOIN_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">wwah rejoin enabled</attribute>
+    <attribute side="server" code="0x000C" define="SL_MAC_POLL_FAILURE_WAIT_TIME" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x03" optional="false">mac poll failure wait time</attribute>
+    <attribute side="server" code="0x000D" define="SL_CONFIGURATION_MODE_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="false">configuration mode enabled</attribute>
+    <attribute side="server" code="0x000E" define="SL_CURRENT_DEBUG_REPORT_ID" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="false">current debug report id</attribute>
+    <attribute side="server" code="0x000F" define="SL_TC_SECURITY_ON_NTWK_KEY_ROTATION_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">tc security on ntwk key rotation enabled</attribute>
+    <attribute side="server" code="0x0010" define="SL_WWAH_BAD_PARENT_RECOVERY_ENABLED" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x00" optional="false">wwah bad parent recovery enabled</attribute>
+    <attribute side="server" code="0x0011" define="SL_PENDING_NETWORK_UPDATE_CHANNEL" type="INT8U" min="0x00" max="0xFF" writable="false" default="0xFF" optional="false">pending network update channel</attribute>
+    <attribute side="server" code="0x0012" define="SL_PENDING_NETWORK_UPDATE_PANID" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0xFFFF" optional="false">pending network update pan id</attribute>
+    <attribute side="server" code="0x0013" define="SL_OTA_MAX_OFFLINE_DURATION" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="false">ota max offline duration</attribute>
+    <command source="client" code="0x00" name="EnableApsLinkKeyAuthorization" optional="false" cli="zcl sl-wwah enable-aps-link-key-auth">
+      <description>
+        Enable enforcement of APS-level security for all cluster commands.
+      </description>
+      <arg name="numberExemptClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberExemptClusters!=0"/>
+    </command>
+    <command source="client" code="0x01" name="DisableApsLinkKeyAuthorization" optional="false" cli="zcl sl-wwah disable-aps-link-key-auth">
+      <description>
+        Disable enforcement of APS-level security for all cluster commands.
+      </description>
+      <arg name="numberExemptClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberExemptClusters!=0"/>
+    </command>
+    <command source="client" code="0x02" name="ApsLinkKeyAuthorizationQuery" optional="false" cli="zcl sl-wwah query-aps-link-key-auth">
+      <description>
+        Query status of APS-level security enforcement for a specified cluster.
+      </description>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+    </command>
+    <command source="client" code="0x03" name="RequestNewApsLinkKey" optional="false" cli="zcl sl-wwah request-new-aps-link-key">
+      <description>
+        Trigger device to request a new APS link key from the Trust Center.
+      </description>
+    </command>
+    <command source="client" code="0x04" name="EnableWwahAppEventRetryAlgorithm" optional="false" cli="zcl sl-wwah enable-app-event-retry-alg">
+      <description>
+        Enable WWAH App Event retry algorithm.
+      </description>
+      <arg name="firstBackoffTimeSeconds" type="INT8U"/>
+      <arg name="backoffSeqCommonRatio" type="INT8U"/>
+      <arg name="maxBackoffTimeSeconds" type="INT32U"/>
+      <arg name="maxRedeliveryAttempts" type="INT8U"/>
+    </command>
+    <command source="client" code="0x05" name="DisableWwahAppEventRetryAlgorithm" optional="false" cli="zcl sl-wwah disable-app-event-retry-alg">
+      <description>
+        Disable WWAH App Event retry algorithm.
+      </description>
+    </command>
+    <command source="client" code="0x06" name="RequestTime" optional="false" cli="zcl sl-wwah req-time">
+      <description>
+        Trigger device to request current attribute values from Time Cluster server.
+      </description>
+    </command>
+    <command source="client" code="0x07" name="EnableWwahRejoinAlgorithm" optional="false" cli="zcl sl-wwah enable-rejoin-alg">
+      <description>
+        Enable WWAH rejoin algorithm.
+      </description>
+      <arg name="fastRejoinTimeoutSeconds" type="INT16U"/>
+      <arg name="durationBetweenRejoinsSeconds" type="INT16U"/>
+      <arg name="fastRejoinFirstBackoffSeconds" type="INT16U"/>
+      <arg name="maxBackoffTimeSeconds" type="INT16U"/>
+      <arg name="maxBackoffIterations" type="INT16U"/>
+    </command>
+    <command source="client" code="0x08" name="DisableWwahRejoinAlgorithm" optional="false" cli="zcl sl-wwah disable-rejoin-alg">
+      <description>
+        Disable WWAH rejoin algorithm.
+      </description>
+    </command>
+    <command source="client" code="0x09" name="SetIasZoneEnrollmentMethod" optional="false" cli="zcl sl-wwah set-ias-enroll-method">
+      <description>
+        Set the enrollment method of an IAS Zone server.
+      </description>
+      <arg name="enrollmentMode" type="WwahIasZoneEnrollmentMode"/>
+    </command>
+    <command source="client" code="0x0A" name="ClearBindingTable" optional="false" cli="zcl sl-wwah clear-binding-table">
+      <description>
+        Clear the binding table.
+      </description>
+    </command>
+    <command source="client" code="0x0B" name="EnablePeriodicRouterCheckIns" optional="false" cli="zcl sl-wwah enable-router-checkins">
+      <description>
+        Enable device to periodically check connectivity with Zigbee Coordinator.
+      </description>
+      <arg name="checkInInterval" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0C" name="DisablePeriodicRouterCheckIns" optional="false" cli="zcl sl-wwah disable-router-checkins">
+      <description>
+        Disable device from periodically checking connectivity with Zigbee Coordinator.
+      </description>
+    </command>
+    <command source="client" code="0x0D" name="SetMacPollFailureWaitTime" optional="false" cli="zcl sl-wwah set-mac-poll-fail-wait-time">
+      <description>
+        Set MAC poll failure wait time.
+      </description>
+      <arg name="waitTime" type="INT8U"/>
+    </command>
+    <command source="client" code="0x0E" name="SetPendingNetworkUpdate" optional="false" cli="zcl sl-wwah set-pending-network-update">
+      <description>
+        Set pending network update parameters.
+      </description>
+      <arg name="channel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+    </command>
+    <command source="client" code="0x0F" name="RequireApsAcksOnUnicasts" optional="false" cli="zcl sl-wwah enable-require-aps-ack-unicast">
+      <description>
+        Require all unicast commands to have APS ACKs enabled.
+      </description>
+      <arg name="numberExemptClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberExemptClusters!=0"/>
+    </command>
+    <command source="client" code="0x10" name="RemoveApsAcksOnUnicastsRequirement" optional="false" cli="zcl sl-wwah disable-require-aps-ack-unicast">
+      <description>
+        Roll back changes made by Require APS ACK on Unicasts.
+      </description>
+    </command>
+    <command source="client" code="0x11" name="ApsAckRequirementQuery" optional="false" cli="zcl sl-wwah query-aps-ack-requirement">
+      <description>
+        Query whether unicast commands are required to have APS ACKs enabled.
+      </description>
+    </command>
+    <command source="client" code="0x12" name="DebugReportQuery" optional="false" cli="zcl sl-wwah query-debug-report">
+      <description>
+        Query for specified debug report.
+      </description>
+      <arg name="debugReportId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x13" name="SurveyBeacons" optional="false" cli="zcl sl-wwah survey-beacons">
+      <description>
+        Causes device to perform a scan for beacons advertising the device's network.
+      </description>
+      <arg name="standardBeacons" type="BOOLEAN"/>
+    </command>
+    <command source="client" code="0x14" name="DisableOtaDowngrades" optional="false" cli="zcl sl-wwah disable-ota-downgrades">
+      <description>
+        Disallow OTA downgrade of all device firmware components.
+      </description>
+    </command>
+    <command source="client" code="0x15" name="DisableMgmtLeaveWithoutRejoin" optional="false" cli="zcl sl-wwah disable-mgmt-leave-wo-rejoin">
+      <description>
+        Causes device to ignore MGMT Leave Without Rejoin commands.
+      </description>
+    </command>
+    <command source="client" code="0x16" name="DisableTouchlinkInterpanMessageSupport" optional="false" cli="zcl sl-wwah disable-tl-interpan-msg-support">
+      <description>
+        Causes device to ignore Touchlink Interpan messages.
+      </description>
+    </command>
+    <command source="client" code="0x17" name="EnableWwahParentClassification" optional="false" cli="zcl sl-wwah enable-parent-classify">
+      <description>
+        Enable WWAH Parent Classification advertisements.
+      </description>
+    </command>
+    <command source="client" code="0x18" name="DisableWwahParentClassification" optional="false" cli="zcl sl-wwah disable-parent-classify">
+      <description>
+        Disable WWAH Parent Classification advertisements.
+      </description>
+    </command>
+    <command source="client" code="0x19" name="EnableTcSecurityOnNtwkKeyRotation" optional="false" cli="zcl sl-wwah enable-tc-sec-ntwk-key-rot">
+      <description>
+        Process only network key rotation commands sent via unicast and encrypted by Trust Center Link Key.
+      </description>
+    </command>
+    <command source="client" code="0x1A" name="EnableWwahBadParentRecovery" optional="false" cli="zcl sl-wwah enable-bad-parent-recovery">
+      <description>
+        Enable WWAH Bad Parent Recovery feature.
+      </description>
+    </command>
+    <command source="client" code="0x1B" name="DisableWwahBadParentRecovery" optional="false" cli="zcl sl-wwah disable-bad-parent-recovery">
+      <description>
+        Disable WWAH Bad Parent Recovery feature.
+      </description>
+    </command>
+    <command source="client" code="0x1C" name="EnableConfigurationMode" optional="false" cli="zcl sl-wwah enable-config-mode">
+      <description>
+        Enable Configuration Mode.
+      </description>
+    </command>
+    <command source="client" code="0x1D" name="DisableConfigurationMode" optional="false" cli="zcl sl-wwah disable-config-mode">
+      <description>
+        Disable Configuration Mode.
+      </description>
+    </command>
+    <command source="client" code="0x1E" name="UseTrustCenterForClusterServer" optional="false" cli="zcl sl-wwah use-tc-for-cluster-server">
+      <description>
+        Use only the Trust Center as cluster server for the set of clusters specified.
+      </description>
+      <arg name="numberOfClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberOfClusters!=0"/>
+    </command>
+    <command source="client" code="0x1F" name="TrustCenterForClusterServerQuery" optional="false" cli="zcl sl-wwah query-tc-for-cluster-server">
+      <description>
+        Causes device to send an appropriate Trust Center for Cluster Server Query Response command.
+      </description>
+    </command>
+    <command source="server" code="0x00" name="ApsLinkKeyAuthorizationQueryResponse" optional="false">
+      <description>
+        Command description for SlAPSLinkKeyAuthorizationQueryResponse
+      </description>
+      <arg name="clusterId" type="CLUSTER_ID"/>
+      <arg name="apsLinkKeyAuthStatus" type="BOOLEAN"/>
+    </command>
+    <command source="server" code="0x01" name="PoweringOffNotification" optional="false">
+      <description>
+        Command description for SlPoweringOffNotification
+      </description>
+      <arg name="powerNotificationReason" type="WwahPowerNotificationReason"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="manufacturerReasonLength" type="INT8U"/>
+      <arg name="manufacturerReason" type="INT8U" array="true" presentIf="manufacturerReasonLength!=0"/>
+    </command>
+    <command source="server" code="0x02" name="PoweringOnNotification" optional="false">
+      <description>
+        Command description for SlPoweringOnNotification
+      </description>
+      <arg name="powerNotificationReason" type="WwahPowerNotificationReason"/>
+      <arg name="manufacturerId" type="INT16U"/>
+      <arg name="manufacturerReasonLength" type="INT8U"/>
+      <arg name="manufacturerReason" type="INT8U" array="true" presentIf="manufacturerReasonLength!=0"/>
+    </command>
+    <command source="server" code="0x03" name="ShortAddressChange" optional="false">
+      <description>
+        Command description for SlShortAddressChange
+      </description>
+      <arg name="deviceEui64" type="IEEE_ADDRESS"/>
+      <arg name="deviceShort" type="INT16U"/>
+    </command>
+    <command source="server" code="0x04" name="ApsAckEnablementQueryResponse" optional="false">
+      <description>
+        Command description for SlAPSAckEnablementQueryResponse
+      </description>
+      <arg name="numberExemptClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberExemptClusters!=0"/>
+    </command>
+    <command source="server" code="0x05" name="PowerDescriptorChange" optional="false">
+      <description>
+        Command description for SlPowerDescriptorChange
+      </description>
+      <arg name="currentPowerMode" type="INT32U"/>
+      <arg name="availablePowerSources" type="INT32U"/>
+      <arg name="currentPowerSource" type="INT32U"/>
+      <arg name="currentPowerSourceLevel" type="INT32U"/>
+    </command>
+    <command source="server" code="0x06" name="NewDebugReportNotification" optional="false">
+      <description>
+        Command description for SlNewDebugReportNotification
+      </description>
+      <arg name="debugReportId" type="INT8U"/>
+      <arg name="debugReportSize" type="INT32U"/>
+    </command>
+    <command source="server" code="0x07" name="DebugReportQueryResponse" optional="false">
+      <description>
+        Command description for SlDebugReportQueryResponse
+      </description>
+      <arg name="debugReportId" type="INT8U"/>
+      <arg name="debugReportData" type="INT8U" array="true"/>
+      <!-- OPAQUE -->
+    </command>
+    <command source="server" code="0x08" name="TrustCenterForClusterServerQueryResponse" optional="false">
+      <description>
+        Command description for SlTrustCenterForClusterServerQueryResponse
+      </description>
+      <arg name="numberOfClusters" type="INT8U"/>
+      <arg name="clusterId" type="CLUSTER_ID" array="true" presentIf="numberOfClusters!=0"/>
+    </command>
+    <command source="server" code="0x09" name="SurveyBeaconsResponse" optional="false">
+      <description>
+        Command description for SlSurveyBeaconsResponse
+      </description>
+      <arg name="numberOfBeacons" type="INT8U"/>
+      <arg name="beacon" type="WwahBeaconSurvey" array="true" presentIf="numberOfBeacons!=0"/>
+    </command>
+    <command source="server" code="0x9E" name="UseTrustCenterForClusterServerResponse" optional="false">
+      <!-- This extra command's integration into the spec is being discussed. Do not remove if updating XML -->
+      <description>
+        Command description for SlUseTrustCenterForClusterServerResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="clusterStatusLength" type="INT8U"/>
+      <arg name="clusterStatus" type="WwahClusterStatusToUseTC" array="true" presentIf="clusterStatusLength!=0"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/z3-nfr.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/z3-nfr.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <!-- Added for NFR 14-0264 -->
+  <clusterExtension code="0x0201">
+    <attribute side="server" code="0x0034" define="OCCUPIED_SETBACK" type="INT8U" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true">occupied setback</attribute>
+    <attribute side="server" code="0x0035" define="OCCUPIED_SETBACK_MIN" type="INT8U" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true">occupied setback min</attribute>
+    <attribute side="server" code="0x0036" define="OCCUPIED_SETBACK_MAX" type="INT8U" min="0x01" max="0xFF" writable="false" default="0xFF" optional="true">occupied setback max</attribute>
+    <attribute side="server" code="0x0037" define="UNOCCUPIED_SETBACK" type="INT8U" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true">unoccupied setback</attribute>
+    <attribute side="server" code="0x0038" define="UNOCCUPIED_SETBACK_MIN" type="INT8U" min="0x00" max="0xFF" writable="false" default="0xFF" optional="true">unoccupied setback min</attribute>
+    <attribute side="server" code="0x0039" define="UNOCCUPIED_SETBACK_MAX" type="INT8U" min="0x01" max="0xFF" writable="false" default="0xFF" optional="true">unoccupied setback max</attribute>
+    <attribute side="server" code="0x003A" define="EMERGENCY_HEAT_DELTA" type="INT8U" min="0x00" max="0xFF" writable="true" default="0xFF" optional="true">emergency heat delta</attribute>
+  </clusterExtension>
+  <clusterExtension code="0x0202">
+    <attribute side="server" code="0x0002" define="FAN_DELAY" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0xFFFF" optional="true">fan delay</attribute>
+  </clusterExtension>
+  <clusterExtension code="0x0204">
+    <attribute side="server" code="0x0003" define="BACKLIGHT_TIMEOUT" type="INT16U" min="0x0000" max="0xFFFE" writable="true" default="0x0014" optional="true">backlight timeout</attribute>
+    <attribute side="server" code="0x0004" define="SETPOINT_SOURCE_INDICATION" type="ENUM8" min="0x00" max="0xFE" writable="true" default="0x00" optional="true">setpoint source indication</attribute>
+  </clusterExtension>
+  <!-- Added for NFR 14-0516 -->
+  <clusterExtension code="0x0000">
+    <attribute side="server" code="0x0015" define="CURRENT_LOCALE" type="CHAR_STRING" length="5" writable="true" default="" optional="true">current locale</attribute>
+    <command source="client" code="0x01" name="GetLocalesSupported" optional="true" cli="zcl basic gls">
+      <description>This command gets locales supported.</description>
+      <arg name="startLocale" type="CHAR_STRING"/>
+      <arg name="maxLocalesRequested" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="GetLocalesSupportedResponse" optional="true" cli="zcl basic glsr">
+      <description>The locales supported response command is sent in response to a get locales supported command, and is used to discover which locales the device supports.</description>
+      <arg name="discoveryComplete" type="INT8U"/>
+      <arg name="localeSupported" type="CHAR_STRING" array="true"/>
+    </command>
+  </clusterExtension>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/zcl-test.properties
+++ b/src/app/zap-templates/zcl/data-model/silabs/zcl-test.properties
@@ -1,0 +1,44 @@
+# This file is provided for test of backwards compatibility.
+# The actual files used to load the ZCL for default configuration
+# is `zcl.json`, so if you want to affect how loading works for
+# built-in configuration, please use that.
+#
+version=ZCL Test Data
+
+xmlRoot=.
+
+xmlFile=\
+  types.xml, general.xml, \
+  ha.xml, ha-devices.xml, \
+  cba.xml, cba-devices.xml, \
+  ota.xml, \
+  ami.xml, ami-devices.xml, \
+  zll.xml, zll-devices.xml, \
+  ta.xml, ta-devices.xml, \
+  hc.xml, hc-devices.xml, \
+  green-power.xml, green-power-devices.xml
+
+manufacturersXml=../shared/manufacturers.xml 
+zclSchema=./schema/zcl.xsd
+zclValidation=./schema/zcl-validation.js
+
+options.text.defaultResponsePolicy=Always, Conditional, Never
+options.bool=commandDiscovery
+
+# NOTE NOTE NOTE: This does not work correctly, because JS
+# converts 0x1002 automatically to a number, so it ends up being decimal
+# 4098, which doesn't match the manufacturer code in the DB.
+# You should not use this file for default.
+#
+# Please use `zcl.json` for these features, because 
+# the properties file is provided for testing backwards compatibility
+# only anyway.
+defaults.text.manufacturerCodes=0x1002
+defaults.text.defaultResponsePolicy=always
+defaults.bool.commandDiscovery=true
+
+zigbeeDeviceType.ZA_COORDINATOR=Coordinator or Router
+zigbeeDeviceType.ZA_ROUTER=Router
+zigbeeDeviceType.ZA_END_DEVICE=End Device
+zigbeeDeviceType.ZA_MOBILE_END_DEVICE=Mobile End Device
+zigbeeDeviceType.ZA_SLEEPY_END_DEVICE=Sleepy End Device

--- a/src/app/zap-templates/zcl/data-model/silabs/zcl.json
+++ b/src/app/zap-templates/zcl/data-model/silabs/zcl.json
@@ -1,0 +1,46 @@
+{
+  "version": "ZCL Test Data",
+  "xmlRoot": ".",
+  "xmlFile": [
+    "chip.xml",
+    "types.xml",
+    "general.xml",
+    "ha.xml",
+    "ha-devices.xml",
+    "cba.xml",
+    "cba-devices.xml",
+    "ota.xml",
+    "ami.xml",
+    "ami-devices.xml",
+    "zll.xml",
+    "zll-devices.xml",
+    "ta.xml",
+    "ta-devices.xml",
+    "hc.xml",
+    "hc-devices.xml",
+    "green-power.xml",
+    "green-power-devices.xml",
+    "silabs.xml",
+    "lo-devices.xml",
+    "wwah-silabs.xml",
+    "wwah-silabs-devices.xml"
+  ],
+  "zclSchema": "./schema/zcl.xsd",
+  "manufacturersXml": "../shared/manufacturers.xml",
+  "zclValidation": "./schema/zcl-validation.js",
+  "options": {
+    "text": {
+      "defaultResponsePolicy": ["Always", "Conditional", "Never"]
+    },
+    "bool": ["commandDiscovery"]
+  },
+  "defaults": {
+    "text": {
+      "manufacturerCodes": "0x1002",
+      "defaultResponsePolicy": "always"
+    },
+    "bool": {
+      "commandDiscovery": true
+    }
+  }
+}

--- a/src/app/zap-templates/zcl/data-model/silabs/zcl.json
+++ b/src/app/zap-templates/zcl/data-model/silabs/zcl.json
@@ -1,46 +1,46 @@
 {
-  "version": "ZCL Test Data",
-  "xmlRoot": ".",
-  "xmlFile": [
-    "chip.xml",
-    "types.xml",
-    "general.xml",
-    "ha.xml",
-    "ha-devices.xml",
-    "cba.xml",
-    "cba-devices.xml",
-    "ota.xml",
-    "ami.xml",
-    "ami-devices.xml",
-    "zll.xml",
-    "zll-devices.xml",
-    "ta.xml",
-    "ta-devices.xml",
-    "hc.xml",
-    "hc-devices.xml",
-    "green-power.xml",
-    "green-power-devices.xml",
-    "silabs.xml",
-    "lo-devices.xml",
-    "wwah-silabs.xml",
-    "wwah-silabs-devices.xml"
-  ],
-  "zclSchema": "./schema/zcl.xsd",
-  "manufacturersXml": "../shared/manufacturers.xml",
-  "zclValidation": "./schema/zcl-validation.js",
-  "options": {
-    "text": {
-      "defaultResponsePolicy": ["Always", "Conditional", "Never"]
+    "version": "ZCL Test Data",
+    "xmlRoot": ".",
+    "xmlFile": [
+        "chip.xml",
+        "types.xml",
+        "general.xml",
+        "ha.xml",
+        "ha-devices.xml",
+        "cba.xml",
+        "cba-devices.xml",
+        "ota.xml",
+        "ami.xml",
+        "ami-devices.xml",
+        "zll.xml",
+        "zll-devices.xml",
+        "ta.xml",
+        "ta-devices.xml",
+        "hc.xml",
+        "hc-devices.xml",
+        "green-power.xml",
+        "green-power-devices.xml",
+        "silabs.xml",
+        "lo-devices.xml",
+        "wwah-silabs.xml",
+        "wwah-silabs-devices.xml"
+    ],
+    "zclSchema": "./schema/zcl.xsd",
+    "manufacturersXml": "../shared/manufacturers.xml",
+    "zclValidation": "./schema/zcl-validation.js",
+    "options": {
+        "text": {
+            "defaultResponsePolicy": ["Always", "Conditional", "Never"]
+        },
+        "bool": ["commandDiscovery"]
     },
-    "bool": ["commandDiscovery"]
-  },
-  "defaults": {
-    "text": {
-      "manufacturerCodes": "0x1002",
-      "defaultResponsePolicy": "always"
-    },
-    "bool": {
-      "commandDiscovery": true
+    "defaults": {
+        "text": {
+            "manufacturerCodes": "0x1002",
+            "defaultResponsePolicy": "always"
+        },
+        "bool": {
+            "commandDiscovery": true
+        }
     }
-  }
 }

--- a/src/app/zap-templates/zcl/data-model/silabs/zll-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/zll-devices.xml
@@ -1,0 +1,1241 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <deviceType>
+    <name>ZLL-onofflight</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL On/Off Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0000</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-onoffpluginunit</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL On/Off Plug-in Unit</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0010</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-dimmablelight</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Dimmable Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0100</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-dimmablepluginunit</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Dimmable Plug-in Unit</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0110</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-colorlight</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Color Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0200</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-extendedcolorlight</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Extended Color Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0210</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-colortemperaturelight</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Color Temperature Light</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0220</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>IDENTIFY_TIME</requireAttribute>
+        <requireCommand>Identify</requireCommand>
+        <requireCommand>IdentifyQuery</requireCommand>
+        <requireCommand>TriggerEffect</requireCommand>
+      </include>
+      <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddGroup</requireCommand>
+        <requireCommand>ViewGroup</requireCommand>
+        <requireCommand>GetGroupMembership</requireCommand>
+        <requireCommand>RemoveGroup</requireCommand>
+        <requireCommand>RemoveAllGroups</requireCommand>
+        <requireCommand>AddGroupIfIdentifying</requireCommand>
+      </include>
+      <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>SCENE_COUNT</requireAttribute>
+        <requireAttribute>CURRENT_SCENE</requireAttribute>
+        <requireAttribute>CURRENT_GROUP</requireAttribute>
+        <requireAttribute>SCENE_VALID</requireAttribute>
+        <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
+        <requireCommand>AddScene</requireCommand>
+        <requireCommand>ViewScene</requireCommand>
+        <requireCommand>RemoveScene</requireCommand>
+        <requireCommand>RemoveAllScenes</requireCommand>
+        <requireCommand>StoreScene</requireCommand>
+        <requireCommand>RecallScene</requireCommand>
+        <requireCommand>GetSceneMembership</requireCommand>
+        <requireCommand>EnhancedAddScene</requireCommand>
+        <requireCommand>EnhancedViewScene</requireCommand>
+        <requireCommand>CopyScene</requireCommand>
+      </include>
+      <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>ON_OFF</requireAttribute>
+        <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
+        <requireAttribute>ON_TIME</requireAttribute>
+        <requireAttribute>OFF_WAIT_TIME</requireAttribute>
+        <requireCommand>Off</requireCommand>
+        <requireCommand>On</requireCommand>
+        <requireCommand>Toggle</requireCommand>
+        <requireCommand>OffWithEffect</requireCommand>
+        <requireCommand>OnWithRecallGlobalScene</requireCommand>
+        <requireCommand>OnWithTimedOff</requireCommand>
+      </include>
+      <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>CURRENT_LEVEL</requireAttribute>
+        <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireCommand>MoveToLevel</requireCommand>
+        <requireCommand>Move</requireCommand>
+        <requireCommand>Step</requireCommand>
+        <requireCommand>Stop</requireCommand>
+        <requireCommand>MoveToLevelWithOnOff</requireCommand>
+        <requireCommand>MoveWithOnOff</requireCommand>
+        <requireCommand>StepWithOnOff</requireCommand>
+        <requireCommand>StopWithOnOff</requireCommand>
+      </include>
+      <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>COLOR_CONTROL_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_SATURATION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_NUMBER_OF_PRIMARIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_1_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_2_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_3_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_4_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_5_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_X</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_Y</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_PRIMARY_6_INTENSITY</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_CURRENT_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_ENHANCED_COLOR_MODE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_ACTIVE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_DIRECTION</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_TIME</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_CAPABILITIES</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN</requireAttribute>
+        <requireAttribute>COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX</requireAttribute>
+        <requireCommand>MoveToHue</requireCommand>
+        <requireCommand>MoveHue</requireCommand>
+        <requireCommand>StepHue</requireCommand>
+        <requireCommand>MoveToSaturation</requireCommand>
+        <requireCommand>MoveSaturation</requireCommand>
+        <requireCommand>StepSaturation</requireCommand>
+        <requireCommand>MoveToHueAndSaturation</requireCommand>
+        <requireCommand>MoveToColor</requireCommand>
+        <requireCommand>MoveColor</requireCommand>
+        <requireCommand>StepColor</requireCommand>
+        <requireCommand>MoveToColorTemperature</requireCommand>
+        <requireCommand>EnhancedMoveToHue</requireCommand>
+        <requireCommand>EnhancedMoveHue</requireCommand>
+        <requireCommand>EnhancedStepHue</requireCommand>
+        <requireCommand>EnhancedMoveToHueAndSaturation</requireCommand>
+        <requireCommand>ColorLoopSet</requireCommand>
+        <requireCommand>StopMoveStep</requireCommand>
+        <requireCommand>MoveColorTemperature</requireCommand>
+        <requireCommand>StepColorTemperature</requireCommand>
+      </include>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-colorremote</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Color Controller</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0800</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-colorsceneremote</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Color Scene Controller</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0810</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddSceneResponse</requireCommand>
+        <requireCommand>ViewSceneResponse</requireCommand>
+        <requireCommand>RemoveSceneResponse</requireCommand>
+        <requireCommand>RemoveAllScenesResponse</requireCommand>
+        <requireCommand>StoreSceneResponse</requireCommand>
+        <requireCommand>GetSceneMembershipResponse</requireCommand>
+        <requireCommand>EnhancedAddSceneResponse</requireCommand>
+        <requireCommand>EnhancedViewSceneResponse</requireCommand>
+        <requireCommand>CopySceneResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-noncolorremote</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Non-color Controller</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0820</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-noncolorsceneremote</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Non-color Scene Controller</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0830</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddSceneResponse</requireCommand>
+        <requireCommand>ViewSceneResponse</requireCommand>
+        <requireCommand>RemoveSceneResponse</requireCommand>
+        <requireCommand>RemoveAllScenesResponse</requireCommand>
+        <requireCommand>StoreSceneResponse</requireCommand>
+        <requireCommand>GetSceneMembershipResponse</requireCommand>
+        <requireCommand>EnhancedAddSceneResponse</requireCommand>
+        <requireCommand>EnhancedViewSceneResponse</requireCommand>
+        <requireCommand>CopySceneResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-controlbridge</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL Control Bridge</typeName>
+    <zigbeeType>Router</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0840</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddSceneResponse</requireCommand>
+        <requireCommand>ViewSceneResponse</requireCommand>
+        <requireCommand>RemoveSceneResponse</requireCommand>
+        <requireCommand>RemoveAllScenesResponse</requireCommand>
+        <requireCommand>StoreSceneResponse</requireCommand>
+        <requireCommand>GetSceneMembershipResponse</requireCommand>
+        <requireCommand>EnhancedAddSceneResponse</requireCommand>
+        <requireCommand>EnhancedViewSceneResponse</requireCommand>
+        <requireCommand>CopySceneResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+  <deviceType>
+    <name>ZLL-onoffsensor</name>
+    <domain>ZLL</domain>
+    <typeName>ZLL On/Off Sensor</typeName>
+    <zigbeeType>End Device</zigbeeType>
+    <profileId editable="false">0x0104</profileId>
+    <deviceId editable="false">0x0850</deviceId>
+    <clusters lockOthers="true">
+      <include cluster="Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+        <requireAttribute>VERSION</requireAttribute>
+        <requireAttribute>APPLICATION_VERSION</requireAttribute>
+        <requireAttribute>STACK_VERSION</requireAttribute>
+        <requireAttribute>HW_VERSION</requireAttribute>
+        <requireAttribute>MANUFACTURER_NAME</requireAttribute>
+        <requireAttribute>MODEL_IDENTIFIER</requireAttribute>
+        <requireAttribute>DATE_CODE</requireAttribute>
+        <requireAttribute>POWER_SOURCE</requireAttribute>
+        <requireAttribute>SW_BUILD_ID</requireAttribute>
+      </include>
+      <include cluster="ZLL Commissioning" client="true" server="true" clientLocked="true" serverLocked="true">
+        <requireCommand>ScanRequest</requireCommand>
+        <requireCommand>DeviceInformationRequest</requireCommand>
+        <requireCommand>IdentifyRequest</requireCommand>
+        <requireCommand>ResetToFactoryNewRequest</requireCommand>
+        <requireCommand>NetworkStartRequest</requireCommand>
+        <requireCommand>NetworkJoinRouterRequest</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceRequest</requireCommand>
+        <requireCommand>NetworkUpdateRequest</requireCommand>
+        <requireCommand>GetGroupIdentifiersRequest</requireCommand>
+        <requireCommand>GetEndpointListRequest</requireCommand>
+        <requireCommand>ScanResponse</requireCommand>
+        <requireCommand>DeviceInformationResponse</requireCommand>
+        <requireCommand>NetworkStartResponse</requireCommand>
+        <requireCommand>NetworkJoinRouterResponse</requireCommand>
+        <requireCommand>NetworkJoinEndDeviceResponse</requireCommand>
+        <requireCommand>EndpointInformation</requireCommand>
+        <requireCommand>GetGroupIdentifiersResponse</requireCommand>
+        <requireCommand>GetEndpointListResponse</requireCommand>
+      </include>
+      <include cluster="Identify" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>IdentifyQueryResponse</requireCommand>
+      </include>
+      <include cluster="Groups" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddGroupResponse</requireCommand>
+        <requireCommand>ViewGroupResponse</requireCommand>
+        <requireCommand>GetGroupMembershipResponse</requireCommand>
+        <requireCommand>RemoveGroupResponse</requireCommand>
+      </include>
+      <include cluster="Scenes" client="true" server="false" clientLocked="true" serverLocked="true">
+        <requireCommand>AddSceneResponse</requireCommand>
+        <requireCommand>ViewSceneResponse</requireCommand>
+        <requireCommand>RemoveSceneResponse</requireCommand>
+        <requireCommand>RemoveAllScenesResponse</requireCommand>
+        <requireCommand>StoreSceneResponse</requireCommand>
+        <requireCommand>GetSceneMembershipResponse</requireCommand>
+        <requireCommand>EnhancedAddSceneResponse</requireCommand>
+        <requireCommand>EnhancedViewSceneResponse</requireCommand>
+        <requireCommand>CopySceneResponse</requireCommand>
+      </include>
+      <include cluster="On/Off" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Level Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Color Control" client="true" server="false" clientLocked="true" serverLocked="true"/>
+      <include cluster="Over the Air Bootloading" client="false" server="false" clientLocked="false" serverLocked="false"/>
+    </clusters>
+  </deviceType>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/zll-thread.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/zll-thread.xml
@@ -1,0 +1,511 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="ZLL" spec="zll-1.0-11-0037-10" dependsOn="zcl-1.0-07-5123-03">
+  </domain>
+  <enum name="IdentifyEffectIdentifier" type="ENUM8">
+    <item name="Blink" value="0x00"/>
+    <item name="Breathe" value="0x01"/>
+    <item name="Okay" value="0x02"/>
+    <item name="ChannelChange" value="0x0B"/>
+    <item name="FinishEffect" value="0xFE"/>
+    <item name="StopEffect" value="0xFF"/>
+  </enum>
+  <enum name="IdentifyEffectVariant" type="ENUM8">
+    <item name="Default" value="0x00"/>
+  </enum>
+  <bitmap name="ScenesCopyMode" type="BITMAP8">
+    <field name="CopyAllScenes" mask="0x01"/>
+  </bitmap>
+  <enum name="OnOffEffectIdentifier" type="ENUM8">
+    <item name="DelayedAllOff" value="0x00"/>
+    <item name="DyingLight" value="0x01"/>
+  </enum>
+  <enum name="OnOffDelayedAllOffEffectVariant" type="ENUM8">
+    <item name="FadeToOffIn_0p8Seconds" value="0x00"/>
+    <item name="NoFade" value="0x01"/>
+    <item name="50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" value="0x02"/>
+  </enum>
+  <enum name="OnOffDyingLightEffectVariant" type="ENUM8">
+    <item name="20PercenterDimUpIn_0p5SecondsThenFadeToOffIn_1Second" value="0x00"/>
+  </enum>
+  <bitmap name="OnOffControl" type="BITMAP8">
+    <field name="AcceptOnlyWhenOn" mask="0x01"/>
+  </bitmap>
+  <enum name="EnhancedColorMode" type="ENUM8">
+    <item name="CurrentHueAndCurrentSaturation" value="0x00"/>
+    <item name="CurrentXAndCurrentY" value="0x01"/>
+    <item name="ColorTemperature" value="0x02"/>
+    <item name="EnhancedCurrentHueAndCurrentSaturation" value="0x03"/>
+  </enum>
+  <bitmap name="ColorCapabilities" type="BITMAP16">
+    <field name="HueSaturationSupported" mask="0x0001"/>
+    <field name="EnhancedHueSupported" mask="0x0002"/>
+    <field name="ColorLoopSupported" mask="0x0004"/>
+    <field name="XYAttributesSupported" mask="0x0008"/>
+    <field name="ColorTemperatureSupported" mask="0x0010"/>
+  </bitmap>
+  <bitmap name="ColorLoopUpdateFlags" type="BITMAP8">
+    <field name="UpdateAction" mask="0x01"/>
+    <field name="UpdateDirection" mask="0x02"/>
+    <field name="UpdateTime" mask="0x04"/>
+    <field name="UpdateStartHue" mask="0x08"/>
+  </bitmap>
+  <enum name="ColorLoopAction" type="ENUM8">
+    <item name="Deactivate" value="0x00"/>
+    <item name="ActivateFromColorLoopStartEnhancedHue" value="0x01"/>
+    <item name="ActivateFromEnhancedCurrentHue" value="0x02"/>
+  </enum>
+  <enum name="ColorLoopDirection" type="ENUM8">
+    <item name="DecrementHue" value="0x00"/>
+    <item name="IncrementHue" value="0x01"/>
+  </enum>
+  <bitmap name="ZigbeeInformation" type="BITMAP8">
+    <field name="LogicalType" mask="0x03"/>
+    <field name="RxOnWhenIdle" mask="0x04"/>
+  </bitmap>
+  <enum name="ZigbeeInformationLogicalType" type="ENUM8">
+    <item name="Coordinator" value="0x00"/>
+    <item name="Router" value="0x01"/>
+    <item name="EndDevice" value="0x02"/>
+  </enum>
+  <bitmap name="ZllInformation" type="BITMAP8">
+    <field name="FactoryNew" mask="0x01"/>
+    <field name="AddressAssignment" mask="0x02"/>
+    <field name="TouchLinkInitiator" mask="0x10"/>
+    <field name="TouchLinkPriorityRequest" mask="0x20"/>
+    <field name="ProfileInterop" mask="0x80"/>
+  </bitmap>
+  <bitmap name="KeyBitmask" type="BITMAP16">
+    <field name="Development" mask="0x0001"/>
+    <field name="Master" mask="0x0010"/>
+    <field name="Certification" mask="0x8000"/>
+  </bitmap>
+  <enum name="KeyIndex" type="ENUM8">
+    <item name="Development" value="0x00"/>
+    <item name="Master" value="0x04"/>
+    <item name="Certification" value="0x0F"/>
+  </enum>
+  <enum name="DeviceInformationRecordSort" type="ENUM8">
+    <item name="NotSorted" value="0x00"/>
+    <item name="TopOfTheList" value="0x01"/>
+  </enum>
+  <struct name="DeviceInformationRecord">
+    <item name="ieeeAddress" type="IEEE_ADDRESS"/>
+    <item name="endpointId" type="INT8U"/>
+    <item name="profileId" type="INT16U"/>
+    <item name="deviceId" type="INT16U"/>
+    <item name="version" type="INT8U"/>
+    <item name="groupIdCount" type="INT8U"/>
+    <item name="sort" type="DeviceInformationRecordSort"/>
+  </struct>
+  <enum name="ZllStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="Failure" value="0x01"/>
+  </enum>
+  <struct name="GroupInformationRecord">
+    <item name="groupId" type="INT16U"/>
+    <item name="groupType" type="INT8U"/>
+  </struct>
+  <struct name="EndpointInformationRecord">
+    <item name="networkAddress" type="INT16U"/>
+    <item name="endpointId" type="INT8U"/>
+    <item name="profileId" type="INT16U"/>
+    <item name="deviceId" type="INT16U"/>
+    <item name="version" type="INT8U"/>
+  </struct>
+  <clusterExtension code="0x0000">
+    <attribute side="server" code="0x4000" define="SW_BUILD_ID" type="CHAR_STRING" length="16" writable="false" default="" optional="true" introducedIn="zll-1.0-11-0037-10">sw build id</attribute>
+  </clusterExtension>
+  <clusterExtension code="0x0003">
+    <command source="client" code="0x40" name="TriggerEffect" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl identify trigger">
+      <description>
+        Command description for TriggerEffect
+      </description>
+      <arg name="effectId" type="IdentifyEffectIdentifier"/>
+      <arg name="effectVariant" type="IdentifyEffectVariant"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0005">
+    <command source="client" code="0x40" name="EnhancedAddScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eadd">
+      <description>
+        Command description for EnhancedAddScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="client" code="0x41" name="EnhancedViewScene" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eview">
+      <description>
+        Command description for EnhancedViewScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x42" name="CopyScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes copy">
+      <description>
+        Command description for CopyScene
+      </description>
+      <arg name="mode" type="ScenesCopyMode"/>
+      <arg name="groupIdFrom" type="INT16U"/>
+      <arg name="sceneIdFrom" type="INT8U"/>
+      <arg name="groupIdTo" type="INT16U"/>
+      <arg name="sceneIdTo" type="INT8U"/>
+    </command>
+    <command source="server" code="0x40" name="EnhancedAddSceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for EnhancedAddSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x41" name="EnhancedViewSceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for EnhancedViewSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="server" code="0x42" name="CopySceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for CopySceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupIdFrom" type="INT16U"/>
+      <arg name="sceneIdFrom" type="INT8U"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0006">
+    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="true" introducedIn="zll-1.0-11-0037-10">global scene control</attribute>
+    <attribute side="server" code="0x4001" define="ON_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">on time</attribute>
+    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">off wait time</attribute>
+    <command source="client" code="0x40" name="OffWithEffect" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off offeffect">
+      <description>
+        Command description for OffWithEffect
+      </description>
+      <arg name="effectId" type="OnOffEffectIdentifier"/>
+      <arg name="effectVariant" type="ENUM8"/>
+    </command>
+    <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off onrecall">
+      <description>
+        Command description for OnWithRecallGlobalScene
+      </description>
+    </command>
+    <command source="client" code="0x42" name="OnWithTimedOff" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off ontimedoff">
+      <description>
+        Command description for OnWithTimedOff
+      </description>
+      <arg name="onOffControl" type="OnOffControl"/>
+      <arg name="onTime" type="INT16U"/>
+      <arg name="offWaitTime" type="INT16U"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0300">
+    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">enhanced current hue</attribute>
+    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x01" optional="true" introducedIn="zll-1.0-11-0037-10">enhanced color mode</attribute>
+    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="zll-1.0-11-0037-10">color loop active</attribute>
+    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="zll-1.0-11-0037-10">color loop direction</attribute>
+    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true" introducedIn="zll-1.0-11-0037-10">color loop time</attribute>
+    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true" introducedIn="zll-1.0-11-0037-10">color loop start enhanced hue</attribute>
+    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color loop stored enhanced hue</attribute>
+    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="BITMAP16" min="0x0000" max="0x001F" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color capabilities</attribute>
+    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="INT16U" min="0x0000" max="0xFEFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color temp physical min</attribute>
+    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="INT16U" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true" introducedIn="zll-1.0-11-0037-10">color temp physical max</attribute>
+    <command source="client" code="0x40" name="EnhancedMoveToHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovetohue">
+      <description>
+        Command description for EnhancedMoveToHue
+      </description>
+      <arg name="enhancedHue" type="INT16U"/>
+      <arg name="direction" type="HueDirection"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x41" name="EnhancedMoveHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovehue">
+      <description>
+        Command description for EnhancedMoveHue
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT16U"/>
+    </command>
+    <command source="client" code="0x42" name="EnhancedStepHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control estephue">
+      <description>
+        Command description for EnhancedStepHue
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x43" name="EnhancedMoveToHueAndSaturation" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovetohueandsat">
+      <description>
+        Command description for EnhancedMoveToHueAndSaturation
+      </description>
+      <arg name="enhancedHue" type="INT16U"/>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x44" name="ColorLoopSet" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control loop">
+      <description>
+        Command description for ColorLoopSet
+      </description>
+      <arg name="updateFlags" type="ColorLoopUpdateFlags"/>
+      <arg name="action" type="ColorLoopAction"/>
+      <arg name="direction" type="ColorLoopDirection"/>
+      <arg name="time" type="INT16U"/>
+      <arg name="startHue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x47" name="StopMoveStep" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control stopmovestep">
+      <description>
+        Command description for StopMoveStep
+      </description>
+    </command>
+    <command source="client" code="0x4B" name="MoveColorTemperature" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control movecolortemp">
+      <description>
+        Command description for MoveColorTemperature
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT16U"/>
+      <arg name="colorTemperatureMinimum" type="INT16U"/>
+      <arg name="colorTemperatureMaximum" type="INT16U"/>
+    </command>
+    <command source="client" code="0x4C" name="StepColorTemperature" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control stepcolortemp">
+      <description>
+        Command description for StepColorTemperature
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="colorTemperatureMinimum" type="INT16U"/>
+      <arg name="colorTemperatureMaximum" type="INT16U"/>
+    </command>
+  </clusterExtension>
+  <cluster introducedIn="zll-1.0-11-0037-10">
+    <name>ZLL Commissioning</name>
+    <domain>ZLL</domain>
+    <description>The ZLL commissioning cluster provides commands to support touch link commissioning.</description>
+    <code>0x1000</code>
+    <define>ZLL_COMMISSIONING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="ScanRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for ScanRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="zigbeeInformation" type="ZigbeeInformation"/>
+      <arg name="zllInformation" type="ZllInformation"/>
+    </command>
+    <command source="client" code="0x02" name="DeviceInformationRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for DeviceInformationRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="IdentifyRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for IdentifyRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="identifyDuration" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="ResetToFactoryNewRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for ResetToFactoryNewRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+    </command>
+    <command source="client" code="0x10" name="NetworkStartRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkStartRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+      <arg name="initiatorIeeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="initiatorNetworkAddress" type="INT16U"/>
+    </command>
+    <command source="client" code="0x12" name="NetworkJoinRouterRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkJoinRouterRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+    </command>
+    <command source="client" code="0x14" name="NetworkJoinEndDeviceRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkJoinEndDeviceRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+    </command>
+    <command source="client" code="0x16" name="NetworkUpdateRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkUpdateRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+    </command>
+    <command source="client" code="0x41" name="GetGroupIdentifiersRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for GetGroupIdentifiersRequest
+      </description>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="client" code="0x42" name="GetEndpointListRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for GetEndpointListRequest
+      </description>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="ScanResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for ScanResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="rssiCorrection" type="INT8U"/>
+      <arg name="zigbeeInformation" type="ZigbeeInformation"/>
+      <arg name="zllInformation" type="ZllInformation"/>
+      <arg name="keyBitmask" type="KeyBitmask"/>
+      <arg name="responseId" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="numberOfSubDevices" type="INT8U"/>
+      <arg name="totalGroupIds" type="INT8U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="profileId" type="INT16U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="deviceId" type="INT16U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="version" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="groupIdCount" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+    </command>
+    <command source="server" code="0x03" name="DeviceInformationResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for DeviceInformationResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="numberOfSubDevices" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="deviceInformationRecordCount" type="INT8U"/>
+      <arg name="deviceInformationRecordList" type="DeviceInformationRecord" array="true"/>
+    </command>
+    <command source="server" code="0x11" name="NetworkStartResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkStartResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x13" name="NetworkJoinRouterResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkJoinRouterResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+    </command>
+    <command source="server" code="0x15" name="NetworkJoinEndDeviceResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkJoinEndDeviceResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+    </command>
+    <command source="server" code="0x40" name="EndpointInformation" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for EndpointInformation
+      </description>
+      <arg name="ieeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <arg name="profileId" type="INT16U"/>
+      <arg name="deviceId" type="INT16U"/>
+      <arg name="version" type="INT8U"/>
+    </command>
+    <command source="server" code="0x41" name="GetGroupIdentifiersResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for GetGroupIdentifiersResponse
+      </description>
+      <arg name="total" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="count" type="INT8U"/>
+      <arg name="groupInformationRecordList" type="GroupInformationRecord" array="true"/>
+    </command>
+    <command source="server" code="0x42" name="GetEndpointListResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for GetEndpointListResponse
+      </description>
+      <arg name="total" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="count" type="INT8U"/>
+      <arg name="endpointInformationRecordList" type="EndpointInformationRecord" array="true"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/silabs/zll.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/zll.xml
@@ -1,0 +1,517 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configurator>
+  <domain name="ZLL" spec="zll-1.0-11-0037-10" dependsOn="zcl-1.0-07-5123-03">
+  </domain>
+  <enum name="IdentifyEffectIdentifier" type="ENUM8">
+    <item name="Blink" value="0x00"/>
+    <item name="Breathe" value="0x01"/>
+    <item name="Okay" value="0x02"/>
+    <item name="ChannelChange" value="0x0B"/>
+    <item name="FinishEffect" value="0xFE"/>
+    <item name="StopEffect" value="0xFF"/>
+  </enum>
+  <enum name="IdentifyEffectVariant" type="ENUM8">
+    <item name="Default" value="0x00"/>
+  </enum>
+  <bitmap name="ScenesCopyMode" type="BITMAP8">
+    <field name="CopyAllScenes" mask="0x01"/>
+  </bitmap>
+  <enum name="OnOffEffectIdentifier" type="ENUM8">
+    <item name="DelayedAllOff" value="0x00"/>
+    <item name="DyingLight" value="0x01"/>
+  </enum>
+  <enum name="OnOffDelayedAllOffEffectVariant" type="ENUM8">
+    <item name="FadeToOffIn_0p8Seconds" value="0x00"/>
+    <item name="NoFade" value="0x01"/>
+    <item name="50PercentDimDownIn_0p8SecondsThenFadeToOffIn_12Seconds" value="0x02"/>
+  </enum>
+  <enum name="OnOffDyingLightEffectVariant" type="ENUM8">
+    <item name="20PercenterDimUpIn_0p5SecondsThenFadeToOffIn_1Second" value="0x00"/>
+  </enum>
+  <bitmap name="OnOffControl" type="BITMAP8">
+    <field name="AcceptOnlyWhenOn" mask="0x01"/>
+  </bitmap>
+  <enum name="EnhancedColorMode" type="ENUM8">
+    <item name="CurrentHueAndCurrentSaturation" value="0x00"/>
+    <item name="CurrentXAndCurrentY" value="0x01"/>
+    <item name="ColorTemperature" value="0x02"/>
+    <item name="EnhancedCurrentHueAndCurrentSaturation" value="0x03"/>
+  </enum>
+  <bitmap name="ColorCapabilities" type="BITMAP16">
+    <field name="HueSaturationSupported" mask="0x0001"/>
+    <field name="EnhancedHueSupported" mask="0x0002"/>
+    <field name="ColorLoopSupported" mask="0x0004"/>
+    <field name="XYAttributesSupported" mask="0x0008"/>
+    <field name="ColorTemperatureSupported" mask="0x0010"/>
+  </bitmap>
+  <bitmap name="ColorLoopUpdateFlags" type="BITMAP8">
+    <field name="UpdateAction" mask="0x01"/>
+    <field name="UpdateDirection" mask="0x02"/>
+    <field name="UpdateTime" mask="0x04"/>
+    <field name="UpdateStartHue" mask="0x08"/>
+  </bitmap>
+  <enum name="ColorLoopAction" type="ENUM8">
+    <item name="Deactivate" value="0x00"/>
+    <item name="ActivateFromColorLoopStartEnhancedHue" value="0x01"/>
+    <item name="ActivateFromEnhancedCurrentHue" value="0x02"/>
+  </enum>
+  <enum name="ColorLoopDirection" type="ENUM8">
+    <item name="DecrementHue" value="0x00"/>
+    <item name="IncrementHue" value="0x01"/>
+  </enum>
+  <bitmap name="ZigbeeInformation" type="BITMAP8">
+    <field name="LogicalType" mask="0x03"/>
+    <field name="RxOnWhenIdle" mask="0x04"/>
+  </bitmap>
+  <enum name="ZigbeeInformationLogicalType" type="ENUM8">
+    <item name="Coordinator" value="0x00"/>
+    <item name="Router" value="0x01"/>
+    <item name="EndDevice" value="0x02"/>
+  </enum>
+  <bitmap name="ZllInformation" type="BITMAP8">
+    <field name="FactoryNew" mask="0x01"/>
+    <field name="AddressAssignment" mask="0x02"/>
+    <field name="TouchLinkInitiator" mask="0x10"/>
+    <field name="TouchLinkPriorityRequest" mask="0x20"/>
+    <field name="ProfileInterop" mask="0x80"/>
+  </bitmap>
+  <bitmap name="KeyBitmask" type="BITMAP16">
+    <field name="Development" mask="0x0001"/>
+    <field name="Master" mask="0x0010"/>
+    <field name="Certification" mask="0x8000"/>
+  </bitmap>
+  <enum name="KeyIndex" type="ENUM8">
+    <item name="Development" value="0x00"/>
+    <item name="Master" value="0x04"/>
+    <item name="Certification" value="0x0F"/>
+  </enum>
+  <enum name="DeviceInformationRecordSort" type="ENUM8">
+    <item name="NotSorted" value="0x00"/>
+    <item name="TopOfTheList" value="0x01"/>
+  </enum>
+  <struct name="DeviceInformationRecord">
+    <item name="ieeeAddress" type="IEEE_ADDRESS"/>
+    <item name="endpointId" type="INT8U"/>
+    <item name="profileId" type="INT16U"/>
+    <item name="deviceId" type="INT16U"/>
+    <item name="version" type="INT8U"/>
+    <item name="groupIdCount" type="INT8U"/>
+    <item name="sort" type="DeviceInformationRecordSort"/>
+  </struct>
+  <enum name="ZllStatus" type="ENUM8">
+    <item name="Success" value="0x00"/>
+    <item name="Failure" value="0x01"/>
+  </enum>
+  <struct name="GroupInformationRecord">
+    <item name="groupId" type="INT16U"/>
+    <item name="groupType" type="INT8U"/>
+  </struct>
+  <struct name="EndpointInformationRecord">
+    <item name="networkAddress" type="INT16U"/>
+    <item name="endpointId" type="INT8U"/>
+    <item name="profileId" type="INT16U"/>
+    <item name="deviceId" type="INT16U"/>
+    <item name="version" type="INT8U"/>
+  </struct>
+  <clusterExtension code="0x0000">
+    <attribute side="server" code="0x4000" define="SW_BUILD_ID" type="CHAR_STRING" length="16" writable="false" default="" optional="true" introducedIn="zll-1.0-11-0037-10">sw build id</attribute>
+  </clusterExtension>
+  <clusterExtension code="0x0003">
+    <command source="client" code="0x40" name="TriggerEffect" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl identify trigger">
+      <description>
+        Command description for TriggerEffect
+      </description>
+      <arg name="effectId" type="IdentifyEffectIdentifier"/>
+      <arg name="effectVariant" type="IdentifyEffectVariant"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0005">
+    <command source="client" code="0x40" name="EnhancedAddScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eadd">
+      <description>
+        Command description for EnhancedAddScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="client" code="0x41" name="EnhancedViewScene" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes eview">
+      <description>
+        Command description for EnhancedViewScene
+      </description>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="client" code="0x42" name="CopyScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl scenes copy">
+      <description>
+        Command description for CopyScene
+      </description>
+      <arg name="mode" type="ScenesCopyMode"/>
+      <arg name="groupIdFrom" type="INT16U"/>
+      <arg name="sceneIdFrom" type="INT8U"/>
+      <arg name="groupIdTo" type="INT16U"/>
+      <arg name="sceneIdTo" type="INT8U"/>
+    </command>
+    <command source="server" code="0x40" name="EnhancedAddSceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for EnhancedAddSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+    </command>
+    <command source="server" code="0x41" name="EnhancedViewSceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for EnhancedViewSceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupId" type="INT16U"/>
+      <arg name="sceneId" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="sceneName" type="CHAR_STRING"/>
+      <arg name="extensionFieldSets" type="SceneExtensionFieldSet" array="true"/>
+    </command>
+    <command source="server" code="0x42" name="CopySceneResponse" optional="true" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for CopySceneResponse
+      </description>
+      <arg name="status" type="Status"/>
+      <arg name="groupIdFrom" type="INT16U"/>
+      <arg name="sceneIdFrom" type="INT8U"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0006">
+    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="BOOLEAN" min="0x00" max="0x01" writable="false" default="0x01" optional="true" introducedIn="zll-1.0-11-0037-10">global scene control</attribute>
+    <attribute side="server" code="0x4001" define="ON_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">on time</attribute>
+    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="true" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">off wait time</attribute>
+    <command source="client" code="0x40" name="OffWithEffect" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off offeffect">
+      <description>
+        Command description for OffWithEffect
+      </description>
+      <arg name="effectId" type="OnOffEffectIdentifier"/>
+      <arg name="effectVariant" type="ENUM8"/>
+    </command>
+    <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off onrecall">
+      <description>
+        Command description for OnWithRecallGlobalScene
+      </description>
+    </command>
+    <command source="client" code="0x42" name="OnWithTimedOff" optional="true" introducedIn="zll-1.0-11-0037-10" cli="zcl on-off ontimedoff">
+      <description>
+        Command description for OnWithTimedOff
+      </description>
+      <arg name="onOffControl" type="OnOffControl"/>
+      <arg name="onTime" type="INT16U"/>
+      <arg name="offWaitTime" type="INT16U"/>
+    </command>
+  </clusterExtension>
+  <clusterExtension code="0x0300">
+    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">enhanced current hue</attribute>
+    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="ENUM8" min="0x00" max="0xFF" writable="false" default="0x01" optional="true" introducedIn="zll-1.0-11-0037-10">enhanced color mode</attribute>
+    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="zll-1.0-11-0037-10">color loop active</attribute>
+    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="INT8U" min="0x00" max="0xFF" writable="false" default="0x00" optional="true" introducedIn="zll-1.0-11-0037-10">color loop direction</attribute>
+    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true" introducedIn="zll-1.0-11-0037-10">color loop time</attribute>
+    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true" introducedIn="zll-1.0-11-0037-10">color loop start enhanced hue</attribute>
+    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color loop stored enhanced hue</attribute>
+    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="BITMAP16" min="0x0000" max="0x001F" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color capabilities</attribute>
+    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="INT16U" min="0x0000" max="0xFEFF" writable="false" default="0x0000" optional="true" introducedIn="zll-1.0-11-0037-10">color temp physical min</attribute>
+    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="INT16U" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true" introducedIn="zll-1.0-11-0037-10">color temp physical max</attribute>
+    <command source="client" code="0x40" name="EnhancedMoveToHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovetohue">
+      <description>
+        Command description for EnhancedMoveToHue
+      </description>
+      <arg name="enhancedHue" type="INT16U"/>
+      <arg name="direction" type="HueDirection"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x41" name="EnhancedMoveHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovehue">
+      <description>
+        Command description for EnhancedMoveHue
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT16U"/>
+    </command>
+    <command source="client" code="0x42" name="EnhancedStepHue" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control estephue">
+      <description>
+        Command description for EnhancedStepHue
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x43" name="EnhancedMoveToHueAndSaturation" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control emovetohueandsat">
+      <description>
+        Command description for EnhancedMoveToHueAndSaturation
+      </description>
+      <arg name="enhancedHue" type="INT16U"/>
+      <arg name="saturation" type="INT8U"/>
+      <arg name="transitionTime" type="INT16U"/>
+    </command>
+    <command source="client" code="0x44" name="ColorLoopSet" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control loop">
+      <description>
+        Command description for ColorLoopSet
+      </description>
+      <arg name="updateFlags" type="ColorLoopUpdateFlags"/>
+      <arg name="action" type="ColorLoopAction"/>
+      <arg name="direction" type="ColorLoopDirection"/>
+      <arg name="time" type="INT16U"/>
+      <arg name="startHue" type="INT16U"/>
+    </command>
+    <command source="client" code="0x47" name="StopMoveStep" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control stopmovestep">
+      <description>
+        Command description for StopMoveStep
+      </description>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x4B" name="MoveColorTemperature" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control movecolortemp">
+      <description>
+        Command description for MoveColorTemperature
+      </description>
+      <arg name="moveMode" type="HueMoveMode"/>
+      <arg name="rate" type="INT16U"/>
+      <arg name="colorTemperatureMinimum" type="INT16U"/>
+      <arg name="colorTemperatureMaximum" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+    <command source="client" code="0x4C" name="StepColorTemperature" optional="true" noDefaultImplementation="true" introducedIn="zll-1.0-11-0037-10" cli="zcl color-control stepcolortemp">
+      <description>
+        Command description for StepColorTemperature
+      </description>
+      <arg name="stepMode" type="HueStepMode"/>
+      <arg name="stepSize" type="INT16U"/>
+      <arg name="transitionTime" type="INT16U"/>
+      <arg name="colorTemperatureMinimum" type="INT16U"/>
+      <arg name="colorTemperatureMaximum" type="INT16U"/>
+      <arg name="optionsMask" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+      <arg name="optionsOverride" type="BITMAP8" introducedIn="zcl6-errata-14-0129-15" optional="1"/>
+    </command>
+  </clusterExtension>
+  <cluster introducedIn="zll-1.0-11-0037-10">
+    <name>ZLL Commissioning</name>
+    <domain>ZLL</domain>
+    <description>The ZLL commissioning cluster provides commands to support touch link commissioning.</description>
+    <code>0x1000</code>
+    <define>ZLL_COMMISSIONING_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="ScanRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for ScanRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="zigbeeInformation" type="ZigbeeInformation"/>
+      <arg name="zllInformation" type="ZllInformation"/>
+    </command>
+    <command source="client" code="0x02" name="DeviceInformationRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for DeviceInformationRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="client" code="0x06" name="IdentifyRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for IdentifyRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="identifyDuration" type="INT16U"/>
+    </command>
+    <command source="client" code="0x07" name="ResetToFactoryNewRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for ResetToFactoryNewRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+    </command>
+    <command source="client" code="0x10" name="NetworkStartRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkStartRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+      <arg name="initiatorIeeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="initiatorNetworkAddress" type="INT16U"/>
+    </command>
+    <command source="client" code="0x12" name="NetworkJoinRouterRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkJoinRouterRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+    </command>
+    <command source="client" code="0x14" name="NetworkJoinEndDeviceRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkJoinEndDeviceRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="keyIndex" type="KeyIndex"/>
+      <arg name="encryptedNetworkKey" type="SECURITY_KEY"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="groupIdentifiersBegin" type="INT16U"/>
+      <arg name="groupIdentifiersEnd" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeBegin" type="INT16U"/>
+      <arg name="freeNetworkAddressRangeEnd" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeBegin" type="INT16U"/>
+      <arg name="freeGroupIdentifierRangeEnd" type="INT16U"/>
+    </command>
+    <command source="client" code="0x16" name="NetworkUpdateRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for NetworkUpdateRequest
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+    </command>
+    <command source="client" code="0x41" name="GetGroupIdentifiersRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for GetGroupIdentifiersRequest
+      </description>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="client" code="0x42" name="GetEndpointListRequest" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for GetEndpointListRequest
+      </description>
+      <arg name="startIndex" type="INT8U"/>
+    </command>
+    <command source="server" code="0x01" name="ScanResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for ScanResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="rssiCorrection" type="INT8U"/>
+      <arg name="zigbeeInformation" type="ZigbeeInformation"/>
+      <arg name="zllInformation" type="ZllInformation"/>
+      <arg name="keyBitmask" type="KeyBitmask"/>
+      <arg name="responseId" type="INT32U"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="numberOfSubDevices" type="INT8U"/>
+      <arg name="totalGroupIds" type="INT8U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="profileId" type="INT16U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="deviceId" type="INT16U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="version" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+      <arg name="groupIdCount" type="INT8U"/>
+      <!-- present if numberOfSubDevices = 1 -->
+    </command>
+    <command source="server" code="0x03" name="DeviceInformationResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for DeviceInformationResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="numberOfSubDevices" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="deviceInformationRecordCount" type="INT8U"/>
+      <arg name="deviceInformationRecordList" type="DeviceInformationRecord" array="true"/>
+    </command>
+    <command source="server" code="0x11" name="NetworkStartResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkStartResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+      <arg name="extendedPanId" type="IEEE_ADDRESS"/>
+      <arg name="networkUpdateId" type="INT8U"/>
+      <arg name="logicalChannel" type="INT8U"/>
+      <arg name="panId" type="INT16U"/>
+    </command>
+    <command source="server" code="0x13" name="NetworkJoinRouterResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkJoinRouterResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+    </command>
+    <command source="server" code="0x15" name="NetworkJoinEndDeviceResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for NetworkJoinEndDeviceResponse
+      </description>
+      <arg name="transaction" type="INT32U"/>
+      <arg name="status" type="ZllStatus"/>
+    </command>
+    <command source="server" code="0x40" name="EndpointInformation" optional="false" introducedIn="zll-1.0-11-0037-10">
+      <description>
+        Command description for EndpointInformation
+      </description>
+      <arg name="ieeeAddress" type="IEEE_ADDRESS"/>
+      <arg name="networkAddress" type="INT16U"/>
+      <arg name="endpointId" type="INT8U"/>
+      <arg name="profileId" type="INT16U"/>
+      <arg name="deviceId" type="INT16U"/>
+      <arg name="version" type="INT8U"/>
+    </command>
+    <command source="server" code="0x41" name="GetGroupIdentifiersResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for GetGroupIdentifiersResponse
+      </description>
+      <arg name="total" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="count" type="INT8U"/>
+      <arg name="groupInformationRecordList" type="GroupInformationRecord" array="true"/>
+    </command>
+    <command source="server" code="0x42" name="GetEndpointListResponse" optional="false" introducedIn="zll-1.0-11-0037-10" disableDefaultResponse="true">
+      <description>
+        Command description for GetEndpointListResponse
+      </description>
+      <arg name="total" type="INT8U"/>
+      <arg name="startIndex" type="INT8U"/>
+      <arg name="count" type="INT8U"/>
+      <arg name="endpointInformationRecordList" type="EndpointInformationRecord" array="true"/>
+    </command>
+  </cluster>
+</configurator>

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -1,6 +1,6 @@
 {
     "version": "ZCL Test Data",
-    "xmlRoot": [".", "../../../../third_party/zap/repo/zcl-builtin/silabs/"],
+    "xmlRoot": [".", "./data-model/silabs/"],
     "xmlFile": [
         "binding-cluster.xml",
         "clusters-extensions.xml",


### PR DESCRIPTION
As discussed in the Software TT meeting of February 2 2021.

 #### Problem
Data Model in XML format lives in the ZAP Github repo as a resource for unit-test. This make the data model unreliable since it could change at anytime. 

 #### Summary of Changes
Move the data model xml files in /src/app/zap-templates/zcl/data-model/silabs/. Goal is to remove the silabs subfolder once the CHIP data-model is implemented completely.

Also added the two missing templates. These templates are design to be use within Silabs Zigbee stack. No changes what so ever was made to the templates for CHIP use. These templates are provided as is to serve as a starting point for a CHIP implementation instead of starting from scratch.

Partial Fix of #3637 

