### PR TITLE
GetModuleName() really should take a length parameter

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -322,7 +322,7 @@ static void LogMessageToPython(uint8_t module, uint8_t category, const char * ms
 
         // Get the module name
         char moduleName[nlChipLoggingModuleNameLen + 1];
-        ::chip:: ::Logging::GetModuleName(moduleName, module);
+        ::chip:: ::Logging::GetModuleName(moduleName, nlChipLoggingModuleNameLen + 1, module);
 
         // Format the log message into a dynamic memory buffer, growing the
         // buffer as needed to fit the message.

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -321,8 +321,8 @@ static void LogMessageToPython(uint8_t module, uint8_t category, const char * ms
         gettimeofday(&tv, NULL);
 
         // Get the module name
-        char moduleName[nlChipLoggingModuleNameLen + 1];
-        ::chip:: ::Logging::GetModuleName(moduleName, nlChipLoggingModuleNameLen + 1, module);
+        char moduleName[chip::Logging::kMaxModuleNameLen + 1];
+        ::chip:: ::Logging::GetModuleName(moduleName, sizeof(moduleName), module);
 
         // Format the log message into a dynamic memory buffer, growing the
         // buffer as needed to fit the message.

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -98,10 +98,11 @@ static const char ModuleNames[] = "-\0\0" // None
 #define chipPrefixSeparator ": "
 #define chipMessageTrailer "\n"
 
-void GetModuleName(char * buf, uint8_t module)
+void GetModuleName(char * buf, uint8_t bufSize, uint8_t module)
 {
     const char * moduleNamePtr = ModuleNames + ((module < ModuleNamesCount) ? module * ChipLoggingModuleNameLen : 0);
-    memcpy(buf, moduleNamePtr, ChipLoggingModuleNameLen);
+
+    snprintf(buf, bufSize, "%s", moduleNamePtr);
     buf[ChipLoggingModuleNameLen] = 0;
 }
 
@@ -109,14 +110,14 @@ void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t module, const cha
 {
     char moduleName[ChipLoggingModuleNameLen + 1];
 
-    GetModuleName(moduleName, module);
+    GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
     snprintf(buf, bufSize, chipPrefix "%s" chipPrefixSeparator "%s" chipMessageTrailer, moduleName, msg);
 }
 
 void PrintMessagePrefix(uint8_t module)
 {
     char moduleName[ChipLoggingModuleNameLen + 1];
-    GetModuleName(moduleName, module);
+    GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
 
 #if CHIP_LOGGING_STYLE_STDIO_WITH_TIMESTAMPS
     struct timeval tv;

--- a/src/lib/support/logging/CHIPLogging.cpp
+++ b/src/lib/support/logging/CHIPLogging.cpp
@@ -52,7 +52,7 @@ namespace Logging {
  *
  * NOTE: The names must be in the order defined in the LogModule
  *       enumeration. Each name must be a fixed number of characters
- *       long (ChipLoggingModuleNameLen) padded with nulls as
+ *       long (chip::Logging::kMaxModuleNameLen) padded with nulls as
  *       necessary.
  *
  */
@@ -92,7 +92,7 @@ static const char ModuleNames[] = "-\0\0" // None
                                   "DIS"   // Discovery
     ;
 
-#define ModuleNamesCount ((sizeof(ModuleNames) - 1) / ChipLoggingModuleNameLen)
+#define ModuleNamesCount ((sizeof(ModuleNames) - 1) / chip::Logging::kMaxModuleNameLen)
 
 #define chipPrefix "CHIP:"
 #define chipPrefixSeparator ": "
@@ -100,24 +100,24 @@ static const char ModuleNames[] = "-\0\0" // None
 
 void GetModuleName(char * buf, uint8_t bufSize, uint8_t module)
 {
-    const char * moduleNamePtr = ModuleNames + ((module < ModuleNamesCount) ? module * ChipLoggingModuleNameLen : 0);
+    const char * moduleNamePtr = ModuleNames + ((module < ModuleNamesCount) ? module * chip::Logging::kMaxModuleNameLen : 0);
 
     snprintf(buf, bufSize, "%s", moduleNamePtr);
-    buf[ChipLoggingModuleNameLen] = 0;
+    buf[chip::Logging::kMaxModuleNameLen] = 0;
 }
 
 void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t module, const char * msg)
 {
-    char moduleName[ChipLoggingModuleNameLen + 1];
+    char moduleName[chip::Logging::kMaxModuleNameLen + 1];
 
-    GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
+    GetModuleName(moduleName, sizeof(moduleName), module);
     snprintf(buf, bufSize, chipPrefix "%s" chipPrefixSeparator "%s" chipMessageTrailer, moduleName, msg);
 }
 
 void PrintMessagePrefix(uint8_t module)
 {
-    char moduleName[ChipLoggingModuleNameLen + 1];
-    GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
+    char moduleName[chip::Logging::kMaxModuleNameLen + 1];
+    GetModuleName(moduleName, sizeof(moduleName), module);
 
 #if CHIP_LOGGING_STYLE_STDIO_WITH_TIMESTAMPS
     struct timeval tv;

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -298,12 +298,15 @@ extern void SetLogFilter(uint8_t category);
 
 #if _CHIP_USE_LOGGING
 
-#define ChipLoggingChipPrefixLen 6
-#define ChipLoggingModuleNameLen 3
-#define ChipLoggingMessageSeparatorLen 2
-#define ChipLoggingMessageTrailerLen 2
-#define ChipLoggingTotalMessagePadding                                                                                             \
-    (ChipLoggingchipPrefixLen + ChipLoggingModuleNameLen + ChipLoggingMessageSeparatorLen + ChipLoggingMessageTrailerLen)
+/**
+ * CHIP logging length constants
+ */
+static constexpr uint16_t kMaxModuleNameLen  = 3;
+static constexpr uint16_t kMaxPrefixLen      = 3;
+static constexpr uint16_t kMaxSeparatorLen   = 2;
+static constexpr uint16_t kMaxTrailerLen     = 2;
+static constexpr uint16_t kMaxMessagePadding = (chip::Logging::kMaxPrefixLen + chip::Logging::kMaxModuleNameLen +
+                                                chip::Logging::kMaxSeparatorLen + chip::Logging::kMaxTrailerLen);
 
 extern void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t module, const char * msg);
 extern void GetModuleName(char * buf, uint8_t bufSize, uint8_t module);

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -306,7 +306,7 @@ extern void SetLogFilter(uint8_t category);
     (ChipLoggingchipPrefixLen + ChipLoggingModuleNameLen + ChipLoggingMessageSeparatorLen + ChipLoggingMessageTrailerLen)
 
 extern void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t module, const char * msg);
-extern void GetModuleName(char * buf, uint8_t module);
+extern void GetModuleName(char * buf, uint8_t bufSize, uint8_t module);
 extern void PrintMessagePrefix(uint8_t module);
 
 #else
@@ -316,7 +316,7 @@ static inline void GetMessageWithPrefix(char * buf, uint8_t bufSize, uint8_t mod
     return;
 }
 
-static inline void GetModuleName(char * buf, uint8_t module)
+static inline void GetModuleName(char * buf, uint8_t bufSize, uint8_t module)
 {
     return;
 }

--- a/src/lib/support/logging/CHIPLoggingLogV.cpp
+++ b/src/lib/support/logging/CHIPLoggingLogV.cpp
@@ -98,7 +98,7 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
 #if CHIP_LOGGING_STYLE_ANDROID
 
         char moduleName[chip::Logging::kMaxModuleNameLen + 1];
-        GetModuleName(moduleName, sizeof(moduleName) module);
+        GetModuleName(moduleName, sizeof(moduleName), module);
 
         int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
 

--- a/src/lib/support/logging/CHIPLoggingLogV.cpp
+++ b/src/lib/support/logging/CHIPLoggingLogV.cpp
@@ -97,8 +97,8 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
 
 #if CHIP_LOGGING_STYLE_ANDROID
 
-        char moduleName[ChipLoggingModuleNameLen + 1];
-        GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
+        char moduleName[chip::Logging::kMaxModuleNameLen + 1];
+        GetModuleName(moduleName, sizeof(moduleName) module);
 
         int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
 
@@ -112,8 +112,8 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
 
 #elif CHIP_LOGGING_STYLE_DARWIN
 
-        char moduleName[ChipLoggingModuleNameLen + 1];
-        GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
+        char moduleName[chip::Logging::kMaxModuleNameLen + 1];
+        GetModuleName(moduleName, sizeof(moduleName), module);
 
         char formattedMsg[512];
         int32_t prefixLen = snprintf(formattedMsg, sizeof(formattedMsg), "CHIP: [%s] ", moduleName);

--- a/src/lib/support/logging/CHIPLoggingLogV.cpp
+++ b/src/lib/support/logging/CHIPLoggingLogV.cpp
@@ -98,7 +98,7 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
 #if CHIP_LOGGING_STYLE_ANDROID
 
         char moduleName[ChipLoggingModuleNameLen + 1];
-        GetModuleName(moduleName, module);
+        GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
 
         int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
 
@@ -113,7 +113,7 @@ DLL_EXPORT __CHIP_LOGGING_LINK_ATTRIBUTE void LogV(uint8_t module, uint8_t categ
 #elif CHIP_LOGGING_STYLE_DARWIN
 
         char moduleName[ChipLoggingModuleNameLen + 1];
-        GetModuleName(moduleName, module);
+        GetModuleName(moduleName, ChipLoggingModuleNameLen + 1, module);
 
         char formattedMsg[512];
         int32_t prefixLen = snprintf(formattedMsg, sizeof(formattedMsg), "CHIP: [%s] ", moduleName);

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -176,7 +176,7 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[formattedMsgLen++] = '[';
-        GetModuleName(formattedMsg + formattedMsgLen, module);
+        GetModuleName(formattedMsg + formattedMsgLen, ChipLoggingModuleNameLen + 1, module);
         formattedMsgLen                 = strlen(formattedMsg);
         formattedMsg[formattedMsgLen++] = ']';
         formattedMsg[formattedMsgLen++] = ' ';

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -154,7 +154,7 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
         char formattedMsg[CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE];
         size_t formattedMsgLen;
 
-        constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 3;
+        constexpr size_t maxPrefixLen = chip::Logging::kMaxModuleNameLen + 3;
         static_assert(sizeof(formattedMsg) > maxPrefixLen);
 
         switch (category)
@@ -176,7 +176,7 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[formattedMsgLen++] = '[';
-        GetModuleName(formattedMsg + formattedMsgLen, ChipLoggingModuleNameLen + 1, module);
+        GetModuleName(formattedMsg + formattedMsgLen, chip::Logging::kMaxModuleNameLen + 1, module);
         formattedMsgLen                 = strlen(formattedMsg);
         formattedMsg[formattedMsgLen++] = ']';
         formattedMsg[formattedMsgLen++] = ' ';

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -54,7 +54,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
         strcpy(tag, "chip[");
         tagLen = strlen(tag);
-        GetModuleName(tag + tagLen, module);
+        GetModuleName(tag + tagLen, ChipLoggingModuleNameLen + 1, module);
         tagLen        = strlen(tag);
         tag[tagLen++] = ']';
         tag[tagLen]   = 0;

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -46,7 +46,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
     {
         enum
         {
-            kMaxTagLen = 7 + ChipLoggingModuleNameLen
+            kMaxTagLen = 7 + chip::Logging::kMaxModuleNameLen
         };
         char tag[kMaxTagLen + 1];
         size_t tagLen;
@@ -54,7 +54,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
         strcpy(tag, "chip[");
         tagLen = strlen(tag);
-        GetModuleName(tag + tagLen, ChipLoggingModuleNameLen + 1, module);
+        GetModuleName(tag + tagLen, chip::Logging::kMaxModuleNameLen + 1, module);
         tagLen        = strlen(tag);
         tag[tagLen++] = ']';
         tag[tagLen]   = 0;

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -94,7 +94,7 @@ void FillPrefix(char * buf, uint8_t bufLen, uint8_t chipCategory, uint8_t otLeve
     prefixLen = strlen(buf);
     VerifyOrDie(bufLen > (prefixLen + ChipLoggingModuleNameLen + 3));
     buf[prefixLen++] = '[';
-    GetModuleName(buf + prefixLen, module);
+    GetModuleName(buf + prefixLen, ChipLoggingModuleNameLen + 1, module);
     prefixLen        = strlen(buf);
     buf[prefixLen++] = ']';
     buf[prefixLen++] = ' ';

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -87,14 +87,14 @@ void FillPrefix(char * buf, uint8_t bufLen, uint8_t chipCategory, uint8_t otLeve
     size_t prefixLen;
 
     /* add the error string */
-    VerifyOrDie(bufLen > ChipLoggingChipPrefixLen);
+    VerifyOrDie(bufLen > chip::Logging::kMaxPrefixLen);
     ::GetMessageString(buf, chipCategory, otLevelLog);
 
     /* add the module name string */
     prefixLen = strlen(buf);
-    VerifyOrDie(bufLen > (prefixLen + ChipLoggingModuleNameLen + 3));
+    VerifyOrDie(bufLen > (prefixLen + chip::Logging::kMaxModuleNameLen + 3));
     buf[prefixLen++] = '[';
-    GetModuleName(buf + prefixLen, ChipLoggingModuleNameLen + 1, module);
+    GetModuleName(buf + prefixLen, chip::Logging::kMaxModuleNameLen + 1, module);
     prefixLen        = strlen(buf);
     buf[prefixLen++] = ']';
     buf[prefixLen++] = ' ';

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -64,14 +64,14 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         size_t prefixLen = 0;
 
         // Max size for "[TAG] {UINT32}"
-        constexpr size_t maxPrefixLen = ChipLoggingModuleNameLen + 10 + 3;
+        constexpr size_t maxPrefixLen = chip::Logging::kMaxModuleNameLen + 10 + 3;
         static_assert(sizeof(formattedMsg) > maxPrefixLen);
 
         prefixLen += snprintf(formattedMsg, sizeof(formattedMsg), "%u", k_uptime_get_32());
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[prefixLen++] = '[';
-        GetModuleName(formattedMsg + prefixLen, ChipLoggingModuleNameLen + 1, module);
+        GetModuleName(formattedMsg + prefixLen, chip::Logging::kMaxModuleNameLen + 1, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -71,7 +71,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
 
         // Form the log prefix, e.g. "[DL] "
         formattedMsg[prefixLen++] = '[';
-        GetModuleName(formattedMsg + prefixLen, module);
+        GetModuleName(formattedMsg + prefixLen, ChipLoggingModuleNameLen + 1, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';

--- a/src/platform/qpg6100/Logging.cpp
+++ b/src/platform/qpg6100/Logging.cpp
@@ -83,7 +83,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         }
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = '[';
-        GetModuleName(&formattedMsg[prefixLen], module);
+        GetModuleName(&formattedMsg[prefixLen], ChipLoggingModuleNameLen + 1, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';

--- a/src/platform/qpg6100/Logging.cpp
+++ b/src/platform/qpg6100/Logging.cpp
@@ -83,7 +83,7 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
         }
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = '[';
-        GetModuleName(&formattedMsg[prefixLen], ChipLoggingModuleNameLen + 1, module);
+        GetModuleName(&formattedMsg[prefixLen], chip::Logging::kMaxModuleNameLen + 1, module);
         prefixLen                 = strlen(formattedMsg);
         formattedMsg[prefixLen++] = ']';
         formattedMsg[prefixLen++] = ' ';


### PR DESCRIPTION
 #### Problem
Logging::GetModuleName() can overflow message buffers if, for example, the platform-specific logging code adds a prefix


 #### Summary of Changes
add a length parameter to GetModuleName(), or if GetModuleName() always returns a static string, have GetModuleName() return a const char*.

Fixes #3811