### PR TITLE
[submodule] Pull ot-br-posix to latest master for network provisioning

### DIFF
--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -109,13 +109,28 @@ class CHIPVirtualHome:
 
     def connect_to_thread_network(self):
         self.logger.info("Running commands to form Thread network")
+        time.sleep(3) # Avoid sending commands at very beginning.
+        otInitCommands = [
+            "ot-ctl thread stop",
+            "ot-ctl ifconfig down",
+            "ot-ctl dataset init new",
+            "ot-ctl dataset panid 0x1234",
+            "ot-ctl dataset networkname OpenThread",
+            "ot-ctl dataset channel 13",
+            "ot-ctl dataset extpanid dead00beef00cafe",
+            "ot-ctl dataset meshlocalprefix \"fd01:2345:6789:0abc::\"",
+            "ot-ctl dataset masterkey 00112233445566778899aabbccddeeff",
+            "ot-ctl dataset commit active",
+            "ot-ctl dataset active", # This will emit an output of dataset in flask.log
+            "ot-ctl ifconfig up",
+            "ot-ctl thread start",
+        ]
         for device in self.non_ap_devices:
-            self.execute_device_cmd(device['id'],
-                                    "bash -c 'ot-ctl panid 0x1234 && \
-                             ot-ctl ifconfig up && \
-                             ot-ctl thread start'")
+            # Set default openthread provisioning
+            for cmd in otInitCommands:
+                self.execute_device_cmd(device['id'], cmd)
         self.logger.info("Waiting for Thread network to be formed...")
-        time.sleep(10)
+        time.sleep(15)
         roles = set()
         for device in self.non_ap_devices:
             reply = self.execute_device_cmd(device['id'], 'ot-ctl state')


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The ot-br-posix in current code base does not supports provisioning thread network by dataset. The latest ot-br-posix implements this.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Pull ot-br-posix to latest master and make necessary changes to cirque tests.

Reasons for adding more time.sleep():

1. When the ot-agent starts, the channel for receiving messages from ot-ctl is not ready. However, openthread will have a default thread setup, so even we does not setup the network / failed to setup the network, the thread network can still be formed. Recent openthread removed this, so we needs extra sleep before we can setup thread network.
2. In this case, we need a bit more sleep to the thread network can be successfully formed.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
