### PR TITLE
Fix unbounded stack in emberAfPrintBuffer()

### DIFF
--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -30,7 +30,7 @@ using namespace chip::Logging;
 
 void emberAfPrint(int category, const char * format, ...)
 {
-    if (format != NULL)
+    if (format != nullptr)
     {
         va_list args;
         va_start(args, format);
@@ -41,7 +41,7 @@ void emberAfPrint(int category, const char * format, ...)
 
 void emberAfPrintln(int category, const char * format, ...)
 {
-    if (format != NULL)
+    if (format != nullptr)
     {
         va_list args;
         va_start(args, format);
@@ -54,24 +54,23 @@ void emberAfPrintln(int category, const char * format, ...)
 
 void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, bool withSpace)
 {
-    if (buffer != NULL && length > 0)
+    if (buffer != nullptr && length > 0)
     {
         constexpr uint16_t kBufferSize = CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE;
         const char * perByteFormatStr  = withSpace ? "%02hhX " : "%02hhX";
         const uint8_t perByteCharCount = withSpace ? 3 : 2;
-        const uint16_t bytesPerBuffer  = (kBufferSize - 1) / perByteCharCount;
+        const uint16_t bytesPerBuffer  = static_cast<uint16_t>((kBufferSize - 1) / perByteCharCount);
         char result[kBufferSize];
 
         uint16_t index = 0;
         while (index < length)
         {
-            const uint16_t remainingBytes = length - index;
+            const uint16_t remainingBytes = static_cast<uint16_t>(length - index);
             const uint16_t segmentLength  = chip::min(bytesPerBuffer, remainingBytes);
-            const uint16_t segmentEnd     = index + segmentLength;
-            const uint16_t outStringEnd   = segmentLength * perByteCharCount;
-            for (uint16_t dst_idx = 0; dst_idx < outStringEnd && index < segmentEnd; dst_idx += perByteCharCount, index++)
+            const uint16_t segmentEnd     = static_cast<uint16_t>(index + segmentLength);
+            const uint32_t outStringEnd   = segmentLength * perByteCharCount;
+            for (uint32_t dst_idx = 0; dst_idx < outStringEnd && index < segmentEnd; dst_idx += perByteCharCount, index++)
             {
-
                 snprintf(result + dst_idx, outStringEnd - dst_idx + 1, perByteFormatStr, buffer[index]);
             }
             result[outStringEnd] = 0;

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -20,6 +20,7 @@
 
 #include "debug-printing.h"
 
+#include <platform/CHIPDeviceConfig.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -53,7 +54,7 @@ void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, b
 {
     if (buffer != NULL && length > 0)
     {
-        constexpr uint16_t kBufferSize = 128;
+        constexpr uint16_t kBufferSize = CHIP_DEVICE_CONFIG_LOG_MESSAGE_MAX_SIZE;
         const char * perByteFormatStr  = withSpace ? "%02hhX " : "%02hhX";
         const uint8_t perByteCharCount = withSpace ? 3 : 2;
         const uint16_t bytesPerBuffer  = (kBufferSize - 1) / perByteCharCount;

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 #include "debug-printing.h"
 
+#include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
 bool emberAfPrintReceivedMessages = true;
@@ -48,34 +49,37 @@ void emberAfPrintln(int category, const char * format, ...)
     }
 }
 
-// TODO: issue #3662 - Unbounded stack in emberAfPrintBuffer()
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstack-usage="
-
 void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, bool withSpace)
 {
     if (buffer != NULL && length > 0)
     {
-        const char * perByteFormatStr = withSpace ? "%02hhX " : "%02hhX";
-        uint8_t perByteCharCount      = withSpace ? 3 : 2;
+        constexpr uint16_t kBufferSize = 128;
+        const char * perByteFormatStr  = withSpace ? "%02hhX " : "%02hhX";
+        const uint8_t perByteCharCount = withSpace ? 3 : 2;
+        const uint16_t bytesPerBuffer  = (kBufferSize - 1) / perByteCharCount;
+        char result[kBufferSize];
 
-        uint32_t outStringLength = length * perByteCharCount + 1;
-        char result[outStringLength];
-        for (uint32_t dst_idx = 0, index = 0; dst_idx < outStringLength - 1 && index < length; dst_idx += perByteCharCount, index++)
+        uint16_t index = 0;
+        while (index < length)
         {
+            const uint16_t remainingBytes = length - index;
+            const uint16_t segmentLength  = chip::min(bytesPerBuffer, remainingBytes);
+            const uint16_t segmentEnd     = index + segmentLength;
+            const uint16_t outStringEnd   = segmentLength * perByteCharCount;
+            for (uint16_t dst_idx = 0; dst_idx < outStringEnd && index < segmentEnd; dst_idx += perByteCharCount, index++)
+            {
 
-            snprintf(result + dst_idx, outStringLength - dst_idx, perByteFormatStr, buffer[index]);
+                snprintf(result + dst_idx, outStringEnd - dst_idx + 1, perByteFormatStr, buffer[index]);
+            }
+            result[outStringEnd] = 0;
+            emberAfPrint(category, "%s", result);
         }
-        result[outStringLength - 1] = 0;
-        emberAfPrint(category, "%s", result);
     }
     else
     {
         emberAfPrint(EMBER_AF_PRINT_CORE, "NULL");
     }
 }
-
-#pragma GCC diagnostic pop // -Wstack-usage
 
 void emberAfPrintString(int category, const uint8_t * string)
 {

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -50,6 +50,8 @@ void emberAfPrintln(int category, const char * format, ...)
     }
 }
 
+// TODO: add unit tests.
+
 void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, bool withSpace)
 {
     if (buffer != NULL && length > 0)


### PR DESCRIPTION
#### Problem

`emberAfPrintBuffer()` allocates stack space based on an argument, with
no upper bound. This could lead to stack exhaustion on small devices.

#### Summary of Changes

Print long buffers in multiple segments.

Fixes #3662 - Unbounded stack in emberAfPrintBuffer()
