### PR TITLE
Load secure session parameters before sending message to the device

### DIFF
--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -320,6 +320,16 @@ private:
      */
     CHIP_ERROR LoadSecureSessionParameters(ResetTransport resetNeeded);
 
+    /**
+     * @brief
+     *   This function loads the secure session object from the serialized operational
+     *   credentials corresponding if needed, based on the current state of the device and
+     *   underlying transport object.
+     *
+     * @param[out] didLoad   Were the secure session params loaded by the call to this function.
+     */
+    CHIP_ERROR LoadSecureSessionParametersIfNeeded(bool & didLoad);
+
     uint16_t mListenPort;
 };
 


### PR DESCRIPTION
 #### Problem
After pairing the device, the first message sent by the controller is corrupted when received by the device. This happen only in certain use cases, where the UDP transport information in not updated in the peer connection table.

 #### Summary of Changes
1. Check peer connection table entry for transport type. If the transport is incorrect, reload the security parameter for the connection.
2. The packet at re-send is corrupted since the original packet got modified (encryption, and header attachment) before the original send failed. So, instead of refcounting the packet for resending, copy the packet data. With the current change, this logic is specifically exercised in scenarios where the OS releases the underlying socket. Otherwise, the original transmissions will not fail. 

 Fixes #4544
