### PR TITLE
[tools] update west to 0.9.0

### DIFF
--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -20,7 +20,7 @@ portpicker
 mobly
 
 # zephyr
-west>=0.8.0
+west>=0.9.0
 
 # happy tests
 lockfile

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -7,11 +7,10 @@
 backcall==0.2.0           # via ipython
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
-chardet==3.0.4            # via requests
+chardet==4.0.0            # via requests
 click==7.1.2              # via -r requirements.in, pip-tools
 colorama==0.4.4           # via west
 coloredlogs==15.0         # via -r requirements.in
-configobj==5.0.6          # via west
 cryptography==3.3.1       # via -r requirements.in
 decorator==4.4.2          # via ipython
 docopt==0.6.2             # via pykwalify
@@ -19,36 +18,38 @@ future==0.18.2            # via -r requirements.in, mobly
 humanfriendly==9.1        # via coloredlogs
 idna==2.10                # via requests
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.19.0           # via -r requirements.in
-jedi==0.17.2              # via ipython
+ipython==7.20.0           # via -r requirements.in
+jedi==0.18.0              # via ipython
 lockfile==0.12.2          # via -r requirements.in
-mobly==1.10               # via -r requirements.in
-packaging==20.7           # via west
-parso==0.7.1              # via jedi
+mobly==1.10.1             # via -r requirements.in
+packaging==20.9           # via west
+parso==0.8.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==5.4.0          # via -r requirements.in
+pip-tools==5.5.0          # via -r requirements.in
 portpicker==1.3.1         # via -r requirements.in, mobly
-prompt-toolkit==3.0.8     # via ipython
+prompt-toolkit==3.0.14    # via ipython
 protobuf==3.14.0          # via -r requirements.in
-psutil==5.7.3             # via -r requirements.in, mobly
-ptyprocess==0.6.0         # via pexpect
+psutil==5.8.0             # via -r requirements.in, mobly
+ptyprocess==0.7.0         # via pexpect
 pycparser==2.20           # via cffi
 pyelftools==0.27          # via -r requirements.in
-pygments==2.7.3           # via ipython
-pykwalify==1.7.0          # via west
+pygments==2.7.4           # via ipython
+pykwalify==1.8.0          # via west
 pyparsing==2.3.1          # via -r requirements.in, packaging
 pyserial==3.5             # via -r requirements.in, mobly
 python-dateutil==2.8.1    # via pykwalify
-pyyaml==5.3.1             # via mobly, pykwalify, west
-requests==2.25.0          # via -r requirements.in
-six==1.15.0               # via configobj, cryptography, pip-tools, protobuf, python-dateutil
+pyyaml==5.4.1             # via mobly west
+requests==2.25.1          # via -r requirements.in
+ruamel.yaml.clib==0.2.2   # via ruamel.yaml
+ruamel.yaml==0.16.12      # via pykwalify
+six==1.15.0               # via cryptography, protobuf, python-dateutil
 timeout-decorator==0.5.0  # via mobly
 traitlets==5.0.5          # via ipython
-urllib3==1.26.2           # via requests
-watchdog==1.0.1           # via -r requirements.in
+urllib3==1.26.3           # via requests
+watchdog==1.0.2           # via -r requirements.in
 wcwidth==0.2.5            # via prompt-toolkit
-west==0.8.0               # via -r requirements.in
+west==0.9.0               # via -r requirements.in
 wheel==0.34.2             # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
#### Problem
New nRF Connect SDK requires the newest version of west.

#### Summary of Changes
Bump up west version.