### PR TITLE
[nrfconnect] revert adding -Werror flag

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -27,8 +27,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-lighting-example)
 
-zephyr_compile_options(-Werror)
-
 target_include_directories(app PRIVATE
                            main/include
                            ${LIGHTING_COMMON}

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -27,8 +27,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-lock-example)
 
-zephyr_compile_options(-Werror)
-
 target_include_directories(app PRIVATE 
                            main/include 
                            ${LOCK_COMMON} 

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -29,8 +29,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-pigweed-example)
 
-zephyr_compile_options(-Werror)
-
 target_include_directories(app PRIVATE main/include 
                            ${NRFCONNECT_COMMON}/util/include
                            ${PIGWEED_ROOT}/pw_sys_io/public

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -26,8 +26,6 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-shell-example)
 
-zephyr_compile_options(-Werror)
-
 target_include_directories(app PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}
                            ${APP_ROOT}/shell_common/include)


### PR DESCRIPTION
#### Problem
Zephyr does not compile without warnings on macOS.

#### Summary of Changes
Revert part of #4528 till warnings are fixed with new update.

Fixes #4581 