### PR TITLE
Add GitHub workflow to verify Mbed OS image build process.

### DIFF
--- a/.github/workflows/mbed-os.yaml
+++ b/.github/workflows/mbed-os.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Mbed OS docker image test
+on:
+  workflow_dispatch:
+    inputs:
+
+jobs:
+    mbed-os:
+        name: Mbed OS docker image test
+        env:
+            BUILD_TYPE: mbed-os
+            BUILD_VERSION: 0.5.0
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  fetch-depth: 1
+                  submodules: false
+                  
+            - name: Build Mbed-OS Docker image (chip-build-mbed-os)
+              run: integrations/docker/images/chip-build-mbed-os/build.sh
+
+            - name: Create chip-build-mbed-os container
+              run: docker run -it -d --name mbed_sdk_test connectedhomeip/chip-build-${{env.BUILD_TYPE}}:${{env.BUILD_VERSION}}
+
+            - name: Check cmake presence
+              run: docker exec mbed_sdk_test cmake --version
+
+            - name: Check mbed-cli presence
+              run: docker exec mbed_sdk_test mbed --version
+
+            - name: Check mbed-tools presence
+              run: docker exec mbed_sdk_test mbed-tools --version
+
+            - name: Check toolchan
+              run: docker exec mbed_sdk_test arm-none-eabi-gcc --version

--- a/.github/workflows/mbed-os.yaml
+++ b/.github/workflows/mbed-os.yaml
@@ -22,7 +22,6 @@ jobs:
         name: Mbed OS docker image test
         env:
             BUILD_TYPE: mbed-os
-            BUILD_VERSION: 0.5.0
 
         runs-on: ubuntu-latest
 
@@ -32,6 +31,9 @@ jobs:
               with:
                   fetch-depth: 1
                   submodules: false
+
+            - name: Get build version from file
+              run: echo "BUILD_VERSION=$(cat integrations/docker/images/chip-build-${{env.BUILD_TYPE}}/version)" >> $GITHUB_ENV
                   
             - name: Build Mbed-OS Docker image (chip-build-mbed-os)
               run: integrations/docker/images/chip-build-mbed-os/build.sh

--- a/.github/workflows/mbed-os.yaml
+++ b/.github/workflows/mbed-os.yaml
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Mbed OS docker image test
+name: Mbed OS - Docker image test
 on:
   workflow_dispatch:
     inputs:
 
 jobs:
     mbed-os:
-        name: Mbed OS docker image test
+        name: Mbed OS - Docker image test
         env:
             BUILD_TYPE: mbed-os
 


### PR DESCRIPTION
 #### Problem
Some way to verify proposed Mbed OS docker image is needed.
Related issue: #4653


 #### Summary of Changes
Add new GitHub workflow which builds mbed-os image and verify that all tools which we need are in the place.
Added workflow has to be triggered manually (workflow_dispatch) and should be used on PR #4620 branch
