### PR TITLE
Encapsulate message footer size requirement

### DIFF
--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -55,7 +55,7 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
         return EMBER_ERR_FATAL;
     }
 
-    System::PacketBufferHandle buffer = System::PacketBufferHandle::New(dataLength);
+    System::PacketBufferHandle buffer = MessagePacketBuffer::New(dataLength);
     if (buffer.IsNull())
     {
         // FIXME: Not quite right... what's the right way to indicate "out of

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -178,7 +178,7 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
-    chip::System::PacketBufferHandle buffer = chip::System::PacketBufferHandle::NewWithData(PAYLOAD, sizeof(PAYLOAD), kMaxTagLen);
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
     IPAddress addr;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR SendEchoRequest(void)
     const char kRequestFormat[] = "Echo Message %" PRIu64 "\n";
     char requestData[(sizeof kRequestFormat) + 20 /* uint64_t decimal digits */];
     snprintf(requestData, sizeof requestData, kRequestFormat, gEchoCount);
-    chip::System::PacketBufferHandle payloadBuf = chip::System::PacketBufferHandle::NewWithData(requestData, strlen(requestData));
+    chip::System::PacketBufferHandle payloadBuf = chip::MessagePacketBuffer::NewWithData(requestData, strlen(requestData));
 
     if (payloadBuf.IsNull())
     {

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -555,7 +555,7 @@ public:
      *
      *  On success, it is guaranteed that \c AvailableDataSize() is no less than \a aAvailableSize.
      *
-     *  @param[in]  aAvailableSize  Minimim number of octets to for application data (at `Start()`).
+     *  @param[in]  aAvailableSize  Minimum number of octets to for application data (at `Start()`).
      *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers (before `Start()`).
      *
      *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -322,8 +322,6 @@ inline System::PacketBufferHandle New(size_t aAvailableSize)
  *
  *  @param[in]  aData           Initial buffer contents.
  *  @param[in]  aDataSize       Size of initial buffer contents.
- *  @param[in]  aAdditionalSize Size of additional application data space after the initial contents.
- *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers.
  *
  *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
  */

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -314,6 +314,11 @@ constexpr uint16_t kMaxFooterSize = kMaxTagLen;
  */
 inline System::PacketBufferHandle New(size_t aAvailableSize)
 {
+    static_assert(CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX > kMaxFooterSize, "inadequate capacity");
+    if (aAvailableSize > CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX - kMaxFooterSize)
+    {
+        return System::PacketBufferHandle();
+    }
     return System::PacketBufferHandle::New(aAvailableSize + kMaxFooterSize);
 }
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -308,7 +308,7 @@ constexpr uint16_t kMaxFooterSize = kMaxTagLen;
  *
  *  Fails and returns \c nullptr if no memory is available, or if the size requested is too large.
  *
- *  @param[in]  aAvailableSize  Minimim number of octets to for application data.
+ *  @param[in]  aAvailableSize  Minimum number of octets to for application data.
  *
  *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
  */

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -296,5 +296,52 @@ private:
      */
     static void ExpiryTimerCallback(System::Layer * layer, void * param, System::Error error);
 };
+
+namespace MessagePacketBuffer {
+/**
+ * Maximum size of a message footer, in bytes.
+ */
+constexpr uint16_t kMaxFooterSize = kMaxTagLen;
+
+/**
+ * Allocates a packet buffer with space for message headers and footers.
+ *
+ *  Fails and returns \c nullptr if no memory is available, or if the size requested is too large.
+ *
+ *  @param[in]  aAvailableSize  Minimim number of octets to for application data.
+ *
+ *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
+ */
+inline System::PacketBufferHandle New(size_t aAvailableSize)
+{
+    return System::PacketBufferHandle::New(aAvailableSize + kMaxFooterSize);
+}
+
+/**
+ * Allocates a packet buffer with initial contents.
+ *
+ *  @param[in]  aData           Initial buffer contents.
+ *  @param[in]  aDataSize       Size of initial buffer contents.
+ *  @param[in]  aAdditionalSize Size of additional application data space after the initial contents.
+ *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers.
+ *
+ *  @return     On success, a PacketBufferHandle to the allocated buffer. On fail, \c nullptr.
+ */
+inline System::PacketBufferHandle NewWithData(const void * aData, size_t aDataSize)
+{
+    return System::PacketBufferHandle::NewWithData(aData, aDataSize, kMaxFooterSize);
+}
+
+/**
+ * Check whether a packet buffer has enough space for a message footer.
+ *
+ * @returns true if there is space, false otherwise.
+ */
+inline bool HasFooterSpace(const System::PacketBufferHandle & aBuffer)
+{
+    return aBuffer->AvailableDataLength() >= kMaxFooterSize;
+}
+
+} // namespace MessagePacketBuffer
 
 } // namespace chip

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -151,7 +151,7 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
-    chip::System::PacketBufferHandle buffer = chip::System::PacketBufferHandle::NewWithData(PAYLOAD, payload_len, kMaxTagLen);
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
     IPAddress addr;
@@ -202,7 +202,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
-    chip::System::PacketBufferHandle buffer = chip::System::PacketBufferHandle::NewWithData(PAYLOAD, payload_len, kMaxTagLen);
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
     IPAddress addr;
@@ -268,7 +268,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
-    chip::System::PacketBufferHandle buffer = chip::System::PacketBufferHandle::NewWithData(PAYLOAD, payload_len, kMaxTagLen);
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
     IPAddress addr;


### PR DESCRIPTION
#### Problem

Application-level code that allocates a packet buffer for a message of
a particular size has to be aware that up to kMaxTagLength additional
bytes may be necessary for the message authentication code. High-level
code shouldn't need to be aware of this.

#### Summary of Changes

Added:
- `chip::MessagePacketBuffer::New()`
- `chip::MessagePacketBuffer::NewWithData()`
- `chip::MessagePacketBuffer::HasFooterSpace()`

Fixes #4666 - Hide low-level message authentication code requirements from high-level packet buffer allocation
