### PR TITLE
[controller] Deprecate old DeviceController in python binding

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -44,7 +44,7 @@
 #include <app/CommandSender.h>
 #include <app/InteractionModelEngine.h>
 #include <controller/CHIPDevice.h>
-#include <controller/CHIPDeviceController_deprecated.h>
+#include <controller/CHIPDeviceController.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
@@ -53,21 +53,17 @@
 
 using namespace chip;
 using namespace chip::Ble;
-using namespace chip::DeviceController;
+using namespace chip::Controller;
 
 extern "C" {
 typedef void (*ConstructBytesArrayFunct)(const uint8_t * dataBuf, uint32_t dataLen);
 typedef void (*LogMessageFunct)(uint64_t time, uint64_t timeUS, const char * moduleName, uint8_t category, const char * msg);
-
-typedef void (*OnConnectFunct)(chip::DeviceController::ChipDeviceController * dc,
-                               const chip::Transport::PeerConnectionState * state, void * appReqState);
-typedef void (*OnErrorFunct)(chip::DeviceController::ChipDeviceController * dc, void * appReqState, CHIP_ERROR err,
-                             const chip::Inet::IPPacketInfo * pi);
-typedef void (*OnMessageFunct)(chip::DeviceController::ChipDeviceController * dc, void * appReqState,
-                               chip::System::PacketBufferHandle buffer);
 }
 
-static chip::Controller::PythonPersistentStorageDelegate sStorageDelegate;
+namespace {
+chip::Controller::PythonPersistentStorageDelegate sStorageDelegate;
+chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
+} // namespace
 
 // NOTE: Remote device ID is in sync with the echo server device id
 // At some point, we may want to add an option to connect to a device without
@@ -79,28 +75,23 @@ extern "C" {
 // Trampolined callback types
 CHIP_ERROR pychip_DeviceController_DriveIO(uint32_t sleepTimeMS);
 
-CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::DeviceController::ChipDeviceController ** outDevCtrl);
-CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::DeviceController::ChipDeviceController * devCtrl);
+CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl);
+CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::Controller::DeviceCommissioner * devCtrl);
 
 // Rendezvous
-CHIP_ERROR pychip_DeviceController_ConnectBLE(chip::DeviceController::ChipDeviceController * devCtrl, uint16_t discriminator,
-                                              uint32_t setupPINCode, OnConnectFunct onConnect, OnMessageFunct onMessage,
-                                              OnErrorFunct onError);
-CHIP_ERROR pychip_DeviceController_ConnectIP(chip::DeviceController::ChipDeviceController * devCtrl, const char * peerAddrStr,
-                                             uint32_t setupPINCode, OnConnectFunct onConnect, OnMessageFunct onMessage,
-                                             OnErrorFunct onError);
+CHIP_ERROR pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissioner * devCtrl, uint16_t discriminator,
+                                              uint32_t setupPINCode);
+CHIP_ERROR pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
+                                             uint32_t setupPINCode);
 
-// Network Provisioning
+// Pairing Delegate
 CHIP_ERROR
-pychip_ScriptDevicePairingDelegate_NewPairingDelegate(chip::DeviceController::ScriptDevicePairingDelegate ** pairingDelegate);
+pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::Controller::DeviceCommissioner * devCtrl, const char * ssid,
+                                                     const char * password);
 CHIP_ERROR
-pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::DeviceController::ScriptDevicePairingDelegate * pairingDelegate,
-                                                     const char * ssid, const char * password);
-CHIP_ERROR pychip_DeviceController_SetDevicePairingDelegate(chip::DeviceController::ChipDeviceController * devCtrl,
-                                                            chip::Controller::DevicePairingDelegate * pairingDelegate);
+pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(chip::Controller::DeviceCommissioner * devCtrl,
+                                                          chip::Controller::DevicePairingDelegate_OnPairingCompleteFunct callback);
 
-bool pychip_DeviceController_IsConnected(chip::DeviceController::ChipDeviceController * devCtrl);
-void pychip_DeviceController_Close(chip::DeviceController::ChipDeviceController * devCtrl);
 uint8_t pychip_DeviceController_GetLogFilter();
 void pychip_DeviceController_SetLogFilter(uint8_t category);
 
@@ -110,18 +101,18 @@ const char * pychip_Stack_ErrorToString(CHIP_ERROR err);
 const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t statusCode);
 void pychip_Stack_SetLogFunct(LogMessageFunct logFunct);
 
-CHIP_ERROR pychip_GetDeviceByNodeId(chip::DeviceController::ChipDeviceController * devCtrl, chip::NodeId nodeId,
+CHIP_ERROR pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
                                     chip::Controller::Device ** device);
 }
 
-CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::DeviceController::ChipDeviceController ** outDevCtrl)
+CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    *outDevCtrl = new chip::DeviceController::ChipDeviceController();
+    *outDevCtrl = new chip::Controller::DeviceCommissioner();
     VerifyOrExit(*outDevCtrl != NULL, err = CHIP_ERROR_NO_MEMORY);
 
-    SuccessOrExit(err = (*outDevCtrl)->Init(kLocalDeviceId, nullptr, nullptr, nullptr, &sStorageDelegate));
+    SuccessOrExit(err = (*outDevCtrl)->Init(kLocalDeviceId, &sStorageDelegate, &sPairingDelegate));
     SuccessOrExit(err = (*outDevCtrl)->ServiceEvents());
 
 exit:
@@ -133,7 +124,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::DeviceController::ChipDeviceController * devCtrl)
+CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::Controller::DeviceCommissioner * devCtrl)
 {
     if (devCtrl != NULL)
     {
@@ -141,13 +132,6 @@ CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::DeviceController
         delete devCtrl;
     }
     return CHIP_NO_ERROR;
-}
-
-void pychip_DeviceController_Close(chip::DeviceController::ChipDeviceController * devCtrl) {}
-
-bool pychip_DeviceController_IsConnected(chip::DeviceController::ChipDeviceController * devCtrl)
-{
-    return devCtrl->IsConnected();
 }
 
 const char * pychip_DeviceController_ErrorToString(CHIP_ERROR err)
@@ -177,28 +161,18 @@ void pychip_DeviceController_SetLogFilter(uint8_t category)
 #endif
 }
 
-CHIP_ERROR pychip_DeviceController_Connect(chip::DeviceController::ChipDeviceController * devCtrl, BLE_CONNECTION_OBJECT connObj,
-                                           uint32_t setupPINCode, OnConnectFunct onConnect, OnMessageFunct onMessage,
-                                           OnErrorFunct onError)
+CHIP_ERROR pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissioner * devCtrl, uint16_t discriminator,
+                                              uint32_t setupPINCode)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return devCtrl->PairDevice(kRemoteDeviceId,
+                               chip::RendezvousParameters()
+                                   .SetPeerAddress(Transport::PeerAddress(Transport::Type::kBle))
+                                   .SetSetupPINCode(setupPINCode)
+                                   .SetDiscriminator(discriminator));
 }
 
-CHIP_ERROR pychip_DeviceController_ConnectBLE(chip::DeviceController::ChipDeviceController * devCtrl, uint16_t discriminator,
-                                              uint32_t setupPINCode, OnConnectFunct onConnect, OnMessageFunct onMessage,
-                                              OnErrorFunct onError)
-{
-    return devCtrl->ConnectDevice(kRemoteDeviceId,
-                                  chip::RendezvousParameters()
-                                      .SetPeerAddress(Transport::PeerAddress(Transport::Type::kBle))
-                                      .SetSetupPINCode(setupPINCode)
-                                      .SetDiscriminator(discriminator),
-                                  (void *) devCtrl, onConnect, onMessage, onError);
-}
-
-CHIP_ERROR pychip_DeviceController_ConnectIP(chip::DeviceController::ChipDeviceController * devCtrl, const char * peerAddrStr,
-                                             uint32_t setupPINCode, OnConnectFunct onConnect, OnMessageFunct onMessage,
-                                             OnErrorFunct onError)
+CHIP_ERROR pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
+                                             uint32_t setupPINCode)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Inet::IPAddress peerAddr;
@@ -209,54 +183,31 @@ CHIP_ERROR pychip_DeviceController_ConnectIP(chip::DeviceController::ChipDeviceC
     // TODO: IP rendezvous should use TCP connection.
     addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
     params.SetPeerAddress(addr).SetDiscriminator(0);
-    return devCtrl->ConnectDevice(kRemoteDeviceId, params, (void *) devCtrl, onConnect, onMessage, onError);
+    return devCtrl->PairDevice(kRemoteDeviceId, params);
 }
 
 CHIP_ERROR
-pychip_ScriptDevicePairingDelegate_NewPairingDelegate(chip::DeviceController::ScriptDevicePairingDelegate ** pairingDelegate)
+pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::Controller::DeviceCommissioner * devCtrl, const char * ssid,
+                                                     const char * password)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    (void) devCtrl;
 
-    VerifyOrExit(pairingDelegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    *pairingDelegate = new chip::DeviceController::ScriptDevicePairingDelegate();
-
-exit:
-    if (err != CHIP_NO_ERROR && pairingDelegate != nullptr && *pairingDelegate != nullptr)
-    {
-        delete *pairingDelegate;
-        *pairingDelegate = nullptr;
-    }
-    return err;
-}
-
-CHIP_ERROR
-pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::DeviceController::ScriptDevicePairingDelegate * pairingDelegate,
-                                                     const char * ssid, const char * password)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(pairingDelegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(ssid != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(password != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    pairingDelegate->SetWifiCredential(ssid, password);
+    sPairingDelegate.SetWifiCredential(ssid, password);
 
 exit:
     return err;
 }
-CHIP_ERROR pychip_DeviceController_SetDevicePairingDelegate(chip::DeviceController::ChipDeviceController * devCtrl,
-                                                            chip::Controller::DevicePairingDelegate * pairingDelegate)
+
+CHIP_ERROR
+pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(chip::Controller::DeviceCommissioner * devCtrl,
+                                                          chip::Controller::DevicePairingDelegate_OnPairingCompleteFunct callback)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit(devCtrl != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(pairingDelegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-    devCtrl->SetDevicePairingDelegate(pairingDelegate);
-
-exit:
-    return err;
+    sPairingDelegate.SetKeyExchangeCallback(callback);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR pychip_Stack_Init()
@@ -297,10 +248,10 @@ const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t stat
     return NULL;
 }
 
-CHIP_ERROR pychip_GetDeviceByNodeId(chip::DeviceController::ChipDeviceController * devCtrl, chip::NodeId nodeId,
+CHIP_ERROR pychip_GetDeviceByNodeId(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
                                     chip::Controller::Device ** device)
 {
-    return devCtrl->GetDeviceController()->GetDevice(nodeId, device);
+    return devCtrl->GetDevice(nodeId, device);
 }
 
 #if _CHIP_USE_LOGGING && CHIP_LOG_ENABLE_DYNAMIC_LOGING_FUNCTION

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
@@ -22,7 +22,7 @@
 #include <transport/RendezvousSessionDelegate.h>
 
 namespace chip {
-namespace DeviceController {
+namespace Controller {
 
 void ScriptDevicePairingDelegate::SetWifiCredential(const char * ssid, const char * password)
 {
@@ -42,5 +42,18 @@ void ScriptDevicePairingDelegate::OnOperationalCredentialsRequested(const char *
     ChipLogDetail(Controller, "ScriptDevicePairingDelegate::OnOperationalCredentialsRequested\n");
 }
 
-} // namespace DeviceController
+void ScriptDevicePairingDelegate::SetKeyExchangeCallback(DevicePairingDelegate_OnPairingCompleteFunct callback)
+{
+    mOnPairingCompleteCallback = callback;
+}
+
+void ScriptDevicePairingDelegate::OnPairingComplete(CHIP_ERROR error)
+{
+    if (mOnPairingCompleteCallback != nullptr)
+    {
+        mOnPairingCompleteCallback(error);
+    }
+}
+
+} // namespace Controller
 } // namespace chip

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
@@ -25,29 +25,39 @@
 
 #pragma once
 
-#include <controller/CHIPDeviceController_deprecated.h>
+#include <controller/CHIPDeviceController.h>
 
 #include <platform/internal/DeviceNetworkInfo.h>
 #include <transport/RendezvousSessionDelegate.h>
 
 namespace chip {
-namespace DeviceController {
+namespace Controller {
+
+extern "C" {
+typedef void (*DevicePairingDelegate_OnPairingCompleteFunct)(CHIP_ERROR err);
+}
 
 class ScriptDevicePairingDelegate final : public Controller::DevicePairingDelegate
 {
 public:
     ~ScriptDevicePairingDelegate() = default;
     void SetWifiCredential(const char * ssid, const char * password);
+    void SetKeyExchangeCallback(DevicePairingDelegate_OnPairingCompleteFunct callback);
+
     void OnNetworkCredentialsRequested(RendezvousDeviceCredentialsDelegate * callback) override;
 
     void OnOperationalCredentialsRequested(const char * csr, size_t csr_length,
                                            RendezvousDeviceCredentialsDelegate * callback) override;
 
+    void OnPairingComplete(CHIP_ERROR error) override;
+
 private:
     // WiFi Provisioning Data
     char mWifiSSID[chip::DeviceLayer::Internal::kMaxWiFiSSIDLength + 1];
     char mWifiPassword[chip::DeviceLayer::Internal::kMaxWiFiKeyLength];
+
+    DevicePairingDelegate_OnPairingCompleteFunct mOnPairingCompleteCallback = nullptr;
 };
 
-} // namespace DeviceController
+} // namespace Controller
 } // namespace chip

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -163,8 +163,6 @@ class DeviceMgrCmd(Cmd):
             pass
 
     command_names = [
-        "close",
-
         "ble-scan",
         "ble-adapter-select",
         "ble-adapter-print",
@@ -172,6 +170,7 @@ class DeviceMgrCmd(Cmd):
 
         "connect",
         "zcl",
+
         "set-pairing-wifi-credential",
     ]
 

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -378,7 +378,6 @@ class DeviceMgrCmd(Cmd):
         except ChipExceptions.ChipStackException as ex:
             print(str(ex))
             return
-        print("Connected")
 
     def do_zcl(self, line):
         """

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -37,15 +37,7 @@ import enum
 
 __all__ = ["ChipDeviceController"]
 
-# typedef void (*OnConnectFunct)(Chip::DeviceController::hipDeviceController * dc,
-#                                const chip::Transport::PeerConnectionState * state, void * appReqState);
-# typedef void (*OnErrorFunct)(Chip::DeviceController::ChipDeviceController * dc, void * appReqState, CHIP_ERROR err,
-#                              const Inet::IPPacketInfo * pi);
-# typedef void (*OnMessageFunct)(Chip::DeviceController::ChipDeviceController * dc, void * appReqState, PacketBuffer * buffer);
-
-_OnConnectFunct = CFUNCTYPE(None, c_void_p, c_void_p, c_void_p)
-_OnRendezvousErrorFunct = CFUNCTYPE(None, c_void_p, c_void_p, c_uint32, c_void_p)
-_OnMessageFunct = CFUNCTYPE(None, c_void_p, c_void_p, c_void_p)
+_DevicePairingDelegate_OnPairingCompleteFunct = CFUNCTYPE(None, c_uint32)
 
 # This is a fix for WEAV-429. Jay Logue recommends revisiting this at a later
 # date to allow for truely multiple instances so this is temporary.
@@ -82,36 +74,24 @@ class ChipDeviceController(object):
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-        pairingDelegate = c_void_p(None)
-        res = self._dmLib.pychip_ScriptDevicePairingDelegate_NewPairingDelegate(pointer(pairingDelegate))
-        if res != 0:
-            raise self._ChipStack.ErrorToException(res)
-
-        res = self._dmLib.pychip_DeviceController_SetDevicePairingDelegate(devCtrl, pairingDelegate)
-        if res != 0:
-            raise self._ChipStack.ErrorToException(res)
-
         self.devCtrl = devCtrl
-        self.pairingDelegate = pairingDelegate
         self._ChipStack.devCtrl = devCtrl
 
         self._Cluster = ChipCluster(self._ChipStack)
         self._Cluster.InitLib(self._dmLib)
 
-        def DeviceCtrlHandleMessage(appReqState, buffer):
-            pass
-
-        self.cbHandleMessage = _OnMessageFunct(DeviceCtrlHandleMessage)
-
-        def HandleRendezvousError(appState, reqState, err, devStatusPtr):
-            if self.state == DCState.RENDEZVOUS_ONGOING:
-                print("Failed to connect to device: {}".format(err))
+        def HandleKeyExchangeComplete(err):
+            if err != 0:
+                print("Failed to establish secure session to device: {}".format(err))
+                self._ChipStack.callbackRes = False
+            else:
+                print("Secure Session to Device Established")
                 self._ChipStack.callbackRes = True
-                self._ChipStack.completeEvent.set()
-            elif self.state == DCState.RENDEZVOUS_CONNECTED:
-                print("Disconnected from device")
+            self.state = DCState.IDLE
+            self._ChipStack.completeEvent.set()
 
-        self.cbHandleRendezvousError = _OnRendezvousErrorFunct(HandleRendezvousError)
+        self.cbHandleKeyExchangeCompleteFunct = _DevicePairingDelegate_OnPairingCompleteFunct(HandleKeyExchangeComplete)
+        self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(self.devCtrl, self.cbHandleKeyExchangeCompleteFunct)
 
         self.state = DCState.IDLE
 
@@ -136,31 +116,15 @@ class ChipDeviceController(object):
         )
 
     def ConnectBLE(self, discriminator, setupPinCode):
-        def HandleComplete(dc, connState, appState):
-            print("Rendezvous Initialized")
-            self.state = DCState.RENDEZVOUS_CONNECTED
-            self._ChipStack.callbackRes = True
-            self._ChipStack.completeEvent.set()
-        onConnectFunct = _OnConnectFunct(HandleComplete)
-
         self.state = DCState.RENDEZVOUS_ONGOING
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_DeviceController_ConnectBLE(
-                self.devCtrl, discriminator, setupPinCode, onConnectFunct, self.cbHandleMessage, self.cbHandleRendezvousError)
+            lambda: self._dmLib.pychip_DeviceController_ConnectBLE(self.devCtrl, discriminator, setupPinCode)
         )
 
     def ConnectIP(self, ipaddr, setupPinCode):
-        def HandleComplete(dc, connState, appState):
-            print("Rendezvous Initialized")
-            self.state = DCState.RENDEZVOUS_CONNECTED
-            self._ChipStack.callbackRes = True
-            self._ChipStack.completeEvent.set()
-        onConnectFunct = _OnConnectFunct(HandleComplete)
-
         self.state = DCState.RENDEZVOUS_ONGOING
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_DeviceController_ConnectIP(
-                self.devCtrl, ipaddr, setupPinCode, onConnectFunct, self.cbHandleMessage, self.cbHandleRendezvousError)
+            lambda: self._dmLib.pychip_DeviceController_ConnectIP(self.devCtrl, ipaddr, setupPinCode)
         )
 
     def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args):
@@ -172,11 +136,6 @@ class ChipDeviceController(object):
 
     def ZCLList(self):
         return self._Cluster.ListClusters()
-
-    def Close(self):
-        self._ChipStack.Call(
-            lambda: self._dmLib.pychip_DeviceController_Close(self.devCtrl)
-        )
 
     def SetLogFilter(self, category):
         if category < 0 or category > pow(2, 8):
@@ -195,7 +154,7 @@ class ChipDeviceController(object):
         self._ChipStack.blockingCB = blockingCB
 
     def SetWifiCredential(self, ssid, password):
-        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential(self.pairingDelegate, ssid.encode("utf-8"), password.encode("utf-8"))
+        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential(self.devCtrl, ssid.encode("utf-8") + b'\0', password.encode("utf-8") + b'\0')
         if ret != 0:
             raise self._ChipStack.ErrorToException(res)
 
@@ -216,25 +175,17 @@ class ChipDeviceController(object):
                 c_uint32
             )
 
-            self._dmLib.pychip_DeviceController_Close.argtypes = [c_void_p]
-            self._dmLib.pychip_DeviceController_Close.restype = None
-
-            self._dmLib.pychip_DeviceController_ConnectBLE.argtypes = [
-                c_void_p, c_uint16, c_uint32, _OnConnectFunct, _OnMessageFunct, _OnRendezvousErrorFunct]
+            self._dmLib.pychip_DeviceController_ConnectBLE.argtypes = [c_void_p, c_uint16, c_uint32]
             self._dmLib.pychip_DeviceController_ConnectBLE.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_ConnectIP.argtypes = [
-                c_void_p, c_char_p, c_uint32, _OnConnectFunct, _OnMessageFunct, _OnRendezvousErrorFunct]
+            self._dmLib.pychip_DeviceController_ConnectIP.argtypes = [c_void_p, c_char_p, c_uint32]
             self._dmLib.pychip_DeviceController_ConnectIP.restype = c_uint32
-
-            self._dmLib.pychip_ScriptDevicePairingDelegate_NewPairingDelegate.argtypes = [POINTER(c_void_p)]
-            self._dmLib.pychip_ScriptDevicePairingDelegate_NewPairingDelegate.restype = c_uint32
 
             self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential.argtypes = [c_void_p, c_char_p, c_char_p]
             self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_SetDevicePairingDelegate.argtypes = [c_void_p, c_void_p]
-            self._dmLib.pychip_DeviceController_SetDevicePairingDelegate.restype = c_uint32
+            self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback.argtypes = [c_void_p, _DevicePairingDelegate_OnPairingCompleteFunct]
+            self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback.restype = c_uint32
 
             self._dmLib.pychip_GetDeviceByNodeId.argtypes = [c_void_p, c_uint64, POINTER(c_void_p)]
             self._dmLib.pychip_GetDeviceByNodeId.restype = c_uint32


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Modify Controller applications to use new DeviceController/DeviceCommissioner interface

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Removed unused APIs in Python binding, no changes on exported APIs.


<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

Issue: #3737

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
