### PR TITLE
Fix code generation failure on zap_generate.sh

### DIFF
--- a/src/app/zap-templates/zcl/manufacturers.xml
+++ b/src/app/zap-templates/zcl/manufacturers.xml
@@ -1,0 +1,586 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2008,2020 Silicon Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<map>
+  <mapping code="0x0001" translation="Panasonic"/>
+  <mapping code="0x0002" translation="Sony"/>
+  <mapping code="0x0003" translation="Samsung"/>
+  <mapping code="0x0004" translation="Philips (RF4CE)"/>
+  <mapping code="0x0005" translation="Freescale (RF4CE)"/>
+  <mapping code="0x0006" translation="Oki Semiconductors (RF4CE)"/>
+  <mapping code="0x0007" translation="Texas Instruments"/>
+  <mapping code="0x1000" translation="Cirronet"/>
+  <mapping code="0x1001" translation="Chipcon"/>
+  <mapping code="0x1002" translation="Ember"/>
+  <mapping code="0x1003" translation="NTS"/>
+  <mapping code="0x1004" translation="Freescale"/>
+  <mapping code="0x1005" translation="IP Com"/>
+  <mapping code="0x1006" translation="San Juan Software"/>
+  <mapping code="0x1007" translation="TUV"/>
+  <mapping code="0x1008" translation="Integration"/>
+  <mapping code="0x1009" translation="BM SpA"/>
+  <mapping code="0x100A" translation="AwarePoint"/>
+  <mapping code="0x100B" translation="Philips Lighting"/>
+  <mapping code="0x100C" translation="Luxoft"/>
+  <mapping code="0x100D" translation="Korwin"/>
+  <mapping code="0x100E" translation="One RF Technology"/>
+  <mapping code="0x100F" translation="Software Technologies Group"/>
+  <mapping code="0x1010" translation="Telegesis"/>
+  <mapping code="0x1011" translation="Visonic"/>
+  <mapping code="0x1012" translation="Insta"/>
+  <mapping code="0x1013" translation="Atalum"/>
+  <mapping code="0x1014" translation="Atmel"/>
+  <mapping code="0x1015" translation="Develco"/>
+  <mapping code="0x1016" translation="Honeywell"/>
+  <mapping code="0x1017" translation="RadioPulse"/>
+  <mapping code="0x1018" translation="Renesas"/>
+  <mapping code="0x1019" translation="Xanadu Wireless"/>
+  <mapping code="0x101A" translation="NEC Engineering"/>
+  <mapping code="0x101B" translation="Yamatake Corporation"/>
+  <mapping code="0x101C" translation="Tendril Networks"/>
+  <mapping code="0x101D" translation="Assa Abloy"/>
+  <mapping code="0x101E" translation="MaxStream"/>
+  <mapping code="0x101F" translation="Neurocom"/>
+  <mapping code="0x1020" translation="Institute for Information Industry"/>
+  <mapping code="0x1021" translation="Legrand Group"/>
+  <mapping code="0x1022" translation="iControl"/>
+  <mapping code="0x1023" translation="Raymarine"/>
+  <mapping code="0x1024" translation="LS Research"/>
+  <mapping code="0x1025" translation="Onity Inc."/>
+  <mapping code="0x1026" translation="Mono Products"/>
+  <mapping code="0x1027" translation="RF Technologies"/>
+  <mapping code="0x1028" translation="Itron"/>
+  <mapping code="0x1029" translation="Tritech"/>
+  <mapping code="0x102A" translation="Embedit A/S"/>
+  <mapping code="0x102B" translation="S3C"/>
+  <mapping code="0x102C" translation="Siemens"/>
+  <mapping code="0x102D" translation="Mindtech"/>
+  <mapping code="0x102E" translation="LG Electronics"/>
+  <mapping code="0x102F" translation="Mitsubishi Electric Corp."/>
+  <mapping code="0x1030" translation="Johnson Controls"/>
+  <mapping code="0x1031" translation="Secure Meters (UK) Ltd"/>
+  <mapping code="0x1032" translation="Knick"/>
+  <mapping code="0x1033" translation="Viconics"/>
+  <mapping code="0x1034" translation="Flexipanel"/>
+  <mapping code="0x1035" translation="Piasim Corporation Pte., Ltd."/>
+  <mapping code="0x1036" translation="Trane"/>
+  <mapping code="0x1037" translation="NXP Semiconductors"/>
+  <mapping code="0x1038" translation="Living Independently Group"/>
+  <mapping code="0x1039" translation="AlertMe.com"/>
+  <mapping code="0x103A" translation="Daintree"/>
+  <mapping code="0x103B" translation="Aiji System"/>
+  <mapping code="0x103C" translation="Telecom Italia"/>
+  <mapping code="0x103D" translation="Mikrokrets AS"/>
+  <mapping code="0x103E" translation="Oki Semiconductor"/>
+  <mapping code="0x103F" translation="Newport Electonics"/>
+  <mapping code="0x1040" translation="Control 4"/>
+  <mapping code="0x1041" translation="STMicroelectronics"/>
+  <mapping code="0x1042" translation="Ad-Sol Nissin Corp"/>
+  <mapping code="0x1043" translation="DCSI"/>
+  <mapping code="0x1044" translation="France Telecom"/>
+  <mapping code="0x1045" translation="muNet"/>
+  <mapping code="0x1046" translation="Autani Corporation"/>
+  <mapping code="0x1047" translation="Colorado vNet"/>
+  <mapping code="0x1048" translation="Aerocomm, Inc."/>
+  <mapping code="0x1049" translation="Silicon Laboratories"/>
+  <mapping code="0x104A" translation="Inncom International Inc."/>
+  <mapping code="0x104B" translation="Cooper Power Systems"/>
+  <mapping code="0x104C" translation="Synapse"/>
+  <mapping code="0x104D" translation="Fisher Pierce/Sunrise"/>
+  <mapping code="0x104E" translation="CentraLite Systems, Inc."/>
+  <mapping code="0x104F" translation="Crane Wireless Monitoring Solutions"/>
+  <mapping code="0x1050" translation="Mobilarm Limited"/>
+  <mapping code="0x1051" translation="iMonitor Research Ltd."/>
+  <mapping code="0x1052" translation="Bartech"/>
+  <mapping code="0x1053" translation="MeshNetics"/>
+  <mapping code="0x1054" translation="LS Industrial Systems Co. Ltd."/>
+  <mapping code="0x1055" translation="Cason Engineering plc"/>
+  <mapping code="0x1056" translation="Wireless Glue Networks Inc."/>
+  <mapping code="0x1057" translation="Elster"/>
+  <mapping code="0x1058" translation="SMS Tecnologia Eletrônica"/>
+  <mapping code="0x1059" translation="Onset Computer Corporation"/>
+  <mapping code="0x105A" translation="Riga Development"/>
+  <mapping code="0x105B" translation="Energate"/>
+  <mapping code="0x105C" translation="ConMed Linvatec"/>
+  <mapping code="0x105D" translation="PowerMand"/>
+  <mapping code="0x105E" translation="Schneider Electric"/>
+  <mapping code="0x105F" translation="Eaton Corporation"/>
+  <mapping code="0x1060" translation="Telular Corporation"/>
+  <mapping code="0x1061" translation="Delphi Medical Systems"/>
+  <mapping code="0x1062" translation="EpiSensor Limited"/>
+  <mapping code="0x1063" translation="Landis+Gyr"/>
+  <mapping code="0x1064" translation="Kaba Group"/>
+  <mapping code="0x1065" translation="Shure Incorporated"/>
+  <mapping code="0x1066" translation="Comverge, Inc."/>
+  <mapping code="0x1067" translation="DBS Lodging Technologies, LLC."/>
+  <mapping code="0x1068" translation="Energy Aware Technology Inc."/>
+  <mapping code="0x1069" translation="Hidalgo Limited"/>
+  <mapping code="0x106A" translation="Air2App"/>
+  <mapping code="0x106B" translation="AMX"/>
+  <mapping code="0x106C" translation="EDMI Pty Ltd"/>
+  <mapping code="0x106D" translation="Cyan Ltd"/>
+  <mapping code="0x106E" translation="System SPA"/>
+  <mapping code="0x106F" translation="Telit"/>
+  <mapping code="0x1070" translation="Kaga Electronics"/>
+  <mapping code="0x1071" translation="Astrel Group SRL"/>
+  <mapping code="0x1072" translation="Certicom"/>
+  <mapping code="0x1073" translation="Gridpoint"/>
+  <mapping code="0x1074" translation="Profile Systems LLC"/>
+  <mapping code="0x1075" translation="Compacta International Ltd"/>
+  <mapping code="0x1076" translation="Freestyle Technology Pty Ltd."/>
+  <mapping code="0x1077" translation="Alektrona"/>
+  <mapping code="0x1078" translation="Computime"/>
+  <mapping code="0x1079" translation="Remote Technologies, Inc."/>
+  <mapping code="0x107A" translation="Wavecom S.A."/>
+  <mapping code="0x107B" translation="Energy Optimizers Ltd."/>
+  <mapping code="0x107C" translation="GE"/>
+  <mapping code="0x107D" translation="Jetlun"/>
+  <mapping code="0x107E" translation="Cipher Systems"/>
+  <mapping code="0x107F" translation="Corporate Systems Engineering"/>
+  <mapping code="0x1080" translation="ecobee"/>
+  <mapping code="0x1081" translation="SMK"/>
+  <mapping code="0x1082" translation="Meshworks Wireless Oy"/>
+  <mapping code="0x1083" translation="Ellips B.V."/>
+  <mapping code="0x1084" translation="Secure electrans"/>
+  <mapping code="0x1085" translation="CEDO"/>
+  <mapping code="0x1086" translation="Toshiba"/>
+  <mapping code="0x1087" translation="Digi International"/>
+  <mapping code="0x1088" translation="Ubilogix"/>
+  <mapping code="0x1089" translation="Echelon"/>
+  <mapping code="0x1090" translation="Green Energy Options"/>
+  <mapping code="0x1091" translation="Silver Spring Networks"/>
+  <mapping code="0x1092" translation="Black &amp; Decker"/>
+  <mapping code="0x1093" translation="Aztech Associates Inc."/>
+  <mapping code="0x1094" translation="A&amp;D Co., Ltd."/>
+  <mapping code="0x1095" translation="Rainforest Automation"/>
+  <mapping code="0x1096" translation="Carrier Electronics"/>
+  <mapping code="0x1097" translation="SyChip/Murata"/>
+  <mapping code="0x1098" translation="OpenPeak"/>
+  <mapping code="0x1099" translation="PassiveSystems"/>
+  <mapping code="0x109A" translation="MMB Research"/>
+  <mapping code="0x109B" translation="Leviton Manufacturing Company"/>
+  <mapping code="0x109C" translation="Korea Electric Power Data Network Co., Ltd."/>
+  <mapping code="0x109D" translation="Comcast"/>
+  <mapping code="0x109E" translation="NEC Electronics"/>
+  <mapping code="0x109F" translation="Netvox"/>
+  <mapping code="0x10A0" translation="U-Control"/>
+  <mapping code="0x10A1" translation="Embedia Technologies Corp"/>
+  <mapping code="0x10A2" translation="Sensus"/>
+  <mapping code="0x10A3" translation="Sunrise Technologies"/>
+  <mapping code="0x10A4" translation="Memtech Corp"/>
+  <mapping code="0x10A5" translation="Freebox"/>
+  <mapping code="0x10A6" translation="M2 Labs Ltd."/>
+  <mapping code="0x10A7" translation="British Gas"/>
+  <mapping code="0x10A8" translation="Sentec Ltd."/>
+  <mapping code="0x10A9" translation="Navetas"/>
+  <mapping code="0x10AA" translation="Lightspeed Technologies"/>
+  <mapping code="0x10AB" translation="Oki Electric Industry Co., Ltd."/>
+  <mapping code="0x10AC" translation="S I - Sistemas Inteligentes Eletrônicos Ltda"/>
+  <mapping code="0x10AD" translation="Dometic"/>
+  <mapping code="0x10AE" translation="Alps"/>
+  <mapping code="0x10AF" translation="EnergyHub"/>
+  <mapping code="0x10B0" translation="Kamstrup"/>
+  <mapping code="0x10B1" translation="EchoStar"/>
+  <mapping code="0x10B2" translation="EnerNOC"/>
+  <mapping code="0x10B3" translation="Eltav"/>
+  <mapping code="0x10B4" translation="Belkin"/>
+  <mapping code="0x10B5" translation="XStreamHD - Wireless Ventures"/>
+  <mapping code="0x10B6" translation="Saturn South Pty Ltd"/>
+  <mapping code="0x10B7" translation="GreenTrapOnline A/S"/>
+  <mapping code="0x10B8" translation="SmartSynch, Inc."/>
+  <mapping code="0x10B9" translation="Nyce Control, Inc."/>
+  <mapping code="0x10BA" translation="ICM Controls Corp"/>
+  <mapping code="0x10BB" translation="Millennium Electronics, PTY Ltd."/>
+  <mapping code="0x10BC" translation="Motorola, Inc"/>
+  <mapping code="0x10BD" translation="Emerson White-Rodgers"/>
+  <mapping code="0x10BE" translation="Radio Thermostat Company of America"/>
+  <mapping code="0x10BF" translation="OMRON Corporation"/>
+  <mapping code="0x10C0" translation="GiiNii Global Limited"/>
+  <mapping code="0x10C1" translation="Fujitsu General Limited"/>
+  <mapping code="0x10C2" translation="Peel Technologies, Inc."/>
+  <mapping code="0x10C3" translation="Accent S.p.A."/>
+  <mapping code="0x10C4" translation="ByteSnap Design Ltd."/>
+  <mapping code="0x10C5" translation="NEC TOKIN Corporation"/>
+  <mapping code="0x10C6" translation="G4S Justice Services"/>
+  <mapping code="0x10C7" translation="Trilliant Networks, Inc."/>
+  <mapping code="0x10C8" translation="Electrolux Italia S.p.A"/>
+  <mapping code="0x10C9" translation="Onzo Ltd"/>
+  <mapping code="0x10CA" translation="EnTek Systems"/>
+  <mapping code="0x10CB" translation="Philips"/>
+  <mapping code="0x10CC" translation="Mainstream Engineering"/>
+  <mapping code="0x10CD" translation="Indesit Company"/>
+  <mapping code="0x10CE" translation="THINKECO, INC."/>
+  <mapping code="0x10CF" translation="2D2C, Inc."/>
+  <mapping code="0x10D0" translation="GreenPeak"/>
+  <mapping code="0x10D1" translation="InterCEL"/>
+  <mapping code="0x10D2" translation="LG Electronics"/>
+  <mapping code="0x10D3" translation="Mitsumi Electric Co.,Ltd."/>
+  <mapping code="0x10D4" translation="Mitsumi Electric Co.,Ltd."/>
+  <mapping code="0x10D5" translation="Zentrum Mikroelektronik Dresden AG (ZMDI)"/>
+  <mapping code="0x10D6" translation="Nest Labs, Inc."/>
+  <mapping code="0x10D7" translation="Exegin Technologies, Ltd."/>
+  <mapping code="0x10D8" translation="Honeywell"/>
+  <mapping code="0x10D9" translation="Takahata Precision Co. Ltd."/>
+  <mapping code="0x10DA" translation="SUMITOMO ELECTRIC NETWORKS, INC."/>
+  <mapping code="0x10DB" translation="GE Energy"/>
+  <mapping code="0x10DC" translation="GE Appliances"/>
+  <mapping code="0x10DD" translation="Radiocrafts AS"/>
+  <mapping code="0x10DE" translation="Ceiva"/>
+  <mapping code="0x10DF" translation="TEC&amp;CO Co., Ltd"/>
+  <mapping code="0x10E0" translation="Chameleon Technology (UK) Ltd"/>
+  <mapping code="0x10E1" translation="Samsung"/>
+  <mapping code="0x10E2" translation="ruwido austria gmbh"/>
+  <mapping code="0x10E3" translation="Huawei Technologies Co., Ltd."/>
+  <mapping code="0x10E4" translation="Huawei Technologies Co., Ltd."/>
+  <mapping code="0x10E5" translation="Greenwave Reality"/>
+  <mapping code="0x10E6" translation="BGlobal Metering Ltd"/>
+  <mapping code="0x10E7" translation="Mindteck"/>
+  <mapping code="0x10E8" translation="Ingersoll-Rand"/>
+  <mapping code="0x10E9" translation="Dius Computing Pty Ltd"/>
+  <mapping code="0x10EA" translation="Embedded Automation, Inc."/>
+  <mapping code="0x10EB" translation="ABB"/>
+  <mapping code="0x10EC" translation="Sony"/>
+  <mapping code="0x10ED" translation="Genus Power Infrastructures Limited"/>
+  <mapping code="0x10EE" translation="Universal Electronics, Inc."/>
+  <mapping code="0x10EF" translation="Universal Electronics, Inc."/>
+  <mapping code="0x10F0" translation="Metrum Technologies, LLC"/>
+  <mapping code="0x10F1" translation="Cisco"/>
+  <mapping code="0x10F2" translation="Ubisys technologies GmbH"/>
+  <mapping code="0x10F3" translation="Consert"/>
+  <mapping code="0x10F4" translation="Crestron Electronics"/>
+  <mapping code="0x10F5" translation="Enphase Energy"/>
+  <mapping code="0x10F6" translation="Invensys Controls"/>
+  <mapping code="0x10F7" translation="Mueller Systems, LLC"/>
+  <mapping code="0x10F8" translation="AAC Technologies Holding"/>
+  <mapping code="0x10F9" translation="U-NEXT Co., Ltd"/>
+  <mapping code="0x10FA" translation="Steelcase Inc."/>
+  <mapping code="0x10FB" translation="Telematics Wireless"/>
+  <mapping code="0x10FC" translation="Samil Power Co., Ltd"/>
+  <mapping code="0x10FD" translation="Pace Plc"/>
+  <mapping code="0x10FE" translation="Osborne Coinage Co."/>
+  <mapping code="0x10FF" translation="Powerwatch"/>
+  <mapping code="0x1100" translation="CANDELED GmbH"/>
+  <mapping code="0x1101" translation="FlexGrid S.R.L"/>
+  <mapping code="0x1102" translation="Humax"/>
+  <mapping code="0x1103" translation="Universal Devices"/>
+  <mapping code="0x1104" translation="Advanced Energy"/>
+  <mapping code="0x1105" translation="BEGA Gantenbrink-Leuchten"/>
+  <mapping code="0x1106" translation="Brunel University"/>
+  <mapping code="0x1107" translation="Panasonic R&amp;D Center Singapore"/>
+  <mapping code="0x1108" translation="eSystems Research"/>
+  <mapping code="0x1109" translation="Panamax"/>
+  <mapping code="0x110A" translation="SmartThings, Inc."/>
+  <mapping code="0x110B" translation="EM-Lite Ltd."/>
+  <mapping code="0x110C" translation="Osram Sylvania"/>
+  <mapping code="0x110D" translation="2 Save Energy Ltd."/>
+  <mapping code="0x110E" translation="Planet Innovation Products Pty Ltd"/>
+  <mapping code="0x110F" translation="Ambient Devices, Inc."/>
+  <mapping code="0x1110" translation="Profalux"/>
+  <mapping code="0x1111" translation="Billion Electric Company (BEC)"/>
+  <mapping code="0x1112" translation="Embertec Pty Ltd"/>
+  <mapping code="0x1113" translation="IT Watchdogs"/>
+  <mapping code="0x1114" translation="Reloc"/>
+  <mapping code="0x1115" translation="Intel Corporation"/>
+  <mapping code="0x1116" translation="Trend Electronics Limited"/>
+  <mapping code="0x1117" translation="Moxa"/>
+  <mapping code="0x1118" translation="QEES"/>
+  <mapping code="0x1119" translation="SAYME Wireless Sensor Networks"/>
+  <mapping code="0x111A" translation="Pentair Aquatic Systems"/>
+  <mapping code="0x111B" translation="Orbit Irrigation"/>
+  <mapping code="0x111C" translation="California Eastern Laboratories"/>
+  <mapping code="0x111D" translation="Comcast"/>
+  <mapping code="0x111E" translation="IDT Technology Limited"/>
+  <mapping code="0x111F" translation="Pixela Corporation"/>
+  <mapping code="0x1120" translation="TiVo, Inc."/>
+  <mapping code="0x1121" translation="Fidure Corp."/>
+  <mapping code="0x1122" translation="Marvell Semiconductor, Inc."/>
+  <mapping code="0x1123" translation="Wasion Group Limited"/>
+  <mapping code="0x1124" translation="Jasco Products Company"/>
+  <mapping code="0x1125" translation="Shenzhen Kaifa Technology (Chengdu) Co., Ltd."/>
+  <mapping code="0x1126" translation="Netcomm Wireless Limited"/>
+  <mapping code="0x1127" translation="Define Instruments Limited"/>
+  <mapping code="0x1128" translation="In Home Displays Ltd."/>
+  <mapping code="0x1129" translation="Miele &amp; Cie. KG"/>
+  <mapping code="0x112A" translation="Televes S.A."/>
+  <mapping code="0x112B" translation="Labelec"/>
+  <mapping code="0x112C" translation="China Electronics Standardization Institute"/>
+  <mapping code="0x112D" translation="Vectorform, LLC"/>
+  <mapping code="0x112E" translation="Busch-Jaeger Elektro"/>
+  <mapping code="0x112F" translation="Redpine Signals, Inc."/>
+  <mapping code="0x1130" translation="Bridges Electronic Technology Pty Ltd."/>
+  <mapping code="0x1131" translation="Sercomm"/>
+  <mapping code="0x1132" translation="WSH GmbH wirsindheller"/>
+  <mapping code="0x1133" translation="Bosch Security Systems, Inc."/>
+  <mapping code="0x1134" translation="eZEX Corporation"/>
+  <mapping code="0x1135" translation="Dresden Elektronik Ingenieurtechnik GmbH"/>
+  <mapping code="0x1136" translation="MEAZON S.A."/>
+  <mapping code="0x1137" translation="Crow Electronic Engineering Ltd."/>
+  <mapping code="0x1138" translation="Harvard Engineering Plc"/>
+  <mapping code="0x1139" translation="Andson(Beijing) Technology CO.,Ltd"/>
+  <mapping code="0x113A" translation="Adhoco AG"/>
+  <mapping code="0x113B" translation="Waxman Consumer Products Group, Inc."/>
+  <mapping code="0x113C" translation="Owon Technology, Inc."/>
+  <mapping code="0x113D" translation="Hitron Technologies, Inc."/>
+  <mapping code="0x113E" translation="Scemtec Hard - und Software für Mess - und Steuerungstechnik GmbH"/>
+  <mapping code="0x113F" translation="Webee LLC"/>
+  <mapping code="0x1140" translation="Grid2Home Inc"/>
+  <mapping code="0x1141" translation="Telink Micro"/>
+  <mapping code="0x1142" translation="Jasmine Systems, Inc."/>
+  <mapping code="0x1143" translation="Bidgely"/>
+  <mapping code="0x1144" translation="Lutron"/>
+  <mapping code="0x1145" translation="IJENKO"/>
+  <mapping code="0x1146" translation="Starfield Electronic Ltd."/>
+  <mapping code="0x1147" translation="TCP, Inc."/>
+  <mapping code="0x1148" translation="Rogers Communications Partnership"/>
+  <mapping code="0x1149" translation="Cree, Inc."/>
+  <mapping code="0x114A" translation="Robert Bosch LLC"/>
+  <mapping code="0x114B" translation="Ibis Networks, Inc."/>
+  <mapping code="0x114C" translation="Quirky, Inc."/>
+  <mapping code="0x114D" translation="Efergy Technologies Limited"/>
+  <mapping code="0x114E" translation="SmartLabs, Inc."/>
+  <mapping code="0x114F" translation="Everspring Industry Co., Ltd."/>
+  <mapping code="0x1150" translation="Swann Communications Ptl Ltd."/>
+  <mapping code="0x1151" translation="Soneter"/>
+  <mapping code="0x1152" translation="Samsung SDS"/>
+  <mapping code="0x1153" translation="Uniband Electronic Corporation"/>
+  <mapping code="0x1154" translation="Accton Technology Corporation"/>
+  <mapping code="0x1155" translation="Bosch Thermotechnik GmbH"/>
+  <mapping code="0x1156" translation="Wincor Nixdorf Inc."/>
+  <mapping code="0x1157" translation="Ohsung Electronics"/>
+  <mapping code="0x1158" translation="Zen Within, Inc."/>
+  <mapping code="0x1159" translation="Tech4home, Lda."/>
+  <mapping code="0x115A" translation="Nanoleaf"/>
+  <mapping code="0x115B" translation="Keen Home, Inc."/>
+  <mapping code="0x115C" translation="Poly-Control APS"/>
+  <mapping code="0x115D" translation="Eastfield Lighting Co., Ltd Shenzhen"/>
+  <mapping code="0x115E" translation="IP Datatel, Inc."/>
+  <mapping code="0x115F" translation="Lumi United Techology, Ltd Shenzhen"/>
+  <mapping code="0x1160" translation="Sengled Optoelectronics Corp"/>
+  <mapping code="0x1161" translation="Remote Solution Co., Ltd."/>
+  <mapping code="0x1162" translation="ABB Genway Xiamen Electrical Equipment Co., Ltd."/>
+  <mapping code="0x1163" translation="Zhejiang Rexense Tech"/>
+  <mapping code="0x1164" translation="ForEE Technology"/>
+  <mapping code="0x1165" translation="Open Access Technology Int’l."/>
+  <mapping code="0x1166" translation="INNR Lighting BV"/>
+  <mapping code="0x1167" translation="Techworld Industries"/>
+  <mapping code="0x1168" translation="Leedarson Lighting Co., Ltd."/>
+  <mapping code="0x1169" translation="Arzel Zoning"/>
+  <mapping code="0x116A" translation="Holley Technology"/>
+  <mapping code="0x116B" translation="Beldon Technologies"/>
+  <mapping code="0x116C" translation="Flextronics"/>
+  <mapping code="0x116D" translation="Shenzhen Meian"/>
+  <mapping code="0x116E" translation="Lowe’s"/>
+  <mapping code="0x116F" translation="Sigma Connectivity"/>
+  <mapping code="0x1171" translation="Wulian"/>
+  <mapping code="0x1172" translation="Plugwise B.V."/>
+  <mapping code="0x1173" translation="Titan Products"/>
+  <mapping code="0x1174" translation="Ecospectral"/>
+  <mapping code="0x1175" translation="D-Link"/>
+  <mapping code="0x1176" translation="Technicolor Home USA"/>
+  <mapping code="0x1177" translation="Opple Lighting"/>
+  <mapping code="0x1178" translation="Wistron NeWeb Corp."/>
+  <mapping code="0x1179" translation="QMotion Shades"/>
+  <mapping code="0x117A" translation="Insta Elektro GmbH"/>
+  <mapping code="0x117B" translation="Shanghai Vancount"/>
+  <mapping code="0x117C" translation="Ikea of Sweden"/>
+  <mapping code="0x117D" translation="RT-RK"/>
+  <mapping code="0x117E" translation="Shenzhen Feibit"/>
+  <mapping code="0x117F" translation="EuControls"/>
+  <mapping code="0x1180" translation="Telkonet"/>
+  <mapping code="0x1181" translation="Thermal Solution Resources"/>
+  <mapping code="0x1182" translation="PomCube"/>
+  <mapping code="0x1183" translation="Ei Electronics"/>
+  <mapping code="0x1184" translation="Optoga"/>
+  <mapping code="0x1185" translation="Stelpro"/>
+  <mapping code="0x1186" translation="Lynxus Technologies Corp."/>
+  <mapping code="0x1187" translation="Semiconductor Components"/>
+  <mapping code="0x1188" translation="TP-Link"/>
+  <mapping code="0x1189" translation="LEDVANCE LLC."/>
+  <mapping code="0x118A" translation="Nortek"/>
+  <mapping code="0x118B" translation="iRevo/Assa Abbloy Korea"/>
+  <mapping code="0x118C" translation="Midea"/>
+  <mapping code="0x118D" translation="ZF Friedrichshafen"/>
+  <mapping code="0x118E" translation="Checkit"/>
+  <mapping code="0x118F" translation="Aclara"/>
+  <mapping code="0x1190" translation="Nokia"/>
+  <mapping code="0x1191" translation="Goldcard High-tech Co., Ltd."/>
+  <mapping code="0x1192" translation="George Wilson Industries Ltd."/>
+  <mapping code="0x1193" translation="EASY SAVER CO.,INC"/>
+  <mapping code="0x1194" translation="ZTE Corporation"/>
+  <mapping code="0x1195" translation="ARRIS"/>
+  <mapping code="0x1196" translation="Reliance BIG TV"/>
+  <mapping code="0x1197" translation="Insight Energy Ventures/Powerley"/>
+  <mapping code="0x1198" translation="Thomas Research Products (Hubbell Lighting Inc.)"/>
+  <mapping code="0x1199" translation="Li Seng Technology"/>
+  <mapping code="0x119A" translation="System Level Solutions Inc."/>
+  <mapping code="0x119B" translation="Matrix Labs"/>
+  <mapping code="0x119C" translation="Sinope Technologies"/>
+  <mapping code="0x119D" translation="Jiuzhou Greeble"/>
+  <mapping code="0x119E" translation="Guangzhou Lanvee Tech. Co. Ltd."/>
+  <mapping code="0x119F" translation="Venstar"/>
+  <mapping code="0x1200" translation="SLV"/>
+  <mapping code="0x1201" translation="Halo Smart Labs"/>
+  <mapping code="0x1202" translation="Scout Security Inc."/>
+  <mapping code="0x1203" translation="Alibaba China Inc."/>
+  <mapping code="0x1204" translation="Resolution Products, Inc."/>
+  <mapping code="0x1205" translation="Smartlok Inc."/>
+  <mapping code="0x1206" translation="Lux Products Corp."/>
+  <mapping code="0x1207" translation="Vimar SpA"/>
+  <mapping code="0x1208" translation="Universal Lighting Technologies"/>
+  <mapping code="0x1209" translation="Robert Bosch, GmbH"/>
+  <mapping code="0x120A" translation="Accenture"/>
+  <mapping code="0x120B" translation="Heiman Technology Co., Ltd."/>
+  <mapping code="0x120C" translation="Shenzhen HOMA Technology Co., Ltd."/>
+  <mapping code="0x120D" translation="Vision-Electronics Technology"/>
+  <mapping code="0x120E" translation="Lenovo"/>
+  <mapping code="0x120F" translation="Presciense R&amp;D"/>
+  <mapping code="0x1210" translation="Shenzhen Seastar Intelligence Co., Ltd."/>
+  <mapping code="0x1211" translation="Sensative AB"/>
+  <mapping code="0x1212" translation="SolarEdge"/>
+  <mapping code="0x1213" translation="Zipato"/>
+  <mapping code="0x1214" translation="China Fire &amp; Security Sensing Manufacturing (iHorn)"/>
+  <mapping code="0x1215" translation="Quby BV"/>
+  <mapping code="0x1216" translation="Hangzhou Roombanker Technology Co., Ltd."/>
+  <mapping code="0x1217" translation="Amazon Lab126"/>
+  <mapping code="0x1218" translation="Paulmann Licht GmbH"/>
+  <mapping code="0x1219" translation="Shenzhen Orvibo Electronics Co. Ltd."/>
+  <mapping code="0x121A" translation="TCI Telecommunications"/>
+  <mapping code="0x121B" translation="Mueller-Licht International Inc."/>
+  <mapping code="0x121C" translation="Aurora Limited"/>
+  <mapping code="0x121D" translation="SmartDCC"/>
+  <mapping code="0x121E" translation="Shanghai UMEinfo Co. Ltd."/>
+  <mapping code="0x121F" translation="carbonTRACK"/>
+  <mapping code="0x1220" translation="Somfy"/>
+  <mapping code="0x1221" translation="Viessmann Elektronik GmbH"/>
+  <mapping code="0x1222" translation="Hildebrand Technology Ltd"/>
+  <mapping code="0x1223" translation="Onkyo Technology Corporation"/>
+  <mapping code="0x1224" translation="Shenzhen Sunricher Technology Ltd."/>
+  <mapping code="0x1225" translation="Xiu Xiu Technology Co., Ltd"/>
+  <mapping code="0x1226" translation="Zumtobel Group"/>
+  <mapping code="0x1227" translation="Shenzhen Kaadas Intelligent Technology Co. Ltd"/>
+  <mapping code="0x1228" translation="Shanghai Xiaoyan Technology Co. Ltd"/>
+  <mapping code="0x1229" translation="Cypress Semiconductor"/>
+  <mapping code="0x122A" translation="XAL GmbH"/>
+  <mapping code="0x122B" translation="Inergy Systems LLC"/>
+  <mapping code="0x122C" translation="Alfred Karcher GmbH &amp; Co KG"/>
+  <mapping code="0x122D" translation="Adurolight Manufacturing"/>
+  <mapping code="0x122E" translation="Groupe Muller"/>
+  <mapping code="0x122F" translation="V-Mark Enterprises Inc."/>
+  <mapping code="0x1230" translation="Lead Energy AG"/>
+  <mapping code="0x1231" translation="Ultimate IOT (Henan) Technology Ltd."/>
+  <mapping code="0x1232" translation="Axxess Industries Inc."/>
+  <mapping code="0x1233" translation="Third Reality Inc."/>
+  <mapping code="0x1234" translation="DSR Corporation"/>
+  <mapping code="0x1235" translation="Guangzhou Vensi Intelligent Technology Co. Ltd."/>
+  <mapping code="0x1236" translation="Schlage Lock (Allegion)"/>
+  <mapping code="0x1237" translation="Net2Grid"/>
+  <mapping code="0x1238" translation="Airam Electric Oy Ab"/>
+  <mapping code="0x1239" translation="IMMAX WPB CZ"/>
+  <mapping code="0x123A" translation="ZIV Automation"/>
+  <mapping code="0x123B" translation="HangZhou iMagicTechnology Co., Ltd"/>
+  <mapping code="0x123C" translation="Xiamen Leelen Technology Co. Ltd."/>
+  <mapping code="0x123D" translation="Overkiz SAS"/>
+  <mapping code="0x123E" translation="Flonidan A/S"/>
+  <mapping code="0x123F" translation="HDL Automation Co., Ltd."/>
+  <mapping code="0x1240" translation="Ardomus Networks Corporation"/>
+  <mapping code="0x1241" translation="Samjin Co., Ltd."/>
+  <mapping code="0x1242" translation="Sprue Aegis PLC"/>
+  <mapping code="0x1243" translation="Indra Sistemas, S.A."/>
+  <mapping code="0x1244" translation="Shenzhen JBT Smart Lighting Co., Ltd."/>
+  <mapping code="0x1245" translation="GE Lighting &amp; Current"/>
+  <mapping code="0x1246" translation="Danfoss A/S"/>
+  <mapping code="0x1247" translation="NIVISS PHP Sp. z o.o. Sp.k."/>
+  <mapping code="0x1248" translation="Shenzhen Fengliyuan Energy Conservating Technology Co. Ltd"/>
+  <mapping code="0x1249" translation="NEXELEC"/>
+  <mapping code="0x124A" translation="Sichuan Behome Prominent Technology Co., Ltd"/>
+  <mapping code="0x124B" translation="Fujian Star-net Communication Co., Ltd."/>
+  <mapping code="0x124C" translation="Toshiba Visual Solutions Corporation"/>
+  <mapping code="0x124D" translation="Latchable, Inc."/>
+  <mapping code="0x124E" translation="L&amp;S Deutschland GmbH"/>
+  <mapping code="0x124F" translation="Gledopto Co., Ltd."/>
+  <mapping code="0x1250" translation="The Home Depot"/>
+  <mapping code="0x1251" translation="Neonlite International Ltd."/>
+  <mapping code="0x1252" translation="Arlo Technologies, Inc."/>
+  <mapping code="0x1253" translation="Xingluo Technology Co., Ltd."/>
+  <mapping code="0x1254" translation="Simon Electric (China) Co., Ltd."/>
+  <mapping code="0x1255" translation="Hangzhou Greatstar Industrial Co., Ltd."/>
+  <mapping code="0x1256" translation="Sequentric Energy Systems, LLC"/>
+  <mapping code="0x1257" translation="Solum Co., Ltd."/>
+  <mapping code="0x1258" translation="Eaglerise Electric &amp; Electronic (China) Co., Ltd."/>
+  <mapping code="0x1259" translation="Fantem Technologies (Shenzhen) Co., Ltd."/>
+  <mapping code="0x125A" translation="Yunding Network Technology (Beijing) Co., Ltd."/>
+  <mapping code="0x125B" translation="Atlantic Group"/>
+  <mapping code="0x125C" translation="Xiamen Intretech, Inc."/>
+  <mapping code="0x125D" translation="Tuya Global Inc."/>
+  <mapping code="0x125E" translation="Dnake (Xiamen) Intelligent Technology Co., Ltd."/>
+  <mapping code="0x125F" translation="Niko nv"/>
+  <mapping code="0x1260" translation="Emporia Energy"/>
+  <mapping code="0x1261" translation="Sikom AS"/>
+  <mapping code="0x1262" translation="AXIS Labs, Inc."/>
+  <mapping code="0x1263" translation="Current Products Corporation"/>
+  <mapping code="0x1264" translation="MeteRSit SRL"/>
+  <mapping code="0x1265" translation="HORNBACH Baumarkt AG"/>
+  <mapping code="0x1266" translation="DiCEworld s.r.l. a socio unico"/>
+  <mapping code="0x1267" translation="ARC Technology Co., Ltd"/>
+  <mapping code="0x1268" translation="Hangzhou Konke Information Technology Co., Ltd."/>
+  <mapping code="0x1269" translation="SALTO Systems S.L."/>
+  <mapping code="0x126A" translation="Shenzhen Shyugj Technology Co., Ltd"/>
+  <mapping code="0x126B" translation="Brayden Automation Corporation"/>
+  <mapping code="0x126C" translation="Environexus Pty. Ltd."/>
+  <mapping code="0x126D" translation="Eltra nv/sa"/>
+  <mapping code="0x126E" translation="Xiaomi Communications Co., Ltd."/>
+  <mapping code="0x126F" translation="Shanghai Shuncom Electronic Technology Co., Ltd."/>
+  <mapping code="0x1270" translation="Voltalis S.A"/>
+  <mapping code="0x1271" translation="FEELUX Co., Ltd."/>
+  <mapping code="0x1272" translation="SmartPlus Inc."/>
+  <mapping code="0x1273" translation="Halemeier GmbH"/>
+  <mapping code="0x1274" translation="Trust International BV"/>
+  <mapping code="0x1275" translation="Duke Energy Business Services LLC"/>
+  <mapping code="0x1276" translation="Calix, Inc."/>
+  <mapping code="0x1277" translation="ADEO"/>
+  <mapping code="0x1278" translation="Connected Response Limited"/>
+  <mapping code="0x1279" translation="StroyEnergoKom, Ltd."/>
+  <mapping code="0x127A" translation="Lumitech Lighting Solution GmbH"/>
+  <mapping code="0x127B" translation="Verdant Environmental Technologies"/>
+  <mapping code="0x127C" translation="Alfred International Inc."/>
+  <mapping code="0x127D" translation="Sansi LED Lighting co., LTD."/>
+  <mapping code="0x127E" translation="Mindtree Limited"/>
+  <mapping code="0x127F" translation="Nordic Semiconductor ASA"/>
+  <mapping code="0x1280" translation="Siterwell Electronics Co., Limited"/>
+  <mapping code="0x1281" translation="Briloner Leuchten GmbH &amp; Co. KG"/>
+  <mapping code="0x1282" translation="Shenzhen SEI Technology Co., Ltd."/>
+  <mapping code="0x1283" translation="Copper Labs, Inc."/>
+  <mapping code="0x1284" translation="Delta Dore"/>
+  <mapping code="0x1285" translation="Hager Group"/>
+  <mapping code="0x1286" translation="Shenzhen CoolKit Technology Co., Ltd"/>
+  <mapping code="0x1287" translation="Hangzhou Sky-Lighting Co., Ltd."/>
+  <mapping code="0x1288" translation="E.ON SE"/>
+  <mapping code="0x1289" translation="Lidl Stiftung &amp; Co. KG"/>
+  <mapping code="0x128A" translation="Sichuan Changhong Network Technologies Co., Ltd."/>
+  <mapping code="0x128B" translation="NodOn"/>
+  <mapping code="0x128C" translation="Jiangxi Innotech Technology Co., Ltd."/>
+  <mapping code="0x128D" translation="Mercator Pty Ltd"/>
+  <mapping code="0x128E" translation="Beijing Ruying Tech Limited"/>
+  <mapping code="0x128F" translation="EGLO Leuchten GmbH"/>
+  <mapping code="0x1290" translation="Pietro Fiorentini S.p.A"/>
+  <mapping code="0x1291" translation="Zehnder Group Vaux-Andigny"/>
+  <mapping code="0x1292" translation="BRK Brands, Inc."/>
+  <mapping code="0x1293" translation="Askey Computer Corp."/>
+  <mapping code="0x1294" translation="PassiveBolt, Inc."/>
+  <mapping code="0x1337" translation="Datek Wireless AS"/>
+  <mapping code="0x1994" translation="Gewiss S.p.A."/>
+  <mapping code="0x2794" translation="Climax Technology Co., Ltd."/>
+</map>

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -30,7 +30,7 @@
         "sample-extensions.xml"
     ],
 
-    "manufacturersXml": "../shared/manufacturers.xml",
+    "manufacturersXml": "manufacturers.xml",
     "options": {
         "text": {
             "defaultResponsePolicy": ["Always", "Conditional", "Never"]


### PR DESCRIPTION
#### Problem

Error message was:
"Default value for: manufacturerCodes/0x1002 does not match an option."

#### Summary of Changes

manufacturers.xml is in a different location in the source tree. Point to the location in third_party/zap/repo/ within zcl.json.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>
