### PR TITLE
Build failure when activating the Thermostat cluster inside ZAP

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -66,6 +66,7 @@ static void OnInt16sAttributeResponse(void * context, int16_t value)
 {{#all_user_cluster_commands}}
 {{#if (isStrEqual clusterName parent.name)}}
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
+{{#if (isStrEndsWith name "Response")}}
 static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}(void * context{{#zcl_command_arguments}}{{#unless (isStrEqual label "status")}}, {{asUnderlyingZclType type}} {{asSymbol label}}{{/unless}}{{/zcl_command_arguments}})
 {
     ChipLogProgress(chipTool, "{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}");
@@ -74,6 +75,7 @@ static void On{{asCamelCased parent.name false}}Cluster{{asCamelCased name false
     command->SetCommandExitStatus(true);
 }
 
+{{/if}}
 {{/if}}
 {{/if}}
 {{/all_user_cluster_commands}}

--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -1054,11 +1054,11 @@ bool emberAfPluginScenesServerParseViewScene(const EmberAfClusterCommand * cmd, 
             emberAfPutInt16uInResp(ZCL_THERMOSTAT_CLUSTER_ID);
             length = &appResponseData[appResponseLength];
             emberAfPutInt8uInResp(0); // temporary length
-            emberAfPutInt16uInResp(entry.occupiedCoolingSetpointValue);
+            emberAfPutInt16sInResp(entry.occupiedCoolingSetpointValue);
             *length += 2;
             if (entry.hasOccupiedHeatingSetpointValue)
             {
-                emberAfPutInt16uInResp(entry.occupiedHeatingSetpointValue);
+                emberAfPutInt16sInResp(entry.occupiedHeatingSetpointValue);
                 *length += 2;
                 if (entry.hasSystemModeValue)
                 {

--- a/src/app/util/message.cpp
+++ b/src/app/util/message.cpp
@@ -177,6 +177,11 @@ uint8_t * emberAfPutDateInResp(EmberAfDate * value)
     }
 }
 
+void emberAfPutInt16sInResp(int16_t value)
+{
+    emberAfPutInt16uInResp(static_cast<uint16_t>(value));
+}
+
 // ------------------------------------
 // Utilities for reading from RAM buffers (reading from incoming message
 // buffer)

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -185,6 +185,7 @@ uint32_t * emberAfPutInt24uInResp(uint32_t value);
 uint8_t * emberAfPutBlockInResp(const uint8_t * data, uint16_t length);
 uint8_t * emberAfPutStringInResp(const uint8_t * buffer);
 uint8_t * emberAfPutDateInResp(EmberAfDate * value);
+void emberAfPutInt16sInResp(int16_t value);
 
 bool emberAfIsThisMyEui64(EmberEUI64 eui64);
 

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -618,6 +618,7 @@ bool emberAfDiscoverCommandsReceivedResponseCallback(ClusterId clusterId, uint16
 {{#all_user_cluster_commands}}
 {{#if (isStrEqual clusterName parent.name)}}
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource name)}}
+{{#if (isStrEndsWith name "Response")}}
 bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}}{{asUnderlyingZclType type}} {{asSymbol label}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}})
 {
     ChipLogProgress(Zcl, "{{asCamelCased name false}}:");
@@ -647,6 +648,7 @@ bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}
     return true;
 }
 
+{{/if}}
 {{/if}}
 {{/if}}
 {{/all_user_cluster_commands}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -361,6 +361,11 @@ function isFirstElement(index)
   return index == 0;
 }
 
+function isStrEndsWith(str, substr)
+{
+  return str.endsWith(substr);
+}
+
 //
 // Module exports
 //
@@ -374,3 +379,4 @@ exports.user_cluster_has_enabled_manufacturer_command = user_cluster_has_enabled
 exports.chip_endpoint_generated_functions             = chip_endpoint_generated_functions
 exports.chip_endpoint_cluster_list                    = chip_endpoint_cluster_list
 exports.isSigned                                      = ChipTypesHelper.isSigned;
+exports.isStrEndsWith                                 = isStrEndsWith;

--- a/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
@@ -51,8 +51,8 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(seqNum, mEndpoint{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}{{/chip_server_cluster_command_arguments}});
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased clusterName false}}Cluster{{asType name}}Command(seqNum, mEndpoint{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}{{/chip_server_cluster_command_arguments}});
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -61,23 +61,23 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
 CHIP_ERROR {{asCamelCased name false}}Cluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encode{{asCamelCased name false}}ClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased name false}}ClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 {{#chip_server_cluster_attributes}}
 CHIP_ERROR {{asCamelCased parent.name false}}Cluster::ReadAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased parent.name false}}ClusterRead{{asCamelCased name false}}Attribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 {{#if (isWritableAttribute)}}
 CHIP_ERROR {{asCamelCased parent.name false}}Cluster::WriteAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, {{asUnderlyingZclType type}} value)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased parent.name false}}ClusterWrite{{asCamelCased name false}}Attribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 {{/if}}
@@ -85,8 +85,8 @@ CHIP_ERROR {{asCamelCased parent.name false}}Cluster::WriteAttribute{{asCamelCas
 CHIP_ERROR {{asCamelCased parent.name false}}Cluster::ConfigureAttribute{{asCamelCased name false}}(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(seqNum, mEndpoint, minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    System::PacketBufferHandle encodedCommand = encode{{asCamelCased parent.name false}}ClusterConfigure{{asCamelCased name false}}Attribute(seqNum, mEndpoint, minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR {{asCamelCased parent.name false}}Cluster::ReportAttribute{{asCamelCased name false}}(Callback::Cancelable * onReportCallback)

--- a/src/controller/CHIPClusters.cpp
+++ b/src/controller/CHIPClusters.cpp
@@ -56,9 +56,9 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeBarrierControlClusterBarrierControlGoToPercentCommand(seqNum, mEndpoint, percentOpen);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -86,9 +86,9 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterBarrierControlStopCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterBarrierControlStopCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -96,48 +96,48 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 CHIP_ERROR BarrierControlCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback,
                                                      Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierMovingState(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterReadBarrierMovingStateAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterReadBarrierMovingStateAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierSafetyStatus(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterReadBarrierSafetyStatusAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierCapabilities(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterReadBarrierCapabilitiesAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BarrierControlCluster::ReadAttributeBarrierPosition(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterReadBarrierPositionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterReadBarrierPositionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BarrierControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBarrierControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBarrierControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // Basic Cluster Commands
@@ -164,9 +164,9 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterMfgSpecificPingCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterMfgSpecificPingCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -193,40 +193,40 @@ CHIP_ERROR BasicCluster::ResetToFactoryDefaults(Callback::Cancelable * onSuccess
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterResetToFactoryDefaultsCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterResetToFactoryDefaultsCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // Basic Cluster Attributes
 CHIP_ERROR BasicCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR BasicCluster::ReadAttributeZclVersion(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterReadZclVersionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterReadZclVersionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BasicCluster::ReadAttributePowerSource(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterReadPowerSourceAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterReadPowerSourceAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR BasicCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBasicClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBasicClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // Binding Cluster Commands
@@ -262,9 +262,10 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBindingClusterBindCommand(seqNum, mEndpoint, nodeId, groupId, endpointId, clusterId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeBindingClusterBindCommand(seqNum, mEndpoint, nodeId, groupId, endpointId, clusterId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -302,25 +303,25 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeBindingClusterUnbindCommand(seqNum, mEndpoint, nodeId, groupId, endpointId, clusterId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // Binding Cluster Attributes
 CHIP_ERROR BindingCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBindingClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBindingClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR BindingCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeBindingClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeBindingClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // ColorControl Cluster Commands
@@ -357,9 +358,9 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterMoveColorCommand(seqNum, mEndpoint, rateX, rateY, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -401,10 +402,10 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterMoveColorTemperatureCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterMoveColorTemperatureCommand(
         seqNum, mEndpoint, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -441,9 +442,9 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterMoveHueCommand(seqNum, mEndpoint, moveMode, rate, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -480,9 +481,9 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterMoveSaturationCommand(seqNum, mEndpoint, moveMode, rate, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -521,10 +522,10 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterMoveToColorCommand(seqNum, mEndpoint, colorX, colorY,
-                                                                                     transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterMoveToColorCommand(
+        seqNum, mEndpoint, colorX, colorY, transitionTime, optionsMask, optionsOverride);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -561,10 +562,10 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterMoveToColorTemperatureCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterMoveToColorTemperatureCommand(
         seqNum, mEndpoint, colorTemperature, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -604,9 +605,9 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterMoveToHueCommand(seqNum, mEndpoint, hue, direction, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -645,10 +646,10 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterMoveToHueAndSaturationCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterMoveToHueAndSaturationCommand(
         seqNum, mEndpoint, hue, saturation, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -685,10 +686,10 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterMoveToSaturationCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterMoveToSaturationCommand(
         seqNum, mEndpoint, saturation, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -728,9 +729,9 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterStepColorCommand(seqNum, mEndpoint, stepX, stepY, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -774,11 +775,11 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterStepColorTemperatureCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterStepColorTemperatureCommand(
         seqNum, mEndpoint, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask,
         optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -817,10 +818,10 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterStepHueCommand(seqNum, mEndpoint, stepMode, stepSize,
-                                                                                 transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterStepHueCommand(
+        seqNum, mEndpoint, stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -859,10 +860,10 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterStepSaturationCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterStepSaturationCommand(
         seqNum, mEndpoint, stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -895,9 +896,9 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterStopMoveStepCommand(seqNum, mEndpoint, optionsMask, optionsOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -905,16 +906,16 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
 CHIP_ERROR ColorControlCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR ColorControlCluster::ReadAttributeCurrentHue(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCurrentHueAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadCurrentHueAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentHue(Callback::Cancelable * onSuccessCallback,
@@ -922,9 +923,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentHue(Callback::Cancelabl
                                                              uint16_t maxInterval, uint8_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterConfigureCurrentHueAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentHue(Callback::Cancelable * onReportCallback)
@@ -935,9 +936,9 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentHue(Callback::Cancelable *
 CHIP_ERROR ColorControlCluster::ReadAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCurrentSaturationAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadCurrentSaturationAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentSaturation(Callback::Cancelable * onSuccessCallback,
@@ -945,9 +946,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentSaturation(Callback::Ca
                                                                     uint16_t maxInterval, uint8_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterConfigureCurrentSaturationAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentSaturation(Callback::Cancelable * onReportCallback)
@@ -958,17 +959,17 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentSaturation(Callback::Cance
 CHIP_ERROR ColorControlCluster::ReadAttributeRemainingTime(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadRemainingTimeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadRemainingTimeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeCurrentX(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCurrentXAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadCurrentXAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentX(Callback::Cancelable * onSuccessCallback,
@@ -976,9 +977,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentX(Callback::Cancelable 
                                                            uint16_t maxInterval, uint16_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterConfigureCurrentXAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentX(Callback::Cancelable * onReportCallback)
@@ -989,9 +990,9 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentX(Callback::Cancelable * o
 CHIP_ERROR ColorControlCluster::ReadAttributeCurrentY(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCurrentYAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadCurrentYAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentY(Callback::Cancelable * onSuccessCallback,
@@ -999,9 +1000,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeCurrentY(Callback::Cancelable 
                                                            uint16_t maxInterval, uint16_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterConfigureCurrentYAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeCurrentY(Callback::Cancelable * onReportCallback)
@@ -1012,25 +1013,25 @@ CHIP_ERROR ColorControlCluster::ReportAttributeCurrentY(Callback::Cancelable * o
 CHIP_ERROR ColorControlCluster::ReadAttributeDriftCompensation(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadDriftCompensationAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadDriftCompensationAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeCompensationText(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCompensationTextAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadCompensationTextAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
                                                               Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorTemperatureAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorTemperatureAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ConfigureAttributeColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -1038,9 +1039,9 @@ CHIP_ERROR ColorControlCluster::ConfigureAttributeColorTemperature(Callback::Can
                                                                    uint16_t maxInterval, uint16_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterConfigureColorTemperatureAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReportAttributeColorTemperature(Callback::Cancelable * onReportCallback)
@@ -1051,433 +1052,439 @@ CHIP_ERROR ColorControlCluster::ReportAttributeColorTemperature(Callback::Cancel
 CHIP_ERROR ColorControlCluster::ReadAttributeColorMode(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorModeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorModeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
                                                                  Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorControlOptionsAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorControlOptionsAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorControlOptions(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorControlOptionsAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterWriteColorControlOptionsAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeNumberOfPrimaries(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadNumberOfPrimariesAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadNumberOfPrimariesAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary1X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary1XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary1XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary1Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary1YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary1YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary1Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary1IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary1IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary2X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary2XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary2XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary2Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary2YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary2YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary2Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary2IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary2IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary3X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary3XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary3XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary3Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary3YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary3YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary3Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary3IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary3IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary4X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary4XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary4XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary4Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary4YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary4YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary4Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary4IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary4IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary5X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary5XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary5XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary5Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary5YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary5YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary5Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary5IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary5IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary6X(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary6XAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary6XAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary6Y(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary6YAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary6YAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributePrimary6Intensity(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadPrimary6IntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadPrimary6IntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointX(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadWhitePointXAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadWhitePointXAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeWhitePointX(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteWhitePointXAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteWhitePointXAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadWhitePointYAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadWhitePointYAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeWhitePointY(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteWhitePointYAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteWhitePointYAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointRXAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointRXAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRX(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointRXAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointRXAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointRYAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointRYAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRY(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointRYAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointRYAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointRIntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointRIntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointRIntensity(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointRIntensityAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterWriteColorPointRIntensityAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointGXAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointGXAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGX(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointGXAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointGXAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointGYAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointGYAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGY(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointGYAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointGYAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointGIntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointGIntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointGIntensity(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointGIntensityAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterWriteColorPointGIntensityAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointBXAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointBXAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBX(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointBXAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointBXAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointBYAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointBYAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBY(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointBYAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterWriteColorPointBYAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorPointBIntensityAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorPointBIntensityAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeColorPointBIntensity(Callback::Cancelable * onSuccessCallback,
                                                                    Callback::Cancelable * onFailureCallback, uint8_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterWriteColorPointBIntensityAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterWriteColorPointBIntensityAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeEnhancedCurrentHue(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadEnhancedCurrentHueAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadEnhancedCurrentHueAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeEnhancedColorMode(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadEnhancedColorModeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadEnhancedColorModeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopActive(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorLoopActiveAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorLoopActiveAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopDirection(Callback::Cancelable * onSuccessCallback,
                                                                 Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorLoopDirectionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorLoopDirectionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorLoopTime(Callback::Cancelable * onSuccessCallback,
                                                            Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorLoopTimeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorLoopTimeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorCapabilities(Callback::Cancelable * onSuccessCallback,
                                                                Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorCapabilitiesAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorCapabilitiesAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorTempPhysicalMin(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorTempPhysicalMinAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorTempPhysicalMinAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeColorTempPhysicalMax(Callback::Cancelable * onSuccessCallback,
                                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadColorTempPhysicalMaxAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadColorTempPhysicalMaxAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeCoupleColorTempToLevelMinMireds(Callback::Cancelable * onSuccessCallback,
                                                                              Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterReadCoupleColorTempToLevelMinMiredsAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
                                                                            Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeColorControlClusterReadStartUpColorTemperatureMiredsAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::WriteAttributeStartUpColorTemperatureMireds(Callback::Cancelable * onSuccessCallback,
@@ -1485,17 +1492,17 @@ CHIP_ERROR ColorControlCluster::WriteAttributeStartUpColorTemperatureMireds(Call
                                                                             uint16_t value)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeColorControlClusterWriteStartUpColorTemperatureMiredsAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ColorControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeColorControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeColorControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // DoorLock Cluster Commands
@@ -1522,9 +1529,9 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearAllPinsCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterClearAllPinsCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1551,9 +1558,9 @@ CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearAllRfidsCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterClearAllRfidsCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1583,9 +1590,9 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearHolidayScheduleCommand(seqNum, mEndpoint, scheduleId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterClearHolidayScheduleCommand(seqNum, mEndpoint, scheduleId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1615,9 +1622,9 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearPinCommand(seqNum, mEndpoint, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterClearPinCommand(seqNum, mEndpoint, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1647,9 +1654,9 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearRfidCommand(seqNum, mEndpoint, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterClearRfidCommand(seqNum, mEndpoint, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1681,9 +1688,10 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearWeekdayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterClearWeekdayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1715,9 +1723,10 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterClearYeardayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterClearYeardayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1747,9 +1756,9 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetHolidayScheduleCommand(seqNum, mEndpoint, scheduleId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterGetHolidayScheduleCommand(seqNum, mEndpoint, scheduleId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1779,9 +1788,9 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetLogRecordCommand(seqNum, mEndpoint, logIndex);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterGetLogRecordCommand(seqNum, mEndpoint, logIndex);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1811,9 +1820,9 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetPinCommand(seqNum, mEndpoint, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterGetPinCommand(seqNum, mEndpoint, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1843,9 +1852,9 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetRfidCommand(seqNum, mEndpoint, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterGetRfidCommand(seqNum, mEndpoint, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1875,9 +1884,9 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetUserTypeCommand(seqNum, mEndpoint, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterGetUserTypeCommand(seqNum, mEndpoint, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1909,9 +1918,10 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetWeekdayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterGetWeekdayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1943,9 +1953,10 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterGetYeardayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterGetYeardayScheduleCommand(seqNum, mEndpoint, scheduleId, userId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -1974,9 +1985,9 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterLockDoorCommand(seqNum, mEndpoint, pin);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterLockDoorCommand(seqNum, mEndpoint, pin);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2013,10 +2024,10 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterSetHolidayScheduleCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterSetHolidayScheduleCommand(
         seqNum, mEndpoint, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2052,9 +2063,10 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterSetPinCommand(seqNum, mEndpoint, userId, userStatus, userType, pin);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterSetPinCommand(seqNum, mEndpoint, userId, userStatus, userType, pin);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2090,9 +2102,10 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterSetRfidCommand(seqNum, mEndpoint, userId, userStatus, userType, id);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterSetRfidCommand(seqNum, mEndpoint, userId, userStatus, userType, id);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2124,9 +2137,9 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterSetUserTypeCommand(seqNum, mEndpoint, userId, userType);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterSetUserTypeCommand(seqNum, mEndpoint, userId, userType);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2169,10 +2182,10 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterSetWeekdayScheduleCommand(
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterSetWeekdayScheduleCommand(
         seqNum, mEndpoint, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2209,9 +2222,9 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeDoorLockClusterSetYeardayScheduleCommand(seqNum, mEndpoint, scheduleId, userId, localStartTime, localEndTime);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2241,9 +2254,9 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterUnlockDoorCommand(seqNum, mEndpoint, pin);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterUnlockDoorCommand(seqNum, mEndpoint, pin);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2275,25 +2288,26 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterUnlockWithTimeoutCommand(seqNum, mEndpoint, timeoutInSeconds, pin);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeDoorLockClusterUnlockWithTimeoutCommand(seqNum, mEndpoint, timeoutInSeconds, pin);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // DoorLock Cluster Attributes
 CHIP_ERROR DoorLockCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR DoorLockCluster::ReadAttributeLockState(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterReadLockStateAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterReadLockStateAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR DoorLockCluster::ConfigureAttributeLockState(Callback::Cancelable * onSuccessCallback,
@@ -2301,9 +2315,9 @@ CHIP_ERROR DoorLockCluster::ConfigureAttributeLockState(Callback::Cancelable * o
                                                         uint16_t maxInterval)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeDoorLockClusterConfigureLockStateAttribute(seqNum, mEndpoint, minInterval, maxInterval);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR DoorLockCluster::ReportAttributeLockState(Callback::Cancelable * onReportCallback)
@@ -2314,25 +2328,25 @@ CHIP_ERROR DoorLockCluster::ReportAttributeLockState(Callback::Cancelable * onRe
 CHIP_ERROR DoorLockCluster::ReadAttributeLockType(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterReadLockTypeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterReadLockTypeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR DoorLockCluster::ReadAttributeActuatorEnabled(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterReadActuatorEnabledAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterReadActuatorEnabledAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR DoorLockCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeDoorLockClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeDoorLockClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // Groups Cluster Commands
@@ -2364,9 +2378,9 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterAddGroupCommand(seqNum, mEndpoint, groupId, groupName);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterAddGroupCommand(seqNum, mEndpoint, groupId, groupName);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2398,9 +2412,10 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterAddGroupIfIdentifyingCommand(seqNum, mEndpoint, groupId, groupName);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeGroupsClusterAddGroupIfIdentifyingCommand(seqNum, mEndpoint, groupId, groupName);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2432,9 +2447,10 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterGetGroupMembershipCommand(seqNum, mEndpoint, groupCount, groupList);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeGroupsClusterGetGroupMembershipCommand(seqNum, mEndpoint, groupCount, groupList);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2461,9 +2477,9 @@ CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterRemoveAllGroupsCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterRemoveAllGroupsCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2493,9 +2509,9 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterRemoveGroupCommand(seqNum, mEndpoint, groupId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterRemoveGroupCommand(seqNum, mEndpoint, groupId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2525,95 +2541,95 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterViewGroupCommand(seqNum, mEndpoint, groupId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterViewGroupCommand(seqNum, mEndpoint, groupId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // Groups Cluster Attributes
 CHIP_ERROR GroupsCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR GroupsCluster::ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterReadNameSupportAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterReadNameSupportAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR GroupsCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeGroupsClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeGroupsClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // IasZone Cluster Commands
 // IasZone Cluster Attributes
 CHIP_ERROR IasZoneCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR IasZoneCluster::ReadAttributeZoneState(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadZoneStateAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadZoneStateAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::ReadAttributeZoneType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadZoneTypeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadZoneTypeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::ReadAttributeZoneStatus(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadZoneStatusAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadZoneStatusAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::ReadAttributeIasCieAddress(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadIasCieAddressAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadIasCieAddressAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::WriteAttributeIasCieAddress(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint64_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterWriteIasCieAddressAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterWriteIasCieAddressAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::ReadAttributeZoneId(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadZoneIdAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadZoneIdAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IasZoneCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                         Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIasZoneClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIasZoneClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // Identify Cluster Commands
@@ -2643,9 +2659,9 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterIdentifyCommand(seqNum, mEndpoint, identifyTime);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterIdentifyCommand(seqNum, mEndpoint, identifyTime);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2672,41 +2688,41 @@ CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterIdentifyQueryCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterIdentifyQueryCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // Identify Cluster Attributes
 CHIP_ERROR IdentifyCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR IdentifyCluster::ReadAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterReadIdentifyTimeAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterReadIdentifyTimeAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IdentifyCluster::WriteAttributeIdentifyTime(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback, uint16_t value)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterWriteIdentifyTimeAttribute(seqNum, mEndpoint, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterWriteIdentifyTimeAttribute(seqNum, mEndpoint, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR IdentifyCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                          Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeIdentifyClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeIdentifyClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // LevelControl Cluster Commands
@@ -2743,9 +2759,9 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterMoveCommand(seqNum, mEndpoint, moveMode, rate, optionMask, optionOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2782,9 +2798,9 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterMoveToLevelCommand(seqNum, mEndpoint, level, transitionTime, optionMask, optionOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2818,9 +2834,9 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterMoveToLevelWithOnOffCommand(seqNum, mEndpoint, level, transitionTime);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2852,9 +2868,9 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterMoveWithOnOffCommand(seqNum, mEndpoint, moveMode, rate);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterMoveWithOnOffCommand(seqNum, mEndpoint, moveMode, rate);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2894,9 +2910,9 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterStepCommand(seqNum, mEndpoint, stepMode, stepSize, transitionTime, optionMask, optionOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2931,9 +2947,9 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     return mDevice->SendCommands();
 #else
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterStepWithOnOffCommand(seqNum, mEndpoint, stepMode, stepSize, transitionTime);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2965,9 +2981,9 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterStopCommand(seqNum, mEndpoint, optionMask, optionOverride);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterStopCommand(seqNum, mEndpoint, optionMask, optionOverride);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -2994,9 +3010,9 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterStopWithOnOffCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterStopWithOnOffCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3004,16 +3020,16 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
 CHIP_ERROR LevelControlCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR LevelControlCluster::ReadAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
                                                           Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterReadCurrentLevelAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterReadCurrentLevelAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancelable * onSuccessCallback,
@@ -3021,9 +3037,9 @@ CHIP_ERROR LevelControlCluster::ConfigureAttributeCurrentLevel(Callback::Cancela
                                                                uint16_t maxInterval, uint8_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeLevelControlClusterConfigureCurrentLevelAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable * onReportCallback)
@@ -3034,9 +3050,9 @@ CHIP_ERROR LevelControlCluster::ReportAttributeCurrentLevel(Callback::Cancelable
 CHIP_ERROR LevelControlCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeLevelControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeLevelControlClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // OnOff Cluster Commands
@@ -3063,9 +3079,9 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterOffCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterOffCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3092,9 +3108,9 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterOnCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterOnCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3121,32 +3137,33 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterToggleCommand(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterToggleCommand(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // OnOff Cluster Attributes
 CHIP_ERROR OnOffCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR OnOffCluster::ReadAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterReadOnOffAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterReadOnOffAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ConfigureAttributeOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
                                                  uint16_t minInterval, uint16_t maxInterval)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterConfigureOnOffAttribute(seqNum, mEndpoint, minInterval, maxInterval);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeOnOffClusterConfigureOnOffAttribute(seqNum, mEndpoint, minInterval, maxInterval);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCallback)
@@ -3157,9 +3174,9 @@ CHIP_ERROR OnOffCluster::ReportAttributeOnOff(Callback::Cancelable * onReportCal
 CHIP_ERROR OnOffCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                       Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeOnOffClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeOnOffClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // Scenes Cluster Commands
@@ -3202,10 +3219,10 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterAddSceneCommand(seqNum, mEndpoint, groupId, sceneId, transitionTime,
-                                                                            sceneName, clusterId, length, value);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterAddSceneCommand(
+        seqNum, mEndpoint, groupId, sceneId, transitionTime, sceneName, clusterId, length, value);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3235,9 +3252,9 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterGetSceneMembershipCommand(seqNum, mEndpoint, groupId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterGetSceneMembershipCommand(seqNum, mEndpoint, groupId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3271,9 +3288,10 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterRecallSceneCommand(seqNum, mEndpoint, groupId, sceneId, transitionTime);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand =
+        encodeScenesClusterRecallSceneCommand(seqNum, mEndpoint, groupId, sceneId, transitionTime);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3303,9 +3321,9 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterRemoveAllScenesCommand(seqNum, mEndpoint, groupId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterRemoveAllScenesCommand(seqNum, mEndpoint, groupId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3337,9 +3355,9 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterRemoveSceneCommand(seqNum, mEndpoint, groupId, sceneId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterRemoveSceneCommand(seqNum, mEndpoint, groupId, sceneId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3371,9 +3389,9 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterStoreSceneCommand(seqNum, mEndpoint, groupId, sceneId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterStoreSceneCommand(seqNum, mEndpoint, groupId, sceneId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
@@ -3405,65 +3423,65 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
 
     return mDevice->SendCommands();
 #else
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterViewSceneCommand(seqNum, mEndpoint, groupId, sceneId);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterViewSceneCommand(seqNum, mEndpoint, groupId, sceneId);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 #endif
 }
 
 // Scenes Cluster Attributes
 CHIP_ERROR ScenesCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR ScenesCluster::ReadAttributeSceneCount(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadSceneCountAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadSceneCountAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ScenesCluster::ReadAttributeCurrentScene(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadCurrentSceneAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadCurrentSceneAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ScenesCluster::ReadAttributeCurrentGroup(Callback::Cancelable * onSuccessCallback,
                                                     Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadCurrentGroupAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadCurrentGroupAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ScenesCluster::ReadAttributeSceneValid(Callback::Cancelable * onSuccessCallback,
                                                   Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadSceneValidAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadSceneValidAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ScenesCluster::ReadAttributeNameSupport(Callback::Cancelable * onSuccessCallback,
                                                    Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadNameSupportAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadNameSupportAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR ScenesCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeScenesClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeScenesClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 // TemperatureMeasurement Cluster Commands
@@ -3471,16 +3489,16 @@ CHIP_ERROR ScenesCluster::ReadAttributeClusterRevision(Callback::Cancelable * on
 CHIP_ERROR TemperatureMeasurementCluster::DiscoverAttributes(Callback::Cancelable * onSuccessCallback,
                                                              Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeTemperatureMeasurementClusterDiscoverAttributes(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeTemperatureMeasurementClusterDiscoverAttributes(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                      Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeTemperatureMeasurementClusterReadMeasuredValueAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callback::Cancelable * onSuccessCallback,
@@ -3489,9 +3507,9 @@ CHIP_ERROR TemperatureMeasurementCluster::ConfigureAttributeMeasuredValue(Callba
                                                                           int16_t change)
 {
     uint8_t seqNum = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload =
+    System::PacketBufferHandle encodedCommand =
         encodeTemperatureMeasurementClusterConfigureMeasuredValueAttribute(seqNum, mEndpoint, minInterval, maxInterval, change);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback::Cancelable * onReportCallback)
@@ -3502,25 +3520,25 @@ CHIP_ERROR TemperatureMeasurementCluster::ReportAttributeMeasuredValue(Callback:
 CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMinMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeTemperatureMeasurementClusterReadMinMeasuredValueAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeMaxMeasuredValue(Callback::Cancelable * onSuccessCallback,
                                                                         Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeTemperatureMeasurementClusterReadMaxMeasuredValueAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 CHIP_ERROR TemperatureMeasurementCluster::ReadAttributeClusterRevision(Callback::Cancelable * onSuccessCallback,
                                                                        Callback::Cancelable * onFailureCallback)
 {
-    uint8_t seqNum                     = mDevice->GetNextSequenceNumber();
-    System::PacketBufferHandle payload = encodeTemperatureMeasurementClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
-    return SendCommand(seqNum, std::move(payload), onSuccessCallback, onFailureCallback);
+    uint8_t seqNum                            = mDevice->GetNextSequenceNumber();
+    System::PacketBufferHandle encodedCommand = encodeTemperatureMeasurementClusterReadClusterRevisionAttribute(seqNum, mEndpoint);
+    return SendCommand(seqNum, std::move(encodedCommand), onSuccessCallback, onFailureCallback);
 }
 
 } // namespace Controller


### PR DESCRIPTION
 #### Problem
Enabling the thermostat cluster in ZAP results in build failure. I would have expected linking issues, but not build failures.
It fails to build because of 2 reasons:
 1. There is an conversion caught by `-Wconversion`
 2. There is a name conflict between one of the thermostat command argument and the code generated by ZAP 

 #### Summary of Changes
 * Fix the conversion issue. The core tries to store an `int16_t' as a `uint16_t`. This is OK I guess
 * Change `payload` to `encodedCommand` inside the templates to generate the cpp API