### PR TITLE
Fix macOS Framework build failures

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -80,17 +80,17 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
         }
 
         _cppCommissioner = new chip::Controller::DeviceCommissioner();
-        if ([self checkForInitError:(_cppCommissioner) logMsg:kErrorCommissionerCreate]) {
+        if ([self checkForInitError:(_cppCommissioner != nullptr) logMsg:kErrorCommissionerCreate]) {
             return nil;
         }
 
         _pairingDelegateBridge = new CHIPDevicePairingDelegateBridge();
-        if ([self checkForInitError:(_pairingDelegateBridge) logMsg:kErrorPairingInit]) {
+        if ([self checkForInitError:(_pairingDelegateBridge != nullptr) logMsg:kErrorPairingInit]) {
             return nil;
         }
 
         _persistentStorageDelegateBridge = new CHIPPersistentStorageDelegateBridge();
-        if ([self checkForInitError:(_persistentStorageDelegateBridge) logMsg:kErrorPersistentStorageInit]) {
+        if ([self checkForInitError:(_persistentStorageDelegateBridge != nullptr) logMsg:kErrorPersistentStorageInit]) {
             return nil;
         }
 
@@ -100,7 +100,7 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
         }
 
         _chipSelectQueue = dispatch_queue_create(CHIP_SELECT_QUEUE, DISPATCH_QUEUE_SERIAL);
-        if ([self checkForInitError:(_chipSelectQueue) logMsg:kErrorNetworkDispatchQueueInit]) {
+        if ([self checkForInitError:(_chipSelectQueue != nil) logMsg:kErrorNetworkDispatchQueueInit]) {
             return nil;
         }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The CHIPFramework fails to build on MacOS with errors while compiling `CHIPDeviceController.mm`. 

A couple of examples:
```
Cannot initialize a parameter of type 'BOOL' (aka 'signed char') with an lvalue of type 'CHIPPersistentStorageDelegateBridge *'

Cannot initialize a parameter of type 'BOOL' (aka 'signed char') with an lvalue of type '__strong dispatch_queue_t' (aka 'NSObject<OS_dispatch_queue> *__strong')
```
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Passing in pointers to a function that expects a Boolean doesn't "just work" on macOS. 
Fixed up the calls to the function in question to ensure the value being passed in is indeed a `BOOL`.
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
