### PR TITLE
Be more consistent about construction/destruction of ChipCertificateData

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -121,6 +121,7 @@ void ChipCertificateSet::Release()
     {
         if (mCerts != nullptr)
         {
+            Clear();
             chip::Platform::MemoryFree(mCerts);
             mCerts = nullptr;
         }
@@ -136,7 +137,7 @@ void ChipCertificateSet::Clear()
 {
     for (int i = 0; i < mCertCount; i++)
     {
-        mCerts[i].Clear();
+        mCerts[i].~ChipCertificateData();
     }
 
     mCertCount = 0;
@@ -240,7 +241,7 @@ exit:
     {
         if (cert != nullptr)
         {
-            cert->Clear();
+            cert->~ChipCertificateData();
         }
     }
 
@@ -316,7 +317,7 @@ exit:
     {
         for (uint8_t i = initialCertCount; i < mCertCount; i++)
         {
-            mCerts[i].Clear();
+            mCerts[i].~ChipCertificateData();
         }
         mCertCount = initialCertCount;
     }
@@ -629,7 +630,10 @@ ChipCertificateData::ChipCertificateData()
     Clear();
 }
 
-ChipCertificateData::~ChipCertificateData() {}
+ChipCertificateData::~ChipCertificateData()
+{
+    Clear();
+}
 
 void ChipCertificateData::Clear()
 {

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -498,7 +498,13 @@ public:
 
 private:
     ChipCertificateData * mCerts; /**< Pointer to an array of certificate data. */
-    uint8_t mCertCount;           /**< Number of certificates in mCerts array. */
+    uint8_t mCertCount;           /**< Number of certificates in mCerts
+                                     array. We maintain the invariant that all
+                                     the slots at indices less than
+                                     mCertCount have been constructed and slots
+                                     at indices >= mCertCount have either never
+                                     had their constructor called, or have had
+                                     their destructor called since then. */
     uint8_t mMaxCerts;            /**< Length of mCerts array. */
     uint8_t * mDecodeBuf;         /**< Certificate decode buffer. */
     uint16_t mDecodeBufSize;      /**< Certificate decode buffer size. */


### PR DESCRIPTION
We are mixing placement new with Clear() calls and no destructor
calls, and in some cases (ChipCertificateSet::Release) doing neither
clearing nor destruction.  Instead, try to consistently use
~ChipCertificateData when we are no longer keeping track of the
relevant object.

The addition of `Clear()` in `~ChipCertificateData` is both to match
existing behavior and on the assumption that we don't want that data
lying around in memory if not needed.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
See commit message.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
See commit message.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/4688

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
