### PR TITLE
Remove dead (uncompilable) code from python script bindings

### DIFF
--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -212,7 +212,7 @@ class ChipStack(object):
             moduleName = ChipUtility.CStringToString(moduleName)
             message = ChipUtility.CStringToString(message)
             if self.addModulePrefixToLogMessage:
-                message = "CP:%s: %s" % (moduleName, message)
+                message = "CHIP:%s: %s" % (moduleName, message)
             logLevel = LogCategory.categoryToLogLevel(logCat)
             msgAttrs = {
                 "chip-module": moduleName,

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -104,7 +104,7 @@ class ChipLogFormatter(logging.Formatter):
     ):
         fmt = "%(message)s"
         if logModulePrefix:
-            fmt = "WEAVE:%(chip-module)s: " + fmt
+            fmt = "CHIP:%(chip-module)s: " + fmt
         if logLevel:
             fmt = "%(levelname)s:" + fmt
         if datefmt is not None or logTimestamp:
@@ -212,7 +212,7 @@ class ChipStack(object):
             moduleName = ChipUtility.CStringToString(moduleName)
             message = ChipUtility.CStringToString(message)
             if self.addModulePrefixToLogMessage:
-                message = "WEAVE:%s: %s" % (moduleName, message)
+                message = "CP:%s: %s" % (moduleName, message)
             logLevel = LogCategory.categoryToLogLevel(logCat)
             msgAttrs = {
                 "chip-module": moduleName,


### PR DESCRIPTION
 #### Problem
 Weave baseline supports log redirection. CHIP lost that capability (unsure why though) and the python chip bindings that were trying to use such redirection would not even compile.

 #### Summary of Changes
Deletes the logging code, adds a todo to figure out final functionality.

Also replaced some WEAVE with CHIP - although realistically that logging does not currently work.

Long term, I believe log redirection should work in some generic way:
  - python wants to use python logging capability
  - android would want android logging
  - embedded devices likely want to redirect to their own uart/debug areas
  
 Updating this seems a larger task though, so for now I just cleaned it and added a TODO.

