### PR TITLE
Use public virtual methods for BdxMessage

### DIFF
--- a/src/protocols/bdx/BdxMessages.cpp
+++ b/src/protocols/bdx/BdxMessages.cpp
@@ -40,7 +40,7 @@ using namespace chip::Encoding::LittleEndian;
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-BufBound & TransferInit::DerivedWriteToBuffer(BufBound & aBuffer) const
+BufBound & TransferInit::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t proposedTransferCtl = 0;
     bool widerange = (StartOffset > std::numeric_limits<uint32_t>::max()) || (MaxLength > std::numeric_limits<uint32_t>::max());
@@ -94,7 +94,7 @@ BufBound & TransferInit::DerivedWriteToBuffer(BufBound & aBuffer) const
     return aBuffer;
 }
 
-CHIP_ERROR TransferInit::DerivedParse(System::PacketBufferHandle aBuffer)
+CHIP_ERROR TransferInit::Parse(System::PacketBufferHandle aBuffer)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t proposedTransferCtl;
@@ -164,7 +164,7 @@ exit:
     return err;
 }
 
-size_t TransferInit::DerivedMessageSize() const
+size_t TransferInit::MessageSize() const
 {
     BufBound emptyBuf(nullptr, 0);
     return WriteToBuffer(emptyBuf).Needed();
@@ -196,7 +196,7 @@ bool TransferInit::operator==(const TransferInit & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-BufBound & SendAccept::DerivedWriteToBuffer(BufBound & aBuffer) const
+BufBound & SendAccept::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t transferCtl = 0;
 
@@ -213,7 +213,7 @@ BufBound & SendAccept::DerivedWriteToBuffer(BufBound & aBuffer) const
     return aBuffer;
 }
 
-CHIP_ERROR SendAccept::DerivedParse(System::PacketBufferHandle aBuffer)
+CHIP_ERROR SendAccept::Parse(System::PacketBufferHandle aBuffer)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     uint8_t transferCtl = 0;
@@ -247,7 +247,7 @@ exit:
     return err;
 }
 
-size_t SendAccept::DerivedMessageSize() const
+size_t SendAccept::MessageSize() const
 {
     BufBound emptyBuf(nullptr, 0);
     return WriteToBuffer(emptyBuf).Needed();
@@ -272,7 +272,7 @@ bool SendAccept::operator==(const SendAccept & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-BufBound & ReceiveAccept::DerivedWriteToBuffer(BufBound & aBuffer) const
+BufBound & ReceiveAccept::WriteToBuffer(BufBound & aBuffer) const
 {
     uint8_t transferCtl = 0;
     bool widerange      = (StartOffset > std::numeric_limits<uint32_t>::max()) || (Length > std::numeric_limits<uint32_t>::max());
@@ -320,7 +320,7 @@ BufBound & ReceiveAccept::DerivedWriteToBuffer(BufBound & aBuffer) const
     return aBuffer;
 }
 
-CHIP_ERROR ReceiveAccept::DerivedParse(System::PacketBufferHandle aBuffer)
+CHIP_ERROR ReceiveAccept::Parse(System::PacketBufferHandle aBuffer)
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     uint8_t transferCtl     = 0;
@@ -387,7 +387,7 @@ exit:
     return err;
 }
 
-size_t ReceiveAccept::DerivedMessageSize() const
+size_t ReceiveAccept::MessageSize() const
 {
     BufBound emptyBuf(nullptr, 0);
     return WriteToBuffer(emptyBuf).Needed();
@@ -413,19 +413,19 @@ bool ReceiveAccept::operator==(const ReceiveAccept & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-BufBound & CounterMessage::DerivedWriteToBuffer(BufBound & aBuffer) const
+BufBound & CounterMessage::WriteToBuffer(BufBound & aBuffer) const
 {
     return aBuffer.Put32(BlockCounter);
 }
 
-CHIP_ERROR CounterMessage::DerivedParse(System::PacketBufferHandle aBuffer)
+CHIP_ERROR CounterMessage::Parse(System::PacketBufferHandle aBuffer)
 {
     uint8_t * bufStart = aBuffer->Start();
     Reader bufReader(bufStart, aBuffer->DataLength());
     return bufReader.Read32(&BlockCounter).StatusCode();
 }
 
-size_t CounterMessage::DerivedMessageSize() const
+size_t CounterMessage::MessageSize() const
 {
     BufBound emptyBuf(nullptr, 0);
     return WriteToBuffer(emptyBuf).Needed();
@@ -438,7 +438,7 @@ bool CounterMessage::operator==(const CounterMessage & another) const
 
 // WARNING: this function should never return early, since MessageSize() relies on it to calculate
 // the size of the message (even if the message is incomplete or filled out incorrectly).
-BufBound & DataBlock::DerivedWriteToBuffer(BufBound & aBuffer) const
+BufBound & DataBlock::WriteToBuffer(BufBound & aBuffer) const
 {
     aBuffer.Put32(BlockCounter);
     if (Data != nullptr)
@@ -448,7 +448,7 @@ BufBound & DataBlock::DerivedWriteToBuffer(BufBound & aBuffer) const
     return aBuffer;
 }
 
-CHIP_ERROR DataBlock::DerivedParse(System::PacketBufferHandle aBuffer)
+CHIP_ERROR DataBlock::Parse(System::PacketBufferHandle aBuffer)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
     uint8_t * bufStart = aBuffer->Start();
@@ -476,7 +476,7 @@ exit:
     return err;
 }
 
-size_t DataBlock::DerivedMessageSize() const
+size_t DataBlock::MessageSize() const
 {
     BufBound emptyBuf(nullptr, 0);
     return WriteToBuffer(emptyBuf).Needed();

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -98,7 +98,7 @@ struct BdxMessage
      * @return CHIP_ERROR Return an error if the message format is invalid and/or can't be parsed
      */
     CHECK_RETURN_VALUE
-    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) { return DerivedParse(std::move(aBuffer)); }
+    virtual CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) = 0;
 
     /**
      * @brief
@@ -111,20 +111,15 @@ struct BdxMessage
      *
      * @param aBuffer A BufBound object that will be used to write the message
      */
-    BufBound & WriteToBuffer(BufBound & aBuffer) const { return DerivedWriteToBuffer(aBuffer); }
+    virtual BufBound & WriteToBuffer(BufBound & aBuffer) const = 0;
 
     /**
      * @brief
      *  Returns the size of buffer needed to write the message.
      */
-    virtual size_t MessageSize() const { return DerivedMessageSize(); }
+    virtual size_t MessageSize() const = 0;
 
     virtual ~BdxMessage() = default;
-
-private:
-    virtual CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) = 0;
-    virtual BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const   = 0;
-    virtual size_t DerivedMessageSize() const                           = 0;
 };
 
 /*
@@ -159,10 +154,9 @@ struct TransferInit : public BdxMessage
     // Retain ownership of the packet buffer so that the FileDesignator and Metadata pointers remain valid.
     System::PacketBufferHandle Buffer;
 
-private:
-    CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) override;
-    BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const override;
-    size_t DerivedMessageSize() const override;
+    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) override;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const override;
+    size_t MessageSize() const override;
 };
 
 using SendInit    = TransferInit;
@@ -194,10 +188,9 @@ struct SendAccept : public BdxMessage
     // Retain ownership of the packet buffer so that the FileDesignator and Metadata pointers remain valid.
     System::PacketBufferHandle Buffer;
 
-private:
-    CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) override;
-    BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const override;
-    size_t DerivedMessageSize() const override;
+    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) override;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const override;
+    size_t MessageSize() const override;
 };
 
 /**
@@ -229,10 +222,9 @@ struct ReceiveAccept : public BdxMessage
     // Retain ownership of the packet buffer so that the FileDesignator and Metadata pointers remain valid.
     System::PacketBufferHandle Buffer;
 
-private:
-    CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) override;
-    BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const override;
-    size_t DerivedMessageSize() const override;
+    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) override;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const override;
+    size_t MessageSize() const override;
 };
 
 /**
@@ -249,10 +241,9 @@ struct CounterMessage : public BdxMessage
 
     uint32_t BlockCounter = 0;
 
-private:
-    CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) override;
-    BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const override;
-    size_t DerivedMessageSize() const override;
+    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) override;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const override;
+    size_t MessageSize() const override;
 };
 
 using BlockQuery  = CounterMessage;
@@ -280,10 +271,9 @@ struct DataBlock : public BdxMessage
     // Retain ownership of the packet buffer so that the FileDesignator and Metadata pointers remain valid.
     System::PacketBufferHandle Buffer;
 
-private:
-    CHIP_ERROR DerivedParse(System::PacketBufferHandle aBuffer) override;
-    BufBound & DerivedWriteToBuffer(BufBound & aBuffer) const override;
-    size_t DerivedMessageSize() const override;
+    CHIP_ERROR Parse(System::PacketBufferHandle aBuffer) override;
+    BufBound & WriteToBuffer(BufBound & aBuffer) const override;
+    size_t MessageSize() const override;
 };
 
 using Block    = DataBlock;


### PR DESCRIPTION
Follow up to https://github.com/project-chip/connectedhomeip/pull/4473#pullrequestreview-584429687 

#### Problem
Splitting the methods in BdxMessage into public non-virtual and private virtual methods is an unnecessary complication, since the derived BdxMessage structs don't need that level of custimization. 

 #### Summary of Changes
Remove additional private virtual methods, make public methods pure-virtual