### PR TITLE
Remove unused parameters ssid and passphrase from chiptool "pairing softap" command

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -50,8 +50,6 @@ public:
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
         case PairingMode::SoftAP:
-            AddArgument("ssid", &mSSID);
-            AddArgument("password", &mPassword);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);

--- a/src/test_driver/linux-cirque/test-on-off-cluster.py
+++ b/src/test_driver/linux-cirque/test-on-off-cluster.py
@@ -83,7 +83,7 @@ class TestOnOffCluster(CHIPVirtualHome):
 
         for ip in server_ip_address:
             ret = self.execute_device_cmd(
-                tool_device_id, "chip-tool pairing softap ssid_not_used passwd_not_used {} {} {} {}".format(SETUPPINCODE, DISCRIMINATOR, ip, CHIP_PORT))
+                tool_device_id, "chip-tool pairing softap {} {} {} {}".format(SETUPPINCODE, DISCRIMINATOR, ip, CHIP_PORT))
             self.assertEqual(ret['return_code'], '0', "{} command failure: {}".format(
                 "pairing softap", ret['output']))
 


### PR DESCRIPTION

 #### Problem
Pairing using SoftAP does not use the network credentials but still it takes the input.

 #### Summary of Changes
Removed the ssid and passphrase parameters from `pairing softap` CLI

Tests done: 
i. Tested that the help command for softAP now does not show the ssid and passphrase.
ii. Tested pairing using softap with the new format is successful.

Note: Pairing over BLE still uses the network credentials and hence it is not removed.

Fixes #4680 