### PR TITLE
BufferWriter revisions

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -969,7 +969,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output)
 
     {
         size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
-        Encoding::LittleEndian::BufferWriter bbuf(output, len);
+        Encoding::BufferWriter bbuf(output, len);
         bbuf.Put(mPublicKey, mPublicKey.Length());
         bbuf.Put(privkey, sizeof(privkey));
         VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
@@ -984,7 +984,7 @@ exit:
 
 CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 {
-    Encoding::LittleEndian::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
+    Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
 
     BIGNUM * pvt_key     = nullptr;
     EC_GROUP * group     = nullptr;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -641,7 +641,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output)
 {
     const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
     size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
-    Encoding::LittleEndian::BufferWriter bbuf(output, len);
+    Encoding::BufferWriter bbuf(output, len);
     uint8_t privkey[kP256_PrivateKey_Length];
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -667,7 +667,7 @@ exit:
 
 CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 {
-    Encoding::LittleEndian::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
+    Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
 
     int result       = 0;
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2020-2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ static_library("support") {
     "BitFlags.h",
     "BufferReader.cpp",
     "BufferReader.h",
+    "BufferWriter.cpp",
     "BufferWriter.h",
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",

--- a/src/lib/support/BufferWriter.cpp
+++ b/src/lib/support/BufferWriter.cpp
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "BufferWriter.h"
+
+namespace chip {
+namespace Encoding {
+
+BufferWriter & BufferWriter::Put(const char * s)
+{
+    static_assert(CHAR_BIT == 8, "We're assuming char and uint8_t are the same size");
+    while (*s != 0)
+    {
+        Put(static_cast<uint8_t>(*s++));
+    }
+    return *this;
+}
+
+BufferWriter & BufferWriter::Put(const void * buf, size_t len)
+{
+    size_t available = Available();
+
+    if (available > 0)
+    {
+        memmove(mBuf + mNeeded, buf, available < len ? available : len);
+    }
+
+    mNeeded += len;
+    return *this;
+}
+
+BufferWriter & BufferWriter::Put(uint8_t c)
+{
+    if (mNeeded < mSize)
+    {
+        mBuf[mNeeded] = c;
+    }
+    ++mNeeded;
+    return *this;
+}
+
+LittleEndian::BufferWriter & LittleEndian::BufferWriter::EndianPut(uint64_t x, size_t size)
+{
+    while (size-- > 0)
+    {
+        uint8_t c = x & 0xff;
+        Put(c);
+        x >>= 8;
+    }
+    return *this;
+}
+
+BigEndian::BufferWriter & BigEndian::BufferWriter::EndianPut(uint64_t x, size_t size)
+{
+    while (size-- > 0)
+    {
+        uint8_t c = (x >> (size * 8)) & 0xff;
+        Put(c);
+    }
+    return *this;
+}
+
+} // namespace Encoding
+} // namespace chip

--- a/src/lib/support/BufferWriter.h
+++ b/src/lib/support/BufferWriter.h
@@ -24,60 +24,27 @@
 namespace chip {
 namespace Encoding {
 
-template <class Derived>
-class BufferWriterBase
+class BufferWriter
 {
 public:
+    BufferWriter(uint8_t * buf, size_t len) : mBuf(buf), mSize(len), mNeeded(0) {}
+    BufferWriter(const BufferWriter & other) = default;
+    BufferWriter & operator=(const BufferWriter & other) = default;
+
     /// Append a null terminated string, exclude the null terminator
-    /// This does NOT care about endianess
-    Derived & Put(const char * s)
-    {
-        static_assert(CHAR_BIT == 8, "We're assuming char and uint8_t are the same size");
-        while (*s != 0)
-        {
-            Put8(static_cast<uint8_t>(*s++));
-        }
-        return *static_cast<Derived *>(this);
-    }
+    BufferWriter & Put(const char * s);
 
     /// Raw append a buffer, regardless of endianess
-    Derived & Put(const void * buf, size_t len)
-    {
-        size_t available = Available();
-
-        if (available > 0)
-        {
-            memmove(mBuf + mNeeded, buf, available < len ? available : len);
-        }
-
-        mNeeded += len;
-
-        return *static_cast<Derived *>(this);
-    }
-
-    Derived & Skip(size_t len)
-    {
-        mNeeded += len;
-        return *static_cast<Derived *>(this);
-    }
+    BufferWriter & Put(const void * buf, size_t len);
 
     /// Append a single byte
-    Derived & Put(uint8_t c)
+    BufferWriter & Put(uint8_t c);
+
+    BufferWriter & Skip(size_t len)
     {
-        if (mNeeded < mSize)
-        {
-            mBuf[mNeeded] = c;
-        }
-        ++mNeeded;
-        return *static_cast<Derived *>(this);
+        mNeeded += len;
+        return *this;
     }
-
-    // write an integer into a buffer, in an endian specific way
-
-    Derived & Put8(uint8_t c) { return static_cast<Derived *>(this)->Put(c); }
-    Derived & Put16(uint16_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
-    Derived & Put32(uint32_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
-    Derived & Put64(uint64_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
 
     /// Number of bytes required to satisfy all calls to Put() so far
     size_t Needed() const { return mNeeded; }
@@ -106,58 +73,57 @@ public:
     const uint8_t * Buffer() const { return mBuf; }
 
 protected:
-    friend Derived;
-
     uint8_t * mBuf;
     size_t mSize;
     size_t mNeeded;
+};
 
-    BufferWriterBase(uint8_t * buf, size_t len) : mBuf(buf), mSize(len), mNeeded(0) {}
-    BufferWriterBase(const BufferWriterBase & other) = default;
-    BufferWriterBase & operator=(const BufferWriterBase & other) = default;
+template <class Derived>
+class EndianBufferWriterBase : public BufferWriter
+{
+public:
+    // typed BufferWriter forwards
+
+    Derived & Put(const char * s) { return static_cast<Derived &>(BufferWriter::Put(s)); }
+    Derived & Put(const void * buf, size_t len) { return static_cast<Derived &>(BufferWriter::Put(buf, len)); }
+    Derived & Put(uint8_t c) { return static_cast<Derived &>(BufferWriter::Put(c)); }
+    Derived & Skip(size_t len) { return static_cast<Derived &>(BufferWriter::Skip(len)); }
+
+    // write an integer into a buffer, in an endian specific way
+
+    Derived & Put8(uint8_t c) { return static_cast<Derived *>(this)->Put(c); }
+    Derived & Put16(uint16_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
+    Derived & Put32(uint32_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
+    Derived & Put64(uint64_t x) { return static_cast<Derived *>(this)->EndianPut(x, sizeof(x)); }
+
+protected:
+    EndianBufferWriterBase(uint8_t * buf, size_t len) : BufferWriter(buf, len) {}
+    EndianBufferWriterBase(const EndianBufferWriterBase & other) = default;
+    EndianBufferWriterBase & operator=(const EndianBufferWriterBase & other) = default;
 };
 
 namespace LittleEndian {
 
-class BufferWriter : public BufferWriterBase<BufferWriter>
+class BufferWriter : public EndianBufferWriterBase<BufferWriter>
 {
 public:
-    BufferWriter(uint8_t * buf, size_t len) : BufferWriterBase<BufferWriter>(buf, len) {}
+    BufferWriter(uint8_t * buf, size_t len) : EndianBufferWriterBase<BufferWriter>(buf, len) {}
     BufferWriter(const BufferWriter & other) = default;
     BufferWriter & operator=(const BufferWriter & other) = default;
-
-    BufferWriter & EndianPut(uint64_t x, size_t size)
-    {
-        while (size-- > 0)
-        {
-            uint8_t c = x & 0xff;
-            Put(c);
-            x >>= 8;
-        }
-        return *this;
-    }
+    BufferWriter & EndianPut(uint64_t x, size_t size);
 };
 
 } // namespace LittleEndian
 
 namespace BigEndian {
 
-class BufferWriter : public BufferWriterBase<BufferWriter>
+class BufferWriter : public EndianBufferWriterBase<BufferWriter>
 {
 public:
-    BufferWriter(uint8_t * buf, size_t len) : BufferWriterBase<BufferWriter>(buf, len) {}
+    BufferWriter(uint8_t * buf, size_t len) : EndianBufferWriterBase<BufferWriter>(buf, len) {}
     BufferWriter(const BufferWriter & other) = default;
     BufferWriter & operator=(const BufferWriter & other) = default;
-
-    BufferWriter & EndianPut(uint64_t x, size_t size)
-    {
-        while (size-- > 0)
-        {
-            uint8_t c = (x >> (size * 8)) & 0xff;
-            Put(c);
-        }
-        return *this;
-    }
+    BufferWriter & EndianPut(uint64_t x, size_t size);
 };
 
 } // namespace BigEndian

--- a/src/lib/support/StringBuilder.h
+++ b/src/lib/support/StringBuilder.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public:
     const char * c_str() const { return reinterpret_cast<const char *>(mWriter.Buffer()); }
 
 private:
-    Encoding::LittleEndian::BufferWriter mWriter;
+    Encoding::BufferWriter mWriter;
 
     void NullTerminate()
     {

--- a/src/lib/support/tests/TestBufferWriter.cpp
+++ b/src/lib/support/tests/TestBufferWriter.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -80,6 +80,17 @@ using namespace chip::Encoding;
 void TestStringWrite(nlTestSuite * inSuite, void * inContext)
 {
     {
+        BWTest<BufferWriter> bb(2);
+        bb.Put("hi");
+        NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
+    }
+    {
+        BWTest<BufferWriter> bb(1);
+        bb.Put("hi");
+        NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
+    }
+
+    {
         BWTest<LittleEndian::BufferWriter> bb(2);
         bb.Put("hi");
         NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
@@ -104,6 +115,17 @@ void TestStringWrite(nlTestSuite * inSuite, void * inContext)
 
 void TestBufferWrite(nlTestSuite * inSuite, void * inContext)
 {
+    {
+        BWTest<BufferWriter> bb(2);
+        bb.Put("hithere", 2);
+        NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
+    }
+    {
+        BWTest<BufferWriter> bb(1);
+        bb.Put("hithere", 2);
+        NL_TEST_ASSERT(inSuite, bb.expect("hi", 2, 0));
+    }
+
     {
         BWTest<LittleEndian::BufferWriter> bb(2);
         bb.Put("hithere", 2);

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -25,7 +25,7 @@ constexpr size_t kStatusReportMinSize = 2 + 4 + 2; ///< 16 bits for GeneralCode,
 CHIP_ERROR WriteToPacketBuffer(const ::chip::bdx::BdxMessage & msgStruct, ::chip::System::PacketBufferHandle & msgBuf)
 {
     size_t msgDataSize = msgStruct.MessageSize();
-    ::chip::System::PacketBufferWriter bbuf(msgDataSize);
+    ::chip::Encoding::LittleEndian::PacketBufferWriter bbuf(msgDataSize);
     if (bbuf.IsNull())
     {
         return CHIP_ERROR_NO_MEMORY;
@@ -851,7 +851,7 @@ void TransferSession::PrepareStatusReport(StatusCode code)
 {
     mStatusReportData.StatusCode = code;
 
-    System::PacketBufferWriter bbuf(kStatusReportMinSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(kStatusReportMinSize);
     VerifyOrReturn(!bbuf.IsNull());
 
     bbuf.Put16(static_cast<uint16_t>(Protocols::Common::StatusCode::Failure));

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -20,7 +20,7 @@ void TestHelperWrittenAndParsedMatch(nlTestSuite * inSuite, void * inContext, Ms
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     size_t msgSize = testMsg.MessageSize();
-    System::PacketBufferWriter bbuf(msgSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(msgSize);
     NL_TEST_ASSERT(inSuite, !bbuf.IsNull());
 
     testMsg.WriteToBuffer(bbuf);

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -598,7 +598,8 @@ void PacketBufferHandle::RightSizeForMemoryAlloc()
 
 namespace Encoding {
 
-void PacketBufferWriterUtil::Initialize(BufferWriter & aBufferWriter, System::PacketBufferHandle & aPacket, size_t aAvailableSize, uint16_t aReservedSize)
+void PacketBufferWriterUtil::Initialize(BufferWriter & aBufferWriter, System::PacketBufferHandle & aPacket, size_t aAvailableSize,
+                                        uint16_t aReservedSize)
 {
     aPacket = System::PacketBufferHandle::New(aAvailableSize, aReservedSize);
     if (!aPacket.IsNull())

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -598,29 +598,29 @@ void PacketBufferHandle::RightSizeForMemoryAlloc()
 
 namespace Encoding {
 
-PacketBufferWriterImpl::PacketBufferWriterImpl(size_t aAvailableSize, uint16_t aReservedSize, BufferWriter & aBufferWriter)
+void PacketBufferWriterUtil::Initialize(BufferWriter & aBufferWriter, System::PacketBufferHandle & aPacket, size_t aAvailableSize, uint16_t aReservedSize)
 {
-    mPacket = System::PacketBufferHandle::New(aAvailableSize, aReservedSize);
-    if (!mPacket.IsNull())
+    aPacket = System::PacketBufferHandle::New(aAvailableSize, aReservedSize);
+    if (!aPacket.IsNull())
     {
-        aBufferWriter = Encoding::BufferWriter(mPacket->Start(), aAvailableSize);
+        aBufferWriter = Encoding::BufferWriter(aPacket->Start(), aAvailableSize);
     }
 }
 
-System::PacketBufferHandle PacketBufferWriterImpl::Finalize(BufferWriter & aBufferWriter)
+System::PacketBufferHandle PacketBufferWriterUtil::Finalize(BufferWriter & aBufferWriter, System::PacketBufferHandle & aPacket)
 {
-    if (!mPacket.IsNull() && aBufferWriter.Fit())
+    if (!aPacket.IsNull() && aBufferWriter.Fit())
     {
         // Since mPacket was successfully allocated to hold the maximum length,
         // we know that the actual length fits in a uint16_t.
-        mPacket->SetDataLength(static_cast<uint16_t>(aBufferWriter.Needed()));
+        aPacket->SetDataLength(static_cast<uint16_t>(aBufferWriter.Needed()));
     }
     else
     {
-        mPacket = nullptr;
+        aPacket = nullptr;
     }
     aBufferWriter = Encoding::BufferWriter(nullptr, 0);
-    return std::move(mPacket);
+    return std::move(aPacket);
 }
 
 } // namespace Encoding

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -53,9 +53,9 @@
 #endif // (LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 1)
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
+using ::chip::Encoding::PacketBufferWriter;
 using ::chip::System::PacketBuffer;
 using ::chip::System::PacketBufferHandle;
-using ::chip::System::PacketBufferWriter;
 
 #if !CHIP_SYSTEM_CONFIG_USE_LWIP
 using ::chip::System::pbuf;

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -229,7 +229,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     const size_t bufferSize = EncodedStringSize(ssid) + EncodedStringSize(passwd);
     VerifyOrExit(CanCastTo<uint16_t>(bufferSize), err = CHIP_ERROR_INVALID_ARGUMENT);
     {
-        System::PacketBufferWriter bbuf(bufferSize);
+        Encoding::LittleEndian::PacketBufferWriter bbuf(bufferSize);
 
         ChipLogProgress(NetworkProvisioning, "Sending Network Creds. Delegate %p\n", mDelegate);
         VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -263,7 +263,7 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         4;                  // threadData.ThreadChannel, threadData.FieldPresent.ThreadExtendedPANId,
                             // threadData.FieldPresent.ThreadMeshPrefix, threadData.FieldPresent.ThreadPSKc
     /* clang-format on */
-    System::PacketBufferWriter bbuf(credentialSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(credentialSize);
 
     ChipLogProgress(NetworkProvisioning, "Sending Thread Credentials");
     VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -568,7 +568,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const PacketHeader & header, con
     data_len = static_cast<uint16_t>(Y_len + verifier_len);
 
     {
-        System::PacketBufferWriter bbuf(data_len);
+        Encoding::PacketBufferWriter bbuf(data_len);
         VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
         bbuf.Put(&Y[0], Y_len);
         bbuf.Put(verifier, verifier_len);
@@ -624,7 +624,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(const PacketHeader & header, con
     }
 
     {
-        System::PacketBufferWriter bbuf(verifier_len);
+        Encoding::PacketBufferWriter bbuf(verifier_len);
         VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
 
         bbuf.Put(verifier, verifier_len);


### PR DESCRIPTION
#### Problem

Followup from PR #4677 _Remove BufBound_
(commit 2d48e75cae9f019f4b1a99b3f1fd3b06d2fe276f)

#### Summary of Changes

- Revised BufferWriter to add a non-endian version, which only allows
  writing bytes, strings, and blobs.
- Meanwhile, out-lined nontrivial BufferWriter methods to save flash
  (1K+ on current builds).
- Revised PacketBufferWriter to provide the same endianness options.
