### PR TITLE
[nrfconnect] Explicitly configure python to be used by GN

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -201,6 +201,8 @@ else()
     endif()
 endif()
 
+find_package(Python3 REQUIRED)
+
 # ==============================================================================
 # Generate configuration for CHIP GN build system
 # ==============================================================================
@@ -244,7 +246,12 @@ ExternalProject_Add(
     PREFIX                  ${CMAKE_CURRENT_BINARY_DIR}
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
-    CONFIGURE_COMMAND       ${GN_EXECUTABLE} --root=${CHIP_ROOT} --root-target=${GN_ROOT_TARGET} --dotfile=${GN_ROOT_TARGET}/.gn gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
+    CONFIGURE_COMMAND       ${GN_EXECUTABLE}
+                                --root=${CHIP_ROOT}
+                                --root-target=${GN_ROOT_TARGET}
+                                --dotfile=${GN_ROOT_TARGET}/.gn
+                                --script-executable=${Python3_EXECUTABLE}
+                                gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
     BUILD_COMMAND           ninja
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}


### PR DESCRIPTION
 #### Problem
GN needs python to run various helper scripts used during the build process. On different operating systems `python` name, which GN defaults to, may point to either python2 or python3 or it may not exist at all. On Windows, on the other hand, python 3 is distributed as python.exe executable, so `python3` name also could not be used for that purpose.

 #### Summary of Changes
Use more portable way to find python 3 in the system and pass the path to GN.
