### PR TITLE
Remove CHIP retain logging

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -168,7 +168,6 @@ LogCategory PersistentStorage::GetLoggingLevel()
             chipLogLevel = kLogCategory_Detail;
         }
     }
-}
 
-return chipLogLevel;
+    return chipLogLevel;
 }

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -167,11 +167,8 @@ LogCategory PersistentStorage::GetLoggingLevel()
         {
             chipLogLevel = kLogCategory_Detail;
         }
-        else if (strcasecmp(value, "retain") == 0)
-        {
-            chipLogLevel = kLogCategory_Retain;
-        }
     }
+}
 
-    return chipLogLevel;
+return chipLogLevel;
 }

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1817,18 +1817,6 @@
 #endif // CHIP_DETAIL_LOGGING
 
 /**
- *  @def CHIP_RETAIN_LOGGING
- *
- *  @brief
- *    If asserted (1), enable logging of all messages in the
- *    chip::Logging::LogCategory::kLogCategory_Retain category.
- *    If not defined by the application, by default CHIP_RETAIN_LOGGING is
- *    remapped to CHIP_PROGRESS_LOGGING
- *
- */
-
-
-/**
  *  @def CHIP_CONFIG_ENABLE_FUNCT_ERROR_LOGGING
  *
  *  @brief

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -261,40 +261,11 @@ extern void SetLogFilter(uint8_t category);
 #define ChipLogDetail(MOD, MSG, ...)
 #endif
 
-#ifndef CHIP_RETAIN_LOGGING
-#define CHIP_RETAIN_LOGGING CHIP_PROGRESS_LOGGING
-#define ChipLogRetain(MOD, MSG, ...) ChipLogProgress(MOD, MSG, ##__VA_ARGS__)
-#endif
-
-#if CHIP_RETAIN_LOGGING
-/**
- * @def ChipLogRetain(MOD, MSG, ...)
- *
- * @brief
- *   Log a chip message for the specified module in the 'Retain'
- *   category. This is used for IE testing.
- *   If the product has not defined CHIP_RETAIN_LOGGING, it defaults to the same as ChipLogProgress
- *
- */
-#ifndef ChipLogRetain
-#define ChipLogRetain(MOD, MSG, ...)                                                                                               \
-    chip::Logging::Log(chip::Logging::kLogModule_##MOD, chip::Logging::kLogCategory_Retain, MSG, ##__VA_ARGS__)
-#endif
-
-#else // #if CHIP_RETAIN_LOGGING
-#ifdef ChipLogRetain
-// This is to ensure that ChipLogRetain is null if
-// the product has defined CHIP_RETAIN_LOGGING to 0 itself
-#undef ChipLogRetain
-#endif
-#define ChipLogRetain(MOD, MSG, ...)
-#endif // #if CHIP_RETAIN_LOGGING
-
-#if CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING || CHIP_RETAIN_LOGGING
+#if CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING
 #define _CHIP_USE_LOGGING 1
 #else
 #define _CHIP_USE_LOGGING 0
-#endif /* CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING || CHIP_RETAIN_LOGGING */
+#endif /* CHIP_ERROR_LOGGING || CHIP_PROGRESS_LOGGING || CHIP_DETAIL_LOGGING */
 
 #if _CHIP_USE_LOGGING
 

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -179,14 +179,7 @@ enum LogCategory
      */
     kLogCategory_Detail = 3,
 
-    /*!<
-     *   Indicates a category of log message that describes information
-     *   needed by IE and QA teams for automated testing.
-     *
-     */
-    kLogCategory_Retain = 4,
-
-    kLogCategory_Max = kLogCategory_Retain
+    kLogCategory_Max = kLogCategory_Detail,
 };
 
 extern void LogV(uint8_t module, uint8_t category, const char * msg, va_list args);

--- a/src/platform/EFR32/Logging.cpp
+++ b/src/platform/EFR32/Logging.cpp
@@ -163,7 +163,6 @@ void LogV(uint8_t module, uint8_t category, const char * aFormat, va_list v)
             strcpy(formattedMsg, LOG_ERROR);
             break;
         case kLogCategory_Progress:
-        case kLogCategory_Retain:
         default:
             strcpy(formattedMsg, LOG_INFO);
             break;

--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -67,7 +67,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
             ESP_LOGE(tag, "%s", formattedMsg);
             break;
         case kLogCategory_Progress:
-        case kLogCategory_Retain:
         default:
             ESP_LOGI(tag, "%s", formattedMsg);
             break;

--- a/src/platform/K32W/Logging.cpp
+++ b/src/platform/K32W/Logging.cpp
@@ -50,7 +50,6 @@ void GetMessageString(char * buf, uint8_t chipCategory, uint8_t otLevelLog)
             memcpy(buf, "[Error]", 7);
             break;
         case kLogCategory_Progress:
-        case kLogCategory_Retain:
         default:
             memcpy(buf, "[Progress]", 10);
             break;

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -641,7 +641,7 @@ void BLEManagerImpl::DriveBLEState(intptr_t arg)
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogRetain(Ble, "Got notification regarding chip connection closure");
+    ChipLogProgress(Ble, "Got notification regarding chip connection closure");
 }
 
 void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -93,7 +93,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
             LOG_ERR("%s", log_strdup(formattedMsg));
             break;
         case kLogCategory_Progress:
-        case kLogCategory_Retain:
         default:
             LOG_INF("%s", log_strdup(formattedMsg));
             break;

--- a/src/platform/qpg6100/Logging.cpp
+++ b/src/platform/qpg6100/Logging.cpp
@@ -76,7 +76,6 @@ void LogV(uint8_t module, uint8_t category, const char * msg, va_list v)
             formattedMsg[prefixLen++] = 'D';
             break;
         case kLogCategory_Progress:
-        case kLogCategory_Retain:
         default:
             formattedMsg[prefixLen++] = 'P';
             break;


### PR DESCRIPTION
 #### Problem
CHIP_RETAIN_LOGS seems to be defined for `IE test` however it is never used.

For testing, it makes more sense to provide log redirection so that the test can capture logs as needed instead of having a completely separate category.

 #### Summary of Changes
Removed retain logs option in preparation of having better log redirection (log redirection is desired for python integration).