### PR TITLE
Move all public API documentation from implementation to header in Re…

### DIFF
--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -65,128 +65,56 @@ void ReliableMessageContext::Release()
     mExchange->Release();
 }
 
-/**
- * Returns whether an acknowledgment will be requested whenever a message is sent.
- */
 bool ReliableMessageContext::AutoRequestAck() const
 {
     return mFlags.Has(Flags::kFlagAutoRequestAck);
 }
 
-/**
- *  Determine whether there is already an acknowledgment pending to be sent
- *  to the peer on this exchange.
- *
- */
 bool ReliableMessageContext::IsAckPending() const
 {
     return mFlags.Has(Flags::kFlagAckPending);
 }
 
-/**
- *  Determine whether peer requested acknowledgment for at least one message
- *  on this exchange.
- *
- *  @return Returns 'true' if acknowledgment requested, else 'false'.
- */
 bool ReliableMessageContext::HasPeerRequestedAck() const
 {
     return mFlags.Has(Flags::kFlagPeerRequestedAck);
 }
 
-/**
- *  Determine whether at least one message has been received
- *  on this exchange from peer.
- *
- *  @return Returns 'true' if message received, else 'false'.
- */
 bool ReliableMessageContext::HasRcvdMsgFromPeer() const
 {
     return mFlags.Has(Flags::kFlagMsgRcvdFromPeer);
 }
 
-/**
- * Set whether an acknowledgment should be requested whenever a message is sent.
- *
- * @param[in] autoReqAck            A Boolean indicating whether or not an
- *                                  acknowledgment should be requested whenever a
- *                                  message is sent.
- */
 void ReliableMessageContext::SetAutoRequestAck(bool autoReqAck)
 {
     mFlags.Set(Flags::kFlagAutoRequestAck, autoReqAck);
 }
 
-/**
- *  Set if a message has been received from the peer
- *  on this exchange.
- *
- *  @param[in]  inMsgRcvdFromPeer  A Boolean indicating whether (true) or not
- *                                 (false) a message has been received
- *                                 from the peer on this exchange context.
- *
- */
 void ReliableMessageContext::SetMsgRcvdFromPeer(bool inMsgRcvdFromPeer)
 {
     mFlags.Set(Flags::kFlagMsgRcvdFromPeer, inMsgRcvdFromPeer);
 }
 
-/**
- *  Set if an acknowledgment needs to be sent back to the peer on this exchange.
- *
- *  @param[in]  inAckPending A Boolean indicating whether (true) or not
- *                          (false) an acknowledgment should be sent back
- *                          in response to a received message.
- *
- */
 void ReliableMessageContext::SetAckPending(bool inAckPending)
 {
     mFlags.Set(Flags::kFlagAckPending, inAckPending);
 }
 
-/**
- *  Set if an acknowledgment was requested in the last message received
- *  on this exchange.
- *
- *  @param[in]  inPeerRequestedAck A Boolean indicating whether (true) or not
- *                                 (false) an acknowledgment was requested
- *                                 in the last received message.
- *
- */
 void ReliableMessageContext::SetPeerRequestedAck(bool inPeerRequestedAck)
 {
     mFlags.Set(Flags::kFlagPeerRequestedAck, inPeerRequestedAck);
 }
 
-/**
- *  Set whether the ChipExchangeManager should not send acknowledgements
- *  for this context.
- *
- *  For internal, debug use only.
- *
- *  @param[in]  inDropAckDebug  A Boolean indicating whether (true) or not
- *                         (false) the acknowledgements should be not
- *                         sent for the exchange.
- *
- */
 void ReliableMessageContext::SetDropAckDebug(bool inDropAckDebug)
 {
     mFlags.Set(Flags::kFlagDropAckDebug, inDropAckDebug);
 }
 
-/**
- *  Determine whether the ChipExchangeManager should not send an
- *  acknowledgement.
- *
- *  For internal, debug use only.
- *
- */
 bool ReliableMessageContext::ShouldDropAckDebug() const
 {
     return mFlags.Has(Flags::kFlagDropAckDebug);
 }
 
-// Flush the pending Ack
 CHIP_ERROR ReliableMessageContext::FlushAcks()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -207,13 +135,6 @@ CHIP_ERROR ReliableMessageContext::FlushAcks()
     return err;
 }
 
-/**
- *  Get the current retransmit timeout. It would be either the initial or
- *  the active retransmit timeout based on whether the ExchangeContext has
- *  an active message exchange going with its peer.
- *
- *  @return the current retransmit time.
- */
 uint64_t ReliableMessageContext::GetCurrentRetransmitTimeoutTick()
 {
     return (HasRcvdMsgFromPeer() ? mConfig.mActiveRetransTimeoutTick : mConfig.mInitialRetransTimeoutTick);
@@ -327,18 +248,6 @@ exit:
     return err;
 }
 
-/**
- *  Send a SecureChannel::StandaloneAck message.
- *
- *  @note  When sent via UDP, the null message is sent *without* requesting an acknowledgment,
- *  even in the case where the auto-request acknowledgment feature has been enabled on the
- *  exchange.
- *
- *  @retval  #CHIP_ERROR_NO_MEMORY   If no available PacketBuffers.
- *  @retval  #CHIP_NO_ERROR          If the method succeeded or the error wasn't critical.
- *  @retval  other                    Another critical error returned by SendMessage().
- *
- */
 CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -63,20 +63,120 @@ public:
     void SetConfig(ReliableMessageProtocolConfig config) { mConfig = config; }
     void SetDelegate(ReliableMessageDelegate * delegate) { mDelegate = delegate; }
 
+    /**
+     * Flush the pending Ack for current exchange.
+     *
+     */
     CHIP_ERROR FlushAcks();
+
+    /**
+     *  Get the current retransmit timeout. It would be either the initial or
+     *  the active retransmit timeout based on whether the ExchangeContext has
+     *  an active message exchange going with its peer.
+     *
+     *  @return the current retransmit time.
+     */
     uint64_t GetCurrentRetransmitTimeoutTick();
 
+    /**
+     *  Send a SecureChannel::StandaloneAck message.
+     *
+     *  @note  When sent via UDP, the null message is sent *without* requesting an acknowledgment,
+     *  even in the case where the auto-request acknowledgment feature has been enabled on the
+     *  exchange.
+     *
+     *  @retval  #CHIP_ERROR_NO_MEMORY   If no available PacketBuffers.
+     *  @retval  #CHIP_NO_ERROR          If the method succeeded or the error wasn't critical.
+     *  @retval  other                    Another critical error returned by SendMessage().
+     */
     CHIP_ERROR SendStandaloneAckMessage();
 
+    /**
+     *  Determine whether an acknowledgment will be requested whenever a message is sent for the exchange.
+     *
+     *  @return Returns 'true' an acknowledgment will be requested whenever a message is sent, else 'false'.
+     */
     bool AutoRequestAck() const;
+
+    /**
+     * Set whether an acknowledgment should be requested whenever a message is sent.
+     *
+     * @param[in] autoReqAck            A Boolean indicating whether or not an
+     *                                  acknowledgment should be requested whenever a
+     *                                  message is sent.
+     */
     void SetAutoRequestAck(bool autoReqAck);
+
+    /**
+     *  Determine whether the ChipExchangeManager should not send an
+     *  acknowledgement.
+     *
+     *  For internal, debug use only.
+     */
     bool ShouldDropAckDebug() const;
+
+    /**
+     *  Set whether the ChipExchangeManager should not send acknowledgements
+     *  for this context.
+     *
+     *  For internal, debug use only.
+     *
+     *  @param[in]  inDropAckDebug  A Boolean indicating whether (true) or not
+     *                         (false) the acknowledgements should be not
+     *                         sent for the exchange.
+     */
     void SetDropAckDebug(bool inDropAckDebug);
+
+    /**
+     *  Determine whether there is already an acknowledgment pending to be sent to the peer on this exchange.
+     *
+     *  @return Returns 'true' if there is already an acknowledgment pending  on this exchange, else 'false'.
+     */
     bool IsAckPending() const;
+
+    /**
+     *  Set if an acknowledgment needs to be sent back to the peer on this exchange.
+     *
+     *  @param[in]  inAckPending A Boolean indicating whether (true) or not
+     *                          (false) an acknowledgment should be sent back
+     *                          in response to a received message.
+     */
     void SetAckPending(bool inAckPending);
+
+    /**
+     *  Determine whether peer requested acknowledgment for at least one message
+     *  on this exchange.
+     *
+     *  @return Returns 'true' if acknowledgment requested, else 'false'.
+     */
     bool HasPeerRequestedAck() const;
+
+    /**
+     *  Set if an acknowledgment was requested in the last message received
+     *  on this exchange.
+     *
+     *  @param[in]  inPeerRequestedAck A Boolean indicating whether (true) or not
+     *                                 (false) an acknowledgment was requested
+     *                                 in the last received message.
+     */
     void SetPeerRequestedAck(bool inPeerRequestedAck);
+
+    /**
+     *  Determine whether at least one message has been received
+     *  on this exchange from peer.
+     *
+     *  @return Returns 'true' if message received, else 'false'.
+     */
     bool HasRcvdMsgFromPeer() const;
+
+    /**
+     *  Set if a message has been received from the peer
+     *  on this exchange.
+     *
+     *  @param[in]  inMsgRcvdFromPeer  A Boolean indicating whether (true) or not
+     *                                 (false) a message has been received
+     *                                 from the peer on this exchange context.
+     */
     void SetMsgRcvdFromPeer(bool inMsgRcvdFromPeer);
 
 private:

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -68,25 +68,11 @@ void ReliableMessageMgr::Shutdown()
     }
 }
 
-/**
- * Return a tick counter value given a time period.
- *
- * @param[in]  newTime        Timestamp value of in milliseconds.
- *
- * @return Tick count for the time period.
- */
 uint64_t ReliableMessageMgr::GetTickCounterFromTimePeriod(uint64_t period)
 {
     return (period >> mTimerIntervalShift);
 }
 
-/**
- * Return a tick counter value between the given time and the stored time.
- *
- * @param[in]  newTime        Timestamp value of in milliseconds.
- *
- * @return Tick count of the difference between the given time and the stored time.
- */
 uint64_t ReliableMessageMgr::GetTickCounterFromTimeDelta(uint64_t newTime)
 {
     return GetTickCounterFromTimePeriod(newTime - mTimeStampBase);
@@ -113,11 +99,6 @@ void ReliableMessageMgr::TicklessDebugDumpRetransTable(const char * log)
 }
 #endif // RMP_TICKLESS_DEBUG
 
-/**
- * Iterate through active exchange contexts and retrans table entries.  If an
- * action needs to be triggered by ReliableMessageProtocol time facilities,
- * execute that action.
- */
 void ReliableMessageMgr::ExecuteActions()
 {
 #if defined(RMP_TICKLESS_DEBUG)
@@ -197,15 +178,6 @@ static void TickProceed(uint16_t & time, uint64_t ticks)
     }
 }
 
-/**
- * Calculate number of virtual ReliableMessageProtocol ticks that have expired
- * since we last called this function. Iterate through active exchange contexts
- * and retrans table entries, subtracting expired virtual ticks to synchronize
- * wakeup times with the current system time. Do not perform any actions beyond
- * updating tick counts, actions will be performed by the physical
- * ReliableMessageProtocol timer tick expiry.
- *
- */
 void ReliableMessageMgr::ExpireTicks()
 {
     uint64_t now = System::Timer::GetCurrentEpoch();
@@ -254,10 +226,6 @@ void ReliableMessageMgr::ExpireTicks()
 #endif
 }
 
-/**
- * Handle physical wakeup of system due to ReliableMessageProtocol wakeup.
- *
- */
 void ReliableMessageMgr::Timeout(System::Layer * aSystemLayer, void * aAppState, System::Error aError)
 {
     ReliableMessageMgr * manager = reinterpret_cast<ReliableMessageMgr *>(aAppState);
@@ -278,18 +246,6 @@ void ReliableMessageMgr::Timeout(System::Layer * aSystemLayer, void * aAppState,
     manager->StartTimer();
 }
 
-/**
- *  Add a CHIP message into the retransmission table to be subsequently resent if a corresponding acknowledgment
- *  is not received within the retransmission timeout.
- *
- *  @param[in]    rc        A pointer to the ExchangeContext object.
- *
- *  @param[out]   rEntry    A pointer to a pointer of a retransmission table entry added into the table.
- *
- *  @retval  #CHIP_ERROR_RETRANS_TABLE_FULL If there is no empty slot left in the table for addition.
- *  @retval  #CHIP_NO_ERROR On success.
- *
- */
 CHIP_ERROR ReliableMessageMgr::AddToRetransTable(ReliableMessageContext * rc, RetransTableEntry ** rEntry)
 {
     bool added     = false;
@@ -383,14 +339,6 @@ bool ReliableMessageMgr::CheckAndRemRetransTable(ReliableMessageContext * rc, ui
     return false;
 }
 
-/**
- *  Send the specified entry from the retransmission table.
- *
- *  @param[in]    entry                A pointer to a retransmission table entry object that needs to be sent.
- *
- *  @return  #CHIP_NO_ERROR On success, else corresponding CHIP_ERROR returned from SendMessage.
- *
- */
 CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
@@ -423,12 +371,6 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
     return err;
 }
 
-/**
- *  Clear entries matching a specified ExchangeContext.
- *
- *  @param[in]    rc    A pointer to the ExchangeContext object.
- *
- */
 void ReliableMessageMgr::ClearRetransTable(ReliableMessageContext * rc)
 {
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++)
@@ -441,12 +383,6 @@ void ReliableMessageMgr::ClearRetransTable(ReliableMessageContext * rc)
     }
 }
 
-/**
- *  Clear an entry in the retransmission table.
- *
- *  @param[in]    rEntry   A reference to the RetransTableEntry object.
- *
- */
 void ReliableMessageMgr::ClearRetransTable(RetransTableEntry & rEntry)
 {
     if (rEntry.rc)
@@ -467,14 +403,6 @@ void ReliableMessageMgr::ClearRetransTable(RetransTableEntry & rEntry)
     }
 }
 
-/**
- *  Fail entries matching a specified ExchangeContext.
- *
- *  @param[in]    rc    A pointer to the ExchangeContext object.
- *
- *  @param[in]    err   The error for failing table entries.
- *
- */
 void ReliableMessageMgr::FailRetransTableEntries(ReliableMessageContext * rc, CHIP_ERROR err)
 {
     for (int i = 0; i < CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE; i++)
@@ -490,12 +418,6 @@ void ReliableMessageMgr::FailRetransTableEntries(ReliableMessageContext * rc, CH
     }
 }
 
-/**
- * Iterate through active exchange contexts and retrans table entries.
- * Determine how many ReliableMessageProtocol ticks we need to sleep before we
- * need to physically wake the CPU to perform an action.  Set a timer to go off
- * when we next need to wake the system.
- */
 void ReliableMessageMgr::StartTimer()
 {
     CHIP_ERROR res            = CHIP_NO_ERROR;


### PR DESCRIPTION
…liableMessageContext/ReliableMessageMgr

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
This is the follow-up of the review comment in #4048, currently, all the documentation of the public APIs in ReliableMessageContext/ReliableMessageMgr are in thier implementation files instead of their interface headers.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Move all public API documentation from implementation to header in ReliableMessageContext/ReliableMessageMgr

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4214

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
