### PR TITLE
Add Silabs SDK as a submodule for backward compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 	path = third_party/freertos/repo
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
 	branch = V10.3.1-kernel-only
+[submodule "third_party/efr32_sdk/repo"]
+	path = third_party/efr32_sdk/repo
+	url = https://github.com/SiliconLabs/sdk_support.git

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -39,11 +39,6 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the [sdk_support](https://github.com/SiliconLabs/sdk_support) from
-    GitHub and export the path with :
-
-            $ export EFR32_SDK_ROOT=<Path to cloned git repo>
-
 -   Download the
     [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
     command line tool, and ensure that `commander` is your shell search path.
@@ -66,6 +61,7 @@ Silicon Labs platform.
     MG12 boards:
 
     -   BRD4161A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@19dBm
+    -   BRD4164A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@19dBm
     -   BRD4166A / SLTB004A / Thunderboard Sense 2 / 2.4GHz@10dBm
     -   BRD4170A / SLWSTK6000B / Multiband Wireless Starter Kit / 2.4GHz@19dBm,
         915MHz@19dBm
@@ -77,10 +73,19 @@ Silicon Labs platform.
 
 *   Build the example application:
 
+          cd ~/connectedhomeip
+          ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app BRD4161A
+
+-   To delete generated executable, libraries and object files use:
+
+          $ cd ~/connectedhomeip
+          $ rm -rf ./out/
+
+OR use GN/Ninja directly
+
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_SDK_ROOT=<path-to-silabs-sdk-v2.7>
           $ export EFR32_BOARD=BRD4161A
           $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" efr32_board=\"${EFR32_BOARD}\""
           $ ninja -C out/debug
@@ -89,17 +94,6 @@ Silicon Labs platform.
 
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ rm -rf out/
-
-OR use the script
-
-          cd ~/connectedhomeip
-          $ export EFR32_SDK_ROOT=<path-to-silabs-sdk-v2.7>
-          $ export EFR32_BOARD=BRD4161A
-          ./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/debug/efr32_lighting_app
-
--   To delete generated executable, libraries and object files use:
-    $ cd ~/connectedhomeip
-          $ rm -rf out/debug/efr32_lighting_app
 
 <a name="flashing"></a>
 
@@ -210,14 +204,12 @@ combination with JLinkRTTClient as follows:
     **Push Button 0** - Press and Release : If not commissioned, start thread
     with default configurations (DEBUG)
 
-
         -   Pressed and hold for 6 s: Initiates the factory reset of the device.
             Releasing the button within the 6-second window cancels the factory reset
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-    **Push Button 1**
-        Toggles the light state On/Off
+    **Push Button 1** Toggles the light state On/Off
 
 -   Once the device is provisioned, it will join the Thread network is
     established, look for the RTT log

--- a/examples/lock-app/efr32/README.md
+++ b/examples/lock-app/efr32/README.md
@@ -39,11 +39,6 @@ Silicon Labs platform.
 
 ## Building
 
--   Download the [sdk_support](https://github.com/SiliconLabs/sdk_support) from
-    GitHub and export the path with :
-
-            $ export EFR32_SDK_ROOT=<Path to cloned git repo>
-
 -   Download the
     [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
     command line tool, and ensure that `commander` is your shell search path.
@@ -66,6 +61,7 @@ Silicon Labs platform.
     MG12 boards:
 
     -   BRD4161A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@19dBm
+    -   BRD4164A / SLWSTK6000B / Wireless Starter Kit / 2.4GHz@19dBm
     -   BRD4166A / SLTB004A / Thunderboard Sense 2 / 2.4GHz@10dBm
     -   BRD4170A / SLWSTK6000B / Multiband Wireless Starter Kit / 2.4GHz@19dBm,
         915MHz@19dBm
@@ -77,10 +73,19 @@ Silicon Labs platform.
 
 *   Build the example application:
 
+          cd ~/connectedhomeip
+          ./scripts/examples/gn_efr32_example.sh ./examples/lock-app/efr32/ ./out/lock_app BRD4161A
+
+-   To delete generated executable, libraries and object files use:
+
+          $ cd ~/connectedhomeip
+          $ rm -rf ./out/
+
+OR use GN/Ninja directly
+
           $ cd ~/connectedhomeip/examples/lock-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_SDK_ROOT=<path-to-silabs-sdk-v2.7>
           $ export EFR32_BOARD=BRD4161A
           $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" efr32_board=\"${EFR32_BOARD}\""
           $ ninja -C out/debug
@@ -89,17 +94,6 @@ Silicon Labs platform.
 
           $ cd ~/connectedhomeip/examples/lock-app/efr32
           $ rm -rf out/
-
-OR use the script
-
-          cd ~/connectedhomeip
-          $ export EFR32_SDK_ROOT=<path-to-silabs-sdk-v2.7>
-          $ export EFR32_BOARD=BRD4161A
-          ./scripts/examples/gn_efr32_example.sh examples/lock-app/efr32/ out/debug/efr32_lock_app
-
--   To delete generated executable, libraries and object files use:
-    $ cd ~/connectedhomeip
-          $ rm -rf out/debug/efr32_lock_app
 
 <a name="flashing"></a>
 
@@ -211,14 +205,12 @@ combination with JLinkRTTClient as follows:
     **Push Button 0** - Press and Release : If not commissioned, start thread
     with default configurations (DEBUG)
 
-
         -   Pressed and hold for 6 s: Initiates the factory reset of the device.
             Releasing the button within the 6-second window cancels the factory reset
             procedure. **LEDs** blink in unison when the factory reset procedure is
             initiated.
 
-    **Push Button 1**
-        Toggles the bolt state On/Off
+    **Push Button 1** Toggles the bolt state On/Off
 
 -   Once the device is provisioned, it will join the Thread network is
     established, look for the RTT log

--- a/examples/persistent-storage/efr32/README.md
+++ b/examples/persistent-storage/efr32/README.md
@@ -42,11 +42,6 @@ defines = [
 
 ### Building
 
--   Download the [sdk_support](https://github.com/SiliconLabs/sdk_support) from
-    GitHub and export the path with :
-
-            $ export EFR32_SDK_ROOT=<Path to cloned git repo>
-
 -   Download the
     [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
     command line tool, and ensure that `commander` is your shell search path.
@@ -80,10 +75,19 @@ defines = [
 
 *   Build the example application:
 
+          cd ~/connectedhomeip
+          ./scripts/examples/gn_efr32_example.sh ./examples/persistent-storage/efr32/ ./out/persistent-storage BRD4161A
+
+-   To delete generated executable, libraries and object files use:
+
+          $ cd ~/connectedhomeip
+          $ rm -rf ./out/persistent-storage
+
+OR use GN/Ninja directly
+
           $ cd ~/connectedhomeip/examples/persistent-storage/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
-          $ export EFR32_SDK_ROOT=<path-to-silabs-sdk-v2.7>
           $ export EFR32_BOARD=BRD4161A
           $ gn gen out/debug --args="efr32_sdk_root=\"${EFR32_SDK_ROOT}\" efr32_board=\"${EFR32_BOARD}\""
           $ ninja -C out/debug

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -77,12 +77,12 @@ user_args=""
 
 for arg; do
     case $arg in
-    enable_qpg6100_builds=true)
-        qpg6100_enabled=1
-        ;;
-    enable_efr32_builds=true)
-        efr32_enabled=1
-        ;;
+        enable_qpg6100_builds=true)
+            qpg6100_enabled=1
+            ;;
+        enable_efr32_builds=true)
+            efr32_enabled=1
+            ;;
     esac
     user_args+=" $arg"
 done

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -77,9 +77,12 @@ user_args=""
 
 for arg; do
     case $arg in
-        enable_qpg6100_builds=true)
-            qpg6100_enabled=1
-            ;;
+    enable_qpg6100_builds=true)
+        qpg6100_enabled=1
+        ;;
+    enable_efr32_builds=true)
+        efr32_enabled=1
+        ;;
     esac
     user_args+=" $arg"
 done
@@ -98,15 +101,11 @@ fi
 echo
 
 # EFR32 SDK setup
-efr32_sdk_args=""
-
-if [[ -d "$EFR32_SDK_ROOT/protocol/" ]]; then
-    efr32_sdk_args+="efr32_sdk_root=\"$EFR32_SDK_ROOT\" efr32_board=\"$EFR32_BOARD\""
-    extra_args+=" $efr32_sdk_args enable_efr32_builds=true"
-    echo 'To build the EFR32 lock sample as a standalone project':
-    echo "(cd $CHIP_ROOT/examples/lock-app/efr32; gn gen out/debug --args='$efr32_sdk_args'; ninja -C out/debug)"
+if [[ -z "$efr32_enabled" ]]; then
+    echo "Hint: Pass enable_efr32_builds=true to enable building for EFR32"
 else
-    echo "Hint: Set \$EFR32_SDK_ROOT to enable building for EFR32"
+    echo 'To build the EFR32 lock sample as a standalone project':
+    echo "(cd $CHIP_ROOT/examples/lock-app/efr32; gn gen out/debug; ninja -C out/debug)"
 fi
 
 # K32W SDK setup

--- a/integrations/docker/images/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/chip-build-efr32/Dockerfile
@@ -11,8 +11,3 @@ RUN set -x \
     gcc-arm-none-eabi \
     binutils-arm-none-eabi \
     ccache
-
-#Clone Gecko SDK
-RUN mkdir -p /opt/SiliconLabs && git clone https://github.com/SiliconLabs/sdk_support.git /opt/SiliconLabs/sdk_support
-
-ENV EFR32_SDK_ROOT=/opt/SiliconLabs/sdk_support

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -22,7 +22,6 @@ ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV GNUARMEMB_TOOLCHAIN_PATH=/opt/ARM-software/gcc-arm-none-eabi-9-2019-q4-major
 ENV ARM_GCC_INSTALL_ROOT=/opt/ARM-software/gcc-arm-none-eabi-9-2019-q4-major/bin
-ENV EFR32_SDK_ROOT=/opt/SiliconLabs/sdk_support
 ENV EFR32_BOARD=BRD4161A
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -22,9 +22,9 @@ set -e
 
 source "$(dirname "$0")/../../scripts/activate.sh"
 
-sdk_root="$(pwd)/third_party/efr32_sdk/repo"
+sdk_root="$PWD/third_party/efr32_sdk/repo"
 
-if [ ! -d $sdk_root ]; then
+if [ ! -d "$sdk_root" ]; then
     echo "ERROR!!!"
     echo "Could not find EFR32 SDK with path :  $sdk_root"
     echo "Make sure you're running the script from the root of project CHIP"

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -22,22 +22,13 @@ set -e
 
 source "$(dirname "$0")/../../scripts/activate.sh"
 
-sdk_root="$PWD/third_party/efr32_sdk/repo"
-
-if [ ! -d "$sdk_root" ]; then
-    echo "ERROR!!!"
-    echo "Could not find EFR32 SDK with path :  $sdk_root"
-    echo "Make sure you're running the script from the root of project CHIP"
-    exit 1
-fi
-
 set -x
 env
 
 if [ -z "$3" ]; then
-    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$sdk_root\"" "$2"/"$EFR32_BOARD"/
+    gn gen --check --fail-on-unused-args --root="$1" "$2"/"$EFR32_BOARD"/
     ninja -v -C "$2"/"$EFR32_BOARD"/
 else
-    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$sdk_root\" efr32_board=\"$3\"" "$2/$3"
+    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_board=\"$3\"" "$2/$3"
     ninja -v -C "$2/$3"
 fi

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -22,13 +22,22 @@ set -e
 
 source "$(dirname "$0")/../../scripts/activate.sh"
 
+sdk_root="$(pwd)/third_party/efr32_sdk/repo"
+
+if [ ! -d $sdk_root ]; then
+    echo "ERROR!!!"
+    echo "Could not find EFR32 SDK with path :  $sdk_root"
+    echo "Make sure you're running the script from the root of project CHIP"
+    exit 1
+fi
+
 set -x
 env
 
 if [ -z "$3" ]; then
-    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\"" "$2"/"$EFR32_BOARD"/
+    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$sdk_root\"" "$2"/"$EFR32_BOARD"/
     ninja -v -C "$2"/"$EFR32_BOARD"/
 else
-    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$EFR32_SDK_ROOT\" efr32_board=\"$3\"" "$2/$3"
+    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_sdk_root=\"$sdk_root\" efr32_board=\"$3\"" "$2/$3"
     ninja -v -C "$2/$3"
 fi

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -21,11 +21,7 @@ import("efr32_board.gni")
 
 declare_args() {
   # Location of the efr32 SDK.
-  efr32_sdk_root = ""
-}
-
-if (efr32_sdk_root == "") {
-  efr32_sdk_root = getenv("EFR32_SDK_ROOT")
+  efr32_sdk_root = "${chip_root}/third_party/efr32_sdk/repo"
 }
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")


### PR DESCRIPTION
 #### Problem
EFR32 examples doesn't build with a newer version of OpenThread

 #### Summary of Changes
Add Silabs SDK as a submodule for later upgrade. This will prevent any build failure when updating to a new version

 Partial Fix of #4527 

