### PR TITLE
Enable pairing of multiple admins with a device

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -261,7 +261,7 @@ public:
         if (i == 0)
         {
             ConnectivityMgr().ClearWiFiStationProvision();
-            OpenDefaultPairingWindow(kResetAdmins);
+            OpenDefaultPairingWindow(ResetAdmins::kYes);
         }
     }
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -261,7 +261,7 @@ public:
         if (i == 0)
         {
             ConnectivityMgr().ClearWiFiStationProvision();
-            OpenDefaultPairingWindow(true);
+            OpenDefaultPairingWindow(kResetAdmins);
         }
     }
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -261,7 +261,7 @@ public:
         if (i == 0)
         {
             ConnectivityMgr().ClearWiFiStationProvision();
-            OpenDefaultPairingWindow();
+            OpenDefaultPairingWindow(true);
         }
     }
 
@@ -435,12 +435,20 @@ std::string createSetupPayload()
     return result;
 };
 
+WiFiWidget pairingWindowLED;
+
 class AppCallbacks : public AppDelegate
 {
 public:
     void OnReceiveError() override { statusLED1.BlinkOnError(); }
     void OnRendezvousStarted() override { bluetoothLED.Set(true); }
-    void OnRendezvousStopped() override { bluetoothLED.Set(false); }
+    void OnRendezvousStopped() override
+    {
+        bluetoothLED.Set(false);
+        pairingWindowLED.Set(false);
+    }
+    void OnPairingWindowOpened() override { pairingWindowLED.Set(true); }
+    void OnPairingWindowClosed() override { pairingWindowLED.Set(false); }
 };
 
 } // namespace
@@ -493,6 +501,7 @@ extern "C" void app_main()
     statusLED2.Init(GPIO_NUM_MAX);
     bluetoothLED.Init();
     wifiLED.Init();
+    pairingWindowLED.Init();
 
     // Init ZCL Data Model and CHIP App Server
     AppCallbacks callbacks;
@@ -585,6 +594,7 @@ extern "C" void app_main()
 
         bluetoothLED.SetVLED(ScreenManager::AddVLED(TFT_BLUE));
         wifiLED.SetVLED(ScreenManager::AddVLED(TFT_YELLOW));
+        pairingWindowLED.SetVLED(ScreenManager::AddVLED(TFT_ORANGE));
     }
 
 #endif // CONFIG_HAVE_DISPLAY

--- a/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/AdditionalDataParseCommand.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 using namespace ::chip;
-using namespace ::chip::SetupPayload;
+using namespace ::chip::SetupPayloadData;
 
 CHIP_ERROR AdditionalDataParseCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
 {

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -26,9 +26,9 @@ class AppDelegate
 {
 public:
     virtual ~AppDelegate() {}
-    virtual void OnReceiveError(){};
-    virtual void OnRendezvousStarted(){};
-    virtual void OnRendezvousStopped(){};
-    virtual void OnPairingWindowOpened(){};
-    virtual void OnPairingWindowClosed(){};
+    virtual void OnReceiveError() {}
+    virtual void OnRendezvousStarted() {}
+    virtual void OnRendezvousStopped() {}
+    virtual void OnPairingWindowOpened() {}
+    virtual void OnPairingWindowClosed() {}
 };

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -192,15 +192,15 @@ public:
             reader.Init(std::move(buffer));
             reader.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
 
-            SuccessOrExit(reader.Next(kTLVType_UnsignedInteger, DeviceLayer::ProfileTag(reader.ImplicitProfileId, 1)));
+            SuccessOrExit(reader.Next(kTLVType_UnsignedInteger, TLV::ProfileTag(reader.ImplicitProfileId, 1)));
             SuccessOrExit(reader.Get(timeout));
 
-            err = reader.Next(kTLVType_UnsignedInteger, DeviceLayer::ProfileTag(reader.ImplicitProfileId, 2));
+            err = reader.Next(kTLVType_UnsignedInteger, TLV::ProfileTag(reader.ImplicitProfileId, 2));
             if (err == CHIP_NO_ERROR)
             {
                 SuccessOrExit(reader.Get(discriminator));
 
-                err = reader.Next(kTLVType_ByteString, DeviceLayer::ProfileTag(reader.ImplicitProfileId, 3));
+                err = reader.Next(kTLVType_ByteString, TLV::ProfileTag(reader.ImplicitProfileId, 3));
                 if (err == CHIP_NO_ERROR)
                 {
                     SuccessOrExit(reader.GetBytes(reinterpret_cast<uint8_t *>(verifier), sizeof(verifier)));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -211,7 +211,7 @@ public:
 
             if (err != CHIP_NO_ERROR)
             {
-                SuccessOrExit(err = OpenDefaultPairingWindow(false));
+                SuccessOrExit(err = OpenDefaultPairingWindow(kDoNotResetAdmins));
             }
             else
             {
@@ -343,7 +343,7 @@ CHIP_ERROR OpenDefaultPairingWindow(bool resetAdmins)
     params.SetSetupPINCode(pinCode);
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-    if (resetAdmins)
+    if (resetAdmins == kResetAdmins)
     {
         gNextAvailableAdminId = 0;
         gAdminPairings.Reset();
@@ -409,7 +409,7 @@ void InitServer(AppDelegate * delegate)
     }
     else
     {
-        SuccessOrExit(err = OpenDefaultPairingWindow(true));
+        SuccessOrExit(err = OpenDefaultPairingWindow(kResetAdmins));
     }
 
 #if CHIP_ENABLE_MDNS

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -63,6 +63,11 @@ bool isRendezvousBypassed()
     return rendezvousMode == RendezvousInformationFlags::kNone;
 }
 
+// TODO: The following class is setting the discriminator in Persistent Storage. This is
+//       is needed since BLE reads the discriminator using ConfigurationMgr APIs. The
+//       better solution will be to pass the discriminator to BLE without changing it
+//       in the persistent storage.
+//       https://github.com/project-chip/connectedhomeip/issues/4767
 class DeviceDiscriminatorCache
 {
 public:

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -211,7 +211,7 @@ public:
 
             if (err != CHIP_NO_ERROR)
             {
-                SuccessOrExit(err = OpenDefaultPairingWindow(kDoNotResetAdmins));
+                SuccessOrExit(err = OpenDefaultPairingWindow(ResetAdmins::kNo));
             }
             else
             {
@@ -325,7 +325,7 @@ SecureSessionMgr & chip::SessionManager()
     return gSessions;
 }
 
-CHIP_ERROR OpenDefaultPairingWindow(bool resetAdmins)
+CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins)
 {
     gDeviceDiscriminatorCache.RestoreDiscriminator();
 
@@ -343,7 +343,7 @@ CHIP_ERROR OpenDefaultPairingWindow(bool resetAdmins)
     params.SetSetupPINCode(pinCode);
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-    if (resetAdmins == kResetAdmins)
+    if (resetAdmins == ResetAdmins::kYes)
     {
         gNextAvailableAdminId = 0;
         gAdminPairings.Reset();
@@ -409,7 +409,7 @@ void InitServer(AppDelegate * delegate)
     }
     else
     {
-        SuccessOrExit(err = OpenDefaultPairingWindow(kResetAdmins));
+        SuccessOrExit(err = OpenDefaultPairingWindow(ResetAdmins::kYes));
     }
 
 #if CHIP_ENABLE_MDNS

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -39,4 +39,4 @@ void InitServer(AppDelegate * delegate = nullptr);
 /**
  * Open the pairing window using default configured parameters.
  */
-CHIP_ERROR OpenDefaultPairingWindow();
+CHIP_ERROR OpenDefaultPairingWindow(bool resetAdmins);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -36,6 +36,13 @@ using DemoTransportMgr = chip::TransportMgr<chip::Transport::UDP>;
  */
 void InitServer(AppDelegate * delegate = nullptr);
 
+namespace chip {
+
+constexpr bool kResetAdmins      = true;
+constexpr bool kDoNotResetAdmins = false;
+
+} // namespace chip
+
 /**
  * Open the pairing window using default configured parameters.
  */

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -38,12 +38,15 @@ void InitServer(AppDelegate * delegate = nullptr);
 
 namespace chip {
 
-constexpr bool kResetAdmins      = true;
-constexpr bool kDoNotResetAdmins = false;
+enum class ResetAdmins
+{
+    kYes,
+    kNo,
+};
 
 } // namespace chip
 
 /**
  * Open the pairing window using default configured parameters.
  */
-CHIP_ERROR OpenDefaultPairingWindow(bool resetAdmins);
+CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins);

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -41,6 +41,7 @@ static_library("controller") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",
     "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport",
   ]
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -47,6 +47,7 @@
 #include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
+#include <system/TLVPacketBufferBackingStore.h>
 
 using namespace chip::Inet;
 using namespace chip::System;
@@ -245,6 +246,46 @@ void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader 
             HandleDataModelMessage(mDeviceId, std::move(msgBuf));
         }
     }
+}
+
+CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t discriminator, SetupPayload & setupPayload)
+{
+    // TODO: This code is temporary, and must be updated to use the Cluster API.
+    // Issue: https://github.com/project-chip/connectedhomeip/issues/4725
+
+    // Construct and send "open pairing window" message to the device
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(0);
+    System::PacketBufferTLVWriter writer;
+
+    writer.Init(std::move(buf));
+    writer.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
+
+    ReturnErrorOnFailure(writer.Put(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 1), timeout));
+
+    if (useToken)
+    {
+        ReturnErrorOnFailure(writer.Put(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 2), discriminator));
+
+        PASEVerifier verifier;
+        ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, setupPayload.setUpPINCode));
+        ReturnErrorOnFailure(writer.PutBytes(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 3),
+                                             reinterpret_cast<const uint8_t *>(verifier), sizeof(verifier)));
+    }
+
+    System::PacketBufferHandle outBuffer;
+    ReturnErrorOnFailure(writer.Finalize(&outBuffer));
+
+    PayloadHeader header;
+
+    header.SetMessageType(chip::Protocols::kProtocol_ServiceProvisioning, 0);
+
+    ReturnErrorOnFailure(SendMessage(std::move(outBuffer), header));
+
+    setupPayload.version               = 1;
+    setupPayload.rendezvousInformation = RendezvousInformationFlags::kBLE;
+    setupPayload.discriminator         = discriminator;
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -260,15 +260,15 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t d
     writer.Init(std::move(buf));
     writer.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
 
-    ReturnErrorOnFailure(writer.Put(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 1), timeout));
+    ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 1), timeout));
 
     if (useToken)
     {
-        ReturnErrorOnFailure(writer.Put(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 2), discriminator));
+        ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 2), discriminator));
 
         PASEVerifier verifier;
         ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, setupPayload.setUpPINCode));
-        ReturnErrorOnFailure(writer.PutBytes(DeviceLayer::ProfileTag(writer.ImplicitProfileId, 3),
+        ReturnErrorOnFailure(writer.PutBytes(TLV::ProfileTag(writer.ImplicitProfileId, 3),
                                              reinterpret_cast<const uint8_t *>(verifier), sizeof(verifier)));
     }
 

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -254,7 +254,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t d
     // Issue: https://github.com/project-chip/connectedhomeip/issues/4725
 
     // Construct and send "open pairing window" message to the device
-    System::PacketBufferHandle buf = System::PacketBufferHandle::New(0);
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::kMaxPacketBufferSize);
     System::PacketBufferTLVWriter writer;
 
     writer.Init(std::move(buf));

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -241,9 +241,11 @@ public:
      *   The device will exit the pairing mode after a successful pairing, or after the given `timeout` time.
      *
      * @param[in] timeout         The pairing mode should terminate after this much time.
-     * @param[in] useToken        The device should use the provided onboarding token instead of the default
-     *                            pairing setup PIN and discriminator.
+     * @param[in] useToken        Generate an onboarding token and send it to the device. The device must
+     *                            use the provided onboarding token instead of the original pairing setup PIN
+     *                            and discriminator.
      * @param[in] discriminator   The discriminator that the device should use for advertising and pairing.
+     * @param[out] setupPayload   The setup payload corresponding to the generated onboarding token.
      *
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
      */

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -32,6 +32,7 @@
 #include <app/util/basic-types.h>
 #include <core/CHIPCallback.h>
 #include <core/CHIPCore.h>
+#include <setup_payload/SetupPayload.h>
 #include <support/Base64.h>
 #include <support/DLLUtil.h>
 #include <transport/PASESession.h>
@@ -233,6 +234,23 @@ public:
 
     /**
      * @brief
+     *   Trigger a paired device to re-enter the pairing mode. If an onboarding token is provided, the device will use
+     *   the provided setup PIN code and the discriminator to advertise itself for pairing availability. If the token
+     *   is not provided, the device will use the manufacturer assigned setup PIN code and discriminator.
+     *
+     *   The device will exit the pairing mode after a successful pairing, or after the given `timeout` time.
+     *
+     * @param[in] timeout         The pairing mode should terminate after this much time.
+     * @param[in] useToken        The device should use the provided onboarding token instead of the default
+     *                            pairing setup PIN and discriminator.
+     * @param[in] discriminator   The discriminator that the device should use for advertising and pairing.
+     *
+     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
+     */
+    CHIP_ERROR OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t discriminator, SetupPayload & setupPayload);
+
+    /**
+     * @brief
      *   Return whether the current device object is actively associated with a paired CHIP
      *   device. An active object can be used to communicate with the corresponding device.
      */
@@ -354,6 +372,14 @@ public:
      * @param[in] msg Received message buffer.
      */
     virtual void OnMessage(System::PacketBufferHandle msg) = 0;
+
+    /**
+     * @brief
+     *   Called when response to OpenPairingWindow is received from the device.
+     *
+     * @param[in] status CHIP_NO_ERROR on success, or corresponding error.
+     */
+    virtual void OnPairingWindowOpenStatus(CHIP_ERROR status){};
 
     /**
      * @brief

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA0E0CE248599BB009087B9 /* OnOffViewController.m */; };
+		2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */; };
 		991DC091247747F500C13860 /* EchoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 991DC090247747F500C13860 /* EchoViewController.m */; };
 		997A639C253F93F7005C64E6 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; };
 		997A639D253F93F7005C64E6 /* CHIP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -52,6 +53,8 @@
 /* Begin PBXFileReference section */
 		0CA0E0CD248599BB009087B9 /* OnOffViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnOffViewController.h; sourceTree = "<group>"; };
 		0CA0E0CE248599BB009087B9 /* OnOffViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnOffViewController.m; sourceTree = "<group>"; };
+		2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiAdminViewController.m; sourceTree = "<group>"; };
+		2C21071425D1A8F200DDA4AD /* MultiAdminViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiAdminViewController.h; sourceTree = "<group>"; };
 		991DC08F247747F500C13860 /* EchoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EchoViewController.h; sourceTree = "<group>"; };
 		991DC090247747F500C13860 /* EchoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EchoViewController.m; sourceTree = "<group>"; };
 		997A639B253F93F7005C64E6 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -129,6 +132,15 @@
 			path = OnOffCluster;
 			sourceTree = "<group>";
 		};
+		2C21071225D1A8F200DDA4AD /* MultiAdmin */ = {
+			isa = PBXGroup;
+			children = (
+				2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */,
+				2C21071425D1A8F200DDA4AD /* MultiAdminViewController.h */,
+			);
+			path = MultiAdmin;
+			sourceTree = "<group>";
+		};
 		B20252DE2459EC7600F97062 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -191,6 +203,7 @@
 		B232D8BF251A0EC500792CB4 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				2C21071225D1A8F200DDA4AD /* MultiAdmin */,
 				B204A61F244E1D0600C7C0E1 /* AppDelegate.h */,
 				B204A620244E1D0600C7C0E1 /* AppDelegate.m */,
 				B204A622244E1D0600C7C0E1 /* SceneDelegate.h */,
@@ -343,6 +356,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */,
 				B204A627244E1D0600C7C0E1 /* QRCodeViewController.m in Sources */,
 				B232D8BA2514BD0800792CB4 /* CHIPUIViewUtils.m in Sources */,
 				B2946A9B24C9A7BF005C87D0 /* DefaultsUtils.m in Sources */,

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.h
@@ -1,6 +1,6 @@
-/*
+/**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,20 +15,12 @@
  *    limitations under the License.
  */
 
-/**
- * @file
- *   This file defines the API for application specific callbacks.
- */
+#import <CHIP/CHIP.h>
+#import <UIKit/UIKit.h>
 
-#pragma once
+NS_ASSUME_NONNULL_BEGIN
 
-class AppDelegate
-{
-public:
-    virtual ~AppDelegate() {}
-    virtual void OnReceiveError(){};
-    virtual void OnRendezvousStarted(){};
-    virtual void OnRendezvousStopped(){};
-    virtual void OnPairingWindowOpened(){};
-    virtual void OnPairingWindowClosed(){};
-};
+@interface MultiAdminViewController : UIViewController
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.m
@@ -1,0 +1,228 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MultiAdminViewController.h"
+
+#import "CHIPUIViewUtils.h"
+#import "DefaultsUtils.h"
+
+static NSString * const DEFAULT_TIMEOUT = @"900";
+static NSString * const DEFAULT_DISCRIMINATOR = @"3840";
+
+@interface MultiAdminViewController ()
+
+@property (strong, nonatomic) UISwitch * useOnboardingTokenSwitch;
+@property (strong, nonatomic) UITextField * discriminatorField;
+@property (strong, nonatomic) UITextField * timeoutField;
+@property (strong, nonatomic) UIButton * openPairingWindowButton;
+
+@property (nonatomic, strong) UILabel * resultLabel;
+@property (nonatomic, strong) UIStackView * stackView;
+
+@property (readwrite) CHIPDevice * chipDevice;
+
+@property (readonly) CHIPToolPersistentStorageDelegate * persistentStorage;
+
+@end
+
+@implementation MultiAdminViewController
+
+// MARK: UIViewController methods
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    [self setupUIElements];
+
+    // listen for taps to dismiss the keyboard
+    UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    [self.view addGestureRecognizer:tap];
+
+    self.chipDevice = GetPairedDevice();
+}
+
+- (void)dismissKeyboard
+{
+    [self.discriminatorField resignFirstResponder];
+    [self.timeoutField resignFirstResponder];
+}
+
+// MARK: UI Setup
+
+- (void)setupUIElements
+{
+    self.view.backgroundColor = UIColor.whiteColor;
+
+    // Title
+    UILabel * titleLabel = [CHIPUIViewUtils addTitle:@"Open Pairing Window" toView:self.view];
+
+    // stack view
+    UIStackView * stackView = [UIStackView new];
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.spacing = 30;
+    [self.view addSubview:stackView];
+
+    stackView.translatesAutoresizingMaskIntoConstraints = false;
+    [stackView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor constant:40].active = YES;
+    [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
+    [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
+
+    // Open Pairing Window
+    UILabel * useOnboardingToken = [UILabel new];
+    useOnboardingToken.text = @"Use Onboarding Token";
+    _useOnboardingTokenSwitch = [UISwitch new];
+    [_useOnboardingTokenSwitch setOn:YES];
+    UIView * useOnboardingTokenView = [CHIPUIViewUtils viewWithLabel:useOnboardingToken toggle:_useOnboardingTokenSwitch];
+    [_useOnboardingTokenSwitch addTarget:self action:@selector(overrideControls:) forControlEvents:UIControlEventTouchUpInside];
+    [stackView addArrangedSubview:useOnboardingTokenView];
+    useOnboardingTokenView.translatesAutoresizingMaskIntoConstraints = false;
+    [useOnboardingTokenView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Discriminator
+    _discriminatorField = [UITextField new];
+    _discriminatorField.keyboardType = UIKeyboardTypeNumberPad;
+    _discriminatorField.placeholder = DEFAULT_DISCRIMINATOR;
+    UILabel * discriminatorLabel = [UILabel new];
+    [discriminatorLabel setText:@"Discriminator"];
+    UIView * discriminatorView = [CHIPUIViewUtils viewWithLabel:discriminatorLabel textField:_discriminatorField];
+    [stackView addArrangedSubview:discriminatorView];
+
+    discriminatorView.translatesAutoresizingMaskIntoConstraints = false;
+    [discriminatorView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Pairing Timeout
+    _timeoutField = [UITextField new];
+    _timeoutField.keyboardType = UIKeyboardTypeNumberPad;
+    _timeoutField.placeholder = DEFAULT_TIMEOUT;
+    UILabel * timeoutLabel = [UILabel new];
+    [timeoutLabel setText:@"Timeout after (seconds)"];
+    UIView * timeoutView = [CHIPUIViewUtils viewWithLabel:timeoutLabel textField:_timeoutField];
+    [stackView addArrangedSubview:timeoutView];
+
+    timeoutView.translatesAutoresizingMaskIntoConstraints = false;
+    [timeoutView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Open Pairing Window button
+    _openPairingWindowButton = [UIButton new];
+    [_openPairingWindowButton setTitle:@"Open Pairing Window" forState:UIControlStateNormal];
+    [_openPairingWindowButton addTarget:self action:@selector(openPairingWindow:) forControlEvents:UIControlEventTouchUpInside];
+    _openPairingWindowButton.backgroundColor = UIColor.systemBlueColor;
+    _openPairingWindowButton.titleLabel.font = [UIFont systemFontOfSize:17];
+    _openPairingWindowButton.titleLabel.textColor = [UIColor whiteColor];
+    _openPairingWindowButton.layer.cornerRadius = 5;
+    _openPairingWindowButton.clipsToBounds = YES;
+    [stackView addArrangedSubview:_openPairingWindowButton];
+
+    _openPairingWindowButton.translatesAutoresizingMaskIntoConstraints = false;
+    [_openPairingWindowButton.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Result message
+    _resultLabel = [UILabel new];
+    _resultLabel.hidden = YES;
+    _resultLabel.font = [UIFont systemFontOfSize:17];
+    _resultLabel.textColor = UIColor.systemBlueColor;
+    _resultLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    _resultLabel.numberOfLines = 0;
+    [stackView addArrangedSubview:_resultLabel];
+
+    _resultLabel.translatesAutoresizingMaskIntoConstraints = false;
+    [_resultLabel.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+    _resultLabel.adjustsFontSizeToFitWidth = YES;
+}
+
+- (void)updateResult:(NSString *)result
+{
+    _resultLabel.hidden = NO;
+    _resultLabel.text = result;
+}
+
+// MARK: UIButton actions
+
+- (IBAction)overrideControls:(id)sender
+{
+    if ([_useOnboardingTokenSwitch isOn]) {
+        _discriminatorField.placeholder = DEFAULT_DISCRIMINATOR;
+        _timeoutField.placeholder = DEFAULT_TIMEOUT;
+        [_discriminatorField setEnabled:YES];
+    } else {
+        _discriminatorField.text = @"";
+        _discriminatorField.placeholder = @"Original discriminator";
+        [_discriminatorField setEnabled:NO];
+    }
+}
+
+- (IBAction)openPairingWindow:(id)sender
+{
+    // send message
+    if ([self.chipDevice isActive]) {
+        NSString * timeoutStr = [self.timeoutField text];
+        if (timeoutStr.length == 0) {
+            timeoutStr = [self.timeoutField placeholder];
+        }
+        int timeout = [timeoutStr intValue];
+
+        NSString * output;
+        NSError * error;
+        if ([_useOnboardingTokenSwitch isOn]) {
+            NSString * discriminatorStr = [self.discriminatorField text];
+            if (discriminatorStr.length == 0) {
+                discriminatorStr = [self.discriminatorField placeholder];
+            }
+            NSInteger discriminator = [discriminatorStr intValue];
+
+            output = [self.chipDevice openPairingWindowWithPIN:timeout discriminator:discriminator error:&error];
+
+            if (output != nil) {
+                NSString * result = [@"Use Manual Code: " stringByAppendingString:output];
+                [self updateResult:result];
+            } else {
+                [self updateResult:@"Failed in opening the pairing window"];
+            }
+        } else {
+            BOOL didSend = [self.chipDevice openPairingWindow:timeout error:&error];
+            if (didSend) {
+                [self updateResult:@"Scan the QR code on the device"];
+            } else {
+                NSString * errorString = [@"Error: " stringByAppendingString:error.localizedDescription];
+                [self updateResult:errorString];
+            }
+        }
+    } else {
+        [self updateResult:@"Controller not connected"];
+    }
+}
+
+// MARK: CHIPDeviceControllerDelegate
+- (void)deviceControllerOnConnected
+{
+    NSLog(@"Status: Device connected");
+}
+
+- (void)deviceControllerOnError:(nonnull NSError *)error
+{
+    NSLog(@"Status: Device Controller error %@", [error description]);
+    if (error) {
+        NSString * stringError = [@"Error: " stringByAppendingString:error.description];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 5.0), dispatch_get_main_queue(), ^{
+            [self updateResult:stringError];
+        });
+    }
+}
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -18,6 +18,7 @@
 #import "RootViewController.h"
 #import "BindingsViewController.h"
 #import "EchoViewController.h"
+#import "MultiAdminViewController.h"
 #import "OnOffViewController.h"
 #import "QRCodeViewController.h"
 #import "TemperatureSensorViewController.h"
@@ -39,7 +40,8 @@
     self.tableView.dataSource = self;
     [self.view addSubview:self.tableView];
     self.options = @[
-        @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration"
+        @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration",
+        @"Enable Pairing"
     ];
 }
 
@@ -83,6 +85,9 @@
     case 5:
         [self pushNetworkConfiguration];
         break;
+    case 6:
+        [self pushMultiAdmin];
+        break;
     default:
         break;
     }
@@ -115,6 +120,12 @@
 - (void)pushEchoClient
 {
     EchoViewController * controller = [EchoViewController new];
+    [self.navigationController pushViewController:controller animated:YES];
+}
+
+- (void)pushMultiAdmin
+{
+    MultiAdminViewController * controller = [MultiAdminViewController new];
     [self.navigationController pushViewController:controller animated:YES];
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -24,6 +24,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPDevice : NSObject
 
+- (BOOL)openPairingWindow:(NSTimeInterval)duration error:(NSError * __autoreleasing *)error;
+- (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
+                         discriminator:(NSInteger)discriminator
+                                 error:(NSError * __autoreleasing *)error;
 - (BOOL)isActive;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -16,6 +16,10 @@
  */
 
 #import "CHIPDevice_Internal.h"
+#import "CHIPLogging.h"
+#import <CHIP/CHIPError.h>
+#import <setup_payload/ManualSetupPayloadGenerator.h>
+#import <setup_payload/SetupPayload.h>
 
 @interface CHIPDevice ()
 
@@ -45,6 +49,72 @@
 - (chip::Controller::Device *)internalDevice
 {
     return _cppDevice;
+}
+
+- (BOOL)openPairingWindow:(NSTimeInterval)duration error:(NSError * __autoreleasing *)error
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    chip::SetupPayload setupPayload;
+
+    [self.lock lock];
+    err = self.cppDevice->OpenPairingWindow(duration, false, 0, setupPayload);
+    [self.lock unlock];
+
+    if (err != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error(%d): %@, Open Pairing Window failed", err, [CHIPError errorForCHIPErrorCode:err]);
+        if (error) {
+            *error = [CHIPError errorForCHIPErrorCode:err];
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
+- (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
+                         discriminator:(NSInteger)discriminator
+                                 error:(NSError * __autoreleasing *)error
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    uint16_t u16Descriminator = 0;
+
+    if (discriminator > 0xfff) {
+        CHIP_LOG_ERROR("Error: Discriminator %ld is too large. Max value %d", discriminator, 0xfff);
+        if (error) {
+            *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+        }
+        return nil;
+    } else {
+        u16Descriminator = (uint16_t) discriminator;
+    }
+
+    chip::SetupPayload setupPayload;
+
+    [self.lock lock];
+    err = self.cppDevice->OpenPairingWindow(duration, true, u16Descriminator, setupPayload);
+    [self.lock unlock];
+
+    if (err != CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Error(%d): %@, Open Pairing Window failed", err, [CHIPError errorForCHIPErrorCode:err]);
+        if (error) {
+            *error = [CHIPError errorForCHIPErrorCode:err];
+        }
+        return nil;
+    }
+
+    chip::ManualSetupPayloadGenerator generator(setupPayload);
+    std::string outCode;
+
+    if (generator.payloadDecimalStringRepresentation(outCode) == CHIP_NO_ERROR) {
+        CHIP_LOG_ERROR("Setup code is %s", outCode.c_str());
+    } else {
+        CHIP_LOG_ERROR("Failed to get decimal setup code");
+        return nil;
+    }
+
+    return [NSString stringWithCString:outCode.c_str() encoding:[NSString defaultCStringEncoding]];
 }
 
 - (BOOL)isActive

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -96,7 +96,9 @@ void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
         } else {
             NSString * value = [mDefaultPersistentStorage objectForKey:keyString];
             NSLog(@"PersistentStorageDelegate Get Value for Key: %@, value %@", keyString, value);
-            mCompletionHandler(keyString, value);
+            if (mCompletionHandler) {
+                mCompletionHandler(keyString, value);
+            }
         }
     });
 }
@@ -146,7 +148,9 @@ void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const ch
             });
         } else {
             [mDefaultPersistentStorage setObject:valueString forKey:keyString];
-            mSetStatusHandler(keyString, [CHIPError errorForCHIPErrorCode:0]);
+            if (mSetStatusHandler) {
+                mSetStatusHandler(keyString, [CHIPError errorForCHIPErrorCode:0]);
+            }
         }
     });
 }
@@ -164,7 +168,9 @@ void CHIPPersistentStorageDelegateBridge::DeleteKeyValue(const char * key)
             });
         } else {
             [mDefaultPersistentStorage removeObjectForKey:keyString];
-            mDeleteStatusHandler(keyString, [CHIPError errorForCHIPErrorCode:0]);
+            if (mDeleteStatusHandler) {
+                mDeleteStatusHandler(keyString, [CHIPError errorForCHIPErrorCode:0]);
+            }
         }
     });
 }

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -133,7 +133,7 @@ namespace DeviceLayer {
                     uint8_t opCode = bytes[0];
                     uint16_t discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;
 
-                    if (opCode == 0 && [self checkDiscriminator:discriminator]) {
+                    if ((opCode == 0 || opCode == 1) && [self checkDiscriminator:discriminator]) {
                         ChipLogProgress(Ble, "Connecting to device with discriminator: %d", discriminator);
                         [self connect:peripheral];
                         [self stopScanning];

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -70,7 +70,7 @@
 #include <system/TLVPacketBufferBackingStore.h>
 
 using namespace ::nl;
-using namespace chip::SetupPayload;
+using namespace chip::SetupPayloadData;
 using namespace chip::Protocols;
 
 namespace chip {

--- a/src/setup_payload/AdditionalDataPayload.h
+++ b/src/setup_payload/AdditionalDataPayload.h
@@ -37,7 +37,7 @@
 #include <string>
 
 namespace chip {
-namespace SetupPayload {
+namespace SetupPayloadData {
 
 constexpr uint8_t kRotatingDeviceIdLength = 18;
 constexpr uint8_t kRotatingDeviceIdTag    = 0x00;
@@ -48,5 +48,5 @@ public:
     std::string rotatingDeviceId;
 };
 
-} // namespace SetupPayload
+} // namespace SetupPayloadData
 } // namespace chip

--- a/src/setup_payload/AdditionalDataPayloadParser.cpp
+++ b/src/setup_payload/AdditionalDataPayloadParser.cpp
@@ -35,7 +35,7 @@
 
 namespace chip {
 
-CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayload::AdditionalDataPayload & outPayload)
+CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayloadData::AdditionalDataPayload & outPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
@@ -49,11 +49,11 @@ CHIP_ERROR AdditionalDataPayloadParser::populatePayload(SetupPayload::Additional
     err = reader.OpenContainer(innerReader);
     SuccessOrExit(err);
 
-    err = innerReader.Next(TLV::kTLVType_UTF8String, TLV::ContextTag(SetupPayload::kRotatingDeviceIdTag));
+    err = innerReader.Next(TLV::kTLVType_UTF8String, TLV::ContextTag(SetupPayloadData::kRotatingDeviceIdTag));
     SuccessOrExit(err);
 
     // Get the value of the rotating device id
-    char rotatingDeviceId[SetupPayload::kRotatingDeviceIdLength];
+    char rotatingDeviceId[SetupPayloadData::kRotatingDeviceIdLength];
     err = innerReader.GetString(rotatingDeviceId, sizeof(rotatingDeviceId));
     SuccessOrExit(err);
     outPayload.rotatingDeviceId = std::string(rotatingDeviceId);

--- a/src/setup_payload/AdditionalDataPayloadParser.h
+++ b/src/setup_payload/AdditionalDataPayloadParser.h
@@ -74,7 +74,7 @@ public:
      *                                      GetNextBuffer() function. Only possible when GetNextBuffer is
      *                                      non-NULL.
      */
-    CHIP_ERROR populatePayload(SetupPayload::AdditionalDataPayload & outPayload);
+    CHIP_ERROR populatePayload(SetupPayloadData::AdditionalDataPayload & outPayload);
 };
 
 } // namespace chip

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -60,6 +60,7 @@ static_library("transport") {
     "${chip_root}/src/lib/mdns",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport/raw",
   ]
 }

--- a/src/transport/PASESession.h
+++ b/src/transport/PASESession.h
@@ -45,6 +45,8 @@ constexpr uint16_t kPBKDFParamRandomNumberSize = 32;
 
 using namespace Crypto;
 
+constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
+
 struct PASESessionSerialized;
 
 struct PASESessionSerializable
@@ -57,6 +59,8 @@ struct PASESessionSerializable
     uint16_t mLocalKeyId;
     uint16_t mPeerKeyId;
 };
+
+typedef uint8_t PASEVerifier[2][kSpake2p_WS_Length];
 
 class DLL_EXPORT PASESession
 {
@@ -88,6 +92,20 @@ public:
 
     /**
      * @brief
+     *   Initialize using PASE verifier and wait for pairing requests.
+     *
+     * @param verifier        PASE verifier to be used for SPAKE2P pairing
+     * @param myNodeId        Optional node id of local node
+     * @param myKeyId         Key ID to be assigned to the secure session on the peer node
+     * @param delegate        Callback object
+     *
+     * @return CHIP_ERROR     The result of initialization
+     */
+    CHIP_ERROR WaitForPairing(const PASEVerifier & verifier, Optional<NodeId> myNodeId, uint16_t myKeyId,
+                              SessionEstablishmentDelegate * delegate);
+
+    /**
+     * @brief
      *   Create a pairing request using peer's setup PIN code.
      *
      * @param peerAddress      Address of peer to pair
@@ -101,6 +119,27 @@ public:
      */
     CHIP_ERROR Pair(const Transport::PeerAddress peerAddress, uint32_t peerSetUpPINCode, Optional<NodeId> myNodeId,
                     NodeId peerNodeId, uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
+
+    /**
+     * @brief
+     *   Create a pairing request using given PASE verifier.
+     *
+     * @param peerAddress      Address of peer to pair
+     * @param verifier         PASE verifier to be used for SPAKE2P pairing
+     * @param myNodeId         Optional node id of local node
+     * @param peerNodeId       Node id assigned to the peer node by commissioner
+     * @param myKeyId          Key ID to be assigned to the secure session on the peer node
+     * @param delegate         Callback object
+     *
+     * @return CHIP_ERROR      The result of initialization
+     */
+    CHIP_ERROR Pair(const Transport::PeerAddress peerAddress, const PASEVerifier & verifier, Optional<NodeId> myNodeId,
+                    NodeId peerNodeId, uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
+
+    static CHIP_ERROR ComputePASEVerifier(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,
+                                          PASEVerifier & verifier);
+
+    static CHIP_ERROR GeneratePASEVerifier(PASEVerifier & verifier, uint32_t & setupPIN);
 
     /**
      * @brief
@@ -207,8 +246,6 @@ private:
 
     void Clear();
 
-    static constexpr size_t kSpake2p_WS_Length = kP256_FE_Length + 8;
-
     SessionEstablishmentDelegate * mDelegate = nullptr;
 
     Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::PASE_Spake2pError;
@@ -218,9 +255,11 @@ private:
     uint8_t mPoint[kMAX_Point_Length];
 
     /* w0s and w1s */
-    uint8_t mWS[2][kSpake2p_WS_Length];
+    PASEVerifier mWS;
 
     uint32_t mSetupPINCode;
+
+    bool mComputeVerifier = true;
 
     Hash_SHA256_stream mCommissioningHash;
     uint32_t mIterationCount = 0;

--- a/src/transport/PASESession.h
+++ b/src/transport/PASESession.h
@@ -255,7 +255,7 @@ private:
     uint8_t mPoint[kMAX_Point_Length];
 
     /* w0s and w1s */
-    PASEVerifier mWS;
+    PASEVerifier mPASEVerifier;
 
     uint32_t mSetupPINCode;
 

--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <transport/PASESession.h>
 #include <transport/raw/Base.h>
 #include <transport/raw/PeerAddress.h>
 #if CONFIG_NETWORK_LAYER_BLE
@@ -95,6 +96,15 @@ public:
         return *this;
     }
 
+    bool HasPASEVerifier() const { return mHasPASEVerifier; }
+    const PASEVerifier & GetPASEVerifier() const { return mPASEVerifier; }
+    RendezvousParameters & SetPASEVerifier(PASEVerifier & verifier)
+    {
+        memmove(mPASEVerifier, verifier, sizeof(verifier));
+        mHasPASEVerifier = true;
+        return *this;
+    }
+
     const RendezvousAdvertisementDelegate * GetAdvertisementDelegate() const { return mAdvDelegate; }
 
     RendezvousParameters & SetAdvertisementDelegate(RendezvousAdvertisementDelegate * delegate)
@@ -129,6 +139,9 @@ private:
     Optional<NodeId> mRemoteNodeId;       ///< the remote node id
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
+
+    PASEVerifier mPASEVerifier;
+    bool mHasPASEVerifier = false;
 
     RendezvousAdvertisementDelegate mDefaultAdvDelegate;
     RendezvousAdvertisementDelegate * mAdvDelegate = &mDefaultAdvDelegate;

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -146,7 +146,9 @@ private:
     CHIP_ERROR HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                     System::PacketBufferHandle msgBuf);
     CHIP_ERROR Pair(Optional<NodeId> nodeId, uint32_t setupPINCode);
+    CHIP_ERROR Pair(Optional<NodeId> nodeId, const PASEVerifier & verifier);
     CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, uint32_t setupPINCode);
+    CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, const PASEVerifier & verifier);
 
     CHIP_ERROR HandleSecureMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                    System::PacketBufferHandle msgBuf);


### PR DESCRIPTION
 #### Problem
Missing implementation for adding multiple administrator to a device.

 #### Summary of Changes
This PR adds mechanism to trigger opening pairing window on a previously paired device. It generates a temporary manual setup code that the second admin can use to pair with the device. Alternatively, the first admin can let the second admin use the original setup code from the device.

The PR adds a bespoke/temporary implementation of commissioning cluster. This will eventually be moved to the code-generated implementation. The code is marked with TODO, and corresponding issue.