### PR TITLE
Mobly integration for esp32

### DIFF
--- a/examples/pigweed-app/esp32/Makefile
+++ b/examples/pigweed-app/esp32/Makefile
@@ -44,13 +44,23 @@ $(FLASHING_SCRIPT): $(APP_BIN) $(BOOTLOADER_BIN) $(PARTITION_TABLE_BIN) $(PROJEC
 	  --use-parttool $(IDF_PATH)/components/partition_table/parttool.py \
 	  --use-sdkconfig $(PROJECT_PATH)/sdkconfig
 
-flashing_script: $(FLASHING_SCRIPT) $(BUILD_DIR_BASE)/esp32_firmware_utils.py $(BUILD_DIR_BASE)/firmware_utils.py
+flashing_script: $(FLASHING_SCRIPT) $(BUILD_DIR_BASE)/esp32_firmware_utils.py $(BUILD_DIR_BASE)/firmware_utils.py $(BUILD_DIR_BASE)/echo_test.py $(BUILD_DIR_BASE)/echo_test_config.yml
 	@echo To flash $(subst $(CURDIR)/,,$(APP_BIN)), run $(subst $(CURDIR)/,,$(FLASHING_SCRIPT))
 
 $(BUILD_DIR_BASE)/esp32_firmware_utils.py: third_party/connectedhomeip/scripts/flashing/esp32_firmware_utils.py
+	echo "Copying esp32_firmware_utils.py"
 	@cp $< $@
 
 $(BUILD_DIR_BASE)/firmware_utils.py: third_party/connectedhomeip/scripts/flashing/firmware_utils.py
+	echo "Copying firmware_utils.py"
+	@cp $< $@
+
+$(BUILD_DIR_BASE)/echo_test.py: ../mobly_tests/echo_test.py
+	echo "Copying echo_test.py"
+	@cp $< $@
+
+$(BUILD_DIR_BASE)/echo_test_config.yml: ./echo_test_config.yml
+	echo "Copying echo_test_config.yml"
 	@cp $< $@
 
 .PHONY: flashing_script

--- a/examples/pigweed-app/esp32/echo_test_config.yml
+++ b/examples/pigweed-app/esp32/echo_test_config.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TestBeds:
+    # A test bed for esp32 where pw_rpc will find a CHIP device
+    - Name: ESP32TestBed
+      Controllers:
+          PigweedDevice:
+              - device_tty: /dev/ttyUSB1
+                baud: 115200
+                platform_module: esp32_firmware_utils
+                platform_args:
+                    - "application": "chip-pigweed-app.bin"
+                      "parttool": None
+                      "port": "/dev/ttyUSB0"
+                      "baud": "921600"
+                      "before": "default_reset"
+                      "after": "hard_reset"
+                      "flash_mode": "dio"
+                      "flash_freq": "40m"
+                      "flash_size": "2MB"
+                      "compress": "y"
+                      "bootloader": "bootloader/bootloader.bin"
+                      "partition": "partitions.bin"
+                      "partition_offset": "0x8000"
+                      "application_offset": "0x10000"

--- a/examples/pigweed-app/mobly_tests/echo_test.py
+++ b/examples/pigweed-app/mobly_tests/echo_test.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from chip_mobly import pigweed_device
+from mobly import asserts
+from mobly import base_test
+from mobly import test_runner
+import time
+
+
+class PigweedEchoTest(base_test.BaseTestClass):
+    def setup_class(self):
+        ''' Registering pigweed_device controller module declares the test's
+        dependency on CHIP/Pigweed device hardware. By default, we expect at least one
+        object is created from this.'''
+        self.ads = self.register_controller(pigweed_device)
+        self.dut = self.ads[0]
+        self.dut.platform.flash() # Flashes the image passed in the configuration yml.
+        time.sleep(1) # give the device time to boot and register rpcs
+
+    def test_hello(self):
+        ''' Tests EchoService.Echo '''
+        expected = "hello!"
+        status, payload = self.dut.rpcs().EchoService.Echo(msg=expected)
+        asserts.assert_true(status.ok(), "Status is %s" % status)
+        asserts.assert_equal(
+            payload.msg,
+            expected,
+            'Returned payload is "%s" expected "%s"' % (payload.msg, expected),
+        )
+
+
+if __name__ == "__main__":
+    test_runner.main()

--- a/integrations/mobly/chip_mobly/pigweed_device.py
+++ b/integrations/mobly/chip_mobly/pigweed_device.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import serial # type: ignore
 import importlib
 
-from pw_hdlc.rpc import HdlcRpcClient
+from pw_hdlc.rpc import HdlcRpcClient, default_channels
 
 # Point the script to the .proto file with our RPC services.
 PROTO = Path(os.environ["PW_ROOT"], "pw_rpc/pw_rpc_protos/echo.proto")
@@ -31,7 +31,9 @@ class Error(Exception):
 
 class PigweedDevice:
     def __init__(self, device_tty, baud, platform_module=None, platform_args=None):
-        self.pw_rpc_client = HdlcRpcClient(serial.Serial(device_tty, baud), [PROTO])
+        ser = serial.Serial(device_tty, baud, timeout=0.01)
+        self.pw_rpc_client = HdlcRpcClient(lambda: ser.read(4096),
+                                           [PROTO], default_channels(ser.write))
         self._platform = None
         print("Platform args: %s" % platform_args)
         print("Platform module: %s" % platform_module)

--- a/scripts/flashing/esp32_firmware_utils.py
+++ b/scripts/flashing/esp32_firmware_utils.py
@@ -445,6 +445,40 @@ class Flasher(firmware_utils.Flasher):
 
         return self
 
+### Mobly integration
+class ESP32Platform:
+  def __init__(self, flasher_args):
+      self.flasher = Flasher(**flasher_args)
+
+  def flash(self):
+      self.flasher.flash_command([os.getcwd()])
+
+def verify_platform_args(platform_args):
+    required_args = [
+        'application',
+        'parttool',
+        'port',
+        'baud',
+        'before',
+        'after',
+        'flash_mode',
+        'flash_freq',
+        'flash_size',
+        'compress',
+        'bootloader',
+        'partition',
+        'partition_offset',
+        'application_offset',
+    ]
+    difference = set(required_args) - set(platform_args)
+    if difference:
+        raise ValueError("Required arguments missing: %s" % difference)
+
+def create_platform(platform_args):
+    verify_platform_args(platform_args[0])
+    return ESP32Platform(platform_args[0])
+
+### End of Mobly integration
 
 if __name__ == '__main__':
     sys.exit(Flasher().flash_command(sys.argv))


### PR DESCRIPTION
 #### Problem

Described as Pillar 1 in
https://github.com/project-chip/connectedhomeip/blob/master/docs/api/device_runner.md

 #### Summary of Changes
- Adds a PigweedDevice python implementation (see integrations/mobly/chip_mobly/pigweed_device.py) to ESP32
- Adds a common echo_test.py mobly test to examples/pigweed-app.
- Adds an echo_test_config.yml to examples/pigweed-app/esp32. Makefile currently copies it into build directory. Later it would be better generated, similarly to how the flashing script is generated.
