### PR TITLE
Use the type system for the size of the buffer arg to PeerAddress::ToString, when possible.

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -117,7 +117,7 @@ public:
 
         VerifyOrExit(state->GetPeerNodeId() != kUndefinedNodeId, ChipLogProgress(AppServer, "Unknown source for received message"));
 
-        state->GetPeerAddress().ToString(src_addr, sizeof(src_addr));
+        state->GetPeerAddress().ToString(src_addr);
 
         ChipLogProgress(AppServer, "Packet received from %s: %zu bytes", src_addr, static_cast<size_t>(data_len));
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -337,7 +337,7 @@ exit:
 void SecureSessionMgr::HandleConnectionExpired(const Transport::PeerConnectionState & state)
 {
     char addr[Transport::PeerAddress::kMaxToStringSize];
-    state.GetPeerAddress().ToString(addr, sizeof(addr));
+    state.GetPeerAddress().ToString(addr);
 
     ChipLogDetail(Inet, "Connection from '%s' expired", addr);
 

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -56,7 +56,7 @@ void TransportMgrBase::HandleMessageReceived(const PacketHeader & packetHeader, 
     else
     {
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
-        peerAddress.ToString(addrBuffer, sizeof(addrBuffer));
+        peerAddress.ToString(addrBuffer);
         ChipLogError(Inet, "%s message from %s is dropped since no corresponding handler is set in TransportMgr.",
                      packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? "Encrypted" : "Unencrypted", addrBuffer);
     }

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -120,6 +120,12 @@ public:
         + 5 /* 16 bit interger */              //
         + 1 /* NullTerminator */;
 
+    template <size_t N>
+    inline void ToString(char (&buf)[N]) const
+    {
+        ToString(buf, N);
+    }
+
     void ToString(char * buf, size_t bufSize) const
     {
         char ip_addr[kInetMaxAddrLen];

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -128,12 +128,12 @@ void TestFindByNodeId(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1NodeId, nullptr));
     char buf[100];
-    statePtr->GetPeerAddress().ToString(buf, sizeof(buf));
+    statePtr->GetPeerAddress().ToString(buf);
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer1Addr);
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer1NodeId);
 
     NL_TEST_ASSERT(inSuite, statePtr = connections.FindPeerConnectionState(kPeer1NodeId, statePtr));
-    statePtr->GetPeerAddress().ToString(buf, sizeof(buf));
+    statePtr->GetPeerAddress().ToString(buf);
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerAddress() == kPeer2Addr);
     NL_TEST_ASSERT(inSuite, statePtr->GetPeerNodeId() == kPeer1NodeId);
 


### PR DESCRIPTION

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Various code has to pass in `buf, sizeof(buf)` when we can just infer the size using the type system.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Infer the size from the type.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
