### PR TITLE
ESP32: Set optimal CHIP task stack size for ESP32

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -321,7 +321,7 @@ menu "CHIP Device Layer"
         config CHIP_TASK_STACK_SIZE
             int "CHIP Task Stack Size"
             range 0 65535
-            default 8192
+            default 5120
             help
                 The size (in bytes) of the CHIP task stack.
 


### PR DESCRIPTION
 #### Problem
 Investigate a drastic increase in CHIP task stack size and find the optimal value for CONFIG_CHIP_TASK_STACK_SIZE

 #### Summary of Changes
Set the CHIP task stack size to 5K. 
_Performed the below test_
We checked the working of code with CHIP task stack size as 4608 on both M5Stack and DevkitC followed by pairing(via BLE and WiFi) -> toggling on on/off cluster -> reset to factory -> repeat. It worked fine, leaving the minimum free stack size as 400, which was checked using FreeRTOS API `uxTaskGetStackHighWaterMark`. These observations were tried out on latest code with commit id - 9318d1307bc437635d740e9a18181c837fecbe0c. On the safer side, we have set it to 5K.
 Fixes #1150 
