### PR TITLE
Add missing path to templates helper inside examples/chip-tool/templa…

### DIFF
--- a/examples/chip-tool/templates/templates.json
+++ b/examples/chip-tool/templates/templates.json
@@ -4,6 +4,7 @@
     "helpers": [
         "../../../src/app/zap-templates/partials/helper.js",
         "../../../src/app/zap-templates/common/StringHelper.js",
+        "../../../src/app/zap-templates/templates/app/helper.js",
         "../../../src/app/zap-templates/templates/chip/helper.js",
         "helper.js"
     ],


### PR DESCRIPTION
…tes/templates.json

 #### Problem

I forgot to update a path while changing some code in  #4661. Adding it back as it prevents to update the chip-tool generated code.