### PR TITLE
Temperate measurement app does not build anymore because of missing <nlbyteorder.hpp>

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/component.mk
+++ b/examples/temperature-measurement-app/esp32/main/component.mk
@@ -35,6 +35,7 @@ COMPONENT_SRCDIRS :=                                                            
 COMPONENT_EXTRA_INCLUDES := $(PROJECT_PATH)/third_party/connectedhomeip/src/app/util                            \
                             $(PROJECT_PATH)/third_party/connectedhomeip/src/app/reporting                       \
                             $(PROJECT_PATH)/third_party/connectedhomeip/src/app/server                          \
+                            $(PROJECT_PATH)/third_party/connectedhomeip/third_party/nlio/repo/include           \
                             $(PROJECT_PATH)/third_party/connectedhomeip/src
 
 # So "gen/*" files are found by the src/app bits.


### PR DESCRIPTION
 #### Problem
 The app does not build anymore and complains with the following error:
```
/path/to/connectedhomeip/examples/temperature-measurement-app/esp32/third_party/connectedhomeip/src/lib/core/CHIPEncoding.h:36:10: fatal error: nlbyteorder.hpp: No such file or directory
 #include <nlbyteorder.hpp>
          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

 #### Summary of Changes
 * Add `$(PROJECT_PATH)/third_party/connectedhomeip/third_party/nlio/repo/include ` to the includes sources