### PR TITLE
Fix too large buffer size in VerifyStatusReport()

### DIFF
--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -129,8 +129,13 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, payloadHeader.GetProtocolID() == Protocols::kProtocol_Protocol_Common);
     NL_TEST_ASSERT(inSuite, payloadHeader.GetMessageType() == static_cast<uint8_t>(Protocols::Common::MsgType::StatusReport));
+    if (headerSize > msg->DataLength())
+    {
+        NL_TEST_ASSERT(inSuite, false);
+        return;
+    }
 
-    Encoding::LittleEndian::Reader reader(msg->Start() + headerSize, msg->DataLength());
+    Encoding::LittleEndian::Reader reader(msg->Start() + headerSize, static_cast<uint16_t>(msg->DataLength() - headerSize));
     err = reader.Read16(&generalCode).Read32(&protocolId).Read16(&protocolCode).StatusCode();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, generalCode == static_cast<uint16_t>(Protocols::Common::StatusCode::Failure));


### PR DESCRIPTION
 #### Problem
In `TestBdxTransferSession.cpp`, `VerifyStatusReport()`, a `Reader` object was being initialized with a length that exceeded the bounds of the PacketBuffer to read.

 #### Summary of Changes
Subtract `headerSize` from the length parameter so that the Reader cannot read data beyond the bounds of the PacketBuffer


 Fixes #4748 
