### PR TITLE
Fix artifact download to deal with changes on the Github side.

### DIFF
--- a/scripts/helpers/github_fetch_artifacts.py
+++ b/scripts/helpers/github_fetch_artifacts.py
@@ -53,10 +53,10 @@ class ArtifactInfo(github.GithubObject.NonCompletableGithubObject):
     url = self.archive_download_url
     logging.info('Fetching: %r' % url)
 
-    headers, _ = self._requester.requestBlobAndCheck('GET', url)
+    status, headers, _ = self._requester.requestBlob('GET', url)
 
-    if 'status' not in headers or headers['status'] != '302 Found':
-        raise Exception('Expected a redirect during blob download but got %r.' % headers)
+    if status != 302:
+        raise Exception('Expected a redirect during blob download but got status %d, headers %r.' % (status, headers))
 
     response = requests.get(headers['location'])
     response.raise_for_status()


### PR DESCRIPTION
It looks like the Github backend used to include the HTTP status as an
actual header, in addition to sending it as a status.  But now they
don't seem to be doing it.

The difference between requestBlobAndCheck and requestBlob, looking at
<https://github.com/PyGithub/PyGithub/blob/master/github/Requester.py>,
is that the former calls requestBlob, then does JSON parsing on the
body, checks that the status is not an error, then returns just the
headers and response body to the caller.

Since we do actually care about the status, and don't care about the
response body and the JSON-decoding that requestBlobAndCheck does, we
can just use requestBlob directly.  That lets us examine the status in
the way we want.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
See commit message.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
See commit message.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
