### PR TITLE
[linux] Fix seg fault error if we do network provisioning twice.

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -842,12 +842,33 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
     GError * err    = nullptr;
     GVariant * args = nullptr;
     GVariantBuilder builder;
+    gboolean result;
 
     // Clean up current network if exists
     if (mWpaSupplicant.networkPath)
     {
-        g_object_unref(mWpaSupplicant.networkPath);
-        mWpaSupplicant.networkPath = nullptr;
+        GError * error = nullptr;
+
+        result = wpa_fi_w1_wpa_supplicant1_interface_call_remove_network_sync(mWpaSupplicant.iface, mWpaSupplicant.networkPath,
+                                                                              nullptr, &error);
+
+        if (result)
+        {
+            ChipLogProgress(DeviceLayer, "wpa_supplicant: removed network: %s", mWpaSupplicant.networkPath);
+            g_free(mWpaSupplicant.networkPath);
+            mWpaSupplicant.networkPath = nullptr;
+        }
+        else
+        {
+            ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to stop AP mode with error: %s",
+                            error ? error->message : "unknown error");
+            ret = CHIP_ERROR_INTERNAL;
+        }
+
+        if (error != nullptr)
+            g_error_free(error);
+
+        SuccessOrExit(ret);
     }
 
     g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
@@ -856,8 +877,8 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
     g_variant_builder_add(&builder, "{sv}", "key_mgmt", g_variant_new_string("WPA-PSK"));
     args = g_variant_builder_end(&builder);
 
-    gboolean result = wpa_fi_w1_wpa_supplicant1_interface_call_add_network_sync(mWpaSupplicant.iface, args,
-                                                                                &mWpaSupplicant.networkPath, nullptr, &err);
+    result = wpa_fi_w1_wpa_supplicant1_interface_call_add_network_sync(mWpaSupplicant.iface, args, &mWpaSupplicant.networkPath,
+                                                                       nullptr, &err);
 
     if (result)
     {
@@ -915,6 +936,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, cons
         ret = CHIP_ERROR_INTERNAL;
     }
 
+exit:
     if (err != nullptr)
         g_error_free(err);
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The linux device crashed if we do network provisioning twice:
chip::DeviceLayer::ConnectivityMgrImpl().StartWiFiManagement();
(wait)
chip::DeviceLayer::ConnectivityManagerImpl::ProvisionWiFiNetwork(ssid, passwd);
(wait)
chip::DeviceLayer::ConnectivityManagerImpl::ProvisionWiFiNetwork(ssid, passwd);

According to the backtrace, seems we have some kind of double free issue:

#0 0x0000fffff7a3000c in g_type_check_instance_is_fundamentally_a () at /lib/aarch64-linux-gnu/libgobject-2.0.so.0
#1 0x0000fffff7a139b8 in g_object_unref () at /lib/aarch64-linux-gnu/libgobject-2.0.so.0
#2 0x0000aaaaaaae46a4 in chip::DeviceLayer::ConnectivityManagerImpl::ProvisionWiFiNetwork(char const*, char const*)
(this=0xaaaaaab919b8 <chip::DeviceLayer::ConnectivityManagerImpl::sInstance>, ssid=0xffffffffe7d0 "Nest-T", key=0xffffffffe7f8 "Nesttesting")
at ../third_party/connectedhomeip/src/platform/Linux/ConnectivityManagerImpl.cpp:849

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Clean up current network if exists before provisioning

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4269

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
