### PR TITLE
Allow app to set the C flag in the packet header for control message.

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -59,6 +59,7 @@ CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer, PayloadHeader 
 {
     System::PacketBufferHandle resend;
     bool loadedSecureSession = false;
+    PacketHeader unusedPacketHeader;
 
     VerifyOrReturnError(mSessionManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
@@ -75,7 +76,7 @@ CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer, PayloadHeader 
         resend = buffer.CloneData();
     }
 
-    CHIP_ERROR err = mSessionManager->SendMessage(mSecureSession, payloadHeader, std::move(buffer));
+    CHIP_ERROR err = mSessionManager->SendMessage(mSecureSession, payloadHeader, unusedPacketHeader, std::move(buffer));
 
     buffer = nullptr;
     ChipLogDetail(Controller, "SendMessage returned %d", err);

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -65,6 +65,8 @@ enum class SendMessageFlags : uint16_t
     /**< Used to indicate that a response is expected within a specified timeout. */
     kExpectResponse = 0x0002,
     /**< Used to indicate that the source node ID in the message header can be reused. */
+    kControlMessage = 0x0004,
+    /**< Used to indicate that the message is a control message. */
     kReuseSourceId = 0x0020,
     /**< Used to indicate that the message is already encoded. */
     kAlreadyEncoded = 0x0080,

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -129,10 +129,11 @@ CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protoc
 {
     VerifyOrReturnError(mPairingSessionHandle != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    PacketHeader unusedPacketHeader;
     PayloadHeader payloadHeader;
     payloadHeader.SetMessageType(static_cast<uint16_t>(protocol), msgType);
 
-    return mSecureSessionMgr->SendMessage(*mPairingSessionHandle, payloadHeader, std::move(msgBuf));
+    return mSecureSessionMgr->SendMessage(*mPairingSessionHandle, payloadHeader, unusedPacketHeader, std::move(msgBuf));
 }
 
 void RendezvousSession::OnSessionEstablishmentError(CHIP_ERROR err)

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -99,14 +99,14 @@ Transport::Type SecureSessionMgr::GetTransportType(NodeId peerNodeId)
 CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, System::PacketBufferHandle && msgBuf)
 {
     PayloadHeader unusedPayloadHeader;
-    return SendMessage(session, unusedPayloadHeader, std::move(msgBuf));
+    PacketHeader unusedPacketHeader;
+    return SendMessage(session, unusedPayloadHeader, unusedPacketHeader, std::move(msgBuf));
 }
 
-CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader,
+CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
                                          System::PacketBufferHandle && msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot)
 {
-    PacketHeader unusedPacketHeader;
-    return SendMessage(session, payloadHeader, unusedPacketHeader, std::move(msgBuf), bufferRetainSlot,
+    return SendMessage(session, payloadHeader, packetHeader, std::move(msgBuf), bufferRetainSlot,
                        EncryptionState::kPayloadIsUnencrypted);
 }
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -175,14 +175,50 @@ public:
      * @brief
      *   Send a message to a currently connected peer.
      *
+     *  @param[in]    session          The secure session of the destination.
+     *
+     *  @param[in]    msgBuf           A hanlde to the PacketBuffer object holding the encoded CHIP message.
+     *
+     */
+    CHIP_ERROR SendMessage(SecureSessionHandle session, System::PacketBufferHandle && msgBuf);
+
+    /**
+     * @brief
+     *   Send a message to a currently connected peer.
+     *
+     *  @param[in]    session          The secure session of the destination.
+     *
+     *  @param[in]    payloadHeader    A reference to the PayloadHeader object of outgoing message.
+     *
+     *  @param[in]    packetHeader     A reference to the PacketHeader object of outgoing message.
+     *
+     *  @param[in]    msgBuf           A hanlde to the PacketBuffer object holding the encoded CHIP message.
+     *
+     *  @param[in]    bufferRetainSlot A hanlde to the PacketBuffer object whose payload has already been encrypted.
+     *
      * @details
      *   msgBuf contains the data to be transmitted.  If bufferRetainSlot is not null and this function
      *   returns success, the encrypted data that was sent, as well as various other information needed
      *   to retransmit it, will be stored in *bufferRetainSlot.
      */
-    CHIP_ERROR SendMessage(SecureSessionHandle session, System::PacketBufferHandle && msgBuf);
-    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, System::PacketBufferHandle && msgBuf,
-                           EncryptedPacketBufferHandle * bufferRetainSlot = nullptr);
+    CHIP_ERROR SendMessage(SecureSessionHandle session, PayloadHeader & payloadHeader, PacketHeader & packetHeader,
+                           System::PacketBufferHandle && msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot = nullptr);
+
+    /**
+     * @brief
+     *   Send an encrypted message to a currently connected peer.
+     *
+     *  @param[in]    session          The secure session of the destination.
+     *
+     *  @param[in]    msgBuf           A hanlde to the PacketBuffer object holding the CHIP message which is encrypted.
+     *
+     *  @param[in]    bufferRetainSlot A hanlde to the PacketBuffer object whose payload has already been encrypted.
+     *
+     * @details
+     *   msgBuf contains the data to be transmitted.  If bufferRetainSlot is not null and this function
+     *   returns success, the encrypted data that was sent, as well as various other information needed
+     *   to retransmit it, will be stored in *bufferRetainSlot.
+     */
     CHIP_ERROR SendEncryptedMessage(SecureSessionHandle session, EncryptedPacketBufferHandle msgBuf,
                                     EncryptedPacketBufferHandle * bufferRetainSlot);
 

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -255,6 +255,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     callback.ReceiveHandlerCallCount = 0;
 
     PayloadHeader payloadHeader;
+    PacketHeader unusedPacketHeader;
     EncryptedPacketBufferHandle msgBuf;
 
     // Set the exchange ID for this header.
@@ -265,7 +266,7 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, std::move(buffer), &msgBuf);
+    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, unusedPacketHeader, std::move(buffer), &msgBuf);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
@@ -329,6 +330,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     callback.ReceiveHandlerCallCount = 0;
 
     PayloadHeader payloadHeader;
+    PacketHeader unusedPacketHeader;
     EncryptedPacketBufferHandle msgBuf;
 
     // Set the exchange ID for this header.
@@ -339,7 +341,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, std::move(buffer), &msgBuf);
+    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, unusedPacketHeader, std::move(buffer), &msgBuf);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, we only can configure payload header before sending message to transport layer. Packetheader are auto-configured in Transport layer,  for example, we shall set the C flag in the packet header for certain type of control message.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add interface in Transport Layer to allows the messaging layer configure packet header

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4641

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
