### PR TITLE
Lock down EncryptedPacketBufferHandle some more.

### DIFF
--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -103,9 +103,7 @@ public:
      * unit tests only.   The CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API define
      * should not be defined normally.
      */
-    CHIP_ERROR ExtractPacketHeader(PacketHeader & aPacketHeader) {
-        return aPacketHeader.DecodeAndConsume(*this);
-    }
+    CHIP_ERROR ExtractPacketHeader(PacketHeader & aPacketHeader) { return aPacketHeader.DecodeAndConsume(*this); }
 
     /**
      * Inserts a new (unencrypted) packet header in the encrypted packet buffer
@@ -113,9 +111,7 @@ public:
      * unit tests only.   The CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API define
      * should not be defined normally.
      */
-    CHIP_ERROR InsertPacketHeader(const PacketHeader& aPacketHeader) {
-        return aPacketHeader.EncodeBeforeData(*this);
-    }
+    CHIP_ERROR InsertPacketHeader(const PacketHeader & aPacketHeader) { return aPacketHeader.EncodeBeforeData(*this); }
 #endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
 private:

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -69,7 +69,7 @@ private:
  *  EncryptedPacketBufferHandle is a kind of PacketBufferHandle class and used to hold a packet buffer
  *  object whose payload has already been encrypted.
  */
-class EncryptedPacketBufferHandle final : public System::PacketBufferHandle
+class EncryptedPacketBufferHandle final : private System::PacketBufferHandle
 {
 public:
     EncryptedPacketBufferHandle() : mMsgId(0) {}
@@ -93,6 +93,30 @@ public:
      * @returns empty handle on allocation failure.
      */
     EncryptedPacketBufferHandle CloneData() { return EncryptedPacketBufferHandle(PacketBufferHandle::CloneData()); }
+
+#ifdef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
+    /**
+     * Extracts the (unencrypted) packet header from this encrypted packet
+     * buffer.  Returns error if a packet header cannot be extracted (e.g. if
+     * there are not enough bytes in this packet buffer).  After this call the
+     * buffer does not have a packet header.  This API is meant for
+     * unit tests only.   The CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API define
+     * should not be defined normally.
+     */
+    CHIP_ERROR ExtractPacketHeader(PacketHeader & aPacketHeader) {
+        return aPacketHeader.DecodeAndConsume(*this);
+    }
+
+    /**
+     * Inserts a new (unencrypted) packet header in the encrypted packet buffer
+     * based on the given PacketHeader.  This API is meant for
+     * unit tests only.   The CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API define
+     * should not be defined normally.
+     */
+    CHIP_ERROR InsertPacketHeader(const PacketHeader& aPacketHeader) {
+        return aPacketHeader.EncodeBeforeData(*this);
+    }
+#endif // CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
 private:
     // Allow SecureSessionMgr to assign or construct us from a PacketBufferHandle

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -21,8 +21,8 @@
  *      This file implements unit tests for the SecureSessionMgr implementation.
  */
 
-#define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API  // Up here in case some other header
-                                               // includes SecureSessionMgr.h indirectly
+#define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API // Up here in case some other header
+                                              // includes SecureSessionMgr.h indirectly
 
 #include <core/CHIPCore.h>
 #include <protocols/Protocols.h>
@@ -363,8 +363,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Source Node ID
     EncryptedPacketBufferHandle badSrcNodeIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite,
-                   badSrcNodeIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, badSrcNodeIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     packetHeader.SetSourceNodeId(kDestinationNodeId);
     NL_TEST_ASSERT(inSuite, badSrcNodeIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
@@ -378,8 +377,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Message ID
     EncryptedPacketBufferHandle badMessageIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite,
-                   badMessageIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, badMessageIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     uint32_t msgID = packetHeader.GetMessageId();
     packetHeader.SetMessageId(msgID + 1);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -21,6 +21,9 @@
  *      This file implements unit tests for the SecureSessionMgr implementation.
  */
 
+#define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API  // Up here in case some other header
+                                               // includes SecureSessionMgr.h indirectly
+
 #include <core/CHIPCore.h>
 #include <protocols/Protocols.h>
 #include <protocols/echo/Echo.h>
@@ -35,6 +38,8 @@
 #include <nlunit-test.h>
 
 #include <errno.h>
+
+#undef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 
 namespace {
 
@@ -339,17 +344,15 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
 
-    uint16_t headerSize = 0;
     PacketHeader packetHeader;
 
     // Change Destination Node ID
     EncryptedPacketBufferHandle badDestNodeIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite,
-                   packetHeader.Decode(badDestNodeIdMsg->Start(), badDestNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, badDestNodeIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, packetHeader.GetDestinationNodeId().Value() == kDestinationNodeId);
     packetHeader.SetDestinationNodeId(kSourceNodeId);
-    packetHeader.EncodeAtStart(badDestNodeIdMsg, &headerSize);
+    NL_TEST_ASSERT(inSuite, badDestNodeIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     err = secureSessionMgr.SendEncryptedMessage(localToRemoteSession, std::move(badDestNodeIdMsg), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -361,10 +364,10 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     // Change Source Node ID
     EncryptedPacketBufferHandle badSrcNodeIdMsg = msgBuf.CloneData();
     NL_TEST_ASSERT(inSuite,
-                   packetHeader.Decode(badSrcNodeIdMsg->Start(), badSrcNodeIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+                   badSrcNodeIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     packetHeader.SetSourceNodeId(kDestinationNodeId);
-    packetHeader.EncodeAtStart(badSrcNodeIdMsg, &headerSize);
+    NL_TEST_ASSERT(inSuite, badSrcNodeIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     err = secureSessionMgr.SendEncryptedMessage(localToRemoteSession, std::move(badSrcNodeIdMsg), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -376,11 +379,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     // Change Message ID
     EncryptedPacketBufferHandle badMessageIdMsg = msgBuf.CloneData();
     NL_TEST_ASSERT(inSuite,
-                   packetHeader.Decode(badMessageIdMsg->Start(), badMessageIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+                   badMessageIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     uint32_t msgID = packetHeader.GetMessageId();
     packetHeader.SetMessageId(msgID + 1);
-    packetHeader.EncodeAtStart(badMessageIdMsg, &headerSize);
+    NL_TEST_ASSERT(inSuite, badMessageIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     err = secureSessionMgr.SendEncryptedMessage(localToRemoteSession, std::move(badMessageIdMsg), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -391,11 +394,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     // Change Key ID
     EncryptedPacketBufferHandle badKeyIdMsg = msgBuf.CloneData();
-    NL_TEST_ASSERT(inSuite, packetHeader.Decode(badKeyIdMsg->Start(), badKeyIdMsg->DataLength(), &headerSize) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, badKeyIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     // the secure channel is setup to use key ID 1, and 2. So let's use 3 here.
     packetHeader.SetEncryptionKeyID(3);
-    packetHeader.EncodeAtStart(badKeyIdMsg, &headerSize);
+    NL_TEST_ASSERT(inSuite, badKeyIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
     err = secureSessionMgr.SendEncryptedMessage(localToRemoteSession, std::move(badKeyIdMsg), nullptr);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);


### PR DESCRIPTION
Our existing EncryptedPacketBufferHandle allowed modification of the
data by just grabbing pointers to the internal buffer and writing to
it.  Making the inheritance from System::PacketBufferHandle private
closes this off.  The SecureSessionMgr class can still do it (because
it's a friend), but no one else can.

To allow us to continue testing what happens if the SecureSessionMgr
messes up the packet header, some test-only APIs are added.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
See https://github.com/project-chip/connectedhomeip/issues/4747

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
See commit message.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/4747

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
