### PR TITLE
Fix warnings -Warray-bounds and add optimized build to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
         strategy:
             matrix:
-                type: [main, clang, mbedtls]
+                type: [gcc_debug, gcc_release, clang, mbedtls]
         env:
             BUILD_TYPE: ${{ matrix.type }}
             BUILD_IMAGE: chip-build-openssl
@@ -56,7 +56,8 @@ jobs:
             - name: Setup Build
               run: |
                   case $BUILD_TYPE in
-                     "main") GN_ARGS='chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true';;
+                     "gcc_debug") GN_ARGS='chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true';;
+                     "gcc_release") GN_ARGS='is_debug=false';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
                      *) ;;

--- a/examples/bridge-app/bridge-common/gen/af-gen-event.h
+++ b/examples/bridge-app/bridge-common/gen/af-gen-event.h
@@ -63,7 +63,7 @@
 #define EMBER_AF_GENERATED_EVENT_STRINGS "Level Control Cluster Server EP 1",
 
 // The length of the event context table used to track and retrieve cluster events
-#define EMBER_AF_EVENT_CONTEXT_LENGTH 4
+#define EMBER_AF_EVENT_CONTEXT_LENGTH 1
 
 // EmberAfEventContext structs used to populate the EmberAfEventContext table
 #define EMBER_AF_GENERATED_EVENT_CONTEXT                                                                                           \

--- a/examples/chip-tool/gen/af-gen-event.h
+++ b/examples/chip-tool/gen/af-gen-event.h
@@ -45,10 +45,4 @@
 #define EMBER_AF_GENERATED_EVENTS
 #define EMBER_AF_GENERATED_EVENT_STRINGS
 
-// The length of the event context table used to track and retrieve cluster events
-#define EMBER_AF_EVENT_CONTEXT_LENGTH 4
-
-// EmberAfEventContext structs used to populate the EmberAfEventContext table
-#define EMBER_AF_GENERATED_EVENT_CONTEXT
-
 #endif // __AF_GEN_EVENT__

--- a/examples/lighting-app/lighting-common/gen/af-gen-event.h
+++ b/examples/lighting-app/lighting-common/gen/af-gen-event.h
@@ -63,7 +63,7 @@
 #define EMBER_AF_GENERATED_EVENT_STRINGS "Level Control Cluster Server EP 1",
 
 // The length of the event context table used to track and retrieve cluster events
-#define EMBER_AF_EVENT_CONTEXT_LENGTH 4
+#define EMBER_AF_EVENT_CONTEXT_LENGTH 1
 
 // EmberAfEventContext structs used to populate the EmberAfEventContext table
 #define EMBER_AF_GENERATED_EVENT_CONTEXT                                                                                           \

--- a/src/darwin/Framework/CHIP/gen/af-gen-event.h
+++ b/src/darwin/Framework/CHIP/gen/af-gen-event.h
@@ -45,10 +45,4 @@
 #define EMBER_AF_GENERATED_EVENTS
 #define EMBER_AF_GENERATED_EVENT_STRINGS
 
-// The length of the event context table used to track and retrieve cluster events
-#define EMBER_AF_EVENT_CONTEXT_LENGTH 4
-
-// EmberAfEventContext structs used to populate the EmberAfEventContext table
-#define EMBER_AF_GENERATED_EVENT_CONTEXT
-
 #endif // __AF_GEN_EVENT__


### PR DESCRIPTION
This fixes a bug diagnosed by a warning that is only available at -O2 or higher:

```
../../src/app/util/af-event.cpp: In function ‘EmberAfEventContext* findEventContext(chip::EndpointId, chip::ClusterId, bool)’:
../../src/app/util/af-event.cpp:142:22: error: array subscript 0 is outside array bounds of ‘EmberAfEventContext [0]’ [-Werror=array-bounds]
  142 |         if (context->endpoint == endpoint && context->clusterId == clusterId && context->isClient == isClient)
      |             ~~~~~~~~~^~~~~~~~
```