### PR TITLE
[crypto] Fix unaligned access on ARM

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -224,7 +224,7 @@ public:
     virtual const PK & Pubkey() = 0;
 };
 
-struct P256KeypairContext
+struct alignas(size_t) P256KeypairContext
 {
     uint8_t mBytes[kMAX_P256Keypair_Context_Size];
 };
@@ -354,7 +354,7 @@ CHIP_ERROR Hash_SHA256(const uint8_t * data, size_t data_length, uint8_t * out_b
  *        All implementations must check for std::is_trivially_copyable.
  **/
 
-struct HashSHA256OpaqueContext
+struct alignas(size_t) HashSHA256OpaqueContext
 {
     uint8_t mOpaque[kMAX_Hash_SHA256_Context_Size];
 };
@@ -797,7 +797,7 @@ protected:
     uint8_t * Ke;
 };
 
-struct Spake2pOpaqueContext
+struct alignas(size_t) Spake2pOpaqueContext
 {
     uint8_t mOpaque[kMAX_Spake2p_Context_Size];
 };

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -42,6 +42,7 @@
 #include <support/BufferWriter.h>
 #include <support/CodeUtils.h>
 #include <support/SafeInt.h>
+#include <support/SafePointerCast.h>
 #include <support/logging/CHIPLogging.h>
 
 #include <string.h>
@@ -300,9 +301,7 @@ Hash_SHA256_stream::~Hash_SHA256_stream() {}
 
 static inline SHA256_CTX * to_inner_hash_sha256_context(HashSHA256OpaqueContext * context)
 {
-    static_assert(sizeof(HashSHA256OpaqueContext) >= sizeof(SHA256_CTX), "Need more memory for SHA256 Context");
-    static_assert(std::is_trivially_copyable<SHA256_CTX>(), "SHA256_CTX values must copyable");
-    return reinterpret_cast<SHA256_CTX *>(context->mOpaque);
+    return SafePointerCast<SHA256_CTX *>(context);
 }
 
 CHIP_ERROR Hash_SHA256_stream::Begin()
@@ -482,20 +481,17 @@ ECName MapECName(SupportedECPKeyTypes keyType)
 
 static inline void from_EC_KEY(EC_KEY * key, P256KeypairContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(key), "Need more memory for EC_KEY");
-    *reinterpret_cast<EC_KEY **>(context->mBytes) = key;
+    *SafePointerCast<EC_KEY **>(context) = key;
 }
 
 static inline EC_KEY * to_EC_KEY(P256KeypairContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(EC_KEY *), "Need more memory for EC_KEY");
-    return *reinterpret_cast<EC_KEY **>(context->mBytes);
+    return *SafePointerCast<EC_KEY **>(context);
 }
 
 static inline const EC_KEY * to_const_EC_KEY(const P256KeypairContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(EC_KEY *), "Need more memory for EC_KEY");
-    return *reinterpret_cast<const EC_KEY * const *>(context->mBytes);
+    return *SafePointerCast<const EC_KEY * const *>(context);
 }
 
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature)
@@ -1183,8 +1179,7 @@ typedef struct Spake2p_Context
 
 static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(Spake2pOpaqueContext) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
-    return reinterpret_cast<Spake2p_Context *>(context->mOpaque);
+    return SafePointerCast<Spake2p_Context *>(context);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal()

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -41,6 +41,7 @@
 #include <core/CHIPSafeCasts.h>
 #include <support/BufferWriter.h>
 #include <support/CodeUtils.h>
+#include <support/SafePointerCast.h>
 #include <support/logging/CHIPLogging.h>
 
 #include <string.h>
@@ -194,9 +195,7 @@ Hash_SHA256_stream::~Hash_SHA256_stream(void) {}
 
 static inline mbedtls_sha256_context * to_inner_hash_sha256_context(HashSHA256OpaqueContext * context)
 {
-    static_assert(sizeof(context->mOpaque) >= sizeof(mbedtls_sha256_context), "Need more memory for SHA256 Context");
-    static_assert(std::is_trivially_copyable<mbedtls_sha256_context>(), "mbedtls_sha256_context values must copyable");
-    return reinterpret_cast<mbedtls_sha256_context *>(context->mOpaque);
+    return SafePointerCast<mbedtls_sha256_context *>(context);
 }
 
 CHIP_ERROR Hash_SHA256_stream::Begin(void)
@@ -410,14 +409,12 @@ mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
 
 static inline mbedtls_ecp_keypair * to_keypair(P256KeypairContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(mbedtls_ecp_keypair), "Need more memory for mbedtls_ecp_keypair");
-    return reinterpret_cast<mbedtls_ecp_keypair *>(context->mBytes);
+    return SafePointerCast<mbedtls_ecp_keypair *>(context);
 }
 
 static inline const mbedtls_ecp_keypair * to_const_keypair(const P256KeypairContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(P256KeypairContext) >= sizeof(mbedtls_ecp_keypair), "Need more memory for mbedtls_ecp_keypair");
-    return reinterpret_cast<const mbedtls_ecp_keypair *>(context->mBytes);
+    return SafePointerCast<const mbedtls_ecp_keypair *>(context);
 }
 
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature)
@@ -767,8 +764,7 @@ typedef struct Spake2p_Context
 
 static inline Spake2p_Context * to_inner_spake2p_context(Spake2pOpaqueContext * context)
 {
-    nlSTATIC_ASSERT_PRINT(sizeof(context->mOpaque) >= sizeof(Spake2p_Context), "Need more memory for Spake2p Context");
-    return reinterpret_cast<Spake2p_Context *>(context->mOpaque);
+    return SafePointerCast<Spake2p_Context *>(context);
 }
 
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)

--- a/src/lib/support/SafePointerCast.h
+++ b/src/lib/support/SafePointerCast.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace chip {
+
+/**
+ * A template function that casts a pointer of type From* to a pointer of type To*
+ * and verifies that both From and To are trivially copyable structures, size of
+ * To is not greater than size of From, and To doesn't have more strict alignment
+ * requirements than From. That is to make sure that access to fields of To is safe.
+ */
+template <class ToPtr, class From>
+std::enable_if_t<std::is_pointer<ToPtr>::value, ToPtr> SafePointerCast(From * from)
+{
+    using To = std::remove_pointer_t<ToPtr>;
+    static_assert(std::is_trivially_copyable<From>(), "Casting from a non-trivially copyable type");
+    static_assert(std::is_trivially_copyable<To>(), "Casting to a non-trivially copyable type");
+    static_assert(sizeof(From) >= sizeof(To), "Casting to a bigger type");
+    static_assert(alignof(From) >= alignof(To), "Casting to a type with more strict alignment requirements");
+    return reinterpret_cast<ToPtr>(from);
+}
+
+} // namespace chip


### PR DESCRIPTION
 #### Problem
Raw `uint8_t` array was casted to `mbedtls_sha256_context` which would cause unaligned access exception on ARM-based platforms. 

 #### Summary of Changes
Align the `mbedtls_sha256_context` structure properly.