### PR TITLE
Add Key Value Storage implementation for nrfconnect

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -469,6 +469,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       sources += [
         "Zephyr/BLEManagerImpl.cpp",
         "Zephyr/ConfigurationManagerImpl.cpp",
+        "Zephyr/KeyValueStoreManagerImpl.cpp",
         "Zephyr/Logging.cpp",
         "Zephyr/PlatformManagerImpl.cpp",
         "Zephyr/SystemTimeSupport.cpp",
@@ -485,6 +486,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "nrfconnect/DeviceNetworkProvisioningDelegateImpl.cpp",
         "nrfconnect/DeviceNetworkProvisioningDelegateImpl.h",
         "nrfconnect/InetPlatformConfig.h",
+        "nrfconnect/KeyValueStoreManagerImpl.h",
         "nrfconnect/PlatformManagerImpl.h",
         "nrfconnect/SystemPlatformConfig.h",
       ]

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
@@ -1,0 +1,126 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific key value storage implementation for Zephyr
+ */
+
+#include <platform/KeyValueStoreManager.h>
+#include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
+#include <support/logging/CHIPLogging.h>
+
+#include <logging/log.h>
+#include <settings/settings.h>
+
+#include <string>
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
+const char * kChipKeyPrefix = "ch/";
+
+void KeyValueStoreManagerImpl::Init()
+{
+    VerifyOrDie(settings_subsys_init() == 0);
+}
+
+struct ReadEntry
+{
+    void * destination;           // destination address
+    size_t destinationBufferSize; // size of destination buffer
+    size_t readSize;              // [out] size of read entry value
+    CHIP_ERROR result;            // [out] read result
+};
+
+static int LoadEntryCallback(const char * name, size_t entrySize, settings_read_cb readCb, void * cbArg, void * param)
+{
+    ReadEntry & entry = *reinterpret_cast<ReadEntry *>(param);
+
+    // If requested a key X, process just node X and ignore all its descendants: X/*
+    if (settings_name_next(name, nullptr) > 0)
+        return 0;
+
+    // Found requested key
+    const ssize_t bytesRead = readCb(cbArg, entry.destination, entry.destinationBufferSize);
+    entry.readSize          = bytesRead > 0 ? bytesRead : 0;
+
+    if (entrySize > entry.destinationBufferSize)
+    {
+        entry.result = CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+    else
+    {
+        entry.result = bytesRead > 0 ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    }
+
+    return 0;
+}
+
+CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,
+                                          size_t offset_bytes) const
+{
+    VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(value, CHIP_ERROR_INVALID_ARGUMENT);
+    // Offset and partial reads are not supported, for now just return NOT_IMPLEMENTED.
+    // Support can be added in the future if this is needed.
+    VerifyOrReturnError(offset_bytes == 0, CHIP_ERROR_NOT_IMPLEMENTED);
+
+    // Concatenate key with the "chip/" prefix to separate it from the other Zephyr settings.
+    std::string fullKey(std::string(kChipKeyPrefix) + key);
+
+    ReadEntry entry{ value, value_size, 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND };
+    settings_load_subtree_direct(fullKey.c_str(), LoadEntryCallback, &entry);
+
+    // Assign readSize only in case read_bytes_size is not nullptr, as it is optional argument
+    if (read_bytes_size)
+        *read_bytes_size = entry.readSize;
+
+    return entry.result;
+}
+
+CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
+{
+    VerifyOrReturnError(key, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(value, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(value_size > 0, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Concatenate key with the "chip/" prefix to separate it from the other Zephyr settings.
+    std::string fullKey(std::string(kChipKeyPrefix) + key);
+    VerifyOrReturnError(settings_save_one(fullKey.c_str(), value, value_size) == 0, CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
+{
+    // Concatenate key with the "chip/" prefix to separate it from the other Zephyr settings.
+    std::string fullKey(std::string(kChipKeyPrefix) + key);
+
+    if (settings_delete(fullKey.c_str()) != 0)
+        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.h
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.h
@@ -1,0 +1,83 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific key value storage implementation for Zephyr.
+ *
+ */
+
+#pragma once
+
+#include <zephyr.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+class KeyValueStoreManagerImpl final : public KeyValueStoreManager
+{
+    // Allow the KeyValueStoreManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class KeyValueStoreManager;
+
+public:
+    void Init();
+
+    // NOTE: Currently this platform does not support partial and offset reads
+    //       these will return CHIP_ERROR_NOT_IMPLEMENTED.
+    CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0) const;
+
+    CHIP_ERROR _Delete(const char * key);
+
+    CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);
+
+private:
+    // ===== Members for internal use by the following friends.
+
+    friend KeyValueStoreManager & KeyValueStoreMgr();
+    friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
+
+    static KeyValueStoreManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications should use this to access features of the KeyValueStoreManager object
+ * that are common to all platforms.
+ */
+inline KeyValueStoreManager & KeyValueStoreMgr()
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications can use this to gain access to features of the KeyValueStoreManager
+ * that are specific to the Zephyr platform.
+ */
+inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl()
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/KeyValueStoreManagerImpl.h
+++ b/src/platform/nrfconnect/KeyValueStoreManagerImpl.h
@@ -1,0 +1,27 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an implementation of the KeyValueStoreManager object
+ *          for nRF Connect SDK platforms, by including Zephyr platform
+ *          implementation.
+ */
+
+#pragma once
+
+#include <platform/Zephyr/KeyValueStoreManagerImpl.h>

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -72,6 +72,10 @@ if (chip_device_platform != "none") {
       ]
       tests = [ "TestCHIPoBLEStackMgr" ]
     }
+
+    if (current_os == "zephyr") {
+      test_sources += [ "TestKeyValueStoreMgr.cpp" ]
+    }
   }
 } else {
   import("${build_root}/chip/chip_test_group.gni")

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -1,0 +1,248 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a unit test suite for the Key Value Store Manager
+ *      code functionality.
+ *
+ */
+
+#include <nlunit-test.h>
+
+#include <support/CHIPMem.h>
+#include <support/UnitTestRegistration.h>
+
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/KeyValueStoreManager.h>
+
+using namespace chip;
+using namespace chip::DeviceLayer;
+using namespace chip::DeviceLayer::PersistedStorage;
+
+static void TestKeyValueStoreMgr_EmptyStringKey(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey   = "str_key";
+    const char kTestValue[] = "";
+    char read_value[sizeof(kTestValue)];
+    size_t read_size;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Verify if read value is the same as wrote one
+    NL_TEST_ASSERT(inSuite, strcmp(kTestValue, read_value) == 0);
+    NL_TEST_ASSERT(inSuite, read_size == sizeof(kTestValue));
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+}
+
+static void TestKeyValueStoreMgr_StringKey(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey   = "str_key";
+    const char kTestValue[] = "test_value";
+    char read_value[sizeof(kTestValue)];
+    size_t read_size;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Verify if read value is the same as wrote one
+    NL_TEST_ASSERT(inSuite, strcmp(kTestValue, read_value) == 0);
+    NL_TEST_ASSERT(inSuite, read_size == sizeof(kTestValue));
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+}
+
+static void TestKeyValueStoreMgr_Uint32Key(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey = "uint32_key";
+    const char kTestValue = 5;
+    uint32_t read_value;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = KeyValueStoreMgr().Get(kTestKey, &read_value);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Verify if read value is the same as wrote one
+    NL_TEST_ASSERT(inSuite, kTestValue == read_value);
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
+    err = KeyValueStoreMgr().Get(kTestKey, &read_value);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+}
+
+static void TestKeyValueStoreMgr_ArrayKey(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey  = "array_key";
+    uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
+    uint32_t read_value[5];
+    size_t read_size;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Verify if read value is the same as wrote one
+    NL_TEST_ASSERT(inSuite, memcmp(kTestValue, read_value, sizeof(kTestValue)) == 0);
+    NL_TEST_ASSERT(inSuite, read_size == sizeof(kTestValue));
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
+    err = KeyValueStoreMgr().Get(kTestKey, read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+}
+
+static void TestKeyValueStoreMgr_StructKey(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    struct TestStruct
+    {
+        uint8_t value1;
+        uint32_t value2;
+    };
+    const char * kTestKey = "struct_key";
+    TestStruct kTestValue{ 1, 2 };
+    TestStruct read_value;
+    size_t read_size;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    err = KeyValueStoreMgr().Get(kTestKey, &read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Verify if read value is the same as wrote one
+    NL_TEST_ASSERT(inSuite, kTestValue.value1 == read_value.value1);
+    NL_TEST_ASSERT(inSuite, kTestValue.value2 == read_value.value2);
+    NL_TEST_ASSERT(inSuite, read_size == sizeof(kTestValue));
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
+    err = KeyValueStoreMgr().Get(kTestKey, &read_value, sizeof(read_value), &read_size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+}
+
+static void TestKeyValueStoreMgr_UpdateKeyValue(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey = "update_key";
+    uint32_t read_value;
+    for (uint32_t i = 0; i < 10; i++)
+    {
+        err = KeyValueStoreMgr().Put(kTestKey, i);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        err = KeyValueStoreMgr().Get(kTestKey, &read_value);
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, i == read_value);
+    }
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+static void TestKeyValueStoreMgr_TooSmallBufferRead(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey  = "too_small_buffer_read_key";
+    uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
+    uint32_t read_value;
+    size_t read_size;
+    err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    // Returns buffer too small and should read as many bytes as possible
+    err = KeyValueStoreMgr().Get(kTestKey, &read_value, sizeof(read_value), &read_size, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite, read_size == sizeof(read_value));
+    NL_TEST_ASSERT(inSuite, kTestValue[0] == read_value);
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+static void TestKeyValueStoreMgr_MultiReadKey(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+    const char * kTestKey  = "multi_key";
+    uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
+    err                    = KeyValueStoreMgr().Put(kTestKey, kTestValue);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    for (uint32_t i = 0; i < 5; i++)
+    {
+        uint32_t read_value;
+        size_t read_size;
+        // Returns buffer too small for all but the last read.
+        err = KeyValueStoreMgr().Get(kTestKey, &read_value, sizeof(read_value), &read_size, i * sizeof(uint32_t));
+        NL_TEST_ASSERT(inSuite, err == (i < 4 ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR));
+        NL_TEST_ASSERT(inSuite, read_size == sizeof(read_value));
+        NL_TEST_ASSERT(inSuite, kTestValue[i] == read_value);
+    }
+    err = KeyValueStoreMgr().Delete(kTestKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = { NL_TEST_DEF("Test KeyValueStoreMgr_EmptyStringKey", TestKeyValueStoreMgr_EmptyStringKey),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_StringKey", TestKeyValueStoreMgr_StringKey),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_Uint32Key", TestKeyValueStoreMgr_Uint32Key),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_ArrayKey", TestKeyValueStoreMgr_ArrayKey),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_StructKey", TestKeyValueStoreMgr_StructKey),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_UpdateKeyValue", TestKeyValueStoreMgr_UpdateKeyValue),
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_TooSmallBufferRead", TestKeyValueStoreMgr_TooSmallBufferRead),
+#ifndef __ZEPHYR__
+                                 // Zephyr platform does not support partial or offset reads yet.
+                                 NL_TEST_DEF("Test KeyValueStoreMgr_MultiReadKey", TestKeyValueStoreMgr_MultiReadKey),
+#endif
+                                 NL_TEST_SENTINEL() };
+
+/**
+ *  Set up the test suite.
+ */
+int TestKeyValueStoreMgr_Setup(void * inContext)
+{
+    CHIP_ERROR error = chip::Platform::MemoryInit();
+    if (error != CHIP_NO_ERROR)
+        return FAILURE;
+
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestKeyValueStoreMgr_Teardown(void * inContext)
+{
+    chip::Platform::MemoryShutdown();
+    return SUCCESS;
+}
+
+int TestKeyValueStoreMgr()
+{
+    nlTestSuite theSuite = { "KeyValueStoreMgr tests", &sTests[0], TestKeyValueStoreMgr_Setup, TestKeyValueStoreMgr_Teardown };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestKeyValueStoreMgr);

--- a/src/test_driver/nrfconnect/CMakeLists.txt
+++ b/src/test_driver/nrfconnect/CMakeLists.txt
@@ -42,8 +42,8 @@ set(CHIP_CFLAGS
     -DCHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF=0
     -DCHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS=1
     -I${CMAKE_CURRENT_SOURCE_DIR}/main/include
-    -isystem${ZEPHYR_BASE}/../modules/crypto/mbedtls/configs
-    -isystem${ZEPHYR_BASE}/../mbedtls/include
+    -isystem$ENV{ZEPHYR_BASE}/../modules/crypto/mbedtls/configs
+    -isystem$ENV{ZEPHYR_BASE}/../mbedtls/include
 )
 
 set(CHIP_TESTS


### PR DESCRIPTION
 #### Problem
The nrfconnect and Zephyr platforms do not have implemented KeyValueStoreManagerImpl.

 #### Summary of Changes
* Added KeyValueStoreManagerImpl for Zephyr and nrfconnect
* Copied tests from examples/persistent-storage/KeyValueStorageTest.cpp to the TestKeyValueStoreMgr unit test suite.
* Added test checking getting too small buffer error, as nrfconnect and ESP32 platforms do not support read offsets.
* Added running TestKeyValueStoreMgr unit test on the Zephyr/nrfconnect platform.

 Fixes #4759 