### PR TITLE
Remove "six" dependency in controller/python

### DIFF
--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -113,7 +113,6 @@ try:
     
     if platform.system() == 'Linux':
         requiredPackages.append('dbus-python')
-        requiredPackages.append('six')
         requiredPackages.append('pygobject')
     
     #

--- a/src/controller/python/chip/ChipBleBase.py
+++ b/src/controller/python/chip/ChipBleBase.py
@@ -25,10 +25,9 @@ from __future__ import absolute_import
 import abc
 import optparse
 import shlex
-import six
 
 
-class ChipBleBase(six.with_metaclass(abc.ABCMeta, object)):
+class ChipBleBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def scan(self, line):
         """ API to initiatae BLE scanning for -t user_timeout seconds."""

--- a/src/controller/python/chip/ChipBleUtility.py
+++ b/src/controller/python/chip/ChipBleUtility.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from ctypes import *
 from .ChipUtility import ChipUtility
-import six
 
 
 # Duplicates of BLE definitions in ChipDeviceController-ScriptBinding.cpp
@@ -68,7 +67,7 @@ def VoidPtrToUUIDString(ptr, len):
 
 
 def ParseBleEventType(val):
-    if isinstance(val, six.integer_types):
+    if isinstance(val, int):
         return val
     if val.lower() == "rx":
         return BLE_EVENT_TYPE_RX

--- a/src/controller/python/chip/ChipBluezMgr.py
+++ b/src/controller/python/chip/ChipBluezMgr.py
@@ -35,12 +35,9 @@ import threading
 import time
 import traceback
 import uuid
-import six.moves.queue
-
+import queue
 
 from ctypes import *
-import six
-from six.moves import range
 
 try:
     from gi.repository import GObject
@@ -97,7 +94,7 @@ def get_bluez_objects(bluez, bus, interface, prefix_path):
     results = []
     if bluez is None or bus is None or interface is None or prefix_path is None:
         return results
-    for item in six.iteritems(bluez.GetManagedObjects()):
+    for item in bluez.GetManagedObjects().items:
         delegates = item[1].get(interface)
         if not delegates:
             continue
@@ -798,7 +795,7 @@ class BluezManager(ChipBleBase):
         self.scan_quiet = False
         self.peripheral_list = []
         self.device_uuid_list = []
-        self.chip_queue = six.moves.queue.Queue()
+        self.chip_queue = queue.Queue()
         self.Gmainloop = None
         self.daemon_thread = None
         self.adapter = None

--- a/src/controller/python/chip/ChipBluezMgr.py
+++ b/src/controller/python/chip/ChipBluezMgr.py
@@ -94,7 +94,7 @@ def get_bluez_objects(bluez, bus, interface, prefix_path):
     results = []
     if bluez is None or bus is None or interface is None or prefix_path is None:
         return results
-    for item in bluez.GetManagedObjects().items:
+    for item in bluez.GetManagedObjects().items():
         delegates = item[1].get(interface)
         if not delegates:
             continue

--- a/src/controller/python/chip/ChipCoreBluetoothMgr.py
+++ b/src/controller/python/chip/ChipCoreBluetoothMgr.py
@@ -29,7 +29,7 @@ from Foundation import *
 
 import logging
 import objc
-import six.moves.queue
+import queue
 import time
 
 from .ChipBleUtility import (
@@ -154,7 +154,7 @@ class CoreBluetoothManager(ChipBleBase):
         self.peripheral_list = []
         self.peripheral_adv_list = []
         self.bg_peripheral_name = None
-        self.chip_queue = six.moves.queue.Queue()
+        self.chip_queue = queue.Queue()
 
         self.manager = CBCentralManager.alloc()
         self.manager.initWithDelegate_queue_options_(self, None, None)


### PR DESCRIPTION
 #### Problem
Python 2 has been sunsetted: https://www.python.org/doc/sunset-python-2/ however we still include the `six` compatibility library.

We could simplify dependencies and code if we removed backwards compatibility with python2.

 #### Summary of Changes
Removes dependency on six, replaces with python 3 specific code.