### PR TITLE
Prepare for Thread Credentials in Darwin Pairing Delegate

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -355,12 +355,17 @@
 }
 
 // MARK: CHIPDevicePairingDelegate
-- (void)onNetworkCredentialsRequested:(SendNetworkCredentials)handler
+- (void)onNetworkCredentialsRequested:(CHIPNetworkCredentialType)type
 {
-    NSLog(@"Network credential requested for pairing");
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DISPATCH_TIME_NOW), dispatch_get_main_queue(), ^{
-        [self retrieveAndSendWifiCredentialsUsing:handler];
-    });
+    NSLog(@"Network credential requested for pairing for type %lu", (unsigned long)type);
+    if (type == kNetworkCredentialTypeWiFi)
+    {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DISPATCH_TIME_NOW), dispatch_get_main_queue(), ^{
+            [self retrieveAndSendWifiCredentials];
+        });
+    } else {
+        NSLog(@"Unsupported credentials requested");
+    }
 }
 
 // MARK: UI Helper methods
@@ -445,7 +450,7 @@
     [self handleRendezVous:payload];
 }
 
-- (void)retrieveAndSendWifiCredentialsUsing:(SendNetworkCredentials)sendCredentials
+- (void)retrieveAndSendWifiCredentials
 {
     UIAlertController * alertController =
         [UIAlertController alertControllerWithTitle:@"Wifi Configuration"
@@ -499,7 +504,7 @@
                                                  }
                                                  NSLog(@"New SSID: %@ Password: %@", networkSSID.text, networkPassword.text);
 
-                                                 sendCredentials(networkSSID.text, networkPassword.text);
+                                                 [strongSelf.chipController sendWiFiCredentials:networkSSID.text password:networkPassword.text];
                                              }
                                          }]];
     [self presentViewController:alertController animated:YES completion:nil];

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -357,9 +357,8 @@
 // MARK: CHIPDevicePairingDelegate
 - (void)onNetworkCredentialsRequested:(CHIPNetworkCredentialType)type
 {
-    NSLog(@"Network credential requested for pairing for type %lu", (unsigned long)type);
-    if (type == kNetworkCredentialTypeWiFi)
-    {
+    NSLog(@"Network credential requested for pairing for type %lu", (unsigned long) type);
+    if (type == kNetworkCredentialTypeWiFi) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, DISPATCH_TIME_NOW), dispatch_get_main_queue(), ^{
             [self retrieveAndSendWifiCredentials];
         });
@@ -504,7 +503,8 @@
                                                  }
                                                  NSLog(@"New SSID: %@ Password: %@", networkSSID.text, networkPassword.text);
 
-                                                 [strongSelf.chipController sendWiFiCredentials:networkSSID.text password:networkPassword.text];
+                                                 [strongSelf.chipController sendWiFiCredentials:networkSSID.text
+                                                                                       password:networkPassword.text];
                                              }
                                          }]];
     [self presentViewController:alertController animated:YES completion:nil];

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
              error:(NSError * __autoreleasing *)error;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
+- (void)sendWiFiCredentials:(NSString *)ssid  password:(NSString *)password;
+- (void)sendThreadCredentials:(NSData *)threadDataSet;
 
 - (CHIPDevice *)getPairedDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
              error:(NSError * __autoreleasing *)error;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
-- (void)sendWiFiCredentials:(NSString *)ssid  password:(NSString *)password;
+- (void)sendWiFiCredentials:(NSString *)ssid password:(NSString *)password;
 - (void)sendThreadCredentials:(NSData *)threadDataSet;
 
 - (CHIPDevice *)getPairedDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -192,6 +192,20 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
     [self.lock unlock];
 }
 
+- (void)sendWiFiCredentials:(NSString *)ssid password:(NSString *)password
+{
+    [self.lock lock];
+    _pairingDelegateBridge->SendWiFiCredentials(ssid, password);
+    [self.lock unlock];
+}
+
+- (void)sendThreadCredentials:(NSData *)threadDataSet
+{
+    [self.lock lock];
+    _pairingDelegateBridge->SendThreadCredentials(threadDataSet);
+    [self.lock unlock];
+}
+
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg
 {
     if (condition) {

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegate.h
@@ -19,14 +19,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SendNetworkCredentials)(NSString * ssid, NSString * password);
-
-typedef NS_ENUM(NSUInteger, PairingStatus) {
+typedef NS_ENUM(NSUInteger, CHIPPairingStatus) {
     kSecurePairingSuccess = 0,
     kSecurePairingFailed,
     kNetworkProvisioningSuccess,
     kNetworkProvisioningFailed,
     kUnknownStatus,
+};
+
+typedef NS_ENUM(NSUInteger, CHIPNetworkCredentialType) {
+    kNetworkCredentialTypeWiFi = 0,
+    kNetworkCredentialTypeThread,
+    kNetworkCredentialTypeAll,
 };
 
 /**
@@ -37,17 +41,17 @@ typedef NS_ENUM(NSUInteger, PairingStatus) {
 @protocol CHIPDevicePairingDelegate <NSObject>
 @required
 /**
- * Notify the delegate when pairing requires network credentials
+ * Notify the delegate when pairing requires network credentials along with the NetworkCredentialType requested
  *
  */
-- (void)onNetworkCredentialsRequested:(SendNetworkCredentials)handler;
+- (void)onNetworkCredentialsRequested:(CHIPNetworkCredentialType)type;
 
 @optional
 /**
  * Notify the delegate when pairing status gets updated
  *
  */
-- (void)onStatusUpdate:(PairingStatus)status;
+- (void)onStatusUpdate:(CHIPPairingStatus)status;
 
 /**
  * Notify the delegate when pairing is completed

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
@@ -21,8 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-class CHIPDevicePairingDelegateBridge : public chip::Controller::DevicePairingDelegate
-{
+class CHIPDevicePairingDelegateBridge : public chip::Controller::DevicePairingDelegate {
 public:
     CHIPDevicePairingDelegateBridge();
     ~CHIPDevicePairingDelegateBridge();
@@ -37,8 +36,8 @@ public:
 
     void OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback) override;
 
-    void OnOperationalCredentialsRequested(const char * csr, size_t csr_length,
-                                           chip::RendezvousDeviceCredentialsDelegate * callback) override;
+    void OnOperationalCredentialsRequested(
+        const char * csr, size_t csr_length, chip::RendezvousDeviceCredentialsDelegate * callback) override;
 
     void OnPairingComplete(CHIP_ERROR error) override;
 

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.h
@@ -29,6 +29,10 @@ public:
 
     void setDelegate(id<CHIPDevicePairingDelegate> delegate, dispatch_queue_t queue);
 
+    void SendWiFiCredentials(NSString * ssid, NSString * password);
+
+    void SendThreadCredentials(NSData * threadDataSet);
+
     void OnStatusUpdate(chip::RendezvousSessionDelegate::Status status) override;
 
     void OnNetworkCredentialsRequested(chip::RendezvousDeviceCredentialsDelegate * callback) override;
@@ -44,10 +48,9 @@ private:
     id<CHIPDevicePairingDelegate> mDelegate;
     dispatch_queue_t mQueue;
 
-    SendNetworkCredentials mHandler;
     chip::RendezvousDeviceCredentialsDelegate * mCallback;
 
-    PairingStatus MapStatus(chip::RendezvousSessionDelegate::Status status);
+    CHIPPairingStatus MapStatus(chip::RendezvousSessionDelegate::Status status);
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevicePairingDelegateBridge.mm
@@ -85,7 +85,6 @@ void CHIPDevicePairingDelegateBridge::OnNetworkCredentialsRequested(chip::Rendez
     }
 }
 
-
 void CHIPDevicePairingDelegateBridge::SendWiFiCredentials(NSString * ssid, NSString * password)
 {
     if (mCallback) {
@@ -99,7 +98,6 @@ void CHIPDevicePairingDelegateBridge::SendThreadCredentials(NSData * threadDataS
 {
     NSLog(@"Thread Provisioning is still a WIP, pairing will timeout...");
 }
-
 
 void CHIPDevicePairingDelegateBridge::OnOperationalCredentialsRequested(
     const char * csr, size_t csr_length, chip::RendezvousDeviceCredentialsDelegate * callback)


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The current pairing delegate API in the Darwin Framework only supports WiFi credentials.
We should prepare for upcoming changes to support Thread credentials in the Darwin Framework.
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
 This PR just updates the Public API to support receiving Thread Credentials. This should get hooked into the Provisioning cluster's APIs. 

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
