### PR TITLE
Added documentation of features of CHIP device controller implementations

### DIFF
--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -1,7 +1,7 @@
-
 # CHIP controller
 
-There are currently 4 implementations of the CHIP device controller with varying support for certain CHIP features.
+There are currently 4 implementations of the CHIP device controller with varying
+support for certain CHIP features.
 
 ## Implementations
 
@@ -15,51 +15,54 @@ The Android chip-tool is located in [../android/CHIPTool](../android/CHIPTool).
 
 ### POSIX CLI
 
-The POSIX CLI chip-tool is located in [../../examples/chip-tool](../../examples/chip-tool).
+The POSIX CLI chip-tool is located in
+[../../examples/chip-tool](../../examples/chip-tool).
 
 ### Python
 
-The Python chip-device-ctrl is located in [../controller/python/](../controller/python).
+The Python chip-device-ctrl is located in
+[../controller/python/](../controller/python).
 
 ## Feature Overview
 
-| Onboarding          | iOS   | Android | CLI | Python |
-| ------------------- | ----- | ------- | --- | ------ |
-| Setup code          | y?    | y?      | y   | y      |
-| QR code             | y     | y       | n   | n      |
-| NFC                 | n     | y       | n   | n      |
+| Onboarding | iOS | Android | CLI | Python |
+| ---------- | --- | ------- | --- | ------ |
+| Setup code | y?  | y?      | y   | y      |
+| QR code    | y   | y       | n   | n      |
+| NFC        | n   | y       | n   | n      |
 
-| Provisioning        | iOS   | Android | CLI | Python |
-| ------------------- | ----- | ------- | --- | ------ |
-| Soft-AP             | y     | y?      | y   | y      |
-| WiFi-BLE            | y?    | y?      | y   | y      |
-| Thread-BLE          | n(*0) | y(*1)   | n   | n      |
+| Provisioning | iOS    | Android | CLI | Python |
+| ------------ | ------ | ------- | --- | ------ |
+| Soft-AP      | y      | y?      | y   | y      |
+| WiFi-BLE     | y?     | y?      | y   | y      |
+| Thread-BLE   | n(\*0) | y(\*1)  | n   | n      |
 
-| Commands/Clusters   | iOS   | Android | CLI | Python |
-| ------------------- | ----- | ------- | --- | ------ |
-| Echo Client         | y?    | y       | y   | y      |
-| On/Off Client       | y     | y       | y   | y      |
-| LevelControl Client | ?     | y       | y   | y      |
-| Identify Client     | ?     | n(*2)   | y   | y      |
-| Scene Client        | n?    | n(*2)   | y   | y      |
-| Group Client        | n?    | n(*2)   | y   | y      |
-| Binding Client      | n?    | n(*2)   | y   | y      |
+| Commands/Clusters   | iOS | Android | CLI | Python |
+| ------------------- | --- | ------- | --- | ------ |
+| Echo Client         | y?  | y       | y   | y      |
+| On/Off Client       | y   | y       | y   | y      |
+| LevelControl Client | ?   | y       | y   | y      |
+| Identify Client     | ?   | n(\*2)  | y   | y      |
+| Scene Client        | n?  | n(\*2)  | y   | y      |
+| Group Client        | n?  | n(\*2)  | y   | y      |
+| Binding Client      | n?  | n(\*2)  | y   | y      |
 
-| Attributes/Clusters | iOS   | Android | CLI | Python |
-| ------------------- | ----- | ------- | --- | ------ |
-| Read                | n     | n(*2)   | y   | n      |
-| Write               | n     | n(*2)   | y   | n      |
+| Attributes/Clusters | iOS | Android | CLI | Python |
+| ------------------- | --- | ------- | --- | ------ |
+| Read                | n   | n(\*2)  | y   | n      |
+| Write               | n   | n(\*2)  | y   | n      |
 
-|                     | iOS   | Android | CLI | Python |
-| ------------------- | ----- | ------- | --- | ------ |
-| Multiple Devices    | y     | n(*3)   | ?   | ?      |
+|                  | iOS | Android | CLI | Python |
+| ---------------- | --- | ------- | --- | ------ |
+| Multiple Devices | y   | n(\*3)  | ?   | ?      |
 
 Notes:
 
-(*0) <https://github.com/project-chip/connectedhomeip/pull/4829>
+(\*0) <https://github.com/project-chip/connectedhomeip/pull/4829>
 
-(*1) Only static commissioning, not MeshCoP.
+(\*1) Only static commissioning, not MeshCoP.
 
-(*2) Locally a patch exists, could be upstreamed.
+(\*2) Locally a patch exists, could be upstreamed.
 
-(*3) Uses deprecated Chip Device Controller, move to new CHIP Device controller WIP according to Slack conversation.
+(\*3) Uses deprecated Chip Device Controller, move to new CHIP Device controller
+WIP according to Slack conversation.

--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -29,12 +29,12 @@ The Python chip-device-ctrl is located in
 | ---------- | --- | ------- | --- | ------ |
 | Setup code | y?  | n       | y   | y      |
 | QR code    | y   | y       | n   | n      |
-| NFC        | n   | y       | n   | n      |
+| NFC        | y   | y       | n   | n      |
 
 | Provisioning | iOS    | Android | CLI | Python |
 | ------------ | ------ | ------- | --- | ------ |
-| Soft-AP      | y      | y?      | y   | y      |
-| WiFi-BLE     | y?     | y?      | y   | y      |
+| Soft-AP      | y      | n       | y   | y      |
+| WiFi-BLE     | y?     | y       | y   | y      |
 | Thread-BLE   | n(\*0) | y(\*1)  | n   | n      |
 
 | Commands/Clusters   | iOS | Android | CLI | Python |

--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -27,7 +27,7 @@ The Python chip-device-ctrl is located in
 
 | Onboarding | iOS | Android | CLI | Python |
 | ---------- | --- | ------- | --- | ------ |
-| Setup code | y?  | y?      | y   | y      |
+| Setup code | y?  | n       | y   | y      |
 | QR code    | y   | y       | n   | n      |
 | NFC        | n   | y       | n   | n      |
 

--- a/src/controller/README.md
+++ b/src/controller/README.md
@@ -1,0 +1,65 @@
+
+# CHIP controller
+
+There are currently 4 implementations of the CHIP device controller with varying support for certain CHIP features.
+
+## Implementations
+
+### iOS
+
+The iOS chip-tool is located in [../darwin/CHIPTool](../darwin/CHIPTool).
+
+### Android
+
+The Android chip-tool is located in [../android/CHIPTool](../android/CHIPTool).
+
+### POSIX CLI
+
+The POSIX CLI chip-tool is located in [../../examples/chip-tool](../../examples/chip-tool).
+
+### Python
+
+The Python chip-device-ctrl is located in [../controller/python/](../controller/python).
+
+## Feature Overview
+
+| Onboarding          | iOS   | Android | CLI | Python |
+| ------------------- | ----- | ------- | --- | ------ |
+| Setup code          | y?    | y?      | y   | y      |
+| QR code             | y     | y       | n   | n      |
+| NFC                 | n     | y       | n   | n      |
+
+| Provisioning        | iOS   | Android | CLI | Python |
+| ------------------- | ----- | ------- | --- | ------ |
+| Soft-AP             | y     | y?      | y   | y      |
+| WiFi-BLE            | y?    | y?      | y   | y      |
+| Thread-BLE          | n(*0) | y(*1)   | n   | n      |
+
+| Commands/Clusters   | iOS   | Android | CLI | Python |
+| ------------------- | ----- | ------- | --- | ------ |
+| Echo Client         | y?    | y       | y   | y      |
+| On/Off Client       | y     | y       | y   | y      |
+| LevelControl Client | ?     | y       | y   | y      |
+| Identify Client     | ?     | n(*2)   | y   | y      |
+| Scene Client        | n?    | n(*2)   | y   | y      |
+| Group Client        | n?    | n(*2)   | y   | y      |
+| Binding Client      | n?    | n(*2)   | y   | y      |
+
+| Attributes/Clusters | iOS   | Android | CLI | Python |
+| ------------------- | ----- | ------- | --- | ------ |
+| Read                | n     | n(*2)   | y   | n      |
+| Write               | n     | n(*2)   | y   | n      |
+
+|                     | iOS   | Android | CLI | Python |
+| ------------------- | ----- | ------- | --- | ------ |
+| Multiple Devices    | y     | n(*3)   | ?   | ?      |
+
+Notes:
+
+(*0) <https://github.com/project-chip/connectedhomeip/pull/4829>
+
+(*1) Only static commissioning, not MeshCoP.
+
+(*2) Locally a patch exists, could be upstreamed.
+
+(*3) Uses deprecated Chip Device Controller, move to new CHIP Device controller WIP according to Slack conversation.


### PR DESCRIPTION
#### Problem

When starting with evaluating CHIP, it is unclear which CHIP functionality is supported by the different device controllers already. E.g., if you want to commission a Thread device, you currently need to use the Android app. If you want to commission multiple devices, you cannot use the Android app.

#### Summary of Changes

Added a README documenting the features of the iOS, Android, CLI and Python controllers.

There are still a few question marks in the tables. Would be good to work with the relevant people to clarify those.

@vivien-apple @shana-apple @pan-apple  @vidhis88 @andy31415 @erjiaqing @Damian-Nordic 

Signed-off-by: Markus Becker <markus.becker@tridonic.com>
