### PR TITLE
nrfconnect: lighting-app: Lowered PWM frequency to 50 Hz.

### DIFF
--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -124,7 +124,7 @@ void LightingManager::Set(bool aOn)
 
 void LightingManager::UpdateLight()
 {
-    constexpr uint32_t kPwmWidthUs = 1000u;
+    constexpr uint32_t kPwmWidthUs = 20000u;
     const uint8_t level            = mState == kState_On ? mLevel : 0;
     pwm_pin_set_usec(mPwmDevice, mPwmChannel, kPwmWidthUs, kPwmWidthUs * level / kMaxLevel, 0);
 }


### PR DESCRIPTION
 #### Problem
PWM frequency is currently set to 1 kHz, what creates hardware problems with signal sampling and implementing functional tests.

 #### Summary of Changes
* Lowered PWM frequency to 50 Hz.