### PR TITLE
nrfconnect: Restored compiling nrfconnect samples with -Werror flag

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-lighting-example)
 
+target_compile_options(app PRIVATE -Werror)
+
 target_include_directories(app PRIVATE
                            main/include
                            ${LIGHTING_COMMON}

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CONF_FILE ${CHIP_ROOT}/config/nrfconnect/app/sample-defaults.conf prj.conf)
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
+target_compile_options(app PRIVATE -Werror)
+
 project(chip-nrf52840-lock-example)
 
 target_include_directories(app PRIVATE 

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-pigweed-example)
 
-zephyr_compile_options(-Werror)
+target_compile_options(app PRIVATE -Werror)
 
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -26,6 +26,8 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-shell-example)
 
+target_compile_options(app PRIVATE -Werror)
+
 target_include_directories(app PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}
                            ${APP_ROOT}/shell_common/include)


### PR DESCRIPTION
 #### Problem
-Werror flag was removed from nrfconnect samples due to Zephyr related warnings on macOS.

 #### Summary of Changes
* Added compiling samples with -Wall and -Werror flags.

 Fixes #4652 

