### PR TITLE
Add an adapter iterator class to bluez

### DIFF
--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -63,7 +63,7 @@ inline char * CopyString(char * dest, const char * source, size_t length)
 template <size_t N>
 inline char * CopyString(char (&dest)[N], const char * source)
 {
-    return CopyString(dest, src, N);
+    return CopyString(dest, source, N);
 }
 
 /**

--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -58,6 +58,15 @@ inline char * CopyString(char * dest, const char * source, size_t length)
 }
 
 /**
+ * Convenience method for CopyString to auto-detect destination size.
+ */
+template <size_t N>
+inline char * CopyString(char (&dest)[N], const char * source)
+{
+    return CopyString(dest, src, N);
+}
+
+/**
  * This function copies a C-style string to memory newly allocated by Platform::MemoryAlloc().
  *
  * @param[in]  string           String to be copied.

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -2079,7 +2079,10 @@ bool AdapterIterator::Advance()
         CopyString(mCurrent.name, bluez_adapter1_get_name(adapter));
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
 
+        g_object_unref(adapter);
+
         mCurrentListItem = mCurrentListItem->next;
+
         return true;
     }
 

--- a/src/platform/Linux/CHIPBluezHelper.cpp
+++ b/src/platform/Linux/CHIPBluezHelper.cpp
@@ -2045,20 +2045,20 @@ exit:
     }
 }
 
-void AdapterIterator::Advance()
+bool AdapterIterator::Advance()
 {
     if (mCurrentListItem == nullptr)
     {
-        return;
+        return false;
     }
 
     while (mCurrentListItem != nullptr)
     {
         BluezAdapter1 * adapter = bluez_object_get_adapter1(BLUEZ_OBJECT(mCurrentListItem->data));
-
         if (adapter == nullptr)
         {
             mCurrentListItem = mCurrentListItem->next;
+            continue;
         }
 
         // PATH is of the for  BLUEZ_PATH / hci<nr>, i.e. like
@@ -2079,6 +2079,7 @@ void AdapterIterator::Advance()
         CopyString(mCurrent.name, bluez_adapter1_get_name(adapter));
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
 
+        mCurrentListItem = mCurrentListItem->next;
         return true;
     }
 

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -224,7 +224,7 @@ public:
     /// used (iterator gets initialized on the first call of Next).
     bool Next();
 
-    // Information about the current value. Save to call only after
+    // Information about the current value. Safe to call only after
     // "Next" has returned true.
     uint32_t GetIndex() const { return mCurrent.index; }
     const char * GetAddress() const { return mCurrent.address; }

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -205,6 +205,58 @@ CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint);
 
 CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);
 
+/// Iterates over available BlueZ adapters
+///
+/// Usage example:
+///
+///  AdapterIterator iterator;
+///  while (iteerator.Next()) {
+///      std::cout << iterator.GetAddress() << std::endl;
+///  }
+class AdapterIterator
+{
+public:
+    ~AdapterIterator();
+
+    /// Moves to the next DBUS interface.
+    ///
+    /// MUST be called at least once
+    bool Next();
+
+    // information about the current value
+    uint32_t GetIndex() const { return mCurrent.index; }
+    const char * GetAddress() const { return mCurrent.address; }
+    const char * GetAlias() const { return mCurrent.alias; }
+    const char * GetName() const { return mCurrent.name; }
+    bool IsPowered() const { return mCurrent.powered; }
+
+private:
+    /// Sets up the DBUS manager and loads the list
+    void Initialize();
+
+    /// Loads the next value in the list
+    void Advance();
+
+    static constexpr size_t kMaxAddressLength = 19; // xx:xx:xx:xx:xx:xx
+    static constexpr size_t kMaxNameLength    = 64;
+
+    GDBusObjectManager * mManager = nullptr; // DBus connection
+    GList * mObjectList           = nullptr; // listing of objects on the bus
+    GList * mCurrentListItem      = nullptr; // current item viewed in the list
+
+    bool mHasCurrentValue = false;
+
+    // data valid only if Next() returns true
+    struct
+    {
+        uint32_t index;
+        char address[kMaxAddressLength];
+        char alias[kMaxNameLength];
+        char name[kMaxNameLength];
+        bool powered;
+    } mCurrent = { 0 };
+};
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -210,7 +210,7 @@ CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);
 /// Usage example:
 ///
 ///  AdapterIterator iterator;
-///  while (iteerator.Next()) {
+///  while (iterator.Next()) {
 ///      std::cout << iterator.GetAddress() << std::endl;
 ///  }
 class AdapterIterator
@@ -221,7 +221,7 @@ public:
     /// Moves to the next DBUS interface.
     ///
     /// MUST be called before any of the 'current value' methods are
-    /// being used (iterator gets initialized on the first call of Next).
+    /// used (iterator gets initialized on the first call of Next).
     bool Next();
 
     // Information about the current value. Save to call only after

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -249,8 +249,6 @@ private:
     GList * mObjectList           = nullptr; // listing of objects on the bus
     GList * mCurrentListItem      = nullptr; // current item viewed in the list
 
-    bool mHasCurrentValue = false;
-
     // data valid only if Next() returns true
     struct
     {

--- a/src/platform/Linux/CHIPBluezHelper.h
+++ b/src/platform/Linux/CHIPBluezHelper.h
@@ -220,10 +220,12 @@ public:
 
     /// Moves to the next DBUS interface.
     ///
-    /// MUST be called at least once
+    /// MUST be called before any of the 'current value' methods are
+    /// being used (iterator gets initialized on the first call of Next).
     bool Next();
 
-    // information about the current value
+    // Information about the current value. Save to call only after
+    // "Next" has returned true.
     uint32_t GetIndex() const { return mCurrent.index; }
     const char * GetAddress() const { return mCurrent.address; }
     const char * GetAlias() const { return mCurrent.alias; }
@@ -234,8 +236,11 @@ private:
     /// Sets up the DBUS manager and loads the list
     void Initialize();
 
-    /// Loads the next value in the list
-    void Advance();
+    /// Loads the next value in the list.
+    ///
+    /// Returns true if a value could be loaded, false if no more items to
+    /// iterate through.
+    bool Advance();
 
     static constexpr size_t kMaxAddressLength = 19; // xx:xx:xx:xx:xx:xx
     static constexpr size_t kMaxNameLength    = 64;


### PR DESCRIPTION
#### Problem
Python code needs the ability to list available bluez interfaces from code (and likely this would also be very useful within native application code).

 #### Summary of Changes

 Adds an 'AdapterIterator' class that is a ble to list available bluez interfaces.
