### PR TITLE
Use an enum class for BDX message types.

### DIFF
--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <protocols/Protocols.h>
 #include <support/BitFlags.h>
 #include <support/BufferWriter.h>
 #include <support/CodeUtils.h>
@@ -31,17 +32,17 @@
 namespace chip {
 namespace bdx {
 
-enum MessageType : uint8_t
+enum class MessageType : uint8_t
 {
-    kBdxMsg_SendInit      = 0x01,
-    kBdxMsg_SendAccept    = 0x02,
-    kBdxMsg_ReceiveInit   = 0x04,
-    kBdxMsg_ReceiveAccept = 0x05,
-    kBdxMsg_BlockQuery    = 0x10,
-    kBdxMsg_Block         = 0x11,
-    kBdxMsg_BlockEOF      = 0x12,
-    kBdxMsg_BlockAck      = 0x13,
-    kBdxMsg_BlockAckEOF   = 0x14,
+    SendInit      = 0x01,
+    SendAccept    = 0x02,
+    ReceiveInit   = 0x04,
+    ReceiveAccept = 0x05,
+    BlockQuery    = 0x10,
+    Block         = 0x11,
+    BlockEOF      = 0x12,
+    BlockAck      = 0x13,
+    BlockAckEOF   = 0x14,
 };
 
 enum StatusCode : uint16_t
@@ -280,4 +281,13 @@ using Block    = DataBlock;
 using BlockEOF = DataBlock;
 
 } // namespace bdx
+
+namespace Protocols {
+template <>
+struct MessageTypeTraits<bdx::MessageType>
+{
+    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_BDX;
+};
+} // namespace Protocols
+
 } // namespace chip

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -40,6 +40,8 @@ CHIP_ERROR WriteToPacketBuffer(const ::chip::bdx::BdxMessage & msgStruct, ::chip
     return CHIP_NO_ERROR;
 }
 
+// We could make this whole method a template, but it's probably smaller code to
+// share the implementation across all message types.
 CHIP_ERROR AttachHeader(uint16_t protocolId, uint8_t msgType, ::chip::System::PacketBufferHandle & msgBuf)
 {
     ::chip::PayloadHeader payloadHeader;
@@ -51,6 +53,12 @@ CHIP_ERROR AttachHeader(uint16_t protocolId, uint8_t msgType, ::chip::System::Pa
 
 exit:
     return err;
+}
+
+template <typename MessageType>
+inline CHIP_ERROR AttachHeader(MessageType msgType, ::chip::System::PacketBufferHandle & msgBuf)
+{
+    return AttachHeader(chip::Protocols::MessageTypeTraits<MessageType>::ProtocolId, static_cast<uint8_t>(msgType), msgBuf);
 }
 } // anonymous namespace
 
@@ -161,8 +169,8 @@ CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitD
     err = WriteToPacketBuffer(initMsg, mPendingMsgHandle);
     SuccessOrExit(err);
 
-    msgType = (mRole == kRole_Sender) ? kBdxMsg_SendInit : kBdxMsg_ReceiveInit;
-    err     = AttachHeader(Protocols::kProtocol_BDX, msgType, mPendingMsgHandle);
+    msgType = (mRole == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
+    err     = AttachHeader(msgType, mPendingMsgHandle);
     SuccessOrExit(err);
 
     mState            = kAwaitingAccept;
@@ -227,7 +235,7 @@ CHIP_ERROR TransferSession::AcceptTransfer(const TransferAcceptData & acceptData
         err = WriteToPacketBuffer(acceptMsg, mPendingMsgHandle);
         SuccessOrExit(err);
 
-        err = AttachHeader(Protocols::kProtocol_BDX, kBdxMsg_ReceiveAccept, mPendingMsgHandle);
+        err = AttachHeader(MessageType::ReceiveAccept, mPendingMsgHandle);
         SuccessOrExit(err);
     }
     else
@@ -242,7 +250,7 @@ CHIP_ERROR TransferSession::AcceptTransfer(const TransferAcceptData & acceptData
         err = WriteToPacketBuffer(acceptMsg, mPendingMsgHandle);
         SuccessOrExit(err);
 
-        err = AttachHeader(Protocols::kProtocol_BDX, kBdxMsg_SendAccept, mPendingMsgHandle);
+        err = AttachHeader(MessageType::SendAccept, mPendingMsgHandle);
         SuccessOrExit(err);
     }
 
@@ -275,7 +283,7 @@ CHIP_ERROR TransferSession::PrepareBlockQuery()
     err = WriteToPacketBuffer(queryMsg, mPendingMsgHandle);
     SuccessOrExit(err);
 
-    err = AttachHeader(Protocols::kProtocol_BDX, kBdxMsg_BlockQuery, mPendingMsgHandle);
+    err = AttachHeader(MessageType::BlockQuery, mPendingMsgHandle);
     SuccessOrExit(err);
 
     mPendingOutput = kMsgToSend;
@@ -308,13 +316,13 @@ CHIP_ERROR TransferSession::PrepareBlock(const BlockData & inData)
     err = WriteToPacketBuffer(blockMsg, mPendingMsgHandle);
     SuccessOrExit(err);
 
-    msgType = inData.IsEof ? kBdxMsg_BlockEOF : kBdxMsg_Block;
-    err     = AttachHeader(Protocols::kProtocol_BDX, msgType, mPendingMsgHandle);
+    msgType = inData.IsEof ? MessageType::BlockEOF : MessageType::Block;
+    err     = AttachHeader(msgType, mPendingMsgHandle);
     SuccessOrExit(err);
 
     mPendingOutput = kMsgToSend;
 
-    if (msgType == kBdxMsg_BlockEOF)
+    if (msgType == MessageType::BlockEOF)
     {
         mState = kAwaitingEOFAck;
     }
@@ -337,12 +345,12 @@ CHIP_ERROR TransferSession::PrepareBlockAck()
     VerifyOrExit(mPendingOutput == kNone, err = CHIP_ERROR_INCORRECT_STATE);
 
     ackMsg.BlockCounter = mLastBlockNum;
-    msgType             = (mState == kReceivedEOF) ? kBdxMsg_BlockAckEOF : kBdxMsg_BlockAck;
+    msgType             = (mState == kReceivedEOF) ? MessageType::BlockAckEOF : MessageType::BlockAck;
 
     err = WriteToPacketBuffer(ackMsg, mPendingMsgHandle);
     SuccessOrExit(err);
 
-    err = AttachHeader(Protocols::kProtocol_BDX, msgType, mPendingMsgHandle);
+    err = AttachHeader(msgType, mPendingMsgHandle);
     SuccessOrExit(err);
 
     if (mState == kTransferInProgress)
@@ -448,29 +456,29 @@ CHIP_ERROR TransferSession::HandleBdxMessage(PayloadHeader & header, System::Pac
 
     switch (msgType)
     {
-    case kBdxMsg_SendInit:
-    case kBdxMsg_ReceiveInit:
+    case MessageType::SendInit:
+    case MessageType::ReceiveInit:
         HandleTransferInit(msgType, std::move(msg));
         break;
-    case kBdxMsg_SendAccept:
+    case MessageType::SendAccept:
         HandleSendAccept(std::move(msg));
         break;
-    case kBdxMsg_ReceiveAccept:
+    case MessageType::ReceiveAccept:
         HandleReceiveAccept(std::move(msg));
         break;
-    case kBdxMsg_BlockQuery:
+    case MessageType::BlockQuery:
         HandleBlockQuery(std::move(msg));
         break;
-    case kBdxMsg_Block:
+    case MessageType::Block:
         HandleBlock(std::move(msg));
         break;
-    case kBdxMsg_BlockEOF:
+    case MessageType::BlockEOF:
         HandleBlockEOF(std::move(msg));
         break;
-    case kBdxMsg_BlockAck:
+    case MessageType::BlockAck:
         HandleBlockAck(std::move(msg));
         break;
-    case kBdxMsg_BlockAckEOF:
+    case MessageType::BlockAckEOF:
         HandleBlockAckEOF(std::move(msg));
         break;
     default:
@@ -519,11 +527,11 @@ void TransferSession::HandleTransferInit(MessageType msgType, System::PacketBuff
 
     if (mRole == kRole_Sender)
     {
-        VerifyOrExit(msgType == kBdxMsg_ReceiveInit, PrepareStatusReport(kStatus_ServerBadState));
+        VerifyOrExit(msgType == MessageType::ReceiveInit, PrepareStatusReport(kStatus_ServerBadState));
     }
     else
     {
-        VerifyOrExit(msgType == kBdxMsg_SendInit, PrepareStatusReport(kStatus_ServerBadState));
+        VerifyOrExit(msgType == MessageType::SendInit, PrepareStatusReport(kStatus_ServerBadState));
     }
 
     err = transferInit.Parse(msgData.Retain());
@@ -854,8 +862,7 @@ void TransferSession::PrepareStatusReport(StatusCode code)
     }
     else
     {
-        CHIP_ERROR err = AttachHeader(Protocols::kProtocol_Protocol_Common,
-                                      static_cast<uint8_t>(Protocols::Common::MsgType::StatusReport), mPendingMsgHandle);
+        CHIP_ERROR err = AttachHeader(Protocols::Common::MsgType::StatusReport, mPendingMsgHandle);
         VerifyOrReturn(err == CHIP_NO_ERROR);
 
         mPendingOutput = kMsgToSend;

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -106,8 +106,7 @@ void VerifyBdxMessageType(nlTestSuite * inSuite, void * inContext, const System:
 
     err = payloadHeader.Decode(msg->Start(), msg->DataLength(), &headerSize);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, payloadHeader.GetProtocolID() == Protocols::kProtocol_BDX);
-    NL_TEST_ASSERT(inSuite, payloadHeader.GetMessageType() == expected);
+    NL_TEST_ASSERT(inSuite, payloadHeader.HasMessageType(expected));
 }
 
 // Helper method for verifying that a PacketBufferHandle contains a valid StatusReport message and contains a specific StatusCode.
@@ -160,7 +159,7 @@ void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, Transfer
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     TransferRole responderRole  = (initiatorRole == kRole_Sender) ? kRole_Receiver : kRole_Sender;
-    MessageType expectedInitMsg = (initiatorRole == kRole_Sender) ? kBdxMsg_SendInit : kBdxMsg_ReceiveInit;
+    MessageType expectedInitMsg = (initiatorRole == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
 
     // Initializer responder to wait for transfer
     err = responder.WaitForTransfer(responderRole, responderControlOpts, responderMaxBlock, timeoutMs);
@@ -224,7 +223,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // If the node sending the Accept message is also the one that will send Blocks, then this should be a ReceiveAccept message.
-    MessageType expectedMsg = (acceptSenderRole == kRole_Sender) ? kBdxMsg_ReceiveAccept : kBdxMsg_SendAccept;
+    MessageType expectedMsg = (acceptSenderRole == kRole_Sender) ? MessageType::ReceiveAccept : MessageType::SendAccept;
 
     err = acceptSender.AcceptTransfer(acceptData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -279,7 +278,7 @@ void SendAndVerifyQuery(nlTestSuite * inSuite, void * inContext, TransferSession
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     querySender.PollOutput(outEvent, kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
-    VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, kBdxMsg_BlockQuery);
+    VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, MessageType::BlockQuery);
     VerifyNoMoreOutput(inSuite, inContext, querySender);
 
     // Pass BlockQuery to queryReceiver and verify queryReceiver emits QueryReceived event
@@ -315,7 +314,7 @@ void SendAndVerifyArbitraryBlock(nlTestSuite * inSuite, void * inContext, Transf
     blockData.Length = maxBlockSize;
     blockData.IsEof  = isEof;
 
-    MessageType expected = isEof ? kBdxMsg_BlockEOF : kBdxMsg_Block;
+    MessageType expected = isEof ? MessageType::BlockEOF : MessageType::Block;
 
     // Provide Block data and verify sender emits Block message
     err = sender.PrepareBlock(blockData);
@@ -344,7 +343,7 @@ void SendAndVerifyBlockAck(nlTestSuite * inSuite, void * inContext, TransferSess
 {
     TransferSession::OutputEventType expectedEventType =
         expectEOF ? TransferSession::kAckEOFReceived : TransferSession::kAckReceived;
-    MessageType expectedMsgType = expectEOF ? kBdxMsg_BlockAckEOF : kBdxMsg_BlockAck;
+    MessageType expectedMsgType = expectEOF ? MessageType::BlockAckEOF : MessageType::BlockAck;
 
     // Verify PrepareBlockAck() outputs message to send
     CHIP_ERROR err = ackSender.PrepareBlockAck();
@@ -618,7 +617,7 @@ void TestTimeout(nlTestSuite * inSuite, void * inContext)
     // First PollOutput() should output the TransferInit message
     initiator.PollOutput(outEvent, startTimeMs);
     NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
-    MessageType expectedInitMsg = (role == kRole_Sender) ? kBdxMsg_SendInit : kBdxMsg_ReceiveInit;
+    MessageType expectedInitMsg = (role == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedInitMsg);
 
     // Second PollOutput() with no call to HandleMessageReceived() should result in a timeout.
@@ -687,7 +686,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     respondingSender.PollOutput(eventWithBlock, kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, eventWithBlock.EventType == TransferSession::kMsgToSend);
-    VerifyBdxMessageType(inSuite, inContext, eventWithBlock.MsgData, kBdxMsg_Block);
+    VerifyBdxMessageType(inSuite, inContext, eventWithBlock.MsgData, MessageType::Block);
     VerifyNoMoreOutput(inSuite, inContext, respondingSender);
     System::PacketBufferHandle blockCopy =
         System::PacketBufferHandle::NewWithData(eventWithBlock.MsgData->Start(), eventWithBlock.MsgData->DataLength());

--- a/src/protocols/common/Constants.h
+++ b/src/protocols/common/Constants.h
@@ -73,5 +73,12 @@ enum class StatusCode
 };
 
 } // namespace Common
+
+template <>
+struct MessageTypeTraits<Common::MsgType>
+{
+    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_Protocol_Common;
+};
+
 } // namespace Protocols
 } // namespace chip


### PR DESCRIPTION
The removal of the "check the protocol id" part of the test is OK,
because the typed version of HasMessageType checks the protocol id
too.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We're doing a bunch of manual "make sure we use the right message type with the right protocol id", even though the message type already implies the protocol.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use an enum class for bdx message types and use our existing trait setup over message types to infer the protocol id.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
