### PR TITLE
Expose controller nodeid to iOS CHIP Tool app

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -133,7 +133,9 @@
 
 - (IBAction)bind:(id)sender
 {
-    int nodeId = [_nodeIDTextField.text intValue];
+    uint64_t nodeId;
+    NSScanner * scanner = [NSScanner scannerWithString:_nodeIDTextField.text];
+    [scanner scanUnsignedLongLong:&nodeId];
     int endpointId = [_endpointIDTextField.text intValue];
     int groupId = [_groupIDTextField.text intValue];
     int clusterId = [_clusterIDTextField.text intValue];

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -122,7 +122,8 @@
 
 - (void)_clearTextFields
 {
-    _nodeIDTextField.text = [NSString stringWithFormat:@"%d", 112233];
+    CHIPDeviceController * chipController = [CHIPDeviceController sharedController];
+    _nodeIDTextField.text = [NSString stringWithFormat:@"%@", chipController.getControllerNodeId];
     _endpointIDTextField.text = @"1";
     _groupIDTextField.text = @"0";
     _clusterIDTextField.text = @"";

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -47,6 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (CHIPDeviceController *)sharedController;
 
 /**
+ * Return the Node Id assigned to the controller.
+ */
+- (NSNumber *)getControllerNodeId;
+
+/**
  * Set the Delegate for the Device Pairing  as well as the Queue on which the Delegate callbacks will be triggered
  *
  * @param[in] delegate The delegate the pairing process should use

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -50,6 +50,7 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
 @property (readonly) chip::Controller::DeviceCommissioner * cppCommissioner;
 @property (readonly) CHIPDevicePairingDelegateBridge * pairingDelegateBridge;
 @property (readonly) CHIPPersistentStorageDelegateBridge * persistentStorageDelegateBridge;
+@property (readonly) chip::NodeId localDeviceId;
 
 @end
 
@@ -93,23 +94,8 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
             return nil;
         }
 
-        chip::NodeId localDeviceId = 0;
-        uint16_t idStringLen = 32;
-        char deviceIdString[idStringLen];
-        if (CHIP_NO_ERROR
-            != _persistentStorageDelegateBridge->GetKeyValue(CHIP_COMMISSIONER_DEVICE_ID_KEY, deviceIdString, idStringLen)) {
-            localDeviceId = arc4random();
-            localDeviceId = localDeviceId << 32 | arc4random();
-            CHIP_LOG_ERROR("Assigned %llx node ID to the controller", localDeviceId);
-            _persistentStorageDelegateBridge->SetKeyValue(
-                CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", localDeviceId] UTF8String]);
-        } else {
-            NSScanner * scanner = [NSScanner scannerWithString:[NSString stringWithUTF8String:deviceIdString]];
-            [scanner scanHexLongLong:&localDeviceId];
-            CHIP_LOG_ERROR("Found %llx node ID for the controller", localDeviceId);
-        }
-
-        errorCode = _cppCommissioner->Init(localDeviceId, _persistentStorageDelegateBridge, _pairingDelegateBridge);
+        [self getControllerNodeId];
+        errorCode = _cppCommissioner->Init(_localDeviceId, _persistentStorageDelegateBridge, _pairingDelegateBridge);
         if ([self checkForInitError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
             return nil;
         }
@@ -125,6 +111,25 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
         });
     }
     return self;
+}
+
+- (NSNumber *)getControllerNodeId
+{
+    uint16_t idStringLen = 32;
+    char deviceIdString[idStringLen];
+    if (CHIP_NO_ERROR
+        != _persistentStorageDelegateBridge->GetKeyValue(CHIP_COMMISSIONER_DEVICE_ID_KEY, deviceIdString, idStringLen)) {
+        _localDeviceId = arc4random();
+        _localDeviceId = _localDeviceId << 32 | arc4random();
+        CHIP_LOG_ERROR("Assigned %llx node ID to the controller", _localDeviceId);
+        _persistentStorageDelegateBridge->SetKeyValue(
+                                                      CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
+    } else {
+        NSScanner * scanner = [NSScanner scannerWithString:[NSString stringWithUTF8String:deviceIdString]];
+        [scanner scanHexLongLong:&_localDeviceId];
+        CHIP_LOG_ERROR("Found %llx node ID for the controller", _localDeviceId);
+    }
+    return [NSNumber numberWithUnsignedLongLong:_localDeviceId];
 }
 
 - (BOOL)pairDevice:(uint64_t)deviceID

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -123,7 +123,7 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
         _localDeviceId = _localDeviceId << 32 | arc4random();
         CHIP_LOG_ERROR("Assigned %llx node ID to the controller", _localDeviceId);
         _persistentStorageDelegateBridge->SetKeyValue(
-                                                      CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
+            CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
     } else {
         NSScanner * scanner = [NSScanner scannerWithString:[NSString stringWithUTF8String:deviceIdString]];
         [scanner scanHexLongLong:&_localDeviceId];
@@ -195,6 +195,8 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
     [self.lock lock];
     _persistentStorageDelegateBridge->setFrameworkDelegate(delegate, queue);
     [self.lock unlock];
+    _persistentStorageDelegateBridge->SetKeyValue(
+        CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
 }
 
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg


### PR DESCRIPTION
 #### Problem
The binding and reporting is not working with latest CHIP Tool iOS application.

 #### Summary of Changes
The tool was using hardcoded controller node ID. The controller is now assigning a random node ID to itself (which is persisted across reboots). This PR adds an API to retrieve that node ID from the CHIP iOS framework.
