### PR TITLE
Fix build warning when building the Darwin Framework on some platforms

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)openPairingWindow:(NSTimeInterval)duration error:(NSError * __autoreleasing *)error;
 - (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
-                         discriminator:(NSInteger)discriminator
+                         discriminator:(NSUInteger)discriminator
                                  error:(NSError * __autoreleasing *)error;
 - (BOOL)isActive;
 

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -73,7 +73,7 @@
 }
 
 - (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
-                         discriminator:(NSInteger)discriminator
+                         discriminator:(NSUInteger)discriminator
                                  error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -81,7 +81,7 @@
     uint16_t u16Descriminator = 0;
 
     if (discriminator > 0xfff) {
-        CHIP_LOG_ERROR("Error: Discriminator %ld is too large. Max value %d", (long) discriminator, 0xfff);
+        CHIP_LOG_ERROR("Error: Discriminator %tu is too large. Max value %d", discriminator, 0xfff);
         if (error) {
             *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
         }

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -81,7 +81,7 @@
     uint16_t u16Descriminator = 0;
 
     if (discriminator > 0xfff) {
-        CHIP_LOG_ERROR("Error: Discriminator %ld is too large. Max value %d", discriminator, 0xfff);
+        CHIP_LOG_ERROR("Error: Discriminator %ld is too large. Max value %d", (long) discriminator, 0xfff);
         if (error) {
             *error = [CHIPError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
         }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
`CHIPDevice.mm` prints the discriminator as a long but NSInteger can either be a 32-bit or 64-bit value depending on the platfrom. So the compiler generates the following warning. 
```
src/darwin/Framework/CHIP/CHIPDevice.mm:84:79: error: values of type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead 
```
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add an explicit cast to long.
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
