### PR TITLE
Add a device selector view in CHIPTool iOS app

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA0E0CE248599BB009087B9 /* OnOffViewController.m */; };
 		2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */; };
+		2C460C2425D7594B000512D6 /* DeviceSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C460C2325D7594B000512D6 /* DeviceSelector.m */; };
 		991DC091247747F500C13860 /* EchoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 991DC090247747F500C13860 /* EchoViewController.m */; };
 		997A639C253F93F7005C64E6 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; };
 		997A639D253F93F7005C64E6 /* CHIP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -55,6 +56,8 @@
 		0CA0E0CE248599BB009087B9 /* OnOffViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnOffViewController.m; sourceTree = "<group>"; };
 		2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultiAdminViewController.m; sourceTree = "<group>"; };
 		2C21071425D1A8F200DDA4AD /* MultiAdminViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiAdminViewController.h; sourceTree = "<group>"; };
+		2C460C2225D7594B000512D6 /* DeviceSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceSelector.h; sourceTree = "<group>"; };
+		2C460C2325D7594B000512D6 /* DeviceSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceSelector.m; sourceTree = "<group>"; };
 		991DC08F247747F500C13860 /* EchoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EchoViewController.h; sourceTree = "<group>"; };
 		991DC090247747F500C13860 /* EchoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EchoViewController.m; sourceTree = "<group>"; };
 		997A639B253F93F7005C64E6 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -203,6 +206,8 @@
 		B232D8BF251A0EC500792CB4 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				2C460C2225D7594B000512D6 /* DeviceSelector.h */,
+				2C460C2325D7594B000512D6 /* DeviceSelector.m */,
 				2C21071225D1A8F200DDA4AD /* MultiAdmin */,
 				B204A61F244E1D0600C7C0E1 /* AppDelegate.h */,
 				B204A620244E1D0600C7C0E1 /* AppDelegate.m */,
@@ -356,6 +361,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C460C2425D7594B000512D6 /* DeviceSelector.m in Sources */,
 				2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */,
 				B204A627244E1D0600C7C0E1 /* QRCodeViewController.m in Sources */,
 				B232D8BA2514BD0800792CB4 /* CHIPUIViewUtils.m in Sources */,

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -28,6 +28,7 @@ void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
 uint64_t CHIPGetNextAvailableDeviceID(void);
 void CHIPSetNextAvailableDeviceID(uint64_t id);
 CHIPDevice * GetPairedDevice(void);
+CHIPDevice * GetPairedDeviceWithID(uint64_t id);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
 

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -27,8 +27,8 @@ void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
 uint64_t CHIPGetNextAvailableDeviceID(void);
 void CHIPSetNextAvailableDeviceID(uint64_t id);
-CHIPDevice * GetPairedDevice(void);
-CHIPDevice * GetPairedDeviceWithID(uint64_t id);
+CHIPDevice * CHIPGetPairedDevice(void);
+CHIPDevice * CHIPGetPairedDeviceWithID(uint64_t id);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
 

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -88,6 +88,8 @@ CHIPDevice * GetPairedDeviceWithID(uint64_t deviceId)
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.persistentstorage.callback", DISPATCH_QUEUE_SERIAL);
 
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    // TODO: setting persistent storage delegate repeatedly is wasteful. This is being done here, and in
+    //       GetPairedDevice() on every call. The delegate should be set once at the controller init time.
     [controller setPersistentStorageDelegate:storage queue:callbackQueue];
 
     NSError * error;

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -82,6 +82,18 @@ CHIPDevice * GetPairedDevice(void)
     return device;
 }
 
+CHIPDevice * GetPairedDeviceWithID(uint64_t deviceId)
+{
+    CHIPToolPersistentStorageDelegate * storage = [[CHIPToolPersistentStorageDelegate alloc] init];
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.persistentstorage.callback", DISPATCH_QUEUE_SERIAL);
+
+    CHIPDeviceController * controller = [CHIPDeviceController sharedController];
+    [controller setPersistentStorageDelegate:storage queue:callbackQueue];
+
+    NSError * error;
+    return [controller getPairedDevice:deviceId error:&error];
+}
+
 @implementation CHIPToolPersistentStorageDelegate
 
 // MARK: CHIPPersistentStorageDelegate

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -38,7 +38,7 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 
-    self.cluster = [[CHIPBinding alloc] initWithDevice:GetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
+    self.cluster = [[CHIPBinding alloc] initWithDevice:CHIPGetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
 }
 
 - (void)dismissKeyboard

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <CHIP/CHIP.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DeviceSelector : UITextField <UIPickerViewDelegate, UIPickerViewDataSource, UITextFieldDelegate>
+- (instancetype)init;
+- (CHIPDevice *)selectedDevice;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.m
@@ -1,0 +1,136 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "DeviceSelector.h"
+
+#import "CHIPUIViewUtils.h"
+#import "DefaultsUtils.h"
+
+@interface DeviceSelector ()
+@property (readwrite) CHIPDevice * chipDevice;
+@property (readwrite) uint64_t nextDeviceID;
+@end
+
+@implementation DeviceSelector {
+    NSMutableArray * _deviceList;
+    UIPickerView * _devicePicker;
+    NSUInteger _selectedDeviceIndex;
+}
+
+- (id)init
+{
+    if (self = [super init]) {
+        _nextDeviceID = CHIPGetNextAvailableDeviceID();
+        _selectedDeviceIndex = self.nextDeviceID + 1;
+        [self refreshDeviceList];
+        [self setupView];
+    }
+    return self;
+}
+
+- (void)refreshDeviceList
+{
+    _deviceList = [NSMutableArray new];
+    for (uint64_t i = 0; i < _nextDeviceID; i++) {
+        if (GetPairedDeviceWithID(i) != nil) {
+            [_deviceList addObject:[@(i) stringValue]];
+        }
+    }
+    _selectedDeviceIndex = 0;
+}
+
+- (void)selectDevice
+{
+    uint64_t deviceID = [_deviceList[_selectedDeviceIndex] intValue];
+    _chipDevice = GetPairedDeviceWithID(deviceID);
+}
+
+- (CHIPDevice *)selectedDevice
+{
+    return _chipDevice;
+}
+
+- (void)setupView
+{
+    self.text = [_deviceList objectAtIndex:_selectedDeviceIndex];
+    _devicePicker = [[UIPickerView alloc] initWithFrame:CGRectMake(0, 100, 0, 0)];
+    self.inputView = _devicePicker;
+    [_devicePicker setDataSource:self];
+    [_devicePicker setDelegate:self];
+    self.delegate = self;
+
+    UIToolbar * deviceSelectButtonView = [[UIToolbar alloc] init];
+    [deviceSelectButtonView sizeToFit];
+    UIBarButtonItem * deviceSelectButton = [[UIBarButtonItem alloc] initWithTitle:@"Select Device"
+                                                                            style:UIBarButtonItemStylePlain
+                                                                           target:self
+                                                                           action:@selector(deviceSelectClicked:)];
+    UIBarButtonItem * flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
+                                                                               target:self
+                                                                               action:nil];
+    [deviceSelectButtonView setItems:[NSArray arrayWithObjects:flexible, deviceSelectButton, nil]];
+    self.inputAccessoryView = deviceSelectButtonView;
+
+    [self selectDevice];
+}
+
+// MARK: UIPickerView
+
+- (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
+{
+    NSLog(@"%@", [_deviceList objectAtIndex:row]);
+    self.text = [NSString stringWithFormat:@"%@", [_deviceList objectAtIndex:row]];
+}
+
+- (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
+{
+    return [_deviceList count];
+}
+
+- (NSInteger)numberOfComponentsInPickerView:(UIPickerView *)pickerView
+{
+    return 1;
+}
+
+- (NSString *)pickerView:(UIPickerView *)pickerView titleForRow:(NSInteger)row forComponent:(NSInteger)component
+{
+    return [_deviceList objectAtIndex:row];
+}
+
+- (CGFloat)pickerView:(UIPickerView *)pickerView widthForComponent:(NSInteger)component
+{
+    return 200;
+}
+
+- (IBAction)deviceSelectClicked:(id)sender
+{
+    _selectedDeviceIndex = [_deviceList indexOfObject:self.text];
+    [self resignFirstResponder];
+    [self selectDevice];
+}
+
+// MARK: CHIPDeviceControllerDelegate
+- (void)deviceControllerOnConnected
+{
+    NSLog(@"Status: Device connected");
+}
+
+- (void)deviceControllerOnError:(nonnull NSError *)error
+{
+}
+
+@end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.m
@@ -46,7 +46,7 @@
 {
     _deviceList = [NSMutableArray new];
     for (uint64_t i = 0; i < _nextDeviceID; i++) {
-        if (GetPairedDeviceWithID(i) != nil) {
+        if (CHIPGetPairedDeviceWithID(i) != nil) {
             [_deviceList addObject:[@(i) stringValue]];
         }
     }
@@ -55,8 +55,10 @@
 
 - (void)selectDevice
 {
-    uint64_t deviceID = [_deviceList[_selectedDeviceIndex] intValue];
-    _chipDevice = GetPairedDeviceWithID(deviceID);
+    if ([_deviceList count] > 0) {
+        uint64_t deviceID = [_deviceList[_selectedDeviceIndex] intValue];
+        _chipDevice = CHIPGetPairedDeviceWithID(deviceID);
+    }
 }
 
 - (CHIPDevice *)selectedDevice
@@ -66,7 +68,9 @@
 
 - (void)setupView
 {
-    self.text = [_deviceList objectAtIndex:_selectedDeviceIndex];
+    if ([_deviceList count] > 0) {
+        self.text = [_deviceList objectAtIndex:_selectedDeviceIndex];
+    }
     _devicePicker = [[UIPickerView alloc] initWithFrame:CGRectMake(0, 100, 0, 0)];
     self.inputView = _devicePicker;
     [_devicePicker setDataSource:self];

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
@@ -45,7 +45,7 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 
-    self.cluster = [[CHIPBasic alloc] initWithDevice:GetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
+    self.cluster = [[CHIPBasic alloc] initWithDevice:CHIPGetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
 }
 
 - (void)dismissKeyboard

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -234,6 +234,10 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 - (IBAction)onButtonTapped:(id)sender
 {
     CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+    if (chipDevice == nil) {
+        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
+        return;
+    }
 
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
@@ -250,6 +254,10 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 - (IBAction)offButtonTapped:(id)sender
 {
     CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+    if (chipDevice == nil) {
+        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
+        return;
+    }
 
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
@@ -266,6 +274,10 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 - (IBAction)toggleButtonTapped:(id)sender
 {
     CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+    if (chipDevice == nil) {
+        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
+        return;
+    }
 
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -18,6 +18,7 @@
 #import "OnOffViewController.h"
 #import "CHIPUIViewUtils.h"
 #import "DefaultsUtils.h"
+#import "DeviceSelector.h"
 #import <CHIP/CHIP.h>
 
 NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
@@ -29,7 +30,7 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 @property (nonatomic, strong) UILabel * titleLabel;
 @property (nonatomic, strong) UIStackView * stackView;
 
-@property (readwrite) CHIPDevice * chipDevice;
+@property (nonatomic, strong) DeviceSelector * deviceSelector;
 
 @end
 
@@ -48,13 +49,12 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     [self.view addGestureRecognizer:tap];
 
     [self setupUIElements];
-
-    self.chipDevice = GetPairedDevice();
 }
 
 - (void)dismissKeyboard
 {
     [_numLightsTextField resignFirstResponder];
+    [_deviceSelector resignFirstResponder];
 }
 
 // MARK: UI Setup
@@ -84,6 +84,18 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     [stackView.topAnchor constraintEqualToAnchor:_titleLabel.bottomAnchor constant:30].active = YES;
     [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
     [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
+
+    // Device List and picker
+    UILabel * deviceIDLabel = [UILabel new];
+    deviceIDLabel.text = @"Device ID:";
+    _deviceSelector = [DeviceSelector new];
+
+    UIView * deviceIDView = [CHIPUIViewUtils viewWithLabel:deviceIDLabel textField:_deviceSelector];
+    deviceIDLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
+
+    [stackView addArrangedSubview:deviceIDView];
+    deviceIDView.translatesAutoresizingMaskIntoConstraints = false;
+    [deviceIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = true;
 
     // Num lights to show
     UILabel * numLightsLabel = [UILabel new];
@@ -174,7 +186,6 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 {
     NSLog(@"%@", [_numLightsOptions objectAtIndex:row]);
     _numLightsTextField.text = [NSString stringWithFormat:@"%@", [_numLightsOptions objectAtIndex:row]];
-    ;
 }
 
 - (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component
@@ -222,11 +233,13 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (IBAction)onButtonTapped:(id)sender
 {
+    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"On command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
     [onOff on:^(NSError * error, NSDictionary * values) {
         NSString * resultString
             = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"On command success";
@@ -236,11 +249,13 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (IBAction)offButtonTapped:(id)sender
 {
+    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"Off command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
     [onOff off:^(NSError * error, NSDictionary * values) {
         NSString * resultString
             = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"Off command success";
@@ -250,11 +265,13 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (IBAction)toggleButtonTapped:(id)sender
 {
+    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
+
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"Toggle command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:self.chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
     [onOff toggle:^(NSError * error, NSDictionary * values) {
         NSString * resultString
             = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"Toggle command success";

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -32,7 +32,9 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 
-    self.cluster = [[CHIPTemperatureMeasurement alloc] initWithDevice:GetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
+    self.cluster = [[CHIPTemperatureMeasurement alloc] initWithDevice:CHIPGetPairedDevice()
+                                                             endpoint:1
+                                                                queue:dispatch_get_main_queue()];
     [self readCurrentTemperature];
 }
 


### PR DESCRIPTION
 #### Problem
CHIP Tool iOS app is missing a mechanism to select a device, if multiple devices have been paired with the controller. The current app can only communicate with the last paired device. 

 #### Summary of Changes
Added a device selector view to the app. This view will show a drop down list of paired devices. The user can select one of the available devices, and communicate with it.

This PR also integrates the selector view with Multi-admin view, and OnOff cluster view on iOS app.