### PR TITLE
Fix missing footer space during WiFi provisioning

### DIFF
--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -23,6 +23,7 @@
 #include <support/ErrorStr.h>
 #include <support/SafeInt.h>
 #include <transport/NetworkProvisioning.h>
+#include <transport/SecureSessionMgr.h>
 
 #if CONFIG_DEVICE_LAYER
 #include <platform/CHIPDeviceLayer.h>
@@ -229,7 +230,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     const size_t bufferSize = EncodedStringSize(ssid) + EncodedStringSize(passwd);
     VerifyOrExit(CanCastTo<uint16_t>(bufferSize), err = CHIP_ERROR_INVALID_ARGUMENT);
     {
-        Encoding::LittleEndian::PacketBufferWriter bbuf(bufferSize);
+        Encoding::LittleEndian::PacketBufferWriter bbuf(bufferSize + MessagePacketBuffer::kMaxFooterSize);
 
         ChipLogProgress(NetworkProvisioning, "Sending Network Creds. Delegate %p\n", mDelegate);
         VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
As of a8681876 ("Reduce use of maximum-sized packet buffers (#4434)"),
network provisioning does not allocate enough space to encrypt the WiFi
credentials payload, resulting in the following error:

 CHIP:NP: Failed in sending Network Creds. error Error 4047 (0x00000FCF)

Pending API improvements to make these errors less likely, manually add
the needed extra space at allocation time.

Fixes #4823