### PR TITLE
[android] Fixes for Android CHIPTool

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -732,8 +732,9 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
         // method to get access to the device, which will fetch
         // the device information from the persistent storage.
         DeviceController::ReleaseDevice(mDeviceBeingPaired);
-        mDeviceBeingPaired = kNumMaxActiveDevices;
     }
+
+    mDeviceBeingPaired = kNumMaxActiveDevices;
 }
 
 void DeviceCommissioner::OnRendezvousError(CHIP_ERROR err)

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -264,7 +264,7 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         4;                  // threadData.ThreadChannel, threadData.FieldPresent.ThreadExtendedPANId,
                             // threadData.FieldPresent.ThreadMeshPrefix, threadData.FieldPresent.ThreadPSKc
     /* clang-format on */
-    Encoding::LittleEndian::PacketBufferWriter bbuf(credentialSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(credentialSize + MessagePacketBuffer::kMaxFooterSize);
 
     ChipLogProgress(NetworkProvisioning, "Sending Thread Credentials");
     VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
 #### Problem
Android CHIPTool fails to send Thread Association Request. Also, it throws an exception when trying to repeat the commissioning procedure.

 #### Summary of Changes
Fix Thread provisioning message construction in the same way as Wi-Fi provisioning was fixed in #4868.
By the way, fix rendezvous clean up to make sure that the app doesn't crash when trying to commission a device for the second time.