### PR TITLE
Revise PacketBufferWriter interface

### DIFF
--- a/src/app/encoder.cpp
+++ b/src/app/encoder.cpp
@@ -77,7 +77,7 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
                                                                                                                                    \
-    PacketBufferWriter buf(kMaxBufferSize);                                                                                        \
+    PacketBufferWriter buf(System::PacketBufferHandle::New(kMaxBufferSize));                                                       \
     if (buf.IsNull())                                                                                                              \
     {                                                                                                                              \
         ChipLogError(Zcl, "Could not allocate packet buffer while trying to encode %s command", kName);                            \

--- a/src/app/zap-templates/templates/chip/encoder-src.zapt
+++ b/src/app/zap-templates/templates/chip/encoder-src.zapt
@@ -61,7 +61,7 @@ uint16_t encodeApsFrame(uint8_t * buffer, uint16_t buf_length, EmberApsFrame * a
 #define COMMAND_HEADER(name, clusterId)                                                                                            \
     const char * kName = name;                                                                                                     \
                                                                                                                                    \
-    PacketBufferWriter buf(kMaxBufferSize);                                                                                        \
+    PacketBufferWriter buf(System::PacketBufferHandle::New(kMaxBufferSize));                                                       \
     if (buf.IsNull())                                                                                                              \
     {                                                                                                                              \
         ChipLogError(Zcl, "Could not allocate packet buffer while trying to encode %s command", kName);                            \

--- a/src/protocols/bdx/BUILD.gn
+++ b/src/protocols/bdx/BUILD.gn
@@ -30,6 +30,6 @@ static_library("bdx") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/system",
-    "${chip_root}/src/transport/raw",
+    "${chip_root}/src/transport",
   ]
 }

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -26,7 +26,7 @@ constexpr size_t kStatusReportMinSize = 2 + 4 + 2; ///< 16 bits for GeneralCode,
 CHIP_ERROR WriteToPacketBuffer(const ::chip::bdx::BdxMessage & msgStruct, ::chip::System::PacketBufferHandle & msgBuf)
 {
     size_t msgDataSize = msgStruct.MessageSize();
-    ::chip::Encoding::LittleEndian::PacketBufferWriter bbuf(chip::MessagePacketBuffer::New(msgDataSize));
+    ::chip::Encoding::LittleEndian::PacketBufferWriter bbuf(chip::MessagePacketBuffer::New(msgDataSize), msgDataSize);
     if (bbuf.IsNull())
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -22,7 +22,7 @@ void TestHelperWrittenAndParsedMatch(nlTestSuite * inSuite, void * inContext, Ms
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     size_t msgSize = testMsg.MessageSize();
-    Encoding::LittleEndian::PacketBufferWriter bbuf(msgSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(msgSize));
     NL_TEST_ASSERT(inSuite, !bbuf.IsNull());
 
     testMsg.WriteToBuffer(bbuf);

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -635,24 +635,5 @@ System::PacketBufferHandle PacketBufferWriterUtil::Finalize(BufferWriter & aBuff
     return std::move(aPacket);
 }
 
-CHIP_ERROR PacketBufferWriterUtil::Finalize(BufferWriter & aBufferWriter, System::PacketBufferHandle & aPacket,
-                                            System::PacketBufferHandle * outPacket)
-{
-    *outPacket = std::move(aPacket);
-    if (outPacket->IsNull())
-    {
-        return CHIP_ERROR_NO_MEMORY;
-    }
-    if (!aBufferWriter.Fit())
-    {
-        return CHIP_ERROR_MESSAGE_TOO_LONG;
-    }
-    // Since mPacket was successfully allocated to hold the maximum length,
-    // we know that the actual length fits in a uint16_t.
-    (*outPacket)->SetDataLength(static_cast<uint16_t>(aBufferWriter.Needed()));
-    aBufferWriter = Encoding::BufferWriter(nullptr, 0);
-    return CHIP_NO_ERROR;
-}
-
 } // namespace Encoding
 } // namespace chip

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -727,8 +727,7 @@ public:
      *  Otherwise, it is guaranteed that the BufferWriter length is \a aAvailableSize. (The underlying packet
      *  buffer may be larger.)
      *
-     *  @param[in]  aAvailableSize  Length bound of the BufferWriter.
-     *  @param[in]  aReservedSize   Reserved packet buffer space for protocol headers; see \c PacketBufferHandle::New().
+     *  @param[in]  aPacket  A handle to PacketBuffer, to be used as backing store for the BufferWriter.
      */
     PacketBufferWriterBase(System::PacketBufferHandle && aPacket) : Writer(aPacket->Start(), aPacket->AvailableDataLength())
     {
@@ -761,7 +760,7 @@ public:
      *
      * This signature matches `PacketBufferTLVWriter::Finalize()`.
      *
-     * @param[out] outBuffer                    The backing packet buffer.
+     * @param[out] outPacket                    The backing packet buffer.
      *
      * @retval #CHIP_NO_ERROR                   If the encoding was finalized successfully.
      * @retval #CHIP_ERROR_NO_MEMORY            If the backing PacketBuffer is null.

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1716,7 +1716,7 @@ void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inC
     const char kPayload[] = "Hello, world!";
 
     PacketBufferWriter yay(PacketBufferHandle::New(sizeof(kPayload)));
-    PacketBufferWriter nay(PacketBufferHandle::New(sizeof(kPayload) - 2));
+    PacketBufferWriter nay(PacketBufferHandle::New(sizeof(kPayload)), sizeof(kPayload) - 2);
     NL_TEST_ASSERT(inSuite, !yay.IsNull());
     NL_TEST_ASSERT(inSuite, !nay.IsNull());
 
@@ -1733,28 +1733,6 @@ void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inC
     NL_TEST_ASSERT(inSuite, nay.IsNull());
     NL_TEST_ASSERT(inSuite, !yayBuffer.IsNull());
     NL_TEST_ASSERT(inSuite, nayBuffer.IsNull());
-    NL_TEST_ASSERT(inSuite, memcmp(yayBuffer->Start(), kPayload, sizeof kPayload) == 0);
-
-    yay = PacketBufferWriter(PacketBufferHandle::New(sizeof(kPayload)));
-    nay = PacketBufferWriter(PacketBufferHandle::New(sizeof(kPayload) - 2));
-
-    yay.Put(kPayload);
-    yay.Put('\0');
-    nay.Put(kPayload);
-    nay.Put('\0');
-    NL_TEST_ASSERT(inSuite, yay.Fit());
-    NL_TEST_ASSERT(inSuite, !nay.Fit());
-
-    CHIP_ERROR yayErr = yay.Finalize(&yayBuffer);
-    CHIP_ERROR nayErr = nay.Finalize(&nayBuffer);
-    NL_TEST_ASSERT(inSuite, yay.IsNull());
-    NL_TEST_ASSERT(inSuite, nay.IsNull());
-    NL_TEST_ASSERT(inSuite, !yayBuffer.IsNull());
-    NL_TEST_ASSERT(inSuite, !nayBuffer.IsNull());
-    NL_TEST_ASSERT(inSuite, yayBuffer->DataLength() == sizeof kPayload);
-    NL_TEST_ASSERT(inSuite, nayBuffer->DataLength() == 0);
-    NL_TEST_ASSERT(inSuite, yayErr == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, nayErr == CHIP_ERROR_MESSAGE_TOO_LONG);
     NL_TEST_ASSERT(inSuite, memcmp(yayBuffer->Start(), kPayload, sizeof kPayload) == 0);
 }
 

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -1715,8 +1715,8 @@ void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inC
 
     const char kPayload[] = "Hello, world!";
 
-    PacketBufferWriter yay(sizeof(kPayload));
-    PacketBufferWriter nay(sizeof(kPayload) - 2);
+    PacketBufferWriter yay(PacketBufferHandle::New(sizeof(kPayload)));
+    PacketBufferWriter nay(PacketBufferHandle::New(sizeof(kPayload) - 2));
     NL_TEST_ASSERT(inSuite, !yay.IsNull());
     NL_TEST_ASSERT(inSuite, !nay.IsNull());
 
@@ -1733,6 +1733,28 @@ void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inC
     NL_TEST_ASSERT(inSuite, nay.IsNull());
     NL_TEST_ASSERT(inSuite, !yayBuffer.IsNull());
     NL_TEST_ASSERT(inSuite, nayBuffer.IsNull());
+    NL_TEST_ASSERT(inSuite, memcmp(yayBuffer->Start(), kPayload, sizeof kPayload) == 0);
+
+    yay = PacketBufferWriter(PacketBufferHandle::New(sizeof(kPayload)));
+    nay = PacketBufferWriter(PacketBufferHandle::New(sizeof(kPayload) - 2));
+
+    yay.Put(kPayload);
+    yay.Put('\0');
+    nay.Put(kPayload);
+    nay.Put('\0');
+    NL_TEST_ASSERT(inSuite, yay.Fit());
+    NL_TEST_ASSERT(inSuite, !nay.Fit());
+
+    CHIP_ERROR yayErr = yay.Finalize(&yayBuffer);
+    CHIP_ERROR nayErr = nay.Finalize(&nayBuffer);
+    NL_TEST_ASSERT(inSuite, yay.IsNull());
+    NL_TEST_ASSERT(inSuite, nay.IsNull());
+    NL_TEST_ASSERT(inSuite, !yayBuffer.IsNull());
+    NL_TEST_ASSERT(inSuite, !nayBuffer.IsNull());
+    NL_TEST_ASSERT(inSuite, yayBuffer->DataLength() == sizeof kPayload);
+    NL_TEST_ASSERT(inSuite, nayBuffer->DataLength() == 0);
+    NL_TEST_ASSERT(inSuite, yayErr == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, nayErr == CHIP_ERROR_MESSAGE_TOO_LONG);
     NL_TEST_ASSERT(inSuite, memcmp(yayBuffer->Start(), kPayload, sizeof kPayload) == 0);
 }
 

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -230,7 +230,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     const size_t bufferSize = EncodedStringSize(ssid) + EncodedStringSize(passwd);
     VerifyOrExit(CanCastTo<uint16_t>(bufferSize), err = CHIP_ERROR_INVALID_ARGUMENT);
     {
-        Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(bufferSize));
+        Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(bufferSize), bufferSize);
 
         ChipLogProgress(NetworkProvisioning, "Sending Network Creds. Delegate %p\n", mDelegate);
         VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -264,7 +264,7 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         4;                  // threadData.ThreadChannel, threadData.FieldPresent.ThreadExtendedPANId,
                             // threadData.FieldPresent.ThreadMeshPrefix, threadData.FieldPresent.ThreadPSKc
     /* clang-format on */
-    Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(credentialSize));
+    Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(credentialSize), credentialSize);
 
     ChipLogProgress(NetworkProvisioning, "Sending Thread Credentials");
     VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -230,7 +230,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
     const size_t bufferSize = EncodedStringSize(ssid) + EncodedStringSize(passwd);
     VerifyOrExit(CanCastTo<uint16_t>(bufferSize), err = CHIP_ERROR_INVALID_ARGUMENT);
     {
-        Encoding::LittleEndian::PacketBufferWriter bbuf(bufferSize + MessagePacketBuffer::kMaxFooterSize);
+        Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(bufferSize));
 
         ChipLogProgress(NetworkProvisioning, "Sending Network Creds. Delegate %p\n", mDelegate);
         VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -264,7 +264,7 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
         4;                  // threadData.ThreadChannel, threadData.FieldPresent.ThreadExtendedPANId,
                             // threadData.FieldPresent.ThreadMeshPrefix, threadData.FieldPresent.ThreadPSKc
     /* clang-format on */
-    Encoding::LittleEndian::PacketBufferWriter bbuf(credentialSize);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(credentialSize));
 
     ChipLogProgress(NetworkProvisioning, "Sending Thread Credentials");
     VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -628,7 +628,7 @@ CHIP_ERROR PASESession::HandleMsg1_and_SendMsg2(const PacketHeader & header, con
     data_len = static_cast<uint16_t>(Y_len + verifier_len);
 
     {
-        Encoding::PacketBufferWriter bbuf(data_len);
+        Encoding::PacketBufferWriter bbuf(System::PacketBufferHandle::New(data_len));
         VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
         bbuf.Put(&Y[0], Y_len);
         bbuf.Put(verifier, verifier_len);
@@ -684,7 +684,7 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(const PacketHeader & header, con
     }
 
     {
-        Encoding::PacketBufferWriter bbuf(verifier_len);
+        Encoding::PacketBufferWriter bbuf(System::PacketBufferHandle::New(verifier_len));
         VerifyOrExit(!bbuf.IsNull(), err = CHIP_SYSTEM_ERROR_NO_MEMORY);
 
         bbuf.Put(verifier, verifier_len);


### PR DESCRIPTION
#### Problem

The `PacketBufferWriter` constructor that takes a size and allocates the
`PacketBuffer` internally is awkward for some cases, and useless for the
case of an existing `PacketBufferHandle`.

#### Summary of Changes

- `PacketBufferWriter()` takes ownership of an existing `PacketBufferHandle`
  (same as `PacketBufferTLVWriter`).
- Added a `Finalize()` overload that matches that of `PacketBufferTLVWriter`.
