### PR TITLE
Implement UI to unpair devices in iOS CHIP Tool

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -248,7 +248,7 @@ void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader 
     }
 }
 
-CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, bool randomSetupPIN, SetupPayload & setupPayload)
+CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption option, SetupPayload & setupPayload)
 {
     // TODO: This code is temporary, and must be updated to use the Cluster API.
     // Issue: https://github.com/project-chip/connectedhomeip/issues/4725
@@ -262,11 +262,12 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, bool rando
 
     ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 1), timeout));
 
-    if (useToken)
+    if (option != PairingWindowOption::kOriginalSetupCode)
     {
         ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 2), setupPayload.discriminator));
 
         PASEVerifier verifier;
+        bool randomSetupPIN = (option == PairingWindowOption::kTokenWithRandomPIN);
         ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, randomSetupPIN, setupPayload.setUpPINCode));
         ReturnErrorOnFailure(writer.PutBytes(TLV::ProfileTag(writer.ImplicitProfileId, 3),
                                              reinterpret_cast<const uint8_t *>(verifier), sizeof(verifier)));

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -248,7 +248,7 @@ void Device::OnMessageReceived(const PacketHeader & header, const PayloadHeader 
     }
 }
 
-CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t discriminator, SetupPayload & setupPayload)
+CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, bool randomSetupPIN, SetupPayload & setupPayload)
 {
     // TODO: This code is temporary, and must be updated to use the Cluster API.
     // Issue: https://github.com/project-chip/connectedhomeip/issues/4725
@@ -264,10 +264,10 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t d
 
     if (useToken)
     {
-        ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 2), discriminator));
+        ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 2), setupPayload.discriminator));
 
         PASEVerifier verifier;
-        ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, setupPayload.setUpPINCode));
+        ReturnErrorOnFailure(PASESession::GeneratePASEVerifier(verifier, randomSetupPIN, setupPayload.setUpPINCode));
         ReturnErrorOnFailure(writer.PutBytes(TLV::ProfileTag(writer.ImplicitProfileId, 3),
                                              reinterpret_cast<const uint8_t *>(verifier), sizeof(verifier)));
     }
@@ -283,7 +283,6 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t d
 
     setupPayload.version               = 1;
     setupPayload.rendezvousInformation = RendezvousInformationFlags::kBLE;
-    setupPayload.discriminator         = discriminator;
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -71,6 +71,13 @@ public:
         }
     }
 
+    enum class PairingWindowOption
+    {
+        kOriginalSetupCode,
+        kTokenWithRandomPIN,
+        kTokenWithProvidedPIN,
+    };
+
     /**
      * @brief
      *   Set the delegate object which will be called when a message is received.
@@ -241,16 +248,15 @@ public:
      *   The device will exit the pairing mode after a successful pairing, or after the given `timeout` time.
      *
      * @param[in] timeout         The pairing mode should terminate after this much time.
-     * @param[in] useToken        Generate an onboarding token and send it to the device. The device must
-     *                            use the provided onboarding token instead of the original pairing setup PIN
-     *                            and discriminator.
-     * @param[in] randomSetupPIN  If true, generate a random setup PIN while opening the pairing window
-     *                            else, use the setup PIN from the setupPayload.
+     * @param[in] option          The pairing window can be opened using the original setup code, or an
+     *                            onboarding token can be generated using a random setup PIN code (or with
+     *                            the PIN code provied in the setupPayload). This argument selects one of these
+     *                            methods.
      * @param[out] setupPayload   The setup payload corresponding to the generated onboarding token.
      *
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR OpenPairingWindow(uint32_t timeout, bool useToken, bool randomSetupPIN, SetupPayload & setupPayload);
+    CHIP_ERROR OpenPairingWindow(uint32_t timeout, PairingWindowOption option, SetupPayload & setupPayload);
 
     /**
      * @brief

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -244,12 +244,13 @@ public:
      * @param[in] useToken        Generate an onboarding token and send it to the device. The device must
      *                            use the provided onboarding token instead of the original pairing setup PIN
      *                            and discriminator.
-     * @param[in] discriminator   The discriminator that the device should use for advertising and pairing.
+     * @param[in] randomSetupPIN  If true, generate a random setup PIN while opening the pairing window
+     *                            else, use the setup PIN from the setupPayload.
      * @param[out] setupPayload   The setup payload corresponding to the generated onboarding token.
      *
      * @return CHIP_ERROR               CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR OpenPairingWindow(uint32_t timeout, bool useToken, uint16_t discriminator, SetupPayload & setupPayload);
+    CHIP_ERROR OpenPairingWindow(uint32_t timeout, bool useToken, bool randomSetupPIN, SetupPayload & setupPayload);
 
     /**
      * @brief

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -198,6 +198,7 @@ protected:
     uint16_t FindDeviceIndex(SecureSessionHandle session);
     uint16_t FindDeviceIndex(NodeId id);
     void ReleaseDevice(uint16_t index);
+    void ReleaseDeviceById(NodeId remoteDeviceId);
     CHIP_ERROR SetPairedDeviceList(const char * pairedDeviceSerializedSet);
 
     Transport::AdminId mAdminId = 0;

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0CA0E0CF248599BB009087B9 /* OnOffViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CA0E0CE248599BB009087B9 /* OnOffViewController.m */; };
 		2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C21071325D1A8F200DDA4AD /* MultiAdminViewController.m */; };
 		2C460C2425D7594B000512D6 /* DeviceSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C460C2325D7594B000512D6 /* DeviceSelector.m */; };
+		2C460C3225D97CB3000512D6 /* UnpairDevicesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C460C3025D97CB3000512D6 /* UnpairDevicesViewController.m */; };
 		991DC091247747F500C13860 /* EchoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 991DC090247747F500C13860 /* EchoViewController.m */; };
 		997A639C253F93F7005C64E6 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; };
 		997A639D253F93F7005C64E6 /* CHIP.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 997A639B253F93F7005C64E6 /* CHIP.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -58,6 +59,8 @@
 		2C21071425D1A8F200DDA4AD /* MultiAdminViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultiAdminViewController.h; sourceTree = "<group>"; };
 		2C460C2225D7594B000512D6 /* DeviceSelector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceSelector.h; sourceTree = "<group>"; };
 		2C460C2325D7594B000512D6 /* DeviceSelector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceSelector.m; sourceTree = "<group>"; };
+		2C460C3025D97CB3000512D6 /* UnpairDevicesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UnpairDevicesViewController.m; sourceTree = "<group>"; };
+		2C460C3125D97CB3000512D6 /* UnpairDevicesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnpairDevicesViewController.h; sourceTree = "<group>"; };
 		991DC08F247747F500C13860 /* EchoViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EchoViewController.h; sourceTree = "<group>"; };
 		991DC090247747F500C13860 /* EchoViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EchoViewController.m; sourceTree = "<group>"; };
 		997A639B253F93F7005C64E6 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -144,6 +147,15 @@
 			path = MultiAdmin;
 			sourceTree = "<group>";
 		};
+		2C460C2F25D97CB3000512D6 /* UnpairDevices */ = {
+			isa = PBXGroup;
+			children = (
+				2C460C3025D97CB3000512D6 /* UnpairDevicesViewController.m */,
+				2C460C3125D97CB3000512D6 /* UnpairDevicesViewController.h */,
+			);
+			path = UnpairDevices;
+			sourceTree = "<group>";
+		};
 		B20252DE2459EC7600F97062 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -206,6 +218,7 @@
 		B232D8BF251A0EC500792CB4 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				2C460C2F25D97CB3000512D6 /* UnpairDevices */,
 				2C460C2225D7594B000512D6 /* DeviceSelector.h */,
 				2C460C2325D7594B000512D6 /* DeviceSelector.m */,
 				2C21071225D1A8F200DDA4AD /* MultiAdmin */,
@@ -364,6 +377,7 @@
 				2C460C2425D7594B000512D6 /* DeviceSelector.m in Sources */,
 				2C21071525D1A8F200DDA4AD /* MultiAdminViewController.m in Sources */,
 				B204A627244E1D0600C7C0E1 /* QRCodeViewController.m in Sources */,
+				2C460C3225D97CB3000512D6 /* UnpairDevicesViewController.m in Sources */,
 				B232D8BA2514BD0800792CB4 /* CHIPUIViewUtils.m in Sources */,
 				B2946A9B24C9A7BF005C87D0 /* DefaultsUtils.m in Sources */,
 				991DC091247747F500C13860 /* EchoViewController.m in Sources */,

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -22,6 +22,7 @@ extern NSString * const kCHIPToolDefaultsDomain;
 extern NSString * const kNetworkSSIDDefaultsKey;
 extern NSString * const kNetworkPasswordDefaultsKey;
 
+CHIPDeviceController * InitializeCHIP(void);
 id CHIPGetDomainValueForKey(NSString * domain, NSString * key);
 void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
@@ -29,6 +30,7 @@ uint64_t CHIPGetNextAvailableDeviceID(void);
 void CHIPSetNextAvailableDeviceID(uint64_t id);
 CHIPDevice * CHIPGetPairedDevice(void);
 CHIPDevice * CHIPGetPairedDeviceWithID(uint64_t id);
+void CHIPUnpairDeviceWithID(uint64_t deviceId);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
 

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -101,6 +101,14 @@ CHIPDevice * CHIPGetPairedDeviceWithID(uint64_t deviceId)
     return [controller getPairedDevice:deviceId error:&error];
 }
 
+void CHIPUnpairDeviceWithID(uint64_t deviceId)
+{
+    CHIPDeviceController * controller = InitializeCHIP();
+
+    NSError * error;
+    [controller unpairDevice:deviceId error:&error];
+}
+
 @implementation CHIPToolPersistentStorageDelegate
 
 // MARK: CHIPPersistentStorageDelegate

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -122,7 +122,7 @@
 
 - (void)_clearTextFields
 {
-    CHIPDeviceController * chipController = [CHIPDeviceController sharedController];
+    CHIPDeviceController * chipController = InitializeCHIP();
     _nodeIDTextField.text = [NSString stringWithFormat:@"%@", chipController.getControllerNodeId];
     _endpointIDTextField.text = @"1";
     _groupIDTextField.text = @"0";

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/DeviceSelector.h
@@ -20,9 +20,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^DeviceAction)(uint64_t deviceId);
+
 @interface DeviceSelector : UITextField <UIPickerViewDelegate, UIPickerViewDataSource, UITextFieldDelegate>
 - (instancetype)init;
-- (CHIPDevice *)selectedDevice;
+- (void)refreshDeviceList;
+- (void)forSelectedDevices:(DeviceAction)action;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/OnOffCluster/OnOffViewController.m
@@ -86,14 +86,13 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
     [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
 
     // Device List and picker
-    UILabel * deviceIDLabel = [UILabel new];
-    deviceIDLabel.text = @"Device ID:";
     _deviceSelector = [DeviceSelector new];
 
+    UILabel * deviceIDLabel = [UILabel new];
+    deviceIDLabel.text = @"Device ID:";
     UIView * deviceIDView = [CHIPUIViewUtils viewWithLabel:deviceIDLabel textField:_deviceSelector];
-    deviceIDLabel.font = [UIFont systemFontOfSize:17 weight:UIFontWeightSemibold];
-
     [stackView addArrangedSubview:deviceIDView];
+
     deviceIDView.translatesAutoresizingMaskIntoConstraints = false;
     [deviceIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = true;
 
@@ -233,61 +232,64 @@ NSString * const kCHIPNumLightOnOffCluster = @"OnOffViewController_NumLights";
 
 - (IBAction)onButtonTapped:(id)sender
 {
-    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
-    if (chipDevice == nil) {
-        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
-        return;
-    }
-
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"On command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
-    [onOff on:^(NSError * error, NSDictionary * values) {
-        NSString * resultString
-            = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"On command success";
-        [self updateResult:resultString];
+    [_deviceSelector forSelectedDevices:^(uint64_t deviceId) {
+        CHIPDevice * chipDevice = CHIPGetPairedDeviceWithID(deviceId);
+        if (chipDevice != nil) {
+            CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+            [onOff on:^(NSError * error, NSDictionary * values) {
+                NSString * resultString
+                    = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"On command success";
+                [self updateResult:resultString];
+            }];
+        } else {
+            [self updateResult:[NSString stringWithFormat:@"Device not found"]];
+        }
     }];
 }
 
 - (IBAction)offButtonTapped:(id)sender
 {
-    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
-    if (chipDevice == nil) {
-        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
-        return;
-    }
-
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"Off command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
-    [onOff off:^(NSError * error, NSDictionary * values) {
-        NSString * resultString
-            = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"Off command success";
-        [self updateResult:resultString];
+    [_deviceSelector forSelectedDevices:^(uint64_t deviceId) {
+        CHIPDevice * chipDevice = CHIPGetPairedDeviceWithID(deviceId);
+        if (chipDevice != nil) {
+            CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+            [onOff off:^(NSError * error, NSDictionary * values) {
+                NSString * resultString = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
+                                                         : @"Off command success";
+                [self updateResult:resultString];
+            }];
+        } else {
+            [self updateResult:[NSString stringWithFormat:@"Device not found"]];
+        }
     }];
 }
 
 - (IBAction)toggleButtonTapped:(id)sender
 {
-    CHIPDevice * chipDevice = [self.deviceSelector selectedDevice];
-    if (chipDevice == nil) {
-        [self updateResult:[NSString stringWithFormat:@"No device has been selected"]];
-        return;
-    }
-
     UIButton * button = (UIButton *) sender;
     NSInteger endpoint = button.tag;
     [self updateResult:[NSString stringWithFormat:@"Toggle command sent on endpoint %@", @(endpoint)]];
 
-    CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
-    [onOff toggle:^(NSError * error, NSDictionary * values) {
-        NSString * resultString
-            = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code] : @"Toggle command success";
-        [self updateResult:resultString];
+    [_deviceSelector forSelectedDevices:^(uint64_t deviceId) {
+        CHIPDevice * chipDevice = CHIPGetPairedDeviceWithID(deviceId);
+        if (chipDevice != nil) {
+            CHIPOnOff * onOff = [[CHIPOnOff alloc] initWithDevice:chipDevice endpoint:endpoint queue:dispatch_get_main_queue()];
+            [onOff toggle:^(NSError * error, NSDictionary * values) {
+                NSString * resultString = (error != nil) ? [NSString stringWithFormat:@"An error occured: 0x%02lx", error.code]
+                                                         : @"Toggle command success";
+                [self updateResult:resultString];
+            }];
+        } else {
+            [self updateResult:[NSString stringWithFormat:@"Device not found"]];
+        }
     }];
 }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -617,9 +617,10 @@
 {
     NSError * error;
     uint64_t deviceID = CHIPGetNextAvailableDeviceID();
-    [self.chipController pairDevice:deviceID discriminator:discriminator setupPINCode:setupPINCode error:&error];
-    deviceID++;
-    CHIPSetNextAvailableDeviceID(deviceID);
+    if ([self.chipController pairDevice:deviceID discriminator:discriminator setupPINCode:setupPINCode error:&error]) {
+        deviceID++;
+        CHIPSetNextAvailableDeviceID(deviceID);
+    }
 }
 
 - (void)handleRendezVousWiFi:(NSString *)name

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/RootViewController.m
@@ -22,6 +22,7 @@
 #import "OnOffViewController.h"
 #import "QRCodeViewController.h"
 #import "TemperatureSensorViewController.h"
+#import "UnpairDevicesViewController.h"
 #import "WifiViewController.h"
 
 @implementation RootViewController
@@ -41,7 +42,7 @@
     [self.view addSubview:self.tableView];
     self.options = @[
         @"QRCode scanner", @"Echo client", @"Light on / off cluster", @"Temperature Sensor", @"Bindings", @"Wifi Configuration",
-        @"Enable Pairing"
+        @"Enable Pairing", @"Unpair Devices"
     ];
 }
 
@@ -88,6 +89,9 @@
     case 6:
         [self pushMultiAdmin];
         break;
+    case 7:
+        [self pushUnpairDevices];
+        break;
     default:
         break;
     }
@@ -132,6 +136,12 @@
 - (void)pushLightOnOffCluster
 {
     OnOffViewController * controller = [OnOffViewController new];
+    [self.navigationController pushViewController:controller animated:YES];
+}
+
+- (void)pushUnpairDevices
+{
+    UnpairDevicesViewController * controller = [UnpairDevicesViewController new];
     [self.navigationController pushViewController:controller animated:YES];
 }
 @end

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/UnpairDevices/UnpairDevicesViewController.h
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/UnpairDevices/UnpairDevicesViewController.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,27 +15,12 @@
  *    limitations under the License.
  */
 
-#ifndef CHIP_DEVICE_H
-#define CHIP_DEVICE_H
-
-#import <Foundation/Foundation.h>
+#import <CHIP/CHIP.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CHIPDevice : NSObject
-
-- (BOOL)openPairingWindow:(NSTimeInterval)duration error:(NSError * __autoreleasing *)error;
-- (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
-                         discriminator:(NSUInteger)discriminator
-                              setupPIN:(NSUInteger)setupPIN
-                                 error:(NSError * __autoreleasing *)error;
-- (BOOL)isActive;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
+@interface UnpairDevicesViewController : UIViewController
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* CHIP_DEVICE_H */

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/UnpairDevices/UnpairDevicesViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/UnpairDevices/UnpairDevicesViewController.m
@@ -1,0 +1,139 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "UnpairDevicesViewController.h"
+#import "CHIPUIViewUtils.h"
+#import "DefaultsUtils.h"
+#import "DeviceSelector.h"
+#import <CHIP/CHIP.h>
+
+@interface UnpairDevicesViewController ()
+@property (strong, nonatomic) UISwitch * unpairAllDevicesSwitch;
+@property (nonatomic, strong) UILabel * unpairLabel;
+@property (nonatomic, strong) UILabel * titleLabel;
+@property (nonatomic, strong) UIStackView * stackView;
+@property (nonatomic, strong) DeviceSelector * deviceSelector;
+@property (strong, nonatomic) UIButton * unpairButton;
+@end
+
+@implementation UnpairDevicesViewController
+
+// MARK: UIViewController methods
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
+    [self.view addGestureRecognizer:tap];
+
+    [self setupUIElements];
+}
+
+- (void)dismissKeyboard
+{
+    [_deviceSelector resignFirstResponder];
+}
+
+// MARK: UI Setup
+
+- (void)setupUIElements
+{
+    self.view.backgroundColor = UIColor.whiteColor;
+
+    // Title
+    _titleLabel = [CHIPUIViewUtils addTitle:@"Unpair Devices" toView:self.view];
+    [self setupStackView];
+}
+
+- (void)setupStackView
+{
+    // stack view
+    UIStackView * stackView = [UIStackView new];
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionEqualSpacing;
+    stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.spacing = 30;
+    [_stackView removeFromSuperview];
+    _stackView = stackView;
+    [self.view addSubview:stackView];
+
+    stackView.translatesAutoresizingMaskIntoConstraints = false;
+    [stackView.topAnchor constraintEqualToAnchor:_titleLabel.bottomAnchor constant:30].active = YES;
+    [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:30].active = YES;
+    [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-30].active = YES;
+
+    // Unpair All Devices
+    UILabel * unpairAllDevices = [UILabel new];
+    unpairAllDevices.text = @"Unpair all devices";
+    _unpairAllDevicesSwitch = [UISwitch new];
+    [_unpairAllDevicesSwitch setOn:YES];
+    UIView * openPairingOnAllDevicesView = [CHIPUIViewUtils viewWithLabel:unpairAllDevices toggle:_unpairAllDevicesSwitch];
+    [_unpairAllDevicesSwitch addTarget:self action:@selector(unpairAllDevicesButton:) forControlEvents:UIControlEventTouchUpInside];
+    [stackView addArrangedSubview:openPairingOnAllDevicesView];
+    openPairingOnAllDevicesView.translatesAutoresizingMaskIntoConstraints = false;
+    [openPairingOnAllDevicesView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+
+    // Device List and picker
+    _deviceSelector = [DeviceSelector new];
+    [_deviceSelector setEnabled:NO];
+
+    UILabel * deviceIDLabel = [UILabel new];
+    deviceIDLabel.text = @"Device ID:";
+    UIView * deviceIDView = [CHIPUIViewUtils viewWithLabel:deviceIDLabel textField:_deviceSelector];
+    [stackView addArrangedSubview:deviceIDView];
+
+    deviceIDView.translatesAutoresizingMaskIntoConstraints = false;
+    [deviceIDView.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = true;
+
+    // Unpair devices button
+    _unpairButton = [UIButton new];
+    [_unpairButton setTitle:@"Unpair Devices" forState:UIControlStateNormal];
+    [_unpairButton addTarget:self action:@selector(unpairSelectedDevices:) forControlEvents:UIControlEventTouchUpInside];
+    _unpairButton.backgroundColor = UIColor.systemBlueColor;
+    _unpairButton.titleLabel.font = [UIFont systemFontOfSize:17];
+    _unpairButton.titleLabel.textColor = [UIColor whiteColor];
+    _unpairButton.layer.cornerRadius = 5;
+    _unpairButton.clipsToBounds = YES;
+    [stackView addArrangedSubview:_unpairButton];
+
+    _unpairButton.translatesAutoresizingMaskIntoConstraints = false;
+    [_unpairButton.trailingAnchor constraintEqualToAnchor:stackView.trailingAnchor].active = YES;
+}
+
+// MARK: UIButton actions
+
+- (IBAction)unpairAllDevicesButton:(id)sender
+{
+    if ([_unpairAllDevicesSwitch isOn]) {
+        [_deviceSelector setEnabled:NO];
+    } else {
+        [_deviceSelector setEnabled:YES];
+    }
+}
+
+- (IBAction)unpairSelectedDevices:(id)sender
+{
+    [_deviceSelector forSelectedDevices:^(uint64_t deviceId) {
+        CHIPUnpairDeviceWithID(deviceId);
+    }];
+
+    [_deviceSelector refreshDeviceList];
+    //[_deviceSelector setEnabled:NO];
+}
+
+@end

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -58,7 +58,8 @@
     chip::SetupPayload setupPayload;
 
     [self.lock lock];
-    err = self.cppDevice->OpenPairingWindow(duration, false, false, setupPayload);
+    err = self.cppDevice->OpenPairingWindow(
+        duration, chip::Controller::Device::PairingWindowOption::kOriginalSetupCode, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
@@ -95,7 +96,8 @@
     setupPayload.setUpPINCode = (uint32_t) setupPIN;
 
     [self.lock lock];
-    err = self.cppDevice->OpenPairingWindow(duration, true, true, setupPayload);
+    err = self.cppDevice->OpenPairingWindow(
+        duration, chip::Controller::Device::PairingWindowOption::kTokenWithProvidedPIN, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -58,7 +58,7 @@
     chip::SetupPayload setupPayload;
 
     [self.lock lock];
-    err = self.cppDevice->OpenPairingWindow(duration, false, 0, setupPayload);
+    err = self.cppDevice->OpenPairingWindow(duration, false, false, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {
@@ -74,11 +74,12 @@
 
 - (NSString *)openPairingWindowWithPIN:(NSTimeInterval)duration
                          discriminator:(NSUInteger)discriminator
+                              setupPIN:(NSUInteger)setupPIN
                                  error:(NSError * __autoreleasing *)error
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    uint16_t u16Descriminator = 0;
+    chip::SetupPayload setupPayload;
 
     if (discriminator > 0xfff) {
         CHIP_LOG_ERROR("Error: Discriminator %tu is too large. Max value %d", discriminator, 0xfff);
@@ -87,13 +88,14 @@
         }
         return nil;
     } else {
-        u16Descriminator = (uint16_t) discriminator;
+        setupPayload.discriminator = (uint16_t) discriminator;
     }
 
-    chip::SetupPayload setupPayload;
+    setupPIN &= ((1 << chip::kSetupPINCodeFieldLengthInBits) - 1);
+    setupPayload.setUpPINCode = (uint32_t) setupPIN;
 
     [self.lock lock];
-    err = self.cppDevice->OpenPairingWindow(duration, true, u16Descriminator, setupPayload);
+    err = self.cppDevice->OpenPairingWindow(duration, true, true, setupPayload);
     [self.lock unlock];
 
     if (err != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -192,11 +192,14 @@ static NSString * const kErrorGetPairedDevice = @"Failure while trying to retrie
 
 - (void)setPersistentStorageDelegate:(id<CHIPPersistentStorageDelegate>)delegate queue:(dispatch_queue_t)queue
 {
-    [self.lock lock];
-    _persistentStorageDelegateBridge->setFrameworkDelegate(delegate, queue);
-    [self.lock unlock];
-    _persistentStorageDelegateBridge->SetKeyValue(
-        CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self.lock lock];
+        _persistentStorageDelegateBridge->setFrameworkDelegate(delegate, queue);
+        [self.lock unlock];
+        _persistentStorageDelegateBridge->SetKeyValue(
+            CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
+    });
 }
 
 - (void)sendWiFiCredentials:(NSString *)ssid password:(NSString *)password

--- a/src/transport/PASESession.h
+++ b/src/transport/PASESession.h
@@ -136,10 +136,17 @@ public:
     CHIP_ERROR Pair(const Transport::PeerAddress peerAddress, const PASEVerifier & verifier, Optional<NodeId> myNodeId,
                     NodeId peerNodeId, uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
 
-    static CHIP_ERROR ComputePASEVerifier(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,
-                                          PASEVerifier & verifier);
-
-    static CHIP_ERROR GeneratePASEVerifier(PASEVerifier & verifier, uint32_t & setupPIN);
+    /**
+     * @brief
+     *   Generate a new PASE verifier.
+     *
+     * @param verifier      The generated PASE verifier
+     * @param useRandomPIN  Generate a random setup PIN, if true. Else, use the provided PIN
+     * @param setupPIN      Provided setup PIN (if useRandomPIN is false), or the generated PIN
+     *
+     * @return CHIP_ERROR      The result of PASE verifier generation
+     */
+    static CHIP_ERROR GeneratePASEVerifier(PASEVerifier & verifier, bool useRandomPIN, uint32_t & setupPIN);
 
     /**
      * @brief
@@ -224,6 +231,9 @@ private:
     };
 
     CHIP_ERROR Init(Optional<NodeId> myNodeId, uint16_t myKeyId, uint32_t setupCode, SessionEstablishmentDelegate * delegate);
+
+    static CHIP_ERROR ComputePASEVerifier(uint32_t mySetUpPINCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,
+                                          PASEVerifier & verifier);
 
     CHIP_ERROR SetupSpake2p(uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen);
 


### PR DESCRIPTION
 #### Problem
CHIP Tool app allows user to pair multiple devices. The UI is lacking a mechanism to unpair devices. Also, need a convenient way to unpair all devices, to reset the controller state.

 #### Summary of Changes
1. Update device selector view to show all devices, and a `block` to iterate thru selected devices and perform the action.
2. Add CHIP Tool UI to unpair selected devices.
3. Enable caller/`CHIPTool app` to provide a setup PIN code while opening the pairing window.
