### PR TITLE
Disable ZLL OnOff specific commands in bridge-app.zap

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -171,6 +171,10 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     enable_linux_all_clusters_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
 
+    # Build the Linux bridge app example.
+    enable_linux_bridge_app_build =
+        enable_default_builds && (host_os == "linux" || host_os == "mac")
+
     # Build the Linux lighting app example.
     enable_linux_lighting_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
@@ -257,6 +261,13 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 
+  if (enable_linux_bridge_app_build) {
+    group("linux_bridge_app") {
+      deps =
+          [ "${chip_root}/examples/bridge-app/linux(${standalone_toolchain})" ]
+    }
+  }
+
   if (enable_linux_lighting_app_build) {
     group("linux_lighting_app") {
       deps = [
@@ -316,6 +327,9 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
     if (enable_linux_all_clusters_app_build) {
       deps += [ ":linux_all_clusters_app" ]
+    }
+    if (enable_linux_bridge_app_build) {
+      deps += [ ":linux_bridge_app" ]
     }
     if (enable_linux_lighting_app_build) {
       deps += [ ":linux_lighting_app" ]

--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -1,5 +1,5 @@
 {
-  "writeTime": "Fri Feb 12 2021 07:41:35 GMT-0800 (Pacific Standard Time)",
+  "writeTime": "Tue Feb 16 2021 18:07:17 GMT+0100 (Central European Standard Time)",
   "featureLevel": 11,
   "creator": "zap",
   "keyValuePairs": [
@@ -451,56 +451,6 @@
           "define": "SCENES_CLUSTER",
           "side": "server",
           "enabled": 0,
-          "commands": [
-            {
-              "name": "AddSceneResponse",
-              "code": 0,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "ViewSceneResponse",
-              "code": 1,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "RemoveSceneResponse",
-              "code": 2,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "RemoveAllScenesResponse",
-              "code": 3,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "StoreSceneResponse",
-              "code": 4,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "GetSceneMembershipResponse",
-              "code": 6,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            }
-          ],
           "attributes": [
             {
               "name": "cluster revision",
@@ -591,6 +541,56 @@
               "minInterval": 0,
               "maxInterval": 65344,
               "reportableChange": 0
+            }
+          ],
+          "commands": [
+            {
+              "name": "AddSceneResponse",
+              "code": 0,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "ViewSceneResponse",
+              "code": 1,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "RemoveSceneResponse",
+              "code": 2,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "RemoveAllScenesResponse",
+              "code": 3,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "StoreSceneResponse",
+              "code": 4,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
+            },
+            {
+              "name": "GetSceneMembershipResponse",
+              "code": 6,
+              "mfgCode": null,
+              "source": "server",
+              "incoming": 0,
+              "outgoing": 1
             }
           ]
         },
@@ -1617,7 +1617,7 @@
               "code": 64,
               "mfgCode": null,
               "source": "client",
-              "incoming": 1,
+              "incoming": 0,
               "outgoing": 0
             },
             {
@@ -1625,7 +1625,7 @@
               "code": 65,
               "mfgCode": null,
               "source": "client",
-              "incoming": 1,
+              "incoming": 0,
               "outgoing": 0
             },
             {
@@ -1633,7 +1633,7 @@
               "code": 66,
               "mfgCode": null,
               "source": "client",
-              "incoming": 1,
+              "incoming": 0,
               "outgoing": 0
             }
           ],

--- a/examples/bridge-app/bridge-common/gen/call-command-handler.cpp
+++ b/examples/bridge-app/bridge-common/gen/call-command-handler.cpp
@@ -338,59 +338,8 @@ EmberAfStatus emberAfOnOffClusterServerCommandParse(EmberAfClusterCommand * cmd)
             wasHandled = emberAfOnOffClusterOffCallback();
             break;
         }
-        case ZCL_OFF_WITH_EFFECT_COMMAND_ID: {
-            uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t effectId;
-            uint8_t effectVariant;
-
-            if (cmd->bufLen < payloadOffset + 1)
-            {
-                return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            effectId      = emberAfGetInt8u(cmd->buffer, payloadOffset, cmd->bufLen);
-            payloadOffset = static_cast<uint16_t>(payloadOffset + 1);
-            if (cmd->bufLen < payloadOffset + 1)
-            {
-                return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            effectVariant = emberAfGetInt8u(cmd->buffer, payloadOffset, cmd->bufLen);
-
-            wasHandled = emberAfOnOffClusterOffWithEffectCallback(effectId, effectVariant);
-            break;
-        }
         case ZCL_ON_COMMAND_ID: {
             wasHandled = emberAfOnOffClusterOnCallback();
-            break;
-        }
-        case ZCL_ON_WITH_RECALL_GLOBAL_SCENE_COMMAND_ID: {
-            wasHandled = emberAfOnOffClusterOnWithRecallGlobalSceneCallback();
-            break;
-        }
-        case ZCL_ON_WITH_TIMED_OFF_COMMAND_ID: {
-            uint16_t payloadOffset = cmd->payloadStartIndex;
-            uint8_t onOffControl;
-            uint16_t onTime;
-            uint16_t offWaitTime;
-
-            if (cmd->bufLen < payloadOffset + 1)
-            {
-                return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            onOffControl  = emberAfGetInt8u(cmd->buffer, payloadOffset, cmd->bufLen);
-            payloadOffset = static_cast<uint16_t>(payloadOffset + 1);
-            if (cmd->bufLen < payloadOffset + 2)
-            {
-                return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            onTime        = emberAfGetInt16u(cmd->buffer, payloadOffset, cmd->bufLen);
-            payloadOffset = static_cast<uint16_t>(payloadOffset + 2);
-            if (cmd->bufLen < payloadOffset + 2)
-            {
-                return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
-            }
-            offWaitTime = emberAfGetInt16u(cmd->buffer, payloadOffset, cmd->bufLen);
-
-            wasHandled = emberAfOnOffClusterOnWithTimedOffCallback(onOffControl, onTime, offWaitTime);
             break;
         }
         case ZCL_TOGGLE_COMMAND_ID: {

--- a/examples/bridge-app/bridge-common/gen/callback.h
+++ b/examples/bridge-app/bridge-common/gen/callback.h
@@ -356,33 +356,10 @@ bool emberAfLevelControlClusterStopWithOnOffCallback();
 bool emberAfOnOffClusterOffCallback();
 
 /**
- * @brief On/off Cluster OffWithEffect Command callback
- * @param effectId
- * @param effectVariant
- */
-
-bool emberAfOnOffClusterOffWithEffectCallback(uint8_t effectId, uint8_t effectVariant);
-
-/**
  * @brief On/off Cluster On Command callback
  */
 
 bool emberAfOnOffClusterOnCallback();
-
-/**
- * @brief On/off Cluster OnWithRecallGlobalScene Command callback
- */
-
-bool emberAfOnOffClusterOnWithRecallGlobalSceneCallback();
-
-/**
- * @brief On/off Cluster OnWithTimedOff Command callback
- * @param onOffControl
- * @param onTime
- * @param offWaitTime
- */
-
-bool emberAfOnOffClusterOnWithTimedOffCallback(uint8_t onOffControl, uint16_t onTime, uint16_t offWaitTime);
 
 /**
  * @brief On/off Cluster Toggle Command callback

--- a/examples/bridge-app/bridge-common/gen/endpoint_config.h
+++ b/examples/bridge-app/bridge-common/gen/endpoint_config.h
@@ -235,11 +235,11 @@
             { 0x0006, 0x02, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): Toggle */                                     \
             { 0x0006, 0x02, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): Toggle */                                     \
             { 0x0006, 0x02, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): Toggle */                                     \
+            { 0x0006, 0x40, 0 },                                 /* On/off (server): OffWithEffect */                              \
             { 0x0006, 0x40, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OffWithEffect */                              \
-            { 0x0006, 0x40, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OffWithEffect */                              \
+            { 0x0006, 0x41, 0 },                                 /* On/off (server): OnWithRecallGlobalScene */                    \
             { 0x0006, 0x41, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OnWithRecallGlobalScene */                    \
-            { 0x0006, 0x41, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OnWithRecallGlobalScene */                    \
-            { 0x0006, 0x42, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OnWithTimedOff */                             \
+            { 0x0006, 0x42, 0 },                                 /* On/off (server): OnWithTimedOff */                             \
             { 0x0006, 0x42, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* On/off (server): OnWithTimedOff */                             \
             { 0x0008, 0x00, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* Level Control (server): MoveToLevel */                         \
             { 0x0008, 0x00, ZAP_COMMAND_MASK(INCOMING_SERVER) }, /* Level Control (server): MoveToLevel */                         \

--- a/examples/bridge-app/linux/BUILD.gn
+++ b/examples/bridge-app/linux/BUILD.gn
@@ -27,7 +27,7 @@ config("includes") {
   ]
 }
 
-executable("chip-tool-server") {
+executable("bridge-app-server") {
   sources = [
     "LightingManager.cpp",
     "Options.cpp",
@@ -52,5 +52,5 @@ executable("chip-tool-server") {
 }
 
 group("linux") {
-  deps = [ ":chip-tool-server" ]
+  deps = [ ":bridge-app-server" ]
 }


### PR DESCRIPTION
### Problem
     #4858 has updated some `.zap` files since a ZAP submodule update has made some unwanted changes to the generated content. Sadly by *saving* the `bridge-app.zap` file to disk some ZLL specific commands for the On/Off cluster got enabled...
    While there is some code to handle those ZLL commands in the tree (under `src/app/clusters/zll-on-off-server`)  it has not been yet updated to compile. So one can't *just* add it to `examples/bridge-app/bridge-common/BUILD.gn`.
    The simpler fix as the moment, is to revert back the `.zap` file with those commands disabled.
    
### Summary of changes
      * Add `bridge-app` to the list of apps built by default with the `gn_build.sh` script. So it will be easy to spot this kind of issue next time
      * Remove the 3 ZLL On/Off commands from the `bridge-app.zap` config file
