### PR TITLE
Use unidirectional encryption keys in secure session

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -407,7 +407,8 @@ void InitServer(AppDelegate * delegate)
         AdminPairingInfo * adminInfo = gAdminPairings.AssignAdminId(gNextAvailableAdminId);
         VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
         adminInfo->SetNodeId(chip::kTestDeviceNodeId);
-        err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, gNextAvailableAdminId);
+        err = gSessions.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, SecureSessionMgr::PairingDirection::kResponder,
+                                   gNextAvailableAdminId);
         SuccessOrExit(err);
     }
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -147,7 +147,8 @@ CHIP_ERROR EstablishSecureSession()
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
                                          chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID)),
-                                     chip::kTestDeviceNodeId, testSecurePairingSecret, gAdminId);
+                                     chip::kTestDeviceNodeId, testSecurePairingSecret,
+                                     chip::SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -131,7 +131,8 @@ int main(int argc, char * argv[])
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager);
     SuccessOrExit(err);
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, gAdminId);
+    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
+                                     chip::SecureSessionMgr::PairingDirection::kResponder, gAdminId);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -315,7 +315,7 @@ CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
 
     err = mSessionManager->NewPairing(
         Optional<Transport::PeerAddress>::Value(Transport::PeerAddress::UDP(mDeviceAddr, mDevicePort, mInterface)), mDeviceId,
-        &pairingSession, mAdminId);
+        &pairingSession, SecureSessionMgr::PairingDirection::kInitiator, mAdminId);
     SuccessOrExit(err);
 
 exit:

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -40,9 +40,11 @@ CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transp
 
     ReturnErrorOnFailure(mExchangeManager.Init(&mSecureSessionMgr));
 
-    ReturnErrorOnFailure(mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer, mSrcAdminId));
+    ReturnErrorOnFailure(mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer,
+                                                      SecureSessionMgr::PairingDirection::kInitiator, mSrcAdminId));
 
-    return mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal, mDestAdminId);
+    return mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal,
+                                        SecureSessionMgr::PairingDirection::kResponder, mDestAdminId);
 }
 
 // Shutdown all layers, finalize operations

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -138,7 +138,8 @@ CHIP_ERROR EstablishSecureSession()
     }
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret, gAdminId);
+    err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
+                                     chip::SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -109,7 +109,8 @@ int main(int argc, char * argv[])
     err = gEchoServer.Init(&gExchangeManager);
     SuccessOrExit(err);
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, gAdminId);
+    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
+                                     chip::SecureSessionMgr::PairingDirection::kResponder, gAdminId);
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Request is received.

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -712,10 +712,6 @@ CHIP_ERROR PASESession::HandleMsg2_and_SendMsg3(const PacketHeader & header, con
 
     mPairingComplete = true;
 
-    err = DeriveSecureSession(reinterpret_cast<const unsigned char *>(kSpake2pI2RSessionInfo), strlen(kSpake2pI2RSessionInfo),
-                              mConnectionState.GetSecureSession());
-    SuccessOrExit(err);
-
     // Call delegate to indicate pairing completion
     mDelegate->OnSessionEstablished();
 
@@ -758,10 +754,6 @@ CHIP_ERROR PASESession::HandleMsg3(const PacketHeader & header, const System::Pa
     SuccessOrExit(err);
 
     mPairingComplete = true;
-
-    err = DeriveSecureSession(reinterpret_cast<const unsigned char *>(kSpake2pI2RSessionInfo), strlen(kSpake2pI2RSessionInfo),
-                              mConnectionState.GetSecureSession());
-    SuccessOrExit(err);
 
     // Call delegate to indicate pairing completion
     mDelegate->OnSessionEstablished();

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -105,6 +105,18 @@ public:
         mReceiverSecureSession.Reset();
     }
 
+    CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
+                                 MessageAuthenticationCode & mac)
+    {
+        return mSenderSecureSession.Encrypt(input, input_length, output, header, mac);
+    }
+
+    CHIP_ERROR DecryptOnReceive(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
+                                const MessageAuthenticationCode & mac)
+    {
+        return mReceiverSecureSession.Decrypt(input, input_length, output, header, mac);
+    }
+
 private:
     PeerAddress mPeerAddress;
     NodeId mPeerNodeId           = kUndefinedNodeId;

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -78,10 +78,7 @@ public:
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
 
     SecureSession & GetSenderSecureSession() { return mSenderSecureSession; }
-    const SecureSession & GetSenderSecureSession() const { return mSenderSecureSession; }
-
     SecureSession & GetReceiverSecureSession() { return mReceiverSecureSession; }
-    const SecureSession & GetReceiverSecureSession() const { return mReceiverSecureSession; }
 
     Transport::AdminId GetAdminId() const { return mAdmin; }
     void SetAdminId(Transport::AdminId admin) { mAdmin = admin; }
@@ -106,13 +103,13 @@ public:
     }
 
     CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
-                                 MessageAuthenticationCode & mac)
+                                 MessageAuthenticationCode & mac) const
     {
         return mSenderSecureSession.Encrypt(input, input_length, output, header, mac);
     }
 
     CHIP_ERROR DecryptOnReceive(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
-                                const MessageAuthenticationCode & mac)
+                                const MessageAuthenticationCode & mac) const
     {
         return mReceiverSecureSession.Decrypt(input, input_length, output, header, mac);
     }

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -77,8 +77,11 @@ public:
     uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
 
-    SecureSession & GetSecureSession() { return mSecureSession; }
-    const SecureSession & GetSecureSession() const { return mSecureSession; }
+    SecureSession & GetSenderSecureSession() { return mSenderSecureSession; }
+    const SecureSession & GetSenderSecureSession() const { return mSenderSecureSession; }
+
+    SecureSession & GetReceiverSecureSession() { return mReceiverSecureSession; }
+    const SecureSession & GetReceiverSecureSession() const { return mReceiverSecureSession; }
 
     Transport::AdminId GetAdminId() const { return mAdmin; }
     void SetAdminId(Transport::AdminId admin) { mAdmin = admin; }
@@ -98,7 +101,8 @@ public:
         mPeerNodeId         = kUndefinedNodeId;
         mSendMessageIndex   = 0;
         mLastActivityTimeMs = 0;
-        mSecureSession.Reset();
+        mSenderSecureSession.Reset();
+        mReceiverSecureSession.Reset();
     }
 
 private:
@@ -109,7 +113,8 @@ private:
     uint16_t mLocalKeyID         = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     Transport::Base * mTransport = nullptr;
-    SecureSession mSecureSession;
+    SecureSession mSenderSecureSession;
+    SecureSession mReceiverSecureSession;
     Transport::AdminId mAdmin = kUndefinedAdminId;
 };
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -149,9 +149,15 @@ void RendezvousSession::OnSessionEstablishmentError(CHIP_ERROR err)
 
 void RendezvousSession::OnSessionEstablished()
 {
+    SecureSessionMgr::PairingDirection direction = SecureSessionMgr::PairingDirection::kInitiator;
+    if (!mParams.IsController())
+    {
+        direction = SecureSessionMgr::PairingDirection::kResponder;
+    }
+
     CHIP_ERROR err = mSecureSessionMgr->NewPairing(
         Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, mAdmin->GetAdminId(), mTransport);
+        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, direction, mAdmin->GetAdminId(), mTransport);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
@@ -359,6 +365,7 @@ CHIP_ERROR RendezvousSession::HandlePairingMessage(const PacketHeader & packetHe
 CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHeader, const PeerAddress & peerAddress,
                                                   PacketBufferHandle msgBuf)
 {
+    ReturnErrorCodeIf(mPairingSessionHandle == nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorCodeIf(msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Check if the source and destination node IDs match with what we already know
@@ -373,8 +380,11 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
         VerifyOrReturnError(packetHeader.GetSourceNodeId().Value() == mParams.GetRemoteNodeId().Value(), CHIP_ERROR_WRONG_NODE_ID);
     }
 
+    PeerConnectionState * state = mSecureSessionMgr->GetPeerConnectionState(*mPairingSessionHandle);
+    ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_KEY_NOT_FOUND_FROM_PEER);
+
     PayloadHeader payloadHeader;
-    ReturnErrorOnFailure(SecureMessageCodec::Decode(&mPairingSession.PeerConnection(), payloadHeader, packetHeader, msgBuf));
+    ReturnErrorOnFailure(SecureMessageCodec::Decode(state, payloadHeader, packetHeader, msgBuf));
 
     // Use the node IDs from the packet header only after it's successfully decrypted
     if (packetHeader.GetDestinationNodeId().HasValue() && !mParams.HasLocalNodeId())

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -71,7 +71,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
     uint16_t totalLen = msgBuf->TotalLength();
 
     MessageAuthenticationCode mac;
-    ReturnErrorOnFailure(state->GetSenderSecureSession().Encrypt(data, totalLen, data, packetHeader, mac));
+    ReturnErrorOnFailure(state->EncryptBeforeSend(data, totalLen, data, packetHeader, mac));
 
     uint16_t taglen = 0;
     ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], msgBuf->AvailableDataLength(), &taglen));
@@ -114,7 +114,7 @@ CHIP_ERROR Decode(Transport::PeerConnectionState * state, PayloadHeader & payloa
     msg->SetDataLength(len);
 
     uint8_t * plainText = msg->Start();
-    ReturnErrorOnFailure(state->GetReceiverSecureSession().Decrypt(data, len, plainText, packetHeader, mac));
+    ReturnErrorOnFailure(state->DecryptOnReceive(data, len, plainText, packetHeader, mac));
 
     ReturnErrorOnFailure(payloadHeader.DecodeAndConsume(msg));
     return CHIP_NO_ERROR;

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -71,7 +71,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
     uint16_t totalLen = msgBuf->TotalLength();
 
     MessageAuthenticationCode mac;
-    ReturnErrorOnFailure(state->GetSecureSession().Encrypt(data, totalLen, data, packetHeader, mac));
+    ReturnErrorOnFailure(state->GetSenderSecureSession().Encrypt(data, totalLen, data, packetHeader, mac));
 
     uint16_t taglen = 0;
     ReturnErrorOnFailure(mac.Encode(packetHeader, &data[totalLen], msgBuf->AvailableDataLength(), &taglen));
@@ -114,7 +114,7 @@ CHIP_ERROR Decode(Transport::PeerConnectionState * state, PayloadHeader & payloa
     msg->SetDataLength(len);
 
     uint8_t * plainText = msg->Start();
-    ReturnErrorOnFailure(state->GetSecureSession().Decrypt(data, len, plainText, packetHeader, mac));
+    ReturnErrorOnFailure(state->GetReceiverSecureSession().Decrypt(data, len, plainText, packetHeader, mac));
 
     ReturnErrorOnFailure(payloadHeader.DecodeAndConsume(msg));
     return CHIP_NO_ERROR;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR SecureSession::GetAdditionalAuthData(const PacketHeader & header, uin
 }
 
 CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
-                                  MessageAuthenticationCode & mac)
+                                  MessageAuthenticationCode & mac) const
 {
 
     constexpr Header::EncryptionType encType = Header::EncryptionType::kAESCCMTagLen16;
@@ -142,7 +142,7 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
 }
 
 CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
-                                  const MessageAuthenticationCode & mac)
+                                  const MessageAuthenticationCode & mac) const
 {
     const size_t taglen = MessageAuthenticationCode::TagLenForEncryptionType(header.GetEncryptionType());
     const uint8_t * tag = mac.GetTag();

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -85,7 +85,7 @@ public:
      * @return CHIP_ERROR The result of encryption
      */
     CHIP_ERROR Encrypt(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
-                       MessageAuthenticationCode & mac);
+                       MessageAuthenticationCode & mac) const;
 
     /**
      * @brief
@@ -99,7 +99,7 @@ public:
      * @param mac Input mac
      */
     CHIP_ERROR Decrypt(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
-                       const MessageAuthenticationCode & mac);
+                       const MessageAuthenticationCode & mac) const;
 
     /**
      * @brief

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -203,6 +203,15 @@ public:
     ~SecureSessionMgr() override;
 
     /**
+     *    Whether the current node initiated the pairing, or it is responding to a pairing request.
+     */
+    enum class PairingDirection
+    {
+        kInitiator, /**< We initiated the pairing request. */
+        kResponder, /**< We are responding to the pairing request. */
+    };
+
+    /**
      * @brief
      *   Send a message to a currently connected peer.
      *
@@ -238,7 +247,7 @@ public:
      *   peer node.
      */
     CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PASESession * pairing,
-                          Transport::AdminId admin, Transport::Base * transport = nullptr);
+                          PairingDirection direction, Transport::AdminId admin, Transport::Base * transport = nullptr);
 
     /**
      * @brief

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -182,11 +182,11 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
@@ -240,11 +240,11 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
@@ -314,11 +314,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;


### PR DESCRIPTION
 #### Problem
As per CHIP spec, a secure session must use unidirectional encryption key. Current code is using the same key for both directions of communication.

 #### Summary of Changes
1. Generate two keys per peer connection. First key for encrypting transmitted messages, the other for decrypting received messages.
2. The keys are generated based on the role of the node during session setup. So the initiator's send key matches responder's receive key, and vice versa.
