### PR TITLE
Add support/BytesToHex.h -> lightweight hex conversion

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -57,6 +57,8 @@ static_library("support") {
     "BufferReader.h",
     "BufferWriter.cpp",
     "BufferWriter.h",
+    "BytesToHex.cpp",
+    "BytesToHex.h",
     "CHIPArgParser.cpp",
     "CHIPCounter.cpp",
     "CHIPCounter.h",

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -32,7 +32,7 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
     }
     else
     {
-        return x + '0';
+        return static_cast<char>(x + '0');
     }
 }
 

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -1,0 +1,72 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "BytesToHex.h"
+
+namespace chip {
+namespace Encoding {
+
+namespace {
+
+char NibbleToHex(uint8_t nibble, bool uppercase)
+{
+    char x = static_cast<char>(nibble & 0xFu);
+
+    if (x >= 10)
+    {
+        return static_cast<char>((x - 10) + (uppercase ? 'A' : 'a'));
+    }
+    else
+    {
+        return x + '0';
+    }
+}
+
+} // namespace
+
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size,
+                      char * dest_hex, size_t dest_size_max,
+                      bool uppercase, bool nul_terminate)
+{
+    if ((src_bytes == nullptr) || (dest_hex == nullptr))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    size_t expected_output_size = (src_size * 2u) + (nul_terminate ? 1u : 0u);
+    if (dest_size_max < expected_output_size)
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    char *cursor = dest_hex;
+    for (size_t byte_idx = 0; byte_idx < src_size; ++byte_idx)
+    {
+        *cursor++ = NibbleToHex((src_bytes[byte_idx] >> 4) & 0xFu, uppercase);
+        *cursor++ = NibbleToHex((src_bytes[byte_idx] >> 0) & 0xFu, uppercase);
+    }
+
+    if (nul_terminate)
+    {
+        *cursor = '\0';
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Encoding
+} // namespace chip

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -38,21 +38,29 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
 
 } // namespace
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, bool uppercase,
-                      bool nul_terminate)
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags)
 {
     if ((src_bytes == nullptr) || (dest_hex == nullptr))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
+    else if (src_size > ((SIZE_MAX - 1) / 2u))
+    {
+        // Output would overflow a size_t, let's bail out to avoid computation wraparounds below.
+        // This condition will hit with slightly less than the very max, but is unlikely to
+        // ever happen unless an error occurs and won't happen on embedded targets.
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
+    bool nul_terminate          = (static_cast<int>(flags) & static_cast<int>(HexFlags::kNullTerminate)) != 0;
     size_t expected_output_size = (src_size * 2u) + (nul_terminate ? 1u : 0u);
     if (dest_size_max < expected_output_size)
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    char * cursor = dest_hex;
+    bool uppercase = (static_cast<int>(flags) & static_cast<int>(HexFlags::kUppercase)) != 0;
+    char * cursor  = dest_hex;
     for (size_t byte_idx = 0; byte_idx < src_size; ++byte_idx)
     {
         *cursor++ = NibbleToHex((src_bytes[byte_idx] >> 4) & 0xFu, uppercase);

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -38,9 +38,8 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
 
 } // namespace
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size,
-                      char * dest_hex, size_t dest_size_max,
-                      bool uppercase, bool nul_terminate)
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, bool uppercase,
+                      bool nul_terminate)
 {
     if ((src_bytes == nullptr) || (dest_hex == nullptr))
     {
@@ -53,7 +52,7 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size,
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    char *cursor = dest_hex;
+    char * cursor = dest_hex;
     for (size_t byte_idx = 0; byte_idx < src_size; ++byte_idx)
     {
         *cursor++ = NibbleToHex((src_bytes[byte_idx] >> 4) & 0xFu, uppercase);

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -38,7 +38,7 @@ namespace Encoding {
  * on overlap, but only the core validity checks are done and it's possible to
  * get CHIP_NO_ERROR with erroneous output.
  *
- * On success, number of writes written to destination is always:
+ * On success, number of bytes written to destination is always:
  *   output_size = (src_size * 2) + (nul_terminate ? 1 : 0);
  *
  * @param src_bytes Pointer to non-null buffer to convert

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPError.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace chip {
+namespace Encoding {
+
+/**
+ * Encode a buffer of bytes into hexadecimal, with or without nul-termination
+ * and using either lowercase or uppercase hex.
+ *
+ * If `nul_terminate` is true, treat `dest_hex` as a nul-terminated string buffer.
+ * The function returns CHIP_ERROR_BUFFER_TOO_SMALL if dest_size_max can't fit
+ * the entire encoded buffer, and the nul-terminator if enabled. This function
+ * will never output truncated data. The result either fits and is written,
+ * or does not fit and nothing is written to dest_hex.
+ *
+ * If src_bytes and dest_hex overlap, the results may be incorrect, depending
+ * on overlap, but only the core validity checks are done and it's possible to
+ * get CHIP_NO_ERROR with erroneous output.
+ *
+ * On success, number of writes written to destination is always:
+ *   output_size = (src_size * 2) + (nul_terminate ? 1 : 0);
+ *
+ * @param src_bytes Pointer to non-null buffer to convert
+ * @param src_size Number of bytes to convert from src_bytes
+ * @param [out] dest_hex Destination buffer to receive hex encoding
+ * @param dest_size_max Maximum buffer size for the hex encoded `dest_hex` buffer
+ *                      including nul-terminator if needed.
+ * @param uppercase Use upper-case hex if true, otherwise lower-case hex
+ * @param nul_terminate Add nul terminator if true. See description
+ *
+ * @return CHIP_ERROR_BUFFER_TOO_SMALL on dest_max_size too small to fit output
+ * @return CHIP_ERROR_INVALID_ARGUMENT if either src_bytes or dest_hex is nullptr
+ * @return CHIP_NO_ERROR on success
+ */
+
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size,
+                      char * dest_hex, size_t dest_size_max,
+                      bool uppercase, bool nul_terminate);
+
+} // namespace Encoding
+} // namespace chip

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -54,9 +54,8 @@ namespace Encoding {
  * @return CHIP_NO_ERROR on success
  */
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size,
-                      char * dest_hex, size_t dest_size_max,
-                      bool uppercase, bool nul_terminate);
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, bool uppercase,
+                      bool nul_terminate);
 
 } // namespace Encoding
 } // namespace chip

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -24,38 +24,75 @@
 namespace chip {
 namespace Encoding {
 
+enum HexFlags : int
+{
+    kNone = 0u,
+    // Use uppercase A-F if set otherwise, lowercase a-f
+    kUppercase = (1u << 0),
+    // Null-terminate buffer
+    kNullTerminate = (1u << 1),
+    // Both use uppercase and null-termination.
+    // Separately stated to avoid casts for common case.
+    kUppercaseAndNullTerminate = ((1u << 0) | (1u << 1))
+};
+
 /**
- * Encode a buffer of bytes into hexadecimal, with or without nul-termination
+ * Encode a buffer of bytes into hexadecimal, with or without null-termination
  * and using either lowercase or uppercase hex.
  *
- * If `nul_terminate` is true, treat `dest_hex` as a nul-terminated string buffer.
- * The function returns CHIP_ERROR_BUFFER_TOO_SMALL if dest_size_max can't fit
- * the entire encoded buffer, and the nul-terminator if enabled. This function
- * will never output truncated data. The result either fits and is written,
- * or does not fit and nothing is written to dest_hex.
+ * Default is lowercase output, not null-terminated.
  *
- * If src_bytes and dest_hex overlap, the results may be incorrect, depending
+ * If `flags` has `HexFlags::kNullTerminate` set, treat `dest_hex` as a
+ * null-terminated string buffer. The function returns CHIP_ERROR_BUFFER_TOO_SMALL
+ * if `dest_size_max` can't fit the entire encoded buffer, and the
+ * null-terminator if enabled. This function will never output truncated data.
+ * The result either fits and is written, or does not fit and nothing is written
+ * to `dest_hex`.
+ *
+ * If `src_bytes` and `dest_hex` overlap, the results may be incorrect, depending
  * on overlap, but only the core validity checks are done and it's possible to
  * get CHIP_NO_ERROR with erroneous output.
  *
- * On success, number of writes written to destination is always:
- *   output_size = (src_size * 2) + (nul_terminate ? 1 : 0);
+ * On success, number of bytes written to destination is always:
+ *   output_size = (src_size * 2) + ((flags & HexFlags::kNullTerminate) ? 1 : 0);
  *
  * @param src_bytes Pointer to non-null buffer to convert
  * @param src_size Number of bytes to convert from src_bytes
  * @param [out] dest_hex Destination buffer to receive hex encoding
  * @param dest_size_max Maximum buffer size for the hex encoded `dest_hex` buffer
- *                      including nul-terminator if needed.
- * @param uppercase Use upper-case hex if true, otherwise lower-case hex
- * @param nul_terminate Add nul terminator if true. See description
+ *                      including null-terminator if needed.
+ * @param flags Flags from `HexFlags` for formatting options
  *
  * @return CHIP_ERROR_BUFFER_TOO_SMALL on dest_max_size too small to fit output
  * @return CHIP_ERROR_INVALID_ARGUMENT if either src_bytes or dest_hex is nullptr
  * @return CHIP_NO_ERROR on success
  */
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, bool uppercase,
-                      bool nul_terminate);
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags);
+
+// Alias for Uppercase option, no null-termination
+inline CHIP_ERROR BytesToUppercaseHexBuffer(const uint8_t * src_bytes, size_t src_size, char * dest_hex_buf, size_t dest_size_max)
+{
+    return BytesToHex(src_bytes, src_size, dest_hex_buf, dest_size_max, HexFlags::kUppercase);
+}
+
+// Alias for Lowercase option, no null-termination
+inline CHIP_ERROR BytesToLowercaseHexBuffer(const uint8_t * src_bytes, size_t src_size, char * dest_hex_buf, size_t dest_size_max)
+{
+    return BytesToHex(src_bytes, src_size, dest_hex_buf, dest_size_max, HexFlags::kNone);
+}
+
+// Alias for Uppercase option, with null-termination
+inline CHIP_ERROR BytesToUppercaseHexString(const uint8_t * src_bytes, size_t src_size, char * dest_hex_str, size_t dest_size_max)
+{
+    return BytesToHex(src_bytes, src_size, dest_hex_str, dest_size_max, HexFlags::kUppercaseAndNullTerminate);
+}
+
+// Alias for Lowercase option, with null-termination
+inline CHIP_ERROR BytesToLowercaseHexString(const uint8_t * src_bytes, size_t src_size, char * dest_hex_str, size_t dest_size_max)
+{
+    return BytesToHex(src_bytes, src_size, dest_hex_str, dest_size_max, HexFlags::kNullTerminate);
+}
 
 } // namespace Encoding
 } // namespace chip

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
   test_sources = [
     "TestBufferReader.cpp",
     "TestBufferWriter.cpp",
+    "TestBytesToHex.cpp",
     "TestCHIPArgParser.cpp",
     "TestCHIPCounter.cpp",
     "TestCHIPMem.cpp",

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -31,31 +31,34 @@ void TestBytesToHexNotNulTerminated(nlTestSuite * inSuite, void * inContext)
 {
     // Uppercase
     {
-        uint8_t src[] = {0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'F', 'E', 'D', 'C', 'B', 'A', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@'};
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
-                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        uint8_t src[]     = { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { 'F', 'E', 'D', 'C', 'B', 'A', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@' };
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                  /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Lowercase
     {
-        uint8_t src[] = {0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'f', 'e', 'd', 'c', 'b', 'a', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@'};
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
-                                           /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        uint8_t src[]     = { 0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10 };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { 'f', 'e', 'd', 'c', 'b', 'a', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@' };
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                  /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Trivial: Zero size input
     {
-        uint8_t src[] = {};
-        char dest[2] =     {'!', '@'};
-        char expected[2] = {'!', '@'};
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
-                                           /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        uint8_t src[]    = {};
+        char dest[2]     = { '!', '@' };
+        char expected[2] = { '!', '@' };
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                  /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
         // Nothing should have been touched.
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
@@ -65,33 +68,36 @@ void TestBytesToHexNulTerminated(nlTestSuite * inSuite, void * inContext)
 {
     // Uppercase
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '\0', '@'};
+        uint8_t src[]     = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '\0', '@' };
         NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
-                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
+                                  /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Lowercase
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@'};
+        uint8_t src[]     = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@' };
         NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
-                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
+                                  /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Trivial: Zero size input
     {
-        uint8_t src[] = {};
-        char dest[2] =     {'!', '@'};
-        char expected[2] = {'\0', '@'};
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
-                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        uint8_t src[]    = {};
+        char dest[2]     = { '!', '@' };
+        char expected[2] = { '\0', '@' };
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
+                                  /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
         // Expect nul termination
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
@@ -102,10 +108,11 @@ void TestBytesToHexErrors(nlTestSuite * inSuite, void * inContext)
     // NULL source
     {
         const uint8_t * src = nullptr;
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], 0, &dest[0], sizeof(dest),
-                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_INVALID_ARGUMENT);
+        char dest[18]       = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18]   = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], 0, &dest[0], sizeof(dest),
+                                  /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_INVALID_ARGUMENT);
 
         // Buffers should not have been touched
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
@@ -113,53 +120,57 @@ void TestBytesToHexErrors(nlTestSuite * inSuite, void * inContext)
 
     // NULL destination
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char * dest = nullptr;
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], 0, dest, sizeof(src) * 2u,
-                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_INVALID_ARGUMENT);
+        uint8_t src[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char * dest   = nullptr;
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], 0, dest, sizeof(src) * 2u,
+                                  /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     // Destination buffer too small for non-nul-terminated
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        uint8_t src[]     = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
         NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) - 1,
-                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_BUFFER_TOO_SMALL);
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) - 1,
+                                  /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_BUFFER_TOO_SMALL);
         // Ensure output not touched
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Destination buffer too small for nul-terminated
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        uint8_t src[]     = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
         NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u),
-                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_BUFFER_TOO_SMALL);
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u),
+                                  /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_BUFFER_TOO_SMALL);
         // Ensure output not touched
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 
     // Writing in a larger buffer is fine, bytes past the nul terminator (when requested) are untouched.
     {
-        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
-        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
-        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@'};
+        uint8_t src[]     = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+        char dest[18]     = { '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@' };
+        char expected[18] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@' };
         NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) < sizeof(dest));
-        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
-                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite,
+                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
+                                  /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
     }
 }
 
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestBytesToHexNotNulTerminated", TestBytesToHexNotNulTerminated),  //
-    NL_TEST_DEF("TestBytesToHexNulTerminated", TestBytesToHexNulTerminated),        //
-    NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                      //
-    NL_TEST_SENTINEL()                                       //
+    NL_TEST_DEF("TestBytesToHexNotNulTerminated", TestBytesToHexNotNulTerminated), //
+    NL_TEST_DEF("TestBytesToHexNulTerminated", TestBytesToHexNulTerminated),       //
+    NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                     //
+    NL_TEST_SENTINEL()                                                             //
 };
 
 } // namespace

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -1,0 +1,174 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <support/BytesToHex.h>
+#include <support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+using namespace chip::Encoding;
+
+void TestBytesToHexNotNulTerminated(nlTestSuite * inSuite, void * inContext)
+{
+    // Uppercase
+    {
+        uint8_t src[] = {0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'F', 'E', 'D', 'C', 'B', 'A', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@'};
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Lowercase
+    {
+        uint8_t src[] = {0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'f', 'e', 'd', 'c', 'b', 'a', '9', '8', '7', '6', '5', '4', '3', '2', '1', '0', '!', '@'};
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                           /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Trivial: Zero size input
+    {
+        uint8_t src[] = {};
+        char dest[2] =     {'!', '@'};
+        char expected[2] = {'!', '@'};
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                                           /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
+        // Nothing should have been touched.
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+}
+
+void TestBytesToHexNulTerminated(nlTestSuite * inSuite, void * inContext)
+{
+    // Uppercase
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', '\0', '@'};
+        NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
+                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Lowercase
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@'};
+        NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) + 1,
+                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Trivial: Zero size input
+    {
+        uint8_t src[] = {};
+        char dest[2] =     {'!', '@'};
+        char expected[2] = {'\0', '@'};
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
+                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        // Expect nul termination
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+}
+
+void TestBytesToHexErrors(nlTestSuite * inSuite, void * inContext)
+{
+    // NULL source
+    {
+        const uint8_t * src = nullptr;
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], 0, &dest[0], sizeof(dest),
+                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_INVALID_ARGUMENT);
+
+        // Buffers should not have been touched
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // NULL destination
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char * dest = nullptr;
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], 0, dest, sizeof(src) * 2u,
+                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    // Destination buffer too small for non-nul-terminated
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u) - 1,
+                                           /*uppercase=*/true, /*nul_terminate=*/false) == CHIP_ERROR_BUFFER_TOO_SMALL);
+        // Ensure output not touched
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Destination buffer too small for nul-terminated
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) <= sizeof(dest));
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], (sizeof(src) * 2u),
+                                           /*uppercase=*/true, /*nul_terminate=*/true) == CHIP_ERROR_BUFFER_TOO_SMALL);
+        // Ensure output not touched
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+
+    // Writing in a larger buffer is fine, bytes past the nul terminator (when requested) are untouched.
+    {
+        uint8_t src[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
+        char dest[18] =     {'?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '!', '@'};
+        char expected[18] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', '\0', '@'};
+        NL_TEST_ASSERT(inSuite, ((sizeof(src) * 2u) + 1u) < sizeof(dest));
+        NL_TEST_ASSERT(inSuite, BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
+                                           /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
+    }
+}
+
+const nlTest sTests[] = {
+    NL_TEST_DEF("TestBytesToHexNotNulTerminated", TestBytesToHexNotNulTerminated),  //
+    NL_TEST_DEF("TestBytesToHexNulTerminated", TestBytesToHexNulTerminated),        //
+    NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                      //
+    NL_TEST_SENTINEL()                                       //
+};
+
+} // namespace
+
+int TestBytesToHex(void)
+{
+    nlTestSuite theSuite = { "BytesToHex", sTests, nullptr, nullptr };
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestBytesToHex)

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -53,11 +53,11 @@ void TestBytesToHexNotNulTerminated(nlTestSuite * inSuite, void * inContext)
 
     // Trivial: Zero size input
     {
-        uint8_t src[]    = {};
+        uint8_t src[]    = { 0x00 };
         char dest[2]     = { '!', '@' };
         char expected[2] = { '!', '@' };
         NL_TEST_ASSERT(inSuite,
-                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(src) * 2u,
+                       BytesToHex(&src[0], 0, &dest[0], sizeof(src) * 2u,
                                   /*uppercase=*/false, /*nul_terminate=*/false) == CHIP_NO_ERROR);
         // Nothing should have been touched.
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);
@@ -92,11 +92,11 @@ void TestBytesToHexNulTerminated(nlTestSuite * inSuite, void * inContext)
 
     // Trivial: Zero size input
     {
-        uint8_t src[]    = {};
+        uint8_t src[]    = { 0x00 };
         char dest[2]     = { '!', '@' };
         char expected[2] = { '\0', '@' };
         NL_TEST_ASSERT(inSuite,
-                       BytesToHex(&src[0], sizeof(src), &dest[0], sizeof(dest),
+                       BytesToHex(&src[0], 0, &dest[0], sizeof(dest),
                                   /*uppercase=*/false, /*nul_terminate=*/true) == CHIP_NO_ERROR);
         // Expect nul termination
         NL_TEST_ASSERT(inSuite, memcmp(&dest[0], &expected[0], sizeof(expected)) == 0);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
PR https://github.com/project-chip/connectedhomeip/pull/4362 and future operational mDNS client/server usage require hex encoded strings in uppercase/lowercase. Some manual code exists to do so, without tests.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add a lightweight hex conversion function and associated tests.

- Lean on stack
- Supports safe output to buffers of any size
- Support uppercase/lowercase
- Support non-nul-terminated and nul-terminated


<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

