### PR TITLE
Fix unwinding on Android

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -330,10 +330,10 @@ config("no_unwind_tables") {
 }
 
 config("unwind_tables_default") {
-  if (current_os == "android") {
-    configs = [ ":unwind_tables" ]
-  } else {
+  if (exclude_unwind_tables) {
     configs = [ ":no_unwind_tables" ]
+  } else {
+    configs = [ ":unwind_tables" ]
   }
 }
 

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -318,11 +318,23 @@ config("exceptions_default") {
   configs = [ ":no_exceptions" ]
 }
 
-config("unwind_tables_default") {
+config("unwind_tables") {
+  cflags = [ "-funwind-tables" ]
+}
+
+config("no_unwind_tables") {
   cflags = [
     "-fno-unwind-tables",
     "-fno-asynchronous-unwind-tables",
   ]
+}
+
+config("unwind_tables_default") {
+  if (current_os == "android") {
+    configs = [ ":unwind_tables" ]
+  } else {
+    configs = [ ":no_unwind_tables" ]
+  }
 }
 
 config("size_default") {

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -31,4 +31,7 @@ declare_args() {
 
   # Enable position independent executables (-pie).
   enable_pie = current_os == "linux"
+
+  # Remove unwind tables from the binary to save space.
+  exclude_unwind_tables = current_os != "android"
 }

--- a/build/config/defaults.gni
+++ b/build/config/defaults.gni
@@ -48,6 +48,10 @@ declare_args() {
   default_configs_exceptions =
       [ "${build_root}/config/compiler:exceptions_default" ]
 
+  # Default configs for unwind tables.
+  default_configs_unwind_tables =
+      [ "${build_root}/config/compiler:unwind_tables_default" ]
+
   # Defaults configs for rtti.
   default_configs_rtti = [ "${build_root}/config/compiler:rtti_default" ]
 
@@ -91,6 +95,7 @@ default_configs += default_configs_symbols
 default_configs += default_configs_size
 default_configs += default_configs_specs
 default_configs += default_configs_exceptions
+default_configs += default_configs_unwind_tables
 default_configs += default_configs_pic
 default_configs += default_configs_rtti
 default_configs += default_configs_warnings


### PR DESCRIPTION
Android isn't able to unwind the CHIP native stack, which interferes
with debugging. Turn on unwind tables to fix this.  Unclear if we want
this in optimized builds, but Android OS seems to be able to unwind all
of its frameworks and OS libraries, so for now assume we do. There's only
a space cost, and we can revisit that later.

This is the difference between this:

```
backtrace:
02-16 20:49:34.628  3872  3872 F DEBUG   : backtrace:
02-16 20:49:34.628  3872  3872 F DEBUG   :       #00 pc 000000000008246c  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160) (BuildId: 5812256023147338b8a9538321d4c456)
02-16 20:49:34.628  3872  3872 F DEBUG   :       #01 pc 00000000000a836c  /data/app/com.google.chip.chiptool-rPVLWEFRvE413khV9YptWg==/base.apk (offset 0x97a000) (chip::NetworkProvisioning::SendNetworkCredentials(char const*, char const*)+96)
```

and this:
```
02-16 20:56:04.323  5040  5040 F DEBUG   : backtrace:
02-16 20:56:04.323  5040  5040 F DEBUG   :       #00 pc 000000000008246c  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160) (BuildId: 5812256023147338b8a9538321d4c456)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #01 pc 00000000000a839c  /data/app/com.google.chip.chiptool-dz3iwqwmItgQDBBaEcevJw==/base.apk (offset 0x97a000) (chip::NetworkProvisioning::SendNetworkCredentials(char const*, char const*)+96)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #02 pc 000000000009bb58  /data/app/com.google.chip.chiptool-dz3iwqwmItgQDBBaEcevJw==/base.apk (offset 0x97a000) (chip::RendezvousSession::SendNetworkCredentials(char const*, char const*)+44)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #03 pc 000000000009bb94  /data/app/com.google.chip.chiptool-dz3iwqwmItgQDBBaEcevJw==/base.apk (offset 0x97a000) (non-virtual thunk to chip::RendezvousSession::SendNetworkCredentials(char const*, char const*)+44)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #04 pc 0000000000051488  /data/app/com.google.chip.chiptool-dz3iwqwmItgQDBBaEcevJw==/base.apk (offset 0x97a000) (AndroidDeviceControllerWrapper::SendNetworkCredentials(char const*, char const*)+128)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #05 pc 0000000000054188  /data/app/com.google.chip.chiptool-dz3iwqwmItgQDBBaEcevJw==/base.apk (offset 0x97a000) (Java_chip_devicecontroller_ChipDeviceController_sendWiFiCredentials+188)
02-16 20:56:04.323  5040  5040 F DEBUG   :       #06 pc 000000000013f350  /apex/com.android.runtime/lib64/libart.so (art_quick_generic_jni_trampoline+144) (BuildId: ccd73e8ae9b59d5596b3b8aeef234d43)
<snip>
02-16 20:56:04.327  5040  5040 F DEBUG   :       #75 pc 00000000000be560  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod(_jclass*, _jmethodID*, ...)+116) (BuildId: e5b25f8fb9f6bb45ccbeca8c07061dad)
02-16 20:56:04.327  5040  5040 F DEBUG   :       #76 pc 00000000000c13d0  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start(char const*, android::Vector<android::String8> const&, bool)+776) (BuildId: e5b25f8fb9f6bb45ccbeca8c07061dad)
02-16 20:56:04.327  5040  5040 F DEBUG   :       #77 pc 00000000000034e0  /system/bin/app_process64 (main+1168) (BuildId: ade4367f7cc82a88f668180d34ce79fe)
02-16 20:56:04.327  5040  5040 F DEBUG   :       #78 pc 000000000007dc24  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+108) (BuildId: 5812256023147338b8a9538321d4c456)
```
