### PR TITLE
[android] always use the recently created device object

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -98,6 +98,7 @@ class DeviceProvisioningFragment : Fragment() {
 
       showMessage(R.string.rendezvous_over_ble_pairing_text)
       deviceController.setCompletionListener(ConnectionCallback())
+      deviceController.disconnectDevice();
       deviceController.beginConnectDeviceBle(gatt, deviceInfo.setupPinCode);
     }
   }

--- a/src/controller/CHIPDeviceController_deprecated.cpp
+++ b/src/controller/CHIPDeviceController_deprecated.cpp
@@ -176,8 +176,7 @@ bool ChipDeviceController::GetIpAddress(Inet::IPAddress & addr)
     if (!IsConnected())
         return false;
 
-    if (mDevice == nullptr)
-        InitDevice();
+    InitDevice();
 
     return mDevice != nullptr && mDevice->GetIpAddress(addr);
 }
@@ -206,10 +205,7 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBufferHan
     }
     VerifyOrExit(mRemoteDeviceId != kUndefinedNodeId, err = CHIP_ERROR_INCORRECT_STATE);
 
-    if (mDevice == nullptr)
-    {
-        SuccessOrExit(InitDevice());
-    }
+    SuccessOrExit(InitDevice());
 
     VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     mDevice->SetDelegate(this);


### PR DESCRIPTION
#### Problem
CHIP Tool for Android supports connection to one device at a time as it uses a deprecated controller. When the second device is commissioned, the application still uses the old device object, and it is not possible to communicate with the newly commissioned device.

#### Summary of Changes
Always use the recently commissioned device's object to communicate with, until CHIP Tool for Android supports multiple connections.