### PR TITLE
[controller] change the way of releasing device

### DIFF
--- a/src/controller/CHIPDeviceController_deprecated.cpp
+++ b/src/controller/CHIPDeviceController_deprecated.cpp
@@ -176,7 +176,8 @@ bool ChipDeviceController::GetIpAddress(Inet::IPAddress & addr)
     if (!IsConnected())
         return false;
 
-    InitDevice();
+    if (mDevice == nullptr)
+        InitDevice();
 
     return mDevice != nullptr && mDevice->GetIpAddress(addr);
 }
@@ -186,6 +187,7 @@ CHIP_ERROR ChipDeviceController::DisconnectDevice()
     if (mDevice != nullptr)
     {
         mCommissioner.ReleaseDevice(mDevice);
+        mDevice = nullptr;
     }
 
     return CHIP_NO_ERROR;
@@ -205,7 +207,10 @@ CHIP_ERROR ChipDeviceController::SendMessage(void * appReqState, PacketBufferHan
     }
     VerifyOrExit(mRemoteDeviceId != kUndefinedNodeId, err = CHIP_ERROR_INCORRECT_STATE);
 
-    SuccessOrExit(InitDevice());
+    if (mDevice == nullptr)
+    {
+        SuccessOrExit(InitDevice());
+    }
 
     VerifyOrExit(mDevice != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     mDevice->SetDelegate(this);


### PR DESCRIPTION
#### Problem
Addressing [comment](https://github.com/project-chip/connectedhomeip/pull/4896#issuecomment-780628058) from already merged PR.

#### Summary of Changes
Reset `device` inside `DisconnectDevice` to avoid calling `InitDevice` multiple times later on.