### PR TITLE
[Discussion] Clone Packet buffer instead of Retain if using LwIP stack

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -137,15 +137,15 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
                                          System::PacketBufferHandle msgBuf, EncryptedPacketBufferHandle * bufferRetainSlot,
                                          EncryptionState encryptionState)
 {
-    CHIP_ERROR err              = CHIP_NO_ERROR;
-    PeerConnectionState * state = nullptr;
+    CHIP_ERROR err                      = CHIP_NO_ERROR;
+    PeerConnectionState * state         = nullptr;
     Transport::AdminPairingInfo * admin = nullptr;
-    NodeId localNodeId          = mLocalNodeId;
+    NodeId localNodeId                  = mLocalNodeId;
 
 #if !CHIP_SYSTEM_CONFIG_USE_LWIP1
-    uint8_t * msgStart          = nullptr;
-    uint16_t msgLen             = 0;
-    uint16_t headerSize         = 0;
+    uint8_t * msgStart  = nullptr;
+    uint16_t msgLen     = 0;
+    uint16_t headerSize = 0;
 #endif
 
     // Hold the reference to encrypted message in stack variable.
@@ -189,9 +189,9 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     if (bufferRetainSlot != nullptr)
     {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP1
-        encryptedMsg        = msgBuf.CloneData(MessagePacketBuffer::kMaxFooterSize);
+        encryptedMsg = msgBuf.CloneData(MessagePacketBuffer::kMaxFooterSize);
 #else
-        encryptedMsg        = msgBuf.Retain();
+        encryptedMsg = msgBuf.Retain();
 #endif
         encryptedMsg.mMsgId = packetHeader.GetMessageId();
     }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -122,7 +122,7 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, E
     PacketHeader packetHeader;
     PayloadHeader payloadHeader;
 
-#if !CHIP_SYSTEM_CONFIG_USE_LWIP1     
+#if !CHIP_SYSTEM_CONFIG_USE_LWIP1
     // Advancing the start to encrypted header, since the transport will attach the packet header on top of it
     ReturnErrorOnFailure(packetHeader.DecodeAndConsume(msgBuf));
 #endif
@@ -142,7 +142,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     Transport::AdminPairingInfo * admin = nullptr;
     NodeId localNodeId          = mLocalNodeId;
 
-#if !CHIP_SYSTEM_CONFIG_USE_LWIP1    
+#if !CHIP_SYSTEM_CONFIG_USE_LWIP1
     uint8_t * msgStart          = nullptr;
     uint16_t msgLen             = 0;
     uint16_t headerSize         = 0;
@@ -188,7 +188,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
-#if CHIP_SYSTEM_CONFIG_USE_LWIP1        
+#if CHIP_SYSTEM_CONFIG_USE_LWIP1
         encryptedMsg        = msgBuf.CloneData(MessagePacketBuffer::kMaxFooterSize);
 #else
         encryptedMsg        = msgBuf.Retain();


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
[bzbarsky-apple]: OK, so if we posit that non-LwIP small devices exist and the cost of cloning is not acceptable there, I see three options, ranked roughly in order in which I think I'd prefer them:

1. Just add an LwIP ifdef in SSM for the clone-or-retain behavior. This is the simplest approach in some ways: it minimizes the moving parts that need to interact, and restricts the complexity to the one place that really cares about it: the CRMP bits in SSM. There's a concern that this is a layering violation, but note that we already have this sort of ifdef in SecureMessageCodec, for example.

2. Modify the transport API so that there are both rvalue-ref and const-lvalue-ref versions of SendMessage (on transport and transport manager). Callers that are actually retaining would call the latter version. This moves the "I am retaining" signal more in-band with the actual call into the transport layer, as long as the retain happens just above transport. Which it does, because it happens in the SecureSessionMgr.

3.Do the thing Weave does: add a flag that you pass along with the packet indicating that even through you look like you are handing over ownership that is actually a lie and you retained it up the callstack and hence the callee should copy if it wants to. This would presumably then mean an LwIP ifdef in the UDP protocol code where that flag is checked, etc.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Pilot solution 1

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4372

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
