### PR TITLE
Remove Peer/local nodeid dependency for PASE

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -140,8 +140,7 @@ CHIP_ERROR EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>(
-        chip::Optional<chip::NodeId>::Value(chip::kTestDeviceNodeId), static_cast<uint16_t>(0), static_cast<uint16_t>(0));
+    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     // Attempt to connect to the peer.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -652,8 +652,7 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mDeviceBeingPaired == kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
 
-    testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>(Optional<NodeId>::Value(remoteDeviceId),
-                                                                                static_cast<uint16_t>(0), static_cast<uint16_t>(0));
+    testSecurePairingSecret = chip::Platform::New<SecurePairingUsingTestSecret>();
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     mDeviceBeingPaired = GetInactiveDeviceIndex();

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -34,9 +34,8 @@ class MessagingContext : public IOContext
 {
 public:
     MessagingContext() :
-        mPeer(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT)),
-        mPairingPeerToLocal(Optional<NodeId>::Value(GetSourceNodeId()), GetLocalKeyId(), GetPeerKeyId()),
-        mPairingLocalToPeer(Optional<NodeId>::Value(GetDestinationNodeId()), GetPeerKeyId(), GetLocalKeyId())
+        mPeer(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT)), mPairingPeerToLocal(GetLocalKeyId(), GetPeerKeyId()),
+        mPairingLocalToPeer(GetPeerKeyId(), GetLocalKeyId())
     {}
 
     /// Initialize the underlying layers and test suite pointer

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -144,15 +144,13 @@ void CheckSendMsgCounterSyncReq(nlTestSuite * inSuite, void * inContext)
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    SecurePairingUsingTestSecret pairingLocalToPeer(Optional<NodeId>::Value(kDestinationNodeId), kTestPeerGroupKeyId,
-                                                    kTestLocalGroupKeyId);
+    SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer,
                                                    SecureSessionMgr::PairingDirection::kInitiator, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairingPeerToLocal(Optional<NodeId>::Value(kSourceNodeId), kTestLocalGroupKeyId,
-                                                    kTestPeerGroupKeyId);
+    SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal,
                                                    SecureSessionMgr::PairingDirection::kResponder, 1);
@@ -192,15 +190,13 @@ void CheckReceiveMsgCounterSyncReq(nlTestSuite * inSuite, void * inContext)
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
 
-    SecurePairingUsingTestSecret pairingLocalToPeer(Optional<NodeId>::Value(kDestinationNodeId), kTestPeerGroupKeyId,
-                                                    kTestLocalGroupKeyId);
+    SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer,
                                                    SecureSessionMgr::PairingDirection::kInitiator, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairingPeerToLocal(Optional<NodeId>::Value(kSourceNodeId), kTestLocalGroupKeyId,
-                                                    kTestPeerGroupKeyId);
+    SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal,
                                                    SecureSessionMgr::PairingDirection::kResponder, 1);

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -123,8 +123,7 @@ CHIP_ERROR EstablishSecureSession()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     chip::Optional<chip::Transport::PeerAddress> peerAddr;
-    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>(
-        chip::Optional<chip::NodeId>::Value(chip::kTestDeviceNodeId), static_cast<uint16_t>(0), static_cast<uint16_t>(0));
+    chip::SecurePairingUsingTestSecret * testSecurePairingSecret = chip::Platform::New<chip::SecurePairingUsingTestSecret>();
     VerifyOrExit(testSecurePairingSecret != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     if (gUseTCP)

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -46,8 +46,7 @@ chip::Protocols::Echo::EchoServer gEchoServer;
 chip::TransportMgr<chip::Transport::UDP> gUDPManager;
 chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
 chip::SecureSessionMgr gSessionManager;
-chip::SecurePairingUsingTestSecret gTestPairing(chip::Optional<chip::NodeId>::Value(chip::kUndefinedNodeId),
-                                                static_cast<uint16_t>(0), static_cast<uint16_t>(0));
+chip::SecurePairingUsingTestSecret gTestPairing;
 
 // Callback handler when a CHIP EchoRequest is received.
 void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle payload)

--- a/src/transport/PASESession.h
+++ b/src/transport/PASESession.h
@@ -308,7 +308,6 @@ public:
         size_t secretLen    = strlen(secret);
         mKeLen              = secretLen;
         memmove(mKe, secret, mKeLen);
-        mConnectionState.SetPeerNodeId(kUndefinedNodeId);
         mConnectionState.SetPeerKeyID(peerKeyId);
         mConnectionState.SetLocalKeyID(localKeyId);
         mPairingComplete = true;

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -155,7 +155,7 @@ void RendezvousSession::OnSessionEstablished()
         direction = SecureSessionMgr::PairingDirection::kResponder;
     }
 
-    // TODO: Once Operational credentials are implemented, this needs revisiting:
+    // TODO: Once Operational credentials are implemented, node id assignment should be done during opcreds configuration.
     // - can use internal node ids (0xFFFF_FFFE_xxxx_xxx - spec still being defined) if a temporary
     //   node id is required for indexing
     // - should only assign a final node id as part of setting operational credentials

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -145,10 +145,10 @@ public:
 private:
     CHIP_ERROR HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                     System::PacketBufferHandle msgBuf);
-    CHIP_ERROR Pair(Optional<NodeId> nodeId, uint32_t setupPINCode);
-    CHIP_ERROR Pair(Optional<NodeId> nodeId, const PASEVerifier & verifier);
-    CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, uint32_t setupPINCode);
-    CHIP_ERROR WaitForPairing(Optional<NodeId> nodeId, const PASEVerifier & verifier);
+    CHIP_ERROR Pair(uint32_t setupPINCode);
+    CHIP_ERROR Pair(const PASEVerifier & verifier);
+    CHIP_ERROR WaitForPairing(uint32_t setupPINCode);
+    CHIP_ERROR WaitForPairing(const PASEVerifier & verifier);
 
     CHIP_ERROR HandleSecureMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                    System::PacketBufferHandle msgBuf);

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -57,10 +57,15 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
                   "Addition to generate payloadLength might overflow");
 
     packetHeader
-        .SetSourceNodeId(localNodeId)                 //
-        .SetDestinationNodeId(state->GetPeerNodeId()) //
-        .SetMessageId(msgId)                          //
+        .SetSourceNodeId(localNodeId) //
+        .SetMessageId(msgId)          //
         .SetEncryptionKeyID(state->GetLocalKeyID());
+
+    if (state->GetPeerNodeId() != kUndefinedNodeId)
+    {
+        packetHeader.SetDestinationNodeId(state->GetPeerNodeId());
+    }
+
     packetHeader.GetFlags().Set(Header::FlagValues::kSecure);
 
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(msgBuf));

--- a/src/transport/tests/TestPASESession.cpp
+++ b/src/transport/tests/TestPASESession.cpp
@@ -62,15 +62,10 @@ void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
 
+    NL_TEST_ASSERT(inSuite, pairing.WaitForPairing(1234, 500, nullptr, 0, 0, &delegate) == CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(1234, 500, nullptr, 0, Optional<NodeId>::Value(1), 0, &delegate) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0, nullptr) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0, &delegate) ==
-                       CHIP_NO_ERROR);
+                   pairing.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, 0, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, pairing.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, 0, &delegate) == CHIP_NO_ERROR);
 }
 
 void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
@@ -79,12 +74,8 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
 
-    NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0, nullptr) !=
-                       CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0, &delegate) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, nullptr) != CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, &delegate) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, delegate.mNumMessageSend == 1);
 
@@ -93,8 +84,7 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     PASESession pairing1;
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(1), 2, 0,
-                                 &delegate) == CHIP_ERROR_BAD_REQUEST);
+                   pairing1.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, &delegate) == CHIP_ERROR_BAD_REQUEST);
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, PASESession & pairingCommissioner,
@@ -108,11 +98,10 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
     delegateAccessory.peer    = &pairingCommissioner;
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, Optional<NodeId>::Value(1), 0,
-                                                   &delegateAccessory) == CHIP_NO_ERROR);
+                   pairingAccessory.WaitForPairing(1234, 500, (const uint8_t *) "salt", 4, 0, &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, Optional<NodeId>::Value(2), 1, 0,
-                                            &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, &delegateCommissioner) ==
+                       CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumMessageSend == 2);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -181,11 +181,11 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     admin = admins.AssignAdminId(1, kDestinationNodeId);
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    SecurePairingUsingTestSecret pairing2(2, 1);
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -239,11 +239,11 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     admin = admins.AssignAdminId(1, kDestinationNodeId);
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    SecurePairingUsingTestSecret pairing2(2, 1);
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -313,11 +313,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     admin = admins.AssignAdminId(1, kDestinationNodeId);
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
-    SecurePairingUsingTestSecret pairing1(Optional<NodeId>::Value(kSourceNodeId), 1, 2);
+    SecurePairingUsingTestSecret pairing1(1, 2);
     err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    SecurePairingUsingTestSecret pairing2(Optional<NodeId>::Value(kDestinationNodeId), 2, 1);
+    SecurePairingUsingTestSecret pairing2(2, 1);
     err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 


### PR DESCRIPTION
 #### Problem
At the time of PASE establishment, the peer does not yet belong to a fabric. Having node ids passeed around results in a larger coupling than necessary.

 #### Summary of Changes
 - Removes nodeid references from PASE.
 - Removes checks for source/destination nodeids within rendezvous (remote may have no nodeid)
 - Remove the setting of destination node id if it is undefined during setting up the header for secure session management

Tested that `chip-tool pairing ble` can still pair devices.
