### PR TITLE
Integrate KVS with device session tables

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -22,13 +22,13 @@
 #include <inipp/inipp.h>
 #include <support/logging/CHIPLogging.h>
 
-class PersistentStorage : public chip::Controller::PersistentStorageDelegate
+class PersistentStorage : public chip::PersistentStorageDelegate
 {
 public:
     CHIP_ERROR Init();
 
     /////////// PersistentStorageDelegate Interface /////////
-    void SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate) override;
+    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override;
     void GetKeyValue(const char * key) override;
     CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
     void SetKeyValue(const char * key, const char * value) override;

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -66,10 +66,13 @@ void RendezvousServer::OnRendezvousComplete()
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
     StorablePeerConnection connection(mRendezvousSession.GetPairingSession(), mRendezvousSession.GetAdminId());
 
-    VerifyOrReturn(connection.StoreUsingKVSMgr(PersistedStorage::KeyValueStoreMgr()) == CHIP_NO_ERROR);
+    VerifyOrReturn(mStorage != nullptr);
+    VerifyOrReturn(connection.StoreIntoKVS(*mStorage) == CHIP_NO_ERROR);
 
     uint16_t nextKeyId = mRendezvousSession.GetNextKeyId();
-    PersistedStorage::KeyValueStoreMgr().Put(kStorablePeerConnectionCountKey, nextKeyId);
+    VerifyOrReturn(CanCastTo<uint16_t>(sizeof(nextKeyId)));
+    uint16_t size = static_cast<uint16_t>(sizeof(nextKeyId));
+    mStorage->SetKeyValue(kStorablePeerConnectionCountKey, &nextKeyId, size);
 }
 
 void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -21,6 +21,7 @@
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
 #include <transport/SecureSessionMgr.h>
+#include <transport/StorablePeerConnection.h>
 
 #if CHIP_ENABLE_OPENTHREAD
 #include <platform/ThreadStackManager.h>
@@ -63,6 +64,12 @@ void RendezvousServer::OnRendezvousMessageReceived(const PacketHeader & packetHe
 void RendezvousServer::OnRendezvousComplete()
 {
     ChipLogProgress(AppServer, "Device completed Rendezvous process");
+    StorablePeerConnection connection(mRendezvousSession.GetPairingSession(), mRendezvousSession.GetAdminId());
+
+    VerifyOrReturn(connection.StoreUsingKVSMgr(PersistedStorage::KeyValueStoreMgr()) == CHIP_NO_ERROR);
+
+    uint16_t nextKeyId = mRendezvousSession.GetNextKeyId();
+    PersistedStorage::KeyValueStoreMgr().Put(kStorablePeerConnectionCountKey, nextKeyId);
 }
 
 void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -20,6 +20,8 @@
 #include <app/server/SessionManager.h>
 #include <core/CHIPError.h>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
 #include <transport/SecureSessionMgr.h>
 #include <transport/StorablePeerConnection.h>
 

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -20,6 +20,7 @@
 #include <app/server/AppDelegate.h>
 #include <core/CHIPPersistentStorageDelegate.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <support/ReturnMacros.h>
 #include <transport/RendezvousSession.h>
 
 namespace chip {
@@ -31,10 +32,13 @@ public:
 
     CHIP_ERROR WaitForPairing(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
                               Transport::AdminPairingInfo * admin);
-    void SetDelegates(AppDelegate * delegate, PersistentStorageDelegate * storage)
+
+    CHIP_ERROR Init(AppDelegate * delegate, PersistentStorageDelegate * storage)
     {
+        VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         mDelegate = delegate;
         mStorage  = storage;
+        return CHIP_NO_ERROR;
     }
 
     //////////////// RendezvousSessionDelegate Implementation ///////////////////

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -29,10 +29,13 @@ class RendezvousServer : public RendezvousSessionDelegate
 public:
     RendezvousServer();
 
-    CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
-                    Transport::AdminPairingInfo * admin);
-    void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; };
-    void SetStorage(PersistentStorageDelegate * delegate) { mStorage = delegate; };
+    CHIP_ERROR WaitForPairing(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
+                              Transport::AdminPairingInfo * admin);
+    void SetDelegates(AppDelegate * delegate, PersistentStorageDelegate * storage)
+    {
+        mDelegate = delegate;
+        mStorage  = storage;
+    }
 
     //////////////// RendezvousSessionDelegate Implementation ///////////////////
 

--- a/src/app/server/RendezvousServer.h
+++ b/src/app/server/RendezvousServer.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/server/AppDelegate.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <transport/RendezvousSession.h>
 
@@ -31,6 +32,7 @@ public:
     CHIP_ERROR Init(const RendezvousParameters & params, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr,
                     Transport::AdminPairingInfo * admin);
     void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; };
+    void SetStorage(PersistentStorageDelegate * delegate) { mStorage = delegate; };
 
     //////////////// RendezvousSessionDelegate Implementation ///////////////////
 
@@ -46,6 +48,7 @@ public:
 private:
     RendezvousSession mRendezvousSession;
     AppDelegate * mDelegate;
+    PersistentStorageDelegate * mStorage = nullptr;
 };
 
 } // namespace chip

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -522,7 +522,10 @@ void InitServer(AppDelegate * delegate)
 
     InitDataModelHandler();
     gCallbacks.SetDelegate(delegate);
-    gRendezvousServer.SetDelegates(delegate, &gServerStorage);
+
+    err = gRendezvousServer.Init(delegate, &gServerStorage);
+    SuccessOrExit(err);
+
     gAdvDelegate.SetDelegate(delegate);
 
     // Init transport before operations with secure session mgr.

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -29,8 +29,8 @@
 #pragma once
 
 #include <controller/CHIPDevice.h>
-#include <controller/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPCore.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPTLV.h>
 #include <messaging/ExchangeMgr.h>
 #include <support/DLLUtil.h>

--- a/src/controller/CHIPDeviceController_deprecated.h
+++ b/src/controller/CHIPDeviceController_deprecated.h
@@ -29,8 +29,8 @@
 #pragma once
 
 #include <controller/CHIPDeviceController.h>
-#include <controller/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPCore.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 #include <core/CHIPTLV.h>
 #include <support/DLLUtil.h>
 #include <transport/RendezvousSession.h>
@@ -68,13 +68,13 @@ public:
      * System::Layer and InetLayer.
      */
     CHIP_ERROR Init(NodeId localDeviceId, Controller::DevicePairingDelegate * pairingDelegate = nullptr,
-                    Controller::PersistentStorageDelegate * storageDelegate = nullptr);
+                    PersistentStorageDelegate * storageDelegate = nullptr);
     /**
      * Init function to be used when already-initialized System::Layer and InetLayer are available.
      */
     CHIP_ERROR Init(NodeId localDeviceId, System::Layer * systemLayer, Inet::InetLayer * inetLayer,
-                    Controller::DevicePairingDelegate * pairingDelegate     = nullptr,
-                    Controller::PersistentStorageDelegate * storageDelegate = nullptr);
+                    Controller::DevicePairingDelegate * pairingDelegate = nullptr,
+                    PersistentStorageDelegate * storageDelegate         = nullptr);
     CHIP_ERROR Shutdown();
 
     CHIP_ERROR SetUdpListenPort(uint16_t listenPort);

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -23,7 +23,7 @@
 #include <map>
 #include <string>
 
-#include <controller/CHIPPersistentStorageDelegate.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <string>
 
-#include <controller/CHIPPersistentStorageDelegate.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 
 class PythonPersistentStorageDelegate;
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -18,11 +18,11 @@
 #import "CHIPPersistentStorageDelegate.h"
 
 #import "CHIPError.h"
-#include <controller/CHIPPersistentStorageDelegate.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-class CHIPPersistentStorageDelegateBridge : public chip::Controller::PersistentStorageDelegate
+class CHIPPersistentStorageDelegateBridge : public chip::PersistentStorageDelegate
 {
 public:
     CHIPPersistentStorageDelegateBridge();
@@ -30,7 +30,7 @@ public:
 
     void setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue);
 
-    void SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate) override;
+    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override;
 
     void GetKeyValue(const char * key) override;
 
@@ -44,7 +44,7 @@ private:
     id<CHIPPersistentStorageDelegate> mDelegate;
     dispatch_queue_t mQueue;
 
-    chip::Controller::PersistentStorageResultDelegate * mCallback;
+    chip::PersistentStorageResultDelegate * mCallback;
     SendKeyValue mCompletionHandler;
     CHIPSendSetStatus mSetStatusHandler;
     CHIPSendDeleteStatus mDeleteStatusHandler;

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -39,14 +39,14 @@ void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(id<CHIPPersistent
     });
 }
 
-void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::Controller::PersistentStorageResultDelegate * delegate)
+void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::PersistentStorageResultDelegate * delegate)
 {
     dispatch_async(mWorkQueue, ^{
         if (delegate) {
             mCallback = delegate;
 
             mCompletionHandler = ^(NSString * key, NSString * value) {
-                chip::Controller::PersistentStorageResultDelegate * callback = mCallback;
+                chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
                         callback->OnValue([key UTF8String], [value UTF8String]);
@@ -55,20 +55,20 @@ void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::Controller::Persiste
             };
 
             mSetStatusHandler = ^(NSString * key, NSError * status) {
-                chip::Controller::PersistentStorageResultDelegate * callback = mCallback;
+                chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
-                        callback->OnStatus([key UTF8String], chip::Controller::PersistentStorageResultDelegate::Operation::kSET,
+                        callback->OnStatus([key UTF8String], chip::PersistentStorageResultDelegate::Operation::kSET,
                             [CHIPError errorToCHIPErrorCode:status]);
                     });
                 }
             };
 
             mDeleteStatusHandler = ^(NSString * key, NSError * status) {
-                chip::Controller::PersistentStorageResultDelegate * callback = mCallback;
+                chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
-                        callback->OnStatus([key UTF8String], chip::Controller::PersistentStorageResultDelegate::Operation::kDELETE,
+                        callback->OnStatus([key UTF8String], chip::PersistentStorageResultDelegate::Operation::kDELETE,
                             [CHIPError errorToCHIPErrorCode:status]);
                     });
                 }

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -22,7 +22,6 @@
 #include <support/DLLUtil.h>
 
 namespace chip {
-namespace Controller {
 
 class DLL_EXPORT PersistentStorageResultDelegate
 {
@@ -96,12 +95,39 @@ public:
 
     /**
      * @brief
-     *   Set the value for the key
+     *   This is a synchronous Get API, where the value is returned via the output
+     *   buffer. This API should be used sparingly, since it may block for
+     *   some duration.
+     *
+     *   This API can be used to retrieve a byte buffer value from the storage.
+     *
+     * @param[in]      key Key to lookup
+     * @param[out]     buffer Value for the key
+     * @param[in, out] size Input value buffer size, output length of value.
+     *                 The output length could be larger than input value. In
+     *                 such cases, the user should allocate the buffer large
+     *                 enough (>= output length), and call the API again.
+     */
+    virtual CHIP_ERROR GetKeyValue(const char * key, void * buffer, uint16_t & size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * @brief
+     *   Set the value for the key to a null terminated string.
      *
      * @param[in] key Key to be set
      * @param[in] value Value to be set
      */
     virtual void SetKeyValue(const char * key, const char * value) = 0;
+
+    /**
+     * @brief
+     *   Set the value for the key to a byte buffer.
+     *
+     * @param[in] key Key to be set
+     * @param[in] value Value to be set
+     * @param[in] size Size of the Value
+     */
+    virtual CHIP_ERROR SetKeyValue(const char * key, const void * value, uint16_t size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     /**
      * @brief
@@ -112,5 +138,4 @@ public:
     virtual void DeleteKeyValue(const char * key) = 0;
 };
 
-} // namespace Controller
 } // namespace chip

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -354,7 +354,10 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "$dir_pw_kvs:crc16",
         "$dir_pw_log",
       ]
-      public_deps += [ "$dir_pw_kvs" ]
+      public_deps += [
+        "$dir_pw_checksum",
+        "$dir_pw_kvs",
+      ]
       sources += [
         "EFR32/KeyValueStoreManagerImpl.cpp",
         "EFR32/KeyValueStoreManagerImpl.h",

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.h
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific key value storage implementation for Darwin.
+ */
+
+#pragma once
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+class KeyValueStoreManagerImpl final : public KeyValueStoreManager
+{
+    // Allow the KeyValueStoreManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class KeyValueStoreManager;
+
+public:
+    // NOTE: Currently this platform does not support partial and offset reads
+    //       these will return CHIP_ERROR_NOT_IMPLEMENTED.
+    CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR _Delete(const char * key) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    CHIP_ERROR _Put(const char * key, const void * value, size_t value_size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+private:
+    // ===== Members for internal use by the following friends.
+    friend KeyValueStoreManager & KeyValueStoreMgr();
+    friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
+
+    static KeyValueStoreManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications should use this to access features of the KeyValueStoreManager object
+ * that are common to all platforms.
+ */
+inline KeyValueStoreManager & KeyValueStoreMgr(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications can use this to gain access to features of the KeyValueStoreManager
+ * that are specific to the ESP32 platform.
+ */
+inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/qpg6100/KeyValueStoreManagerImpl.h
+++ b/src/platform/qpg6100/KeyValueStoreManagerImpl.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Platform-specific key value storage implementation for QPG6100.
+ */
+
+#pragma once
+
+namespace chip {
+namespace DeviceLayer {
+namespace PersistedStorage {
+
+class KeyValueStoreManagerImpl final : public KeyValueStoreManager
+{
+    // Allow the KeyValueStoreManager interface class to delegate method calls to
+    // the implementation methods provided by this class.
+    friend class KeyValueStoreManager;
+
+public:
+    // NOTE: Currently this platform does not support partial and offset reads
+    //       these will return CHIP_ERROR_NOT_IMPLEMENTED.
+    CHIP_ERROR _Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size = nullptr, size_t offset = 0)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    CHIP_ERROR _Delete(const char * key) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    CHIP_ERROR _Put(const char * key, const void * value, size_t value_size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+private:
+    // ===== Members for internal use by the following friends.
+    friend KeyValueStoreManager & KeyValueStoreMgr();
+    friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
+
+    static KeyValueStoreManagerImpl sInstance;
+};
+
+/**
+ * Returns the public interface of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications should use this to access features of the KeyValueStoreManager object
+ * that are common to all platforms.
+ */
+inline KeyValueStoreManager & KeyValueStoreMgr(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+/**
+ * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
+ *
+ * Chip applications can use this to gain access to features of the KeyValueStoreManager
+ * that are specific to the ESP32 platform.
+ */
+inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl(void)
+{
+    return KeyValueStoreManagerImpl::sInstance;
+}
+
+} // namespace PersistedStorage
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -1,0 +1,144 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief Defines a table of admins that have provisioned the device.
+ */
+
+#include <core/CHIPEncoding.h>
+#include <support/CHIPMem.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
+#include <transport/AdminPairingTable.h>
+
+namespace chip {
+namespace Transport {
+
+CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate & kvs)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+
+    StorableAdminPairingInfo info;
+    info.mNodeId = Encoding::LittleEndian::HostSwap64(mNodeId);
+    info.mAdmin  = Encoding::LittleEndian::HostSwap16(mAdmin);
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(info)), CHIP_ERROR_INTERNAL);
+    uint16_t size = static_cast<uint16_t>(sizeof(info));
+    return kvs.SetKeyValue(key, &info, size);
+}
+
+CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate & kvs)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+
+    StorableAdminPairingInfo info;
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(info)), CHIP_ERROR_INTERNAL);
+    uint16_t size = static_cast<uint16_t>(sizeof(info));
+    ReturnErrorOnFailure(kvs.GetKeyValue(key, &info, size));
+
+    mNodeId    = Encoding::LittleEndian::HostSwap64(info.mNodeId);
+    AdminId id = Encoding::LittleEndian::HostSwap16(info.mAdmin);
+    ReturnErrorCodeIf(mAdmin != id, CHIP_ERROR_INCORRECT_STATE);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AdminPairingInfo::DeleteFromKVS(PersistentStorageDelegate & kvs, AdminId id)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(id, key, sizeof(key)));
+
+    kvs.DeleteKeyValue(key);
+    return CHIP_NO_ERROR;
+}
+
+constexpr size_t AdminPairingInfo::KeySize()
+{
+    return sizeof(kAdminTableKeyPrefix) + 2 * sizeof(AdminId);
+}
+
+CHIP_ERROR AdminPairingInfo::GenerateKey(AdminId id, char * key, size_t len)
+{
+    VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
+    int keySize = snprintf(key, len, "%s%x", kAdminTableKeyPrefix, id);
+    VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);
+    return CHIP_NO_ERROR;
+}
+
+AdminPairingInfo * AdminPairingTable::AssignAdminId(AdminId adminId)
+{
+    for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
+    {
+        if (!mStates[i].IsInitialized())
+        {
+            mStates[i].SetAdminId(adminId);
+
+            return &mStates[i];
+        }
+    }
+
+    return nullptr;
+}
+
+AdminPairingInfo * AdminPairingTable::AssignAdminId(AdminId adminId, NodeId nodeId)
+{
+    AdminPairingInfo * admin = AssignAdminId(adminId);
+
+    if (admin != nullptr)
+    {
+        admin->SetNodeId(nodeId);
+    }
+
+    return admin;
+}
+
+void AdminPairingTable::ReleaseAdminId(AdminId adminId)
+{
+    AdminPairingInfo * admin = FindAdmin(adminId);
+    if (admin != nullptr)
+    {
+        admin->Reset();
+    }
+}
+
+AdminPairingInfo * AdminPairingTable::FindAdmin(AdminId adminId)
+{
+    for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
+    {
+        if (mStates[i].IsInitialized() && mStates[i].GetAdminId() == adminId)
+        {
+            return &mStates[i];
+        }
+    }
+
+    return nullptr;
+}
+
+void AdminPairingTable::Reset()
+{
+    for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
+    {
+        return mStates[i].Reset();
+    }
+}
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -21,7 +21,14 @@
 
 #pragma once
 
+#include <core/CHIPEncoding.h>
+#include <core/CHIPSafeCasts.h>
+#include <platform/KeyValueStoreManager.h>
+#include <support/Base64.h>
+#include <support/CHIPMem.h>
 #include <support/DLLUtil.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
 #include <transport/raw/MessageHeader.h>
 
 namespace chip {
@@ -29,6 +36,11 @@ namespace Transport {
 
 typedef uint16_t AdminId;
 static constexpr AdminId kUndefinedAdminId = UINT16_MAX;
+
+// KVS store is sensitive to length of key strings, based on the underlying
+// platform. Keeping them short.
+constexpr char kAdminTableKeyPrefix[] = "CHIPAdmin";
+constexpr char kAdminTableCountKey[]  = "CHIPAdminNextId";
 
 struct OperationalCredentials
 {
@@ -81,12 +93,64 @@ public:
         mAdmin  = kUndefinedAdminId;
     }
 
+    CHIP_ERROR StoreUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+
+        StorableAdminPairingInfo info;
+        info.mNodeId = Encoding::LittleEndian::HostSwap64(mNodeId);
+        info.mAdmin  = Encoding::LittleEndian::HostSwap16(mAdmin);
+
+        return mgr.Put(key, info);
+    }
+
+    CHIP_ERROR FetchUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+
+        StorableAdminPairingInfo info;
+
+        ReturnErrorOnFailure(mgr.Get(key, &info, sizeof(info)));
+        mNodeId    = Encoding::LittleEndian::HostSwap64(info.mNodeId);
+        AdminId id = Encoding::LittleEndian::HostSwap16(info.mAdmin);
+        ReturnErrorCodeIf(mAdmin != id, CHIP_ERROR_INCORRECT_STATE);
+
+        return CHIP_NO_ERROR;
+    }
+
+    static CHIP_ERROR DeleteUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr, AdminId id)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(id, key, sizeof(key)));
+
+        return mgr.Delete(key);
+    }
+
 private:
     AdminId mAdmin = kUndefinedAdminId;
     NodeId mNodeId = kUndefinedNodeId;
 
     OperationalCredentials mOpCred;
     AccessControlList mACL;
+
+    static constexpr size_t KeySize() { return sizeof(kAdminTableKeyPrefix) + 2 * sizeof(AdminId); }
+
+    static CHIP_ERROR GenerateKey(AdminId id, char * key, size_t len)
+    {
+        VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
+        int keySize = snprintf(key, len, "%s%x", kAdminTableKeyPrefix, id);
+        VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);
+        return CHIP_NO_ERROR;
+    }
+
+    struct StorableAdminPairingInfo
+    {
+        uint16_t mAdmin;  /* This field is serialized in LittleEndian byte order */
+        uint64_t mNodeId; /* This field is serialized in LittleEndian byte order */
+    };
 };
 
 class DLL_EXPORT AdminPairingTable

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -20,6 +20,7 @@ static_library("transport") {
   output_name = "libTransportLayer"
 
   sources = [
+    "AdminPairingTable.cpp",
     "AdminPairingTable.h",
     "CASESession.cpp",
     "CASESession.h",
@@ -40,6 +41,7 @@ static_library("transport") {
     "SecureSessionMgr.cpp",
     "SecureSessionMgr.h",
     "SessionEstablishmentDelegate.h",
+    "StorablePeerConnection.cpp",
     "StorablePeerConnection.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -39,6 +39,7 @@ static_library("transport") {
     "SecureSessionMgr.cpp",
     "SecureSessionMgr.h",
     "SessionEstablishmentDelegate.h",
+    "StorablePeerConnection.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",
     "TransportMgrBase.h",

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("//build_overrides/nlio.gni")
 import("${chip_root}/src/ble/ble.gni")
 
 static_library("transport") {
@@ -63,5 +64,6 @@ static_library("transport") {
     "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport/raw",
+    "${nlio_root}:nlio",
   ]
 }

--- a/src/transport/PASESession.h
+++ b/src/transport/PASESession.h
@@ -159,7 +159,7 @@ public:
      *                    initialized once pairing is complete
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session);
+    CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session);
 
     /**
      * @brief
@@ -223,6 +223,10 @@ public:
      **/
     CHIP_ERROR FromSerializable(const PASESessionSerializable & output);
 
+    /** @brief This function zeroes out and resets the memory used by the object.
+     **/
+    void Clear();
+
 private:
     enum Spake2pErrorType : uint8_t
     {
@@ -253,8 +257,6 @@ private:
     void HandleErrorMsg(const PacketHeader & header, const System::PacketBufferHandle & msg);
 
     CHIP_ERROR AttachHeaderAndSend(Protocols::SecureChannel::MsgType msgType, System::PacketBufferHandle msgBuf);
-
-    void Clear();
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -440,13 +440,13 @@ CHIP_ERROR RendezvousSession::WaitForPairing(Optional<NodeId> nodeId, uint32_t s
     UpdateState(State::kSecurePairing);
     return mPairingSession.WaitForPairing(setupPINCode, kSpake2p_Iteration_Count,
                                           reinterpret_cast<const unsigned char *>(kSpake2pKeyExchangeSalt),
-                                          strlen(kSpake2pKeyExchangeSalt), nodeId, 0, this);
+                                          strlen(kSpake2pKeyExchangeSalt), nodeId, mNextKeyId++, this);
 }
 
 CHIP_ERROR RendezvousSession::WaitForPairing(Optional<NodeId> nodeId, const PASEVerifier & verifier)
 {
     UpdateState(State::kSecurePairing);
-    return mPairingSession.WaitForPairing(verifier, nodeId, 0, this);
+    return mPairingSession.WaitForPairing(verifier, nodeId, mNextKeyId++, this);
 }
 
 CHIP_ERROR RendezvousSession::Pair(Optional<NodeId> nodeId, uint32_t setupPINCode)

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -142,6 +142,11 @@ public:
      */
     const Inet::IPAddress & GetIPAddress() const { return mNetworkProvision.GetIPAddress(); }
 
+    Transport::AdminId GetAdminId() const { return (mAdmin != nullptr) ? mAdmin->GetAdminId() : Transport::kUndefinedAdminId; }
+
+    uint16_t GetNextKeyId() const { return mNextKeyId; }
+    void SetNextKeyId(uint16_t id) { mNextKeyId = id; }
+
 private:
     CHIP_ERROR HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                     System::PacketBufferHandle msgBuf);

--- a/src/transport/StorablePeerConnection.cpp
+++ b/src/transport/StorablePeerConnection.cpp
@@ -1,0 +1,75 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <core/CHIPEncoding.h>
+#include <support/ReturnMacros.h>
+#include <support/SafeInt.h>
+#include <transport/StorablePeerConnection.h>
+
+namespace chip {
+
+StorablePeerConnection::StorablePeerConnection(PASESession & session, Transport::AdminId admin)
+{
+    session.ToSerializable(mSession.mOpCreds);
+    mSession.mAdmin = Encoding::LittleEndian::HostSwap16(admin);
+    mKeyId          = session.GetLocalKeyId();
+}
+
+CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(mKeyId, key, sizeof(key)));
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(mSession)), CHIP_ERROR_INTERNAL);
+    uint16_t size = static_cast<uint16_t>(sizeof(mSession));
+    return kvs.SetKeyValue(key, &mSession, size);
+}
+
+CHIP_ERROR StorablePeerConnection::FetchFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
+
+    VerifyOrReturnError(CanCastTo<uint16_t>(sizeof(mSession)), CHIP_ERROR_INTERNAL);
+    uint16_t size = static_cast<uint16_t>(sizeof(mSession));
+    return kvs.GetKeyValue(key, &mSession, size);
+}
+
+CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
+{
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
+
+    kvs.DeleteKeyValue(key);
+    return CHIP_NO_ERROR;
+}
+
+constexpr size_t StorablePeerConnection::KeySize()
+{
+    return sizeof(kStorablePeerConnectionKeyPrefix) + 2 * sizeof(uint16_t);
+}
+
+CHIP_ERROR StorablePeerConnection::GenerateKey(uint16_t id, char * key, size_t len)
+{
+    VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
+    int keySize = snprintf(key, len, "%s%x", kStorablePeerConnectionKeyPrefix, id);
+    VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/transport/StorablePeerConnection.h
+++ b/src/transport/StorablePeerConnection.h
@@ -1,0 +1,95 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPEncoding.h>
+#include <platform/KeyValueStoreManager.h>
+#include <transport/PASESession.h>
+
+namespace chip {
+
+// KVS store is sensitive to length of key strings, based on the underlying
+// platform. Keeping them short.
+constexpr char kStorablePeerConnectionKeyPrefix[] = "CHIPCnxn";
+constexpr char kStorablePeerConnectionCountKey[]  = "CHIPNxtCnxn";
+
+class DLL_EXPORT StorablePeerConnection
+{
+public:
+    StorablePeerConnection() {}
+
+    StorablePeerConnection(PASESession & session, Transport::AdminId admin)
+    {
+        session.ToSerializable(mSession.mOpCreds);
+        mSession.mAdmin = Encoding::LittleEndian::HostSwap16(admin);
+        mKeyId          = session.GetLocalKeyId();
+    }
+
+    virtual ~StorablePeerConnection() {}
+
+    CHIP_ERROR StoreUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(mKeyId, key, sizeof(key)));
+
+        return mgr.Put(key, &mSession, sizeof(mSession));
+    }
+
+    CHIP_ERROR FetchUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr, uint16_t keyId)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
+
+        return mgr.Get(key, &mSession, sizeof(mSession));
+    }
+
+    static CHIP_ERROR DeleteUsingKVSMgr(DeviceLayer::PersistedStorage::KeyValueStoreManager & mgr, uint16_t keyId)
+    {
+        char key[KeySize()];
+        ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
+
+        return mgr.Delete(key);
+    }
+
+    void GetPASESession(PASESession & session) { session.FromSerializable(mSession.mOpCreds); }
+
+    Transport::AdminId GetAdminId() { return mSession.mAdmin; }
+
+private:
+    static constexpr size_t KeySize() { return sizeof(kStorablePeerConnectionKeyPrefix) + 2 * sizeof(uint16_t); }
+
+    static CHIP_ERROR GenerateKey(uint16_t id, char * key, size_t len)
+    {
+        VerifyOrReturnError(len >= KeySize(), CHIP_ERROR_INVALID_ARGUMENT);
+        int keySize = snprintf(key, len, "%s%x", kStorablePeerConnectionKeyPrefix, id);
+        VerifyOrReturnError(keySize > 0, CHIP_ERROR_INTERNAL);
+        VerifyOrReturnError(len > (size_t) keySize, CHIP_ERROR_INTERNAL);
+        return CHIP_NO_ERROR;
+    }
+
+    struct StorableSession
+    {
+        PASESessionSerializable mOpCreds;
+        Transport::AdminId mAdmin; /* This field is serialized in LittleEndian byte order */
+    };
+
+    StorableSession mSession;
+    uint16_t mKeyId;
+};
+
+} // namespace chip

--- a/src/transport/StorablePeerConnection.h
+++ b/src/transport/StorablePeerConnection.h
@@ -42,7 +42,7 @@ public:
 
     static CHIP_ERROR DeleteFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId);
 
-    void GetPASESession(PASESession & session) { session.FromSerializable(mSession.mOpCreds); }
+    void GetPASESession(PASESession * session) { session->FromSerializable(mSession.mOpCreds); }
 
     Transport::AdminId GetAdminId() { return mSession.mAdmin; }
 


### PR DESCRIPTION
 #### Problem
Need to persist session and admin information on the device.

 #### Summary of Changes
Added code to store relevant information for Admin and Peer Connection/PASE Session in KVS storage. The device will read KVS and recreate the tables at boot up. Tested the change on m5stack.