### PR TITLE
Python based device scanning interfacing with native C++ code on linux.

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -43,6 +43,7 @@ shared_library("ChipDeviceCtrl") {
     "ChipDeviceController-ScriptDevicePairingDelegate.h",
     "ChipDeviceController-StorageDelegate.cpp",
     "ChipDeviceController-StorageDelegate.h",
+    "chip/native/StackInit.cpp",
   ]
 
   if (current_os == "linux" && chip_enable_ble) {
@@ -99,7 +100,13 @@ pw_python_action("python") {
     _py_manifest_files += [
       {
         src_dir = "."
-        sources = [ "chip/ble/__init__.py" ]
+        sources = [
+          "chip/ble/__init__.py",
+          "chip/ble/get_adapters.py",
+          "chip/ble/library_handle.py",
+          "chip/ble/scan_devices.py",
+          "chip/ble/types.py",
+        ]
       },
     ]
   }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -72,9 +72,6 @@ chip::NodeId kLocalDeviceId  = chip::kTestControllerNodeId;
 chip::NodeId kRemoteDeviceId = chip::kTestDeviceNodeId;
 
 extern "C" {
-// Trampolined callback types
-CHIP_ERROR pychip_DeviceController_DriveIO(uint32_t sleepTimeMS);
-
 CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl);
 CHIP_ERROR pychip_DeviceController_DeleteDeviceController(chip::Controller::DeviceCommissioner * devCtrl);
 

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -78,7 +78,6 @@ public:
 
     ~ScannerDelegateImpl()
     {
-        mContext          = nullptr;
         mScanCallback     = nullptr;
         mCompleteCallback = nullptr;
     }
@@ -106,7 +105,7 @@ public:
 
 private:
     ChipDeviceScanner::Ptr mScanner;
-    PyObject * mContext;
+    PyObject * const mContext;
     DeviceScannedCallback mScanCallback;
     ScanCompleteCallback mCompleteCallback;
 };

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -100,7 +100,7 @@ private:
     const std::unique_ptr<ChipDeviceScanner> mScanner;
     PyObject * const mContext;
     const DeviceScannedCallback mScanCallback;
-    const kScanCompleteCallback mCompleteCallback;
+    const ScanCompleteCallback mCompleteCallback;
 };
 
 } // namespace

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -25,9 +25,8 @@ extern "C" bool pychip_ble_adapter_list_next(void * adapterIterator)
     return static_cast<AdapterIterator *>(adapterIterator)->Next();
 }
 
-extern "C" unsigned pychip_ble_adapter_list_get_index(void * adapterIterator)
+extern "C" uint32_t pychip_ble_adapter_list_get_index(void * adapterIterator)
 {
-    /// NOTE: returning unsigned because python native has no sized values
     return static_cast<AdapterIterator *>(adapterIterator)->GetIndex();
 }
 
@@ -76,12 +75,6 @@ public:
         mContext(context), mScanCallback(scanCallback), mCompleteCallback(completeCallback)
     {}
 
-    ~ScannerDelegateImpl()
-    {
-        mScanCallback     = nullptr;
-        mCompleteCallback = nullptr;
-    }
-
     void SetScanner(std::unique_ptr<ChipDeviceScanner> scanner) { mScanner = std::move(scanner); }
 
     void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override
@@ -104,15 +97,15 @@ public:
     }
 
 private:
-    std::unique_ptr<ChipDeviceScanner> mScanner;
+    const std::unique_ptr<ChipDeviceScanner> mScanner;
     PyObject * const mContext;
-    DeviceScannedCallback mScanCallback;
-    ScanCompleteCallback mCompleteCallback;
+    const DeviceScannedCallback mScanCallback;
+    const kScanCompleteCallback mCompleteCallback;
 };
 
 } // namespace
 
-extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, unsigned timeout,
+extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeout,
                                             ScannerDelegateImpl::DeviceScannedCallback scanCallback,
                                             ScannerDelegateImpl::ScanCompleteCallback completeCallback)
 {

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -97,7 +97,7 @@ public:
     }
 
 private:
-    const std::unique_ptr<ChipDeviceScanner> mScanner;
+    std::unique_ptr<ChipDeviceScanner> mScanner;
     PyObject * const mContext;
     const DeviceScannedCallback mScanCallback;
     const ScanCompleteCallback mCompleteCallback;

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -1,6 +1,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Linux/bluez/AdapterIterator.h>
+#include <platform/Linux/bluez/MainLoop.h>
 #include <platform/internal/BLEManager.h>
 #include <support/CHIPMem.h>
 #include <support/ReturnMacros.h>
@@ -11,41 +12,126 @@ using namespace chip::DeviceLayer::Internal;
 
 extern "C" void * pychip_ble_adapter_list_new()
 {
-    return static_cast<void *>(new chip::DeviceLayer::Internal::AdapterIterator());
+    return static_cast<void *>(new AdapterIterator());
 }
 
-extern "C" void pychip_ble_adapter_list_delete(void * adapter)
+extern "C" void pychip_ble_adapter_list_delete(void * adapterIterator)
 {
-    delete static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter);
+    delete static_cast<AdapterIterator *>(adapterIterator);
 }
 
-extern "C" bool pychip_ble_adapter_list_next(void * adapter)
+extern "C" bool pychip_ble_adapter_list_next(void * adapterIterator)
 {
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->Next();
+    return static_cast<AdapterIterator *>(adapterIterator)->Next();
 }
 
-extern "C" unsigned pychip_ble_adapter_list_get_index(void * adapter)
+extern "C" unsigned pychip_ble_adapter_list_get_index(void * adapterIterator)
 {
     /// NOTE: returning unsigned because python native has no sized values
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->GetIndex();
+    return static_cast<AdapterIterator *>(adapterIterator)->GetIndex();
 }
 
-extern "C" const char * pychip_ble_adapter_list_get_address(void * adapter)
+extern "C" const char * pychip_ble_adapter_list_get_address(void * adapterIterator)
 {
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->GetAddress();
+    return static_cast<AdapterIterator *>(adapterIterator)->GetAddress();
 }
 
-extern "C" const char * pychip_ble_adapter_list_get_alias(void * adapter)
+extern "C" const char * pychip_ble_adapter_list_get_alias(void * adapterIterator)
 {
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->GetAlias();
+    return static_cast<AdapterIterator *>(adapterIterator)->GetAlias();
 }
 
-extern "C" const char * pychip_ble_adapter_list_get_name(void * adapter)
+extern "C" const char * pychip_ble_adapter_list_get_name(void * adapterIterator)
 {
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->GetName();
+    return static_cast<AdapterIterator *>(adapterIterator)->GetName();
 }
 
-extern "C" bool pychip_ble_adapter_list_is_powered(void * adapter)
+extern "C" bool pychip_ble_adapter_list_is_powered(void * adapterIterator)
 {
-    return static_cast<chip::DeviceLayer::Internal::AdapterIterator *>(adapter)->IsPowered();
+    return static_cast<AdapterIterator *>(adapterIterator)->IsPowered();
+}
+
+extern "C" void * pychip_ble_adapter_list_get_raw_adapter(void * adapterIterator)
+{
+    return static_cast<AdapterIterator *>(adapterIterator)->GetAdapter();
+}
+
+/////////// CHIP Device scanner implementation //////////
+
+namespace {
+
+// To avoid pythoon compatibility issues on inc/dec references,
+// code assumes an abstract type and leaves it up to python to keep track of
+// reference counts
+struct PyObject;
+
+class ScannerDelegateImpl : public ChipDeviceScannerDelegate
+{
+public:
+    using DeviceScannedCallback = void (*)(PyObject * context, const char * address, uint16_t discriminator, uint16_t vendorId,
+                                           uint16_t productId);
+    using ScanCompleteCallback  = void (*)(PyObject * context);
+
+    ScannerDelegateImpl(PyObject * context, DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback) :
+        mContext(context), mScanCallback(scanCallback), mCompleteCallback(completeCallback)
+    {}
+
+    ~ScannerDelegateImpl()
+    {
+        mContext          = nullptr;
+        mScanCallback     = nullptr;
+        mCompleteCallback = nullptr;
+    }
+
+    void SetScanner(ChipDeviceScanner::Ptr scanner) { mScanner = std::move(scanner); }
+
+    void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override
+    {
+        if (mScanCallback)
+        {
+            mScanCallback(mContext, bluez_device1_get_address(device), info.GetDeviceDiscriminator(), info.GetProductId(),
+                          info.GetVendorId());
+        }
+    }
+
+    void OnScanComplete() override
+    {
+        if (mCompleteCallback)
+        {
+            mCompleteCallback(mContext);
+        }
+
+        delete this;
+    }
+
+private:
+    ChipDeviceScanner::Ptr mScanner;
+    PyObject * mContext;
+    DeviceScannedCallback mScanCallback;
+    ScanCompleteCallback mCompleteCallback;
+};
+
+} // namespace
+
+extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, unsigned timeout,
+                                            ScannerDelegateImpl::DeviceScannedCallback scanCallback,
+                                            ScannerDelegateImpl::ScanCompleteCallback completeCallback)
+{
+    std::unique_ptr<ScannerDelegateImpl> delegate = std::make_unique<ScannerDelegateImpl>(context, scanCallback, completeCallback);
+
+    ChipDeviceScanner::Ptr scanner = ChipDeviceScanner::Create(static_cast<BluezAdapter1 *>(adapter), delegate.get());
+
+    if (!scanner)
+    {
+        return nullptr;
+    }
+
+    if (scanner->StartScan(timeout) != CHIP_NO_ERROR)
+    {
+        return nullptr;
+    }
+
+    delegate->SetScanner(std::move(scanner));
+
+    return delegate.release();
 }

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -82,7 +82,7 @@ public:
         mCompleteCallback = nullptr;
     }
 
-    void SetScanner(ChipDeviceScanner::Ptr scanner) { mScanner = std::move(scanner); }
+    void SetScanner(std::unique_ptr<ChipDeviceScanner> scanner) { mScanner = std::move(scanner); }
 
     void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override
     {
@@ -104,7 +104,7 @@ public:
     }
 
 private:
-    ChipDeviceScanner::Ptr mScanner;
+    std::unique_ptr<ChipDeviceScanner> mScanner;
     PyObject * const mContext;
     DeviceScannedCallback mScanCallback;
     ScanCompleteCallback mCompleteCallback;
@@ -118,7 +118,7 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
 {
     std::unique_ptr<ScannerDelegateImpl> delegate = std::make_unique<ScannerDelegateImpl>(context, scanCallback, completeCallback);
 
-    ChipDeviceScanner::Ptr scanner = ChipDeviceScanner::Create(static_cast<BluezAdapter1 *>(adapter), delegate.get());
+    std::unique_ptr<ChipDeviceScanner> scanner = ChipDeviceScanner::Create(static_cast<BluezAdapter1 *>(adapter), delegate.get());
 
     if (!scanner)
     {

--- a/src/controller/python/chip/ble/__init__.py
+++ b/src/controller/python/chip/ble/__init__.py
@@ -11,76 +11,11 @@
 #    limitations under the License.
 """BLE-related functionality within CHIP"""
 
-import sys
-import platform
-import chip.native
-import ctypes
-from typing import List
-from ctypes import c_bool, c_void_p, c_char_p, c_uint
-from dataclasses import dataclass
-
-
-@dataclass
-class AdapterInfo:
-  index: int
-  address: str
-  name: str
-  alias: str
-  powered_on: bool
-
-
-def _GetBleLibraryHandle() -> ctypes.CDLL:
-  """ Get the native library handle with BLE method initialization.
-
-    Retreives the CHIP native library handle and attaches signatures to
-    native methods.
-    """
-
-  handle = chip.native.GetLibraryHandle()
-
-  # Uses one of the type decorators as an indicator for everything being
-  # initialized. Native methods default to c_int return types
-  if handle.pychip_ble_adapter_list_new.restype != c_void_p:
-    setter = chip.native.NativeLibraryHandleMethodArguments(handle)
-
-    setter.Set('pychip_ble_adapter_list_new', c_void_p, [])
-    setter.Set('pychip_ble_adapter_list_next', c_bool, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_index', c_uint, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_address', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_alias', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_name', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_is_powered', c_bool, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_delete', None, [c_void_p])
-
-  return handle
-
-
-def GetAdapters() -> List[AdapterInfo]:
-  """Get a list of BLE adapters available on the system. """
-  handle = _GetBleLibraryHandle()
-
-  result = []
-  nativeList = handle.pychip_ble_adapter_list_new()
-  if nativeList == 0:
-    raise Exception('Failed to get BLE adapter list')
-
-  try:
-    while handle.pychip_ble_adapter_list_next(nativeList):
-      result.append(
-          AdapterInfo(
-              index=handle.pychip_ble_adapter_list_get_index(nativeList),
-              address=handle.pychip_ble_adapter_list_get_address(nativeList).decode('utf8'),
-              name=handle.pychip_ble_adapter_list_get_name(nativeList).decode('utf8'),
-              alias=handle.pychip_ble_adapter_list_get_alias(nativeList).decode('utf8'),
-              powered_on=handle.pychip_ble_adapter_list_is_powered(nativeList),
-          ))
-
-  finally:
-    handle.pychip_ble_adapter_list_delete(nativeList)
-
-  return result
-
+from chip.ble.scan_devices import DiscoverAsync, DiscoverSync
+from chip.ble.get_adapters import GetAdapters
 
 __all__ = [
     'GetAdapters',
+    'DiscoverAsync',
+    'DiscoverSync',
 ]

--- a/src/controller/python/chip/ble/get_adapters.py
+++ b/src/controller/python/chip/ble/get_adapters.py
@@ -1,0 +1,41 @@
+from typing import List
+from dataclasses import dataclass
+from chip.ble.library_handle import _GetBleLibraryHandle
+
+
+@dataclass
+class AdapterInfo:
+  index: int
+  address: str
+  name: str
+  alias: str
+  powered_on: bool
+
+
+def GetAdapters() -> List[AdapterInfo]:
+  """Get a list of BLE adapters available on the system. """
+  handle = _GetBleLibraryHandle()
+
+  result = []
+  nativeList = handle.pychip_ble_adapter_list_new()
+  if nativeList == 0:
+    raise Exception('Failed to get BLE adapter list')
+
+  try:
+    while handle.pychip_ble_adapter_list_next(nativeList):
+      result.append(
+          AdapterInfo(
+              index=handle.pychip_ble_adapter_list_get_index(nativeList),
+              address=handle.pychip_ble_adapter_list_get_address(
+                  nativeList).decode('utf8'),
+              name=handle.pychip_ble_adapter_list_get_name(nativeList).decode(
+                  'utf8'),
+              alias=handle.pychip_ble_adapter_list_get_alias(nativeList).decode(
+                  'utf8'),
+              powered_on=handle.pychip_ble_adapter_list_is_powered(nativeList),
+          ))
+
+  finally:
+    handle.pychip_ble_adapter_list_delete(nativeList)
+
+  return result

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -1,0 +1,51 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import chip.native
+import ctypes
+from ctypes import c_bool, c_void_p, c_char_p, c_uint, py_object
+from chip.ble.types import DeviceScannedCallback_t, ScanDoneCallback_t
+
+
+def _GetBleLibraryHandle() -> ctypes.CDLL:
+  """ Get the native library handle with BLE method initialization.
+
+    Retreives the CHIP native library handle and attaches signatures to
+    native methods.
+    """
+
+  handle = chip.native.GetLibraryHandle()
+
+  # Uses one of the type decorators as an indicator for everything being
+  # initialized. Native methods default to c_int return types
+  if handle.pychip_ble_adapter_list_new.restype != c_void_p:
+    setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+
+    setter.Set('pychip_ble_adapter_list_new', c_void_p, [])
+    setter.Set('pychip_ble_adapter_list_next', c_bool, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_get_index', c_uint, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_get_address', c_char_p, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_get_alias', c_char_p, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_get_name', c_char_p, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_is_powered', c_bool, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_delete', None, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_get_raw_adapter', c_void_p, [c_void_p])
+
+    setter.Set('pychip_ble_start_scanning', c_void_p, [
+        py_object, c_void_p, c_uint, DeviceScannedCallback_t, ScanDoneCallback_t
+    ])
+
+  return handle

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -16,7 +16,7 @@
 
 import chip.native
 import ctypes
-from ctypes import c_bool, c_void_p, c_char_p, c_uint, py_object
+from ctypes import c_bool, c_void_p, c_char_p, c_uint32, py_object
 from chip.ble.types import DeviceScannedCallback, ScanDoneCallback
 
 
@@ -44,7 +44,7 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
 
     setter.Set('pychip_ble_adapter_list_new', VoidPointer, [])
     setter.Set('pychip_ble_adapter_list_next', c_bool, [VoidPointer])
-    setter.Set('pychip_ble_adapter_list_get_index', c_uint, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_index', c_uint32, [VoidPointer])
     setter.Set('pychip_ble_adapter_list_get_address', c_char_p, [VoidPointer])
     setter.Set('pychip_ble_adapter_list_get_alias', c_char_p, [VoidPointer])
     setter.Set('pychip_ble_adapter_list_get_name', c_char_p, [VoidPointer])
@@ -53,7 +53,7 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
     setter.Set('pychip_ble_adapter_list_get_raw_adapter', VoidPointer, [VoidPointer])
 
     setter.Set('pychip_ble_start_scanning', VoidPointer, [
-        py_object, VoidPointer, c_uint, DeviceScannedCallback, ScanDoneCallback
+        py_object, VoidPointer, c_uint32, DeviceScannedCallback, ScanDoneCallback
     ])
 
   return handle

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -17,7 +17,7 @@
 import chip.native
 import ctypes
 from ctypes import c_bool, c_void_p, c_char_p, c_uint, py_object
-from chip.ble.types import DeviceScannedCallback_t, ScanDoneCallback_t
+from chip.ble.types import DeviceScannedCallback, ScanDoneCallback
 
 
 # This prevents python auto-casting c_void_p to integers and 
@@ -53,7 +53,7 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
     setter.Set('pychip_ble_adapter_list_get_raw_adapter', VoidPointer, [VoidPointer])
 
     setter.Set('pychip_ble_start_scanning', VoidPointer, [
-        py_object, VoidPointer, c_uint, DeviceScannedCallback_t, ScanDoneCallback_t
+        py_object, VoidPointer, c_uint, DeviceScannedCallback, ScanDoneCallback
     ])
 
   return handle

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -20,6 +20,14 @@ from ctypes import c_bool, c_void_p, c_char_p, c_uint, py_object
 from chip.ble.types import DeviceScannedCallback_t, ScanDoneCallback_t
 
 
+# This prevents python auto-casting c_void_p to integers and 
+# auto-casting 32/64 bit values to int/long respectively. Without this
+# passing in c_void_p does not see to work well for numbers 
+# in [0x80000000; 0xFFFFFFFF] (argument will be auto-cast to 64-bit negative)
+class VoidPointer(c_void_p):
+    pass
+
+
 def _GetBleLibraryHandle() -> ctypes.CDLL:
   """ Get the native library handle with BLE method initialization.
 
@@ -31,21 +39,21 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
 
   # Uses one of the type decorators as an indicator for everything being
   # initialized. Native methods default to c_int return types
-  if handle.pychip_ble_adapter_list_new.restype != c_void_p:
+  if handle.pychip_ble_adapter_list_new.restype != VoidPointer:
     setter = chip.native.NativeLibraryHandleMethodArguments(handle)
 
-    setter.Set('pychip_ble_adapter_list_new', c_void_p, [])
-    setter.Set('pychip_ble_adapter_list_next', c_bool, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_index', c_uint, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_address', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_alias', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_name', c_char_p, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_is_powered', c_bool, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_delete', None, [c_void_p])
-    setter.Set('pychip_ble_adapter_list_get_raw_adapter', c_void_p, [c_void_p])
+    setter.Set('pychip_ble_adapter_list_new', VoidPointer, [])
+    setter.Set('pychip_ble_adapter_list_next', c_bool, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_index', c_uint, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_address', c_char_p, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_alias', c_char_p, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_name', c_char_p, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_is_powered', c_bool, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_delete', None, [VoidPointer])
+    setter.Set('pychip_ble_adapter_list_get_raw_adapter', VoidPointer, [VoidPointer])
 
-    setter.Set('pychip_ble_start_scanning', c_void_p, [
-        py_object, c_void_p, c_uint, DeviceScannedCallback_t, ScanDoneCallback_t
+    setter.Set('pychip_ble_start_scanning', VoidPointer, [
+        py_object, VoidPointer, c_uint, DeviceScannedCallback_t, ScanDoneCallback_t
     ])
 
   return handle

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -38,12 +38,13 @@ def DiscoverAsync(timeoutMs: int, scanCallback, doneCallback, adapter=None):
   NOTE: devices are not guaranteed to be unique. New entries are returned
   as soon as the underlying BLE manager detects changes.
 
-  :param timeoutMs    - scan will complete after this time
-  :param scanCallback - callback when a device is found
-  :param doneCallback - callback when the scan is complete
-  :param adapter      - what adapter to choose. Either an AdapterInfo object or
-                        a string with the adapter address. If None, the first
-                        adapter on the system is used.
+  Args:
+    timeoutMs:    scan will complete after this time
+    scanCallback: callback when a device is found
+    doneCallback: callback when the scan is complete
+    adapter:      what adapter to choose. Either an AdapterInfo object or
+                  a string with the adapter address. If None, the first
+                  adapter on the system is used.
   """
   if adapter and not isinstance(adapter, str):
     adapter = adapter.address
@@ -115,12 +116,13 @@ def DiscoverSync(timeoutMs: int, adapter = None) -> Generator[DeviceInfo, None, 
   NOTE: devices are not guaranteed to be unique. New entries are returned
   as soon as the underlying BLE manager detects changes.
 
-  :param timeoutMs    - scan will complete after this time
-  :param scanCallback - callback when a device is found
-  :param doneCallback - callback when the scan is complete
-  :param adapter      - what adapter to choose. Either an AdapterInfo object or
-                        a string with the adapter address. If None, the first
-                        adapter on the system is used.
+  Args:
+    timeoutMs:    scan will complete after this time
+    scanCallback: callback when a device is found
+    doneCallback: callback when the scan is complete
+    adapter:      what adapter to choose. Either an AdapterInfo object or
+                  a string with the adapter address. If None, the first
+                  adapter on the system is used.
   """
 
   receiver = _DeviceInfoReceiver()

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -1,0 +1,133 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import ctypes
+from typing import Generator
+from dataclasses import dataclass
+from chip.ble.library_handle import _GetBleLibraryHandle
+from queue import Queue
+from chip.ble.types import DeviceScannedCallback_t, ScanDoneCallback_t
+
+@DeviceScannedCallback_t
+def ScanFoundCallback(closure, address: str, discriminator: int, vendor: int,
+                      product: int):
+  closure.DeviceFound(address, discriminator, vendor, product)
+
+
+@ScanDoneCallback_t
+def ScanDoneCallback(closure):
+  closure.ScanCompleted()
+
+
+def DiscoverAsync(timeoutMs: int, scanCallback, doneCallback, adapter=None):
+  """Initiate a BLE discovery of devices with the given timeout.
+
+  NOTE: devices are not guaranteed to be unique. New entries are returned
+  as soon as the underlying BLE manager detects changes.
+
+  :param timeoutMs    - scan will complete after this time
+  :param scanCallback - callback when a device is found
+  :param doneCallback - callback when the scan is complete
+  :param adapter      - what adapter to choose. Either an AdapterInfo object or
+                        a string with the adapter address. If None, the first
+                        adapter on the system is used.
+  """
+  if adapter and not isinstance(adapter, str):
+    adapter = adapter.address
+
+  handle = _GetBleLibraryHandle()
+
+  nativeList = handle.pychip_ble_adapter_list_new()
+  if nativeList == 0:
+    raise Exception('Failed to list available adapters')
+
+  try:
+    while handle.pychip_ble_adapter_list_next(nativeList):
+      if adapter and (adapter != handle.pychip_ble_adapter_list_get_address(
+          nativeList).decode('utf8')):
+        continue
+
+      class ScannerClosure:
+
+        def DeviceFound(self, *args):
+          scanCallback(*args)
+
+        def ScanCompleted(self, *args):
+          doneCallback(*args)
+          ctypes.pythonapi.Py_DecRef(ctypes.py_object(self))
+
+      closure = ScannerClosure()
+      ctypes.pythonapi.Py_IncRef(ctypes.py_object(closure))
+
+      scanner = handle.pychip_ble_start_scanning(
+          ctypes.py_object(closure),
+          handle.pychip_ble_adapter_list_get_raw_adapter(nativeList), timeoutMs,
+          ScanFoundCallback, ScanDoneCallback)
+
+      if scanner == 0:
+        raise Exception('Failed to initiate scan')
+      break
+  finally:
+    handle.pychip_ble_adapter_list_delete(nativeList)
+
+
+@dataclass
+class DeviceInfo:
+    address: str
+    discriminator: int
+    vendor: int
+    product: int
+
+class _DeviceInfoReceiver:
+    """Uses a queue to notify of objects received asynchronously
+       from a ble scan.
+
+       Internal queue gets filled on DeviceFound and ends with None when
+       ScanCompleted.
+    """
+    def __init__(self):
+        self.queue = Queue()
+
+    def DeviceFound(self, address, discriminator, vendor, product):
+        self.queue.put(DeviceInfo(address, discriminator, vendor, product))
+
+    def ScanCompleted(self):
+        self.queue.put(None)
+
+
+
+def DiscoverSync(timeoutMs: int, adapter = None) -> Generator[DeviceInfo, None, None]:
+  """Discover BLE devices over the specified period of time. 
+
+  NOTE: devices are not guaranteed to be unique. New entries are returned
+  as soon as the underlying BLE manager detects changes.
+
+  :param timeoutMs    - scan will complete after this time
+  :param scanCallback - callback when a device is found
+  :param doneCallback - callback when the scan is complete
+  :param adapter      - what adapter to choose. Either an AdapterInfo object or
+                        a string with the adapter address. If None, the first
+                        adapter on the system is used.
+  """
+
+  receiver = _DeviceInfoReceiver()
+  DiscoverAsync(timeoutMs, receiver.DeviceFound, receiver.ScanCompleted, adapter)
+
+  while True:
+      data = receiver.queue.get()
+      if not data:
+          break
+      yield data

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -19,15 +19,15 @@ from typing import Generator
 from dataclasses import dataclass
 from chip.ble.library_handle import _GetBleLibraryHandle
 from queue import Queue
-from chip.ble.types import DeviceScannedCallback_t, ScanDoneCallback_t
+from chip.ble.types import DeviceScannedCallback, ScanDoneCallback
 
-@DeviceScannedCallback_t
+@DeviceScannedCallback
 def ScanFoundCallback(closure, address: str, discriminator: int, vendor: int,
                       product: int):
   closure.DeviceFound(address, discriminator, vendor, product)
 
 
-@ScanDoneCallback_t
+@ScanDoneCallback
 def ScanDoneCallback(closure):
   closure.ScanCompleted()
 

--- a/src/controller/python/chip/ble/types.py
+++ b/src/controller/python/chip/ble/types.py
@@ -16,7 +16,7 @@
 
 from ctypes import CFUNCTYPE, py_object, c_char_p, c_uint16
 
-DeviceScannedCallback_t = CFUNCTYPE(None, py_object, c_char_p, c_uint16,
+DeviceScannedCallback = CFUNCTYPE(None, py_object, c_char_p, c_uint16,
                                     c_uint16, c_uint16)
 
-ScanDoneCallback_t = CFUNCTYPE(None, py_object)
+ScanDoneCallback = CFUNCTYPE(None, py_object)

--- a/src/controller/python/chip/ble/types.py
+++ b/src/controller/python/chip/ble/types.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python
-
 #
 #    Copyright (c) 2021 Project CHIP Authors
-#    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -17,29 +14,9 @@
 #    limitations under the License.
 #
 
-from IPython import embed
-import chip
+from ctypes import CFUNCTYPE, py_object, c_char_p, c_uint16
 
-def main():
-    # The chip import at the top level will be visible in the ipython REPL.
-    embed(header = '''
-Welcome to the CHIP python REPL utilty.
+DeviceScannedCallback_t = CFUNCTYPE(None, py_object, c_char_p, c_uint16,
+                                    c_uint16, c_uint16)
 
-Usage examples:
-
-import chip.ble
-
-######## List available BLE adapters #########
-print(chip.ble.GetAdapters())
-
-######## Discover chip devices #########
-
-chip.ble.DiscoverAsync(2000, lambda *x: print('Discovered: %r' % (x,)), lambda: print('Done'))
-
-for device in chip.ble.DiscoverSync(2000):
-    print(device)
-
-    '''.strip())
-
-if __name__ == "__main__":
-    main()
+ScanDoneCallback_t = CFUNCTYPE(None, py_object)

--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <errno.h>
 #include <pthread.h>
 
 #include <platform/CHIPDeviceLayer.h>

--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <pthread.h>
+
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
+#include <support/CHIPMem.h>
+#include <support/ErrorStr.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace {
+
+pthread_t sPlatformMainThread;
+
+void * PlatfomrMainLoop(void *)
+{
+    ChipLogProgress(DeviceLayer, "Platform main loop started.");
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    ChipLogProgress(DeviceLayer, "Platform main loop completed.");
+    return nullptr;
+}
+
+} // namespace
+
+extern "C" void pychip_native_init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = chip::Platform::MemoryInit();
+    if (err != CHIP_NO_ERROR)
+    {
+        // FIXME: implement
+        ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: memory init failed: %s", chip::ErrorStr(err));
+    }
+
+    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+    if (err != CHIP_NO_ERROR)
+    {
+        // FIXME: implement
+        ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
+    }
+    int result   = pthread_create(&sPlatformMainThread, nullptr, PlatfomrMainLoop, nullptr);
+    int tmpErrno = errno;
+
+    if (result != 0)
+    {
+        ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: pthread_create failed: %s", strerror(tmpErrno));
+    }
+}

--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -27,7 +27,7 @@ namespace {
 
 pthread_t sPlatformMainThread;
 
-void * PlatfomrMainLoop(void *)
+void * PlatformMainLoop(void *)
 {
     ChipLogProgress(DeviceLayer, "Platform main loop started.");
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
@@ -52,7 +52,7 @@ extern "C" void pychip_native_init()
     {
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
     }
-    int result   = pthread_create(&sPlatformMainThread, nullptr, PlatfomrMainLoop, nullptr);
+    int result   = pthread_create(&sPlatformMainThread, nullptr, PlatformMainLoop, nullptr);
     int tmpErrno = errno;
 
     if (result != 0)

--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -43,14 +43,12 @@ extern "C" void pychip_native_init()
     err = chip::Platform::MemoryInit();
     if (err != CHIP_NO_ERROR)
     {
-        // FIXME: implement
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: memory init failed: %s", chip::ErrorStr(err));
     }
 
     err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     if (err != CHIP_NO_ERROR)
     {
-        // FIXME: implement
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
     }
     int result   = pthread_create(&sPlatformMainThread, nullptr, PlatfomrMainLoop, nullptr);

--- a/src/controller/python/chip/native/__init__.py
+++ b/src/controller/python/chip/native/__init__.py
@@ -76,4 +76,10 @@ def GetLibraryHandle() -> ctypes.CDLL:
   if _nativeLibraryHandle is None:
     _nativeLibraryHandle = ctypes.CDLL(FindNativeLibraryPath())
 
+    setter = NativeLibraryHandleMethodArguments(_nativeLibraryHandle)
+
+    setter.Set("pychip_native_init", ctypes.c_void_p, [])
+
+    _nativeLibraryHandle.pychip_native_init()
+
   return _nativeLibraryHandle

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -466,8 +466,12 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "Linux/SystemTimeSupport.cpp",
         "Linux/bluez/AdapterIterator.cpp",
         "Linux/bluez/AdapterIterator.h",
+        "Linux/bluez/ChipDeviceScanner.cpp",
+        "Linux/bluez/ChipDeviceScanner.h",
         "Linux/bluez/Helper.cpp",
         "Linux/bluez/Helper.h",
+        "Linux/bluez/MainLoop.cpp",
+        "Linux/bluez/MainLoop.h",
         "Linux/bluez/Types.h",
       ]
 

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -44,6 +44,9 @@ namespace DeviceLayer {
 namespace Internal {
 
 namespace {
+
+static constexpr unsigned kNewConnectionScanTimeoutMs = 10000;
+
 const ChipBleUUID ChipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
                                                  0x9D, 0x11 } };
 const ChipBleUUID ChipUUID_CHIPoBLEChar_TX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
@@ -190,12 +193,12 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aNodeId, bool aIsCentral)
 
 CHIP_ERROR BLEManagerImpl::StartBLEAdvertising()
 {
-    return StartBluezAdv(static_cast<BluezEndpoint *>(mpAppState));
+    return StartBluezAdv(mpEndpoint);
 }
 
 CHIP_ERROR BLEManagerImpl::StopBLEAdvertising()
 {
-    return StopBluezAdv(static_cast<BluezEndpoint *>(mpAppState));
+    return StopBluezAdv(mpEndpoint);
 }
 
 void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
@@ -561,7 +564,7 @@ void BLEManagerImpl::DriveBLEState()
     // Initializes the Bluez BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_BluezBLELayerInitialized))
     {
-        err = InitBluezBleLayer(mIsCentral, nullptr, mBLEAdvConfig, mpAppState);
+        err = InitBluezBleLayer(mIsCentral, nullptr, mBLEAdvConfig, mpEndpoint);
         SuccessOrExit(err);
         SetFlag(mFlags, kFlag_BluezBLELayerInitialized);
     }
@@ -569,7 +572,7 @@ void BLEManagerImpl::DriveBLEState()
     // Register the CHIPoBLE application with the Bluez BLE layer if needed.
     if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
     {
-        err = BluezGattsAppRegister(static_cast<BluezEndpoint *>(mpAppState));
+        err = BluezGattsAppRegister(mpEndpoint);
         SetFlag(mFlags, kFlag_ControlOpInProgress);
         ExitNow();
     }
@@ -586,7 +589,7 @@ void BLEManagerImpl::DriveBLEState()
             // be called again, and execution will proceed to the code below.
             if (!GetFlag(mFlags, kFlag_AdvertisingConfigured))
             {
-                err = BluezAdvertisementSetup(static_cast<BluezEndpoint *>(mpAppState));
+                err = BluezAdvertisementSetup(mpEndpoint);
                 ExitNow();
             }
 
@@ -612,20 +615,6 @@ void BLEManagerImpl::DriveBLEState()
         }
     }
 
-    // Configure BLE scanning
-    if (mBLEScanConfig.mDiscriminator && !GetFlag(mFlags, kFlag_Scanning))
-    {
-        err = StartDiscovery(static_cast<BluezEndpoint *>(mpAppState), { mBLEScanConfig.mDiscriminator });
-        SuccessOrExit(err);
-        SetFlag(mFlags, kFlag_Scanning);
-    }
-    else if (!mBLEScanConfig.mDiscriminator && GetFlag(mFlags, kFlag_Scanning))
-    {
-        err = StopDiscovery(static_cast<BluezEndpoint *>(mpAppState));
-        SuccessOrExit(err);
-        ClearFlag(mFlags, kFlag_Scanning);
-    }
-
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -644,11 +633,74 @@ void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
     ChipLogProgress(Ble, "Got notification regarding chip connection closure");
 }
 
+void BLEManagerImpl::InitiateScan(BleScanState scanType)
+{
+    DriveBLEState();
+
+    if (scanType == BleScanState::kNotScanning)
+    {
+        OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);
+        ChipLogError(Ble, "Invalid scan type requested");
+        return;
+    }
+
+    if (mpEndpoint == nullptr)
+    {
+        OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);
+        ChipLogError(Ble, "BLE Layer is not yet initialized");
+        return;
+    }
+
+    // Bluez BLE state will asynchronously schedule an initialization of the
+    // BLE adapters on the glib MainLoop.
+
+    // TODO: this wait is error prone. Find a better way.
+    while (mpEndpoint->mpAdapter == nullptr)
+    {
+        pthread_yield();
+    }
+
+    if (mpEndpoint->mpAdapter == nullptr)
+    {
+        OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);
+        ChipLogError(Ble, "No adapter available for new connection establishment");
+        return;
+    }
+
+    mDeviceScanner = Internal::ChipDeviceScanner::Create(mpEndpoint->mpAdapter, this);
+
+    mBLEScanConfig.bleScanState = BleScanState::kScanForDiscriminator;
+
+    if (!mDeviceScanner)
+    {
+        mBLEScanConfig.bleScanState = BleScanState::kNotScanning;
+        OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INTERNAL);
+        ChipLogError(Ble, "Failed to create a BLE device scanner");
+        return;
+    }
+
+    CHIP_ERROR err = mDeviceScanner->StartScan(kNewConnectionScanTimeoutMs);
+    if (err != CHIP_NO_ERROR)
+    {
+        mBLEScanConfig.bleScanState = BleScanState::kNotScanning;
+        ChipLogError(Ble, "Failed to start a BLE can: %s", chip::ErrorStr(err));
+        OnConnectionError(mBLEScanConfig.mAppState, err);
+        return;
+    }
+}
+
+void BLEManagerImpl::InitiateScan(intptr_t arg)
+{
+    sInstance.InitiateScan(static_cast<BleScanState>(arg));
+}
+
 void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
 {
     mBLEScanConfig.mDiscriminator = connDiscriminator;
     mBLEScanConfig.mAppState      = appState;
-    PlatformMgr().ScheduleWork(DriveBLEState, 0);
+
+    // Scan initiation performed async, to ensure that the BLE subsystem is initialized.
+    PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));
 }
 
 void BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate)
@@ -685,6 +737,51 @@ void BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * 
     event.Platform.BLEPeripheralAdvStopComplete.mIsSuccess = aIsSuccess;
     event.Platform.BLEPeripheralAdvStopComplete.mpAppstate = apAppstate;
     PlatformMgr().PostEvent(&event);
+}
+
+void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info)
+{
+    ChipLogProgress(Ble, "New device scanned: %s", bluez_device1_get_address(device));
+
+    if (mBLEScanConfig.bleScanState == BleScanState::kScanForDiscriminator)
+    {
+        if (info.GetDeviceDiscriminator() != mBLEScanConfig.mDiscriminator)
+        {
+            return;
+        }
+        ChipLogProgress(Ble, "Device discriminator match. Attempting to connect.");
+    }
+    else if (mBLEScanConfig.bleScanState == BleScanState::kScanForAddress)
+    {
+        if (strcmp(bluez_device1_get_address(device), mBLEScanConfig.mAddress.c_str()) != 0)
+        {
+            return;
+        }
+        ChipLogProgress(Ble, "Device address match. Attempting to connect.");
+    }
+    else
+    {
+        // Internal consistency eerror
+        ChipLogError(Ble, "Unknown discovery type. Ignoring scanned device.");
+        return;
+    }
+
+    mBLEScanConfig.bleScanState = BleScanState::kNotScanning;
+    mDeviceScanner->StopScan();
+
+    ConnectDevice(device);
+}
+
+void BLEManagerImpl::OnScanComplete()
+{
+    if (mBLEScanConfig.bleScanState == BleScanState::kNotScanning)
+    {
+        ChipLogError(Ble, "Scan complete notification without an active scan.");
+        return;
+    }
+
+    OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_TIMEOUT);
+    mBLEScanConfig.bleScanState = BleScanState::kNotScanning;
 }
 
 } // namespace Internal

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -651,15 +651,6 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
         return;
     }
 
-    // Bluez BLE state will asynchronously schedule an initialization of the
-    // BLE adapters on the glib MainLoop.
-
-    // TODO: this wait is error prone. Find a better way.
-    while (mpEndpoint->mpAdapter == nullptr)
-    {
-        pthread_yield();
-    }
-
     if (mpEndpoint->mpAdapter == nullptr)
     {
         OnConnectionError(mBLEScanConfig.mAppState, CHIP_ERROR_INCORRECT_STATE);

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -28,30 +28,14 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include "bluez/ChipDeviceScanner.h"
+#include "bluez/Types.h"
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-struct BluezEndpoint;
-
 void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
-
-enum ChipAdvType
-{
-    BLUEZ_ADV_TYPE_CONNECTABLE = 0x01,
-    BLUEZ_ADV_TYPE_SCANNABLE   = 0x02,
-    BLUEZ_ADV_TYPE_DIRECTED    = 0x04,
-
-    BLUEZ_ADV_TYPE_UNDIRECTED_NONCONNECTABLE_NONSCANNABLE = 0,
-    BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_NONSCANNABLE    = BLUEZ_ADV_TYPE_CONNECTABLE,
-    BLUEZ_ADV_TYPE_UNDIRECTED_NONCONNECTABLE_SCANNABLE    = BLUEZ_ADV_TYPE_SCANNABLE,
-    BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE       = BLUEZ_ADV_TYPE_CONNECTABLE | BLUEZ_ADV_TYPE_SCANNABLE,
-
-    BLUEZ_ADV_TYPE_DIRECTED_NONCONNECTABLE_NONSCANNABLE = BLUEZ_ADV_TYPE_DIRECTED,
-    BLUEZ_ADV_TYPE_DIRECTED_CONNECTABLE_NONSCANNABLE    = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_CONNECTABLE,
-    BLUEZ_ADV_TYPE_DIRECTED_NONCONNECTABLE_SCANNABLE    = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_SCANNABLE,
-    BLUEZ_ADV_TYPE_DIRECTED_CONNECTABLE_SCANNABLE = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_CONNECTABLE | BLUEZ_ADV_TYPE_SCANNABLE,
-};
 
 struct BLEAdvConfig
 {
@@ -68,10 +52,23 @@ struct BLEAdvConfig
     const char * mpAdvertisingUUID;
 };
 
+enum class BleScanState
+{
+    kNotScanning,
+    kScanForDiscriminator,
+    kScanForAddress,
+};
+
 struct BLEScanConfig
 {
-    // Discriminator of seeked device (encoded in its BLE advertising payload)
+    // If a active scan for connection is being performed
+    BleScanState bleScanState = BleScanState::kNotScanning;
+
+    // If scanning by discriminator, what are we scanning for
     uint16_t mDiscriminator = 0;
+
+    // If scanning by address, what address are we searching for
+    std::string mAddress;
 
     // Optional argument to be passed to callback functions provided by the BLE scan/connect requestor
     void * mAppState = nullptr;
@@ -84,7 +81,8 @@ class BLEManagerImpl final : public BLEManager,
                              private Ble::BleLayer,
                              private Ble::BlePlatformDelegate,
                              private Ble::BleApplicationDelegate,
-                             private Ble::BleConnectionDelegate
+                             private Ble::BleConnectionDelegate,
+                             private ChipDeviceScannerDelegate
 {
     // Allow the BLEManager interface class to delegate method calls to
     // the implementation methods provided by this class.
@@ -153,6 +151,10 @@ private:
 
     void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
 
+    // ===== Members that implement virtual methods on ChipDeviceScannerDelegate
+    void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override;
+    void OnScanComplete() override;
+
     // ===== Members for internal use by the following friends.
 
     friend BLEManager & BLEMgr();
@@ -173,7 +175,6 @@ private:
         kFlag_FastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
         kFlag_UseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
         kFlag_AdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
-        kFlag_Scanning                 = 0x0400, /**< The system is currently scanning for CHIPoBLE devices */
     };
 
     enum
@@ -189,13 +190,17 @@ private:
     void DriveBLEState();
     static void DriveBLEState(intptr_t arg);
 
+    void InitiateScan(BleScanState scanType);
+    static void InitiateScan(intptr_t arg);
+
     CHIPoBLEServiceMode mServiceMode;
     BLEAdvConfig mBLEAdvConfig;
     BLEScanConfig mBLEScanConfig;
     uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
-    bool mIsCentral = false;
-    void * mpAppState;
+    bool mIsCentral            = false;
+    BluezEndpoint * mpEndpoint = nullptr;
+    ChipDeviceScanner::Ptr mDeviceScanner;
 };
 
 /**

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -200,7 +200,7 @@ private:
     char mDeviceName[kMaxDeviceNameLength + 1];
     bool mIsCentral            = false;
     BluezEndpoint * mpEndpoint = nullptr;
-    ChipDeviceScanner::Ptr mDeviceScanner;
+    std::unique_ptr<ChipDeviceScanner> mDeviceScanner;
 };
 
 /**

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -19,6 +19,9 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -33,6 +36,12 @@ AdapterIterator::~AdapterIterator()
     if (mObjectList != nullptr)
     {
         g_list_free_full(mObjectList, g_object_unref);
+    }
+
+    if (mCurrent.adapter != nullptr)
+    {
+        g_object_unref(mCurrent.adapter);
+        mCurrent.adapter = nullptr;
     }
 }
 
@@ -86,13 +95,18 @@ bool AdapterIterator::Advance()
             index = 0;
         }
 
+        if (mCurrent.adapter != nullptr)
+        {
+            g_object_unref(mCurrent.adapter);
+            mCurrent.adapter = nullptr;
+        }
+
         mCurrent.index   = index;
         mCurrent.address = bluez_adapter1_get_address(adapter);
         mCurrent.alias   = bluez_adapter1_get_alias(adapter);
         mCurrent.name    = bluez_adapter1_get_name(adapter);
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
-
-        g_object_unref(adapter);
+        mCurrent.adapter = adapter;
 
         mCurrentListItem = mCurrentListItem->next;
 

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -56,6 +56,7 @@ public:
     const char * GetAlias() const { return mCurrent.alias.c_str(); }
     const char * GetName() const { return mCurrent.name.c_str(); }
     bool IsPowered() const { return mCurrent.powered; }
+    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter; }
 
 private:
     /// Sets up the DBUS manager and loads the list
@@ -82,6 +83,7 @@ private:
         std::string alias;
         std::string name;
         bool powered;
+        BluezAdapter1 * adapter;
     } mCurrent = { 0 };
 };
 

--- a/src/platform/Linux/bluez/BluezObjectIterator.h
+++ b/src/platform/Linux/bluez/BluezObjectIterator.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#include <platform/CHIPDeviceConfig.h>
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *  Helper class to iterate over a list of Bluez objects.
+ */
+class BluezObjectIterator
+{
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = BluezObject;
+    using pointer           = BluezObject *;
+    using reference         = BluezObject &;
+
+    BluezObjectIterator() = default;
+    explicit BluezObjectIterator(GList * position) : mPosition(position) {}
+
+    reference operator*() const { return *BLUEZ_OBJECT(mPosition->data); }
+    pointer operator->() const { return BLUEZ_OBJECT(mPosition->data); }
+    bool operator==(const BluezObjectIterator & other) const { return mPosition == other.mPosition; }
+    bool operator!=(const BluezObjectIterator & other) const { return mPosition != other.mPosition; }
+
+    BluezObjectIterator & operator++()
+    {
+        mPosition = mPosition->next;
+        return *this;
+    }
+
+    BluezObjectIterator operator++(int)
+    {
+        const auto currentPosition = mPosition;
+        mPosition                  = mPosition->next;
+        return BluezObjectIterator(currentPosition);
+    }
+
+private:
+    GList * mPosition = nullptr;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/bluez/BluezObjectList.h
+++ b/src/platform/Linux/bluez/BluezObjectList.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#include <platform/CHIPDeviceConfig.h>
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <support/logging/CHIPLogging.h>
+
+#include "BluezObjectIterator.h"
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *  C++ wrapper for a Bluez object list based on a object manager
+ */
+class BluezObjectList
+{
+public:
+    explicit BluezObjectList(GDBusObjectManager * manager) { Initialize(manager); }
+
+    ~BluezObjectList() { g_list_free_full(mObjectList, g_object_unref); }
+
+    BluezObjectIterator begin() const { return BluezObjectIterator(mObjectList); }
+    BluezObjectIterator end() const { return BluezObjectIterator(); }
+
+protected:
+    BluezObjectList() {}
+
+    void Initialize(GDBusObjectManager * manager)
+    {
+        if (manager == nullptr)
+        {
+            ChipLogError(DeviceLayer, "Manager is NULL in %s", __func__);
+            return;
+        }
+
+        mObjectList = g_dbus_object_manager_get_objects(manager);
+    }
+
+private:
+    GList * mObjectList = nullptr;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -91,7 +91,7 @@ ChipDeviceScanner::~ChipDeviceScanner()
     mDelegate    = nullptr;
 }
 
-ChipDeviceScanner::Ptr ChipDeviceScanner::Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate)
+std::unique_ptr<ChipDeviceScanner> ChipDeviceScanner::Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate)
 {
     GError * error = nullptr;
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -45,7 +45,6 @@ struct GObjectUnref
 using GCancellableUniquePtr       = std::unique_ptr<GCancellable, GObjectUnref>;
 using GDBusObjectManagerUniquePtr = std::unique_ptr<GDBusObjectManager, GObjectUnref>;
 
-/// TODO: dedup this!
 /// Retrieve CHIP device identification info from the device advertising data
 bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
 {

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -81,11 +81,6 @@ ChipDeviceScanner::~ChipDeviceScanner()
     // In case the timeout timer is still active
     chip::DeviceLayer::SystemLayer.CancelTimer(TimerExpiredCallback, this);
 
-    while (mIsScanning)
-    {
-        g_thread_yield();
-    }
-
     g_object_unref(mManager);
     g_object_unref(mCancellable);
     g_object_unref(mAdapter);
@@ -173,7 +168,7 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
         mInterfaceChangedSignal = 0;
     }
 
-    if (!MainLoop::Instance().Schedule(MainLoopStopScan, this))
+    if (!MainLoop::Instance().ScheduleAndWait(MainLoopStopScan, this))
     {
         ChipLogError(Ble, "Failed to schedule BLE scan stop.");
         return CHIP_ERROR_INTERNAL;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -1,0 +1,271 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ChipDeviceScanner.h"
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include "BluezObjectList.h"
+#include "MainLoop.h"
+#include "Types.h"
+
+#include <errno.h>
+#include <pthread.h>
+#include <support/ReturnMacros.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+namespace {
+
+struct GObjectUnref
+{
+    template <typename T>
+    void operator()(T * value)
+    {
+        g_object_unref(value);
+    }
+};
+
+using GCancellableUniquePtr       = std::unique_ptr<GCancellable, GObjectUnref>;
+using GDBusObjectManagerUniquePtr = std::unique_ptr<GDBusObjectManager, GObjectUnref>;
+
+/// TODO: dedup this!
+/// Retrieve CHIP device identification info from the device advertising data
+bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
+{
+    GVariant * serviceData = bluez_device1_get_service_data(&aDevice);
+    VerifyOrReturnError(serviceData != nullptr, false);
+
+    GVariant * dataValue = g_variant_lookup_value(serviceData, CHIP_BLE_UUID_SERVICE_STRING, nullptr);
+    VerifyOrReturnError(dataValue != nullptr, false);
+
+    size_t dataLen         = 0;
+    const void * dataBytes = g_variant_get_fixed_array(dataValue, &dataLen, sizeof(uint8_t));
+    VerifyOrReturnError(dataBytes != nullptr && dataLen >= sizeof(aDeviceInfo), false);
+
+    memcpy(&aDeviceInfo, dataBytes, sizeof(aDeviceInfo));
+    return true;
+}
+
+} // namespace
+
+ChipDeviceScanner::ChipDeviceScanner(GDBusObjectManager * manager, BluezAdapter1 * adapter, GCancellable * cancellable,
+                                     ChipDeviceScannerDelegate * delegate) :
+    mManager(manager),
+    mAdapter(adapter), mCancellable(cancellable), mDelegate(delegate)
+{
+    g_object_ref(mAdapter);
+    g_object_ref(mCancellable);
+    g_object_ref(mManager);
+}
+
+ChipDeviceScanner::~ChipDeviceScanner()
+{
+    StopScan();
+
+    // In case the timeout timer is still active
+    chip::DeviceLayer::SystemLayer.CancelTimer(TimerExpiredCallback, this);
+
+    while (mIsScanning)
+    {
+        g_thread_yield();
+    }
+
+    g_object_unref(mManager);
+    g_object_unref(mCancellable);
+    g_object_unref(mAdapter);
+
+    mManager     = nullptr;
+    mAdapter     = nullptr;
+    mCancellable = nullptr;
+    mDelegate    = nullptr;
+}
+
+ChipDeviceScanner::Ptr ChipDeviceScanner::Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate)
+{
+    GError * error = nullptr;
+
+    GCancellableUniquePtr cancellable(g_cancellable_new(), GObjectUnref());
+
+    if (!cancellable)
+    {
+        return std::unique_ptr<ChipDeviceScanner>();
+    }
+
+    GDBusObjectManagerUniquePtr manager(
+        g_dbus_object_manager_client_new_for_bus_sync(G_BUS_TYPE_SYSTEM, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE,
+                                                      "/", bluez_object_manager_client_get_proxy_type,
+                                                      nullptr /* unused user data in the Proxy Type Func */,
+                                                      nullptr /*destroy notify */, cancellable.get(), &error),
+        GObjectUnref());
+    if (!manager)
+    {
+        ChipLogError(Ble, "Failed to get DBUS object manager for device scanning: %s", error->message);
+        g_error_free(error);
+        return std::unique_ptr<ChipDeviceScanner>();
+    }
+
+    return std::make_unique<ChipDeviceScanner>(manager.get(), adapter, cancellable.get(), delegate);
+}
+
+CHIP_ERROR ChipDeviceScanner::StartScan(unsigned timeoutMs)
+{
+    ReturnErrorCodeIf(mIsScanning, CHIP_ERROR_INCORRECT_STATE);
+
+    ReturnErrorOnFailure(MainLoop::Instance().EnsureStarted());
+
+    mIsScanning = true; // optimistic, to allow all callbacks to check this
+    if (!MainLoop::Instance().Schedule(MainLoopStartScan, this))
+    {
+        ChipLogError(Ble, "Failed to schedule BLE scan start.");
+        mIsScanning = false;
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR err = chip::DeviceLayer::SystemLayer.StartTimer(timeoutMs, TimerExpiredCallback, static_cast<void *>(this));
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Ble, "Failed to schedule scan timeout.");
+        StopScan();
+        return err;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void ChipDeviceScanner::TimerExpiredCallback(chip::System::Layer * layer, void * appState, chip::System::Error error)
+{
+    static_cast<ChipDeviceScanner *>(appState)->StopScan();
+}
+
+CHIP_ERROR ChipDeviceScanner::StopScan()
+{
+    ReturnErrorCodeIf(!mIsScanning, CHIP_NO_ERROR);
+    ReturnErrorCodeIf(mIsStopping, CHIP_NO_ERROR);
+    mIsStopping = true;
+    g_cancellable_cancel(mCancellable); // in case we are currently running a scan
+
+    if (mObjectAddedSignal)
+    {
+        g_signal_handler_disconnect(mManager, mObjectAddedSignal);
+        mObjectAddedSignal = 0;
+    }
+
+    if (mInterfaceChangedSignal)
+    {
+        g_signal_handler_disconnect(mManager, mInterfaceChangedSignal);
+        mInterfaceChangedSignal = 0;
+    }
+
+    if (!MainLoop::Instance().Schedule(MainLoopStopScan, this))
+    {
+        ChipLogError(Ble, "Failed to schedule BLE scan stop.");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+int ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
+{
+    GError * error = nullptr;
+
+    if (!bluez_adapter1_call_stop_discovery_sync(self->mAdapter, nullptr /* not cancellable */, &error))
+    {
+        ChipLogError(Ble, "Failed to stop discovery %s", error->message);
+        g_error_free(error);
+    }
+    ChipDeviceScannerDelegate * delegate = self->mDelegate;
+    self->mIsScanning                    = false;
+
+    // callback is explicitly allowed to delete the scanner (hence no more
+    // references to 'self' here)
+    delegate->OnScanComplete();
+
+    return 0;
+}
+
+void ChipDeviceScanner::SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self)
+{
+    self->ReportDevice(bluez_object_get_device1(BLUEZ_OBJECT(object)));
+}
+
+void ChipDeviceScanner::SignalInterfaceChanged(GDBusObjectManagerClient * manager, GDBusObjectProxy * object,
+                                               GDBusProxy * aInterface, GVariant * aChangedProperties,
+                                               const gchar * const * aInvalidatedProps, ChipDeviceScanner * self)
+{
+    self->ReportDevice(bluez_object_get_device1(BLUEZ_OBJECT(object)));
+}
+
+void ChipDeviceScanner::ReportDevice(BluezDevice1 * device)
+{
+    if (device == nullptr)
+    {
+        return;
+    }
+
+    if (strcmp(bluez_device1_get_adapter(device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter))) != 0)
+    {
+        return;
+    }
+
+    chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
+
+    if (!BluezGetChipDeviceInfo(*device, deviceInfo))
+    {
+        ChipLogDetail(Ble, "Device %s does not look like a CHIP device.", bluez_device1_get_address(device));
+        return;
+    }
+
+    mDelegate->OnDeviceScanned(device, deviceInfo);
+}
+
+int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
+{
+    GError * error = nullptr;
+
+    self->mObjectAddedSignal = g_signal_connect(self->mManager, "object-added", G_CALLBACK(SignalObjectAdded), self);
+    self->mInterfaceChangedSignal =
+        g_signal_connect(self->mManager, "interface-proxy-properties-changed", G_CALLBACK(SignalInterfaceChanged), self);
+
+    ChipLogProgress(Ble, "BLE scanning through known devices.");
+    for (BluezObject & object : BluezObjectList(self->mManager))
+    {
+        self->ReportDevice(bluez_object_get_device1(&object));
+    }
+
+    ChipLogProgress(Ble, "BLE initiating scan.");
+    if (!bluez_adapter1_call_start_discovery_sync(self->mAdapter, self->mCancellable, &error))
+    {
+        ChipLogError(Ble, "Failed to start discovery: %s", error->message);
+        g_error_free(error);
+
+        self->mIsScanning = false;
+        self->mDelegate->OnScanComplete();
+    }
+
+    return 0;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/CHIPDeviceConfig.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include <glib.h>
+#include <memory>
+
+#include <ble/CHIPBleServiceData.h>
+#include <core/CHIPError.h>
+#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <system/SystemLayer.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/// Receives callbacks when chip devices are being scanned
+class ChipDeviceScannerDelegate
+{
+public:
+    virtual ~ChipDeviceScannerDelegate() {}
+
+    // Called when a CHIP device was found
+    virtual void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
+
+    // Called when a scan was completed (stopped or timed out)
+    virtual void OnScanComplete() = 0;
+};
+
+/// Allows scanning for CHIP devices
+///
+/// Will perform scan operations and call back whenever a device is discovered.
+class ChipDeviceScanner
+{
+public:
+    using Ptr = std::unique_ptr<ChipDeviceScanner>;
+
+    /// NOTE: prefer to use the  ::Create method instead direct constructor calling.
+    ChipDeviceScanner(GDBusObjectManager * manager, BluezAdapter1 * adapter, GCancellable * cancellable,
+                      ChipDeviceScannerDelegate * delegate);
+
+    ChipDeviceScanner(ChipDeviceScanner &&)      = default;
+    ChipDeviceScanner(const ChipDeviceScanner &) = delete;
+    ChipDeviceScanner & operator=(const ChipDeviceScanner &) = delete;
+
+    ~ChipDeviceScanner();
+
+    /// Initiate a scan for devices, with the given timeout
+    CHIP_ERROR StartScan(unsigned timeoutMs);
+
+    /// Stop any currently running scan
+    CHIP_ERROR StopScan();
+
+    /// Create a new device scanner
+    ///
+    /// Convenience method to allocate any required variables.
+    /// On success, maintains a reference to the provided adapter.
+    static Ptr Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate);
+
+private:
+    static void TimerExpiredCallback(chip::System::Layer * layer, void * appState, chip::System::Error error);
+    static int MainLoopStartScan(ChipDeviceScanner * self);
+    static int MainLoopStopScan(ChipDeviceScanner * self);
+    static void SignalObjectAdded(GDBusObjectManager * manager, GDBusObject * object, ChipDeviceScanner * self);
+    static void SignalInterfaceChanged(GDBusObjectManagerClient * manager, GDBusObjectProxy * object, GDBusProxy * aInterface,
+                                       GVariant * aChangedProperties, const gchar * const * aInvalidatedProps,
+                                       ChipDeviceScanner * self);
+
+    /// Check if a given device is a CHIP device and if yes, report it as discovered
+    void ReportDevice(BluezDevice1 * device);
+
+    GDBusObjectManager * mManager         = nullptr;
+    BluezAdapter1 * mAdapter              = nullptr;
+    GCancellable * mCancellable           = nullptr;
+    ChipDeviceScannerDelegate * mDelegate = nullptr;
+    gulong mObjectAddedSignal             = 0;
+    gulong mInterfaceChangedSignal        = 0;
+    volatile bool mIsScanning             = false;
+    volatile bool mIsStopping             = false;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -52,8 +52,6 @@ public:
 class ChipDeviceScanner
 {
 public:
-    using Ptr = std::unique_ptr<ChipDeviceScanner>;
-
     /// NOTE: prefer to use the  ::Create method instead direct constructor calling.
     ChipDeviceScanner(GDBusObjectManager * manager, BluezAdapter1 * adapter, GCancellable * cancellable,
                       ChipDeviceScannerDelegate * delegate);
@@ -74,7 +72,7 @@ public:
     ///
     /// Convenience method to allocate any required variables.
     /// On success, maintains a reference to the provided adapter.
-    static Ptr Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate);
+    static std::unique_ptr<ChipDeviceScanner> Create(BluezAdapter1 * adapter, ChipDeviceScannerDelegate * delegate);
 
 private:
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState, chip::System::Error error);

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -94,8 +94,8 @@ private:
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;
-    volatile bool mIsScanning             = false;
-    volatile bool mIsStopping             = false;
+    bool mIsScanning                      = false;
+    bool mIsStopping                      = false;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1549,7 +1549,7 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
     err = MainLoop::Instance().EnsureStarted();
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start BLE main loop"));
 
-    if (!MainLoop::Instance().Schedule(StartupEndpointBindings, endpoint))
+    if (!MainLoop::Instance().ScheduleAndWait(StartupEndpointBindings, endpoint))
     {
         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization");
         ExitNow();

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -70,7 +70,10 @@
 #include <support/ReturnMacros.h>
 #include <system/TLVPacketBufferBackingStore.h>
 
+#include "BluezObjectIterator.h"
+#include "BluezObjectList.h"
 #include "Helper.h"
+#include "MainLoop.h"
 
 using namespace ::nl;
 using namespace chip::Protocols;
@@ -83,69 +86,15 @@ namespace Internal {
 static BluezConnection * GetBluezConnectionViaDevice(BluezEndpoint * apEndpoint);
 
 namespace {
-int sBluezFD[2];
-GMainLoop * sBluezMainLoop = nullptr;
-pthread_t sBluezThread;
 
-/**    @class BluezObjectIterator
- *
- *     @brief Helper class to iterate over a list of Bluez objects
- */
-class BluezObjectIterator
+class BluezEndpointObjectList : public BluezObjectList
 {
 public:
-    using iterator_category = std::forward_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type        = BluezObject;
-    using pointer           = BluezObject *;
-    using reference         = BluezObject &;
-
-    BluezObjectIterator() = default;
-    explicit BluezObjectIterator(GList * position) : mPosition(position) {}
-
-    reference operator*() const { return *BLUEZ_OBJECT(mPosition->data); }
-    pointer operator->() const { return BLUEZ_OBJECT(mPosition->data); }
-    bool operator==(const BluezObjectIterator & other) const { return mPosition == other.mPosition; }
-    bool operator!=(const BluezObjectIterator & other) const { return mPosition != other.mPosition; }
-
-    BluezObjectIterator & operator++()
-    {
-        mPosition = mPosition->next;
-        return *this;
-    }
-
-    BluezObjectIterator operator++(int)
-    {
-        const auto currentPosition = mPosition;
-        mPosition                  = mPosition->next;
-        return BluezObjectIterator(currentPosition);
-    }
-
-private:
-    GList * mPosition = nullptr;
-};
-
-/**    @class BluezObjectList
- *
- *     @brief C++ wrapper for a Bluez object list
- */
-class BluezObjectList
-{
-public:
-    explicit BluezObjectList(BluezEndpoint * apEndpoint)
+    explicit BluezEndpointObjectList(BluezEndpoint * apEndpoint)
     {
         VerifyOrReturn(apEndpoint != nullptr, ChipLogError(DeviceLayer, "apEndpoint is NULL in %s", __func__));
-        VerifyOrReturn(apEndpoint->mpObjMgr != nullptr, ChipLogError(DeviceLayer, "mpObjMgr is NULL in %s", __func__));
-        mObjectList = g_dbus_object_manager_get_objects(apEndpoint->mpObjMgr);
+        Initialize(apEndpoint->mpObjMgr);
     }
-
-    ~BluezObjectList() { g_list_free_full(mObjectList, g_object_unref); }
-
-    BluezObjectIterator begin() const { return BluezObjectIterator(mObjectList); }
-    BluezObjectIterator end() const { return BluezObjectIterator(); }
-
-private:
-    GList * mObjectList = nullptr;
 };
 
 } // namespace
@@ -294,9 +243,8 @@ exit:
         g_error_free(error);
 }
 
-static gboolean BluezAdvSetup(void * apClosure)
+static gboolean BluezAdvSetup(BluezEndpoint * endpoint)
 {
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
     BluezLEAdvertisement1 * adv;
 
     VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
@@ -310,13 +258,12 @@ exit:
     return G_SOURCE_REMOVE;
 }
 
-static gboolean BluezAdvStart(void * apEndpoint)
+static gboolean BluezAdvStart(BluezEndpoint * endpoint)
 {
     GDBusObject * adapter;
     BluezLEAdvertisingManager1 * advMgr = nullptr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
 
     VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
     VerifyOrExit(!endpoint->mIsAdvertising,
@@ -333,16 +280,15 @@ static gboolean BluezAdvStart(void * apEndpoint)
     options = g_variant_builder_end(&optionsBuilder);
 
     bluez_leadvertising_manager1_call_register_advertisement(advMgr, endpoint->mpAdvPath, options, nullptr, BluezAdvStartDone,
-                                                             apEndpoint);
+                                                             endpoint);
 
 exit:
     return G_SOURCE_REMOVE;
 }
 
-static gboolean BluezAdvStop(void * apEndpoint)
+static gboolean BluezAdvStop(BluezEndpoint * endpoint)
 {
     GDBusObject * adapter;
-    BluezEndpoint * endpoint            = static_cast<BluezEndpoint *>(apEndpoint);
     BluezLEAdvertisingManager1 * advMgr = nullptr;
 
     VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
@@ -356,7 +302,7 @@ static gboolean BluezAdvStop(void * apEndpoint)
     advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapter));
     VerifyOrExit(advMgr != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
-    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, nullptr, BluezAdvStopDone, apEndpoint);
+    bluez_leadvertising_manager1_call_unregister_advertisement(advMgr, endpoint->mpAdvPath, nullptr, BluezAdvStopDone, endpoint);
 
 exit:
     return G_SOURCE_REMOVE;
@@ -864,14 +810,13 @@ exit:
     }
 }
 
-gboolean BluezPeripheralRegisterApp(void * apClosure)
+gboolean BluezPeripheralRegisterApp(BluezEndpoint * endpoint)
 {
     GDBusObject * adapter;
     BluezGattManager1 * gattMgr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
 
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
     VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL endpoint->mpAdapter in %s", __func__));
 
     adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(endpoint->mpAdapter));
@@ -888,44 +833,6 @@ gboolean BluezPeripheralRegisterApp(void * apClosure)
 
 exit:
     return G_SOURCE_REMOVE;
-}
-
-/// Retrieve CHIP device identification info from the device advertising data
-static bool BluezGetChipDeviceInfo(BluezDevice1 & aDevice, chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
-{
-    GVariant * serviceData = bluez_device1_get_service_data(&aDevice);
-    VerifyOrReturnError(serviceData != nullptr, false);
-
-    GVariant * dataValue = g_variant_lookup_value(serviceData, CHIP_BLE_UUID_SERVICE_STRING, nullptr);
-    VerifyOrReturnError(dataValue != nullptr, false);
-
-    size_t dataLen         = 0;
-    const void * dataBytes = g_variant_get_fixed_array(dataValue, &dataLen, sizeof(uint8_t));
-    VerifyOrReturnError(dataBytes != nullptr && dataLen >= sizeof(aDeviceInfo), false);
-
-    memcpy(&aDeviceInfo, dataBytes, sizeof(aDeviceInfo));
-    return true;
-}
-
-/// Handle advertisement from a device and connect to it if its discriminator is the requested one.
-static void BluezHandleAdvertisementFromDevice(BluezDevice1 * aDevice, BluezEndpoint * aEndpoint)
-{
-    GVariant * serviceData = bluez_device1_get_service_data(aDevice);
-    char * debugStr        = nullptr;
-    chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
-
-    VerifyOrExit(serviceData != nullptr, );
-
-    debugStr = g_variant_print(serviceData, TRUE);
-    ChipLogDetail(DeviceLayer, "TRACE: Device %s Service data: %s", bluez_device1_get_address(aDevice), debugStr);
-
-    VerifyOrExit(BluezGetChipDeviceInfo(*aDevice, deviceInfo), );
-    ChipLogDetail(DeviceLayer, "TRACE: Found CHIP BLE Device: %" PRIu16, deviceInfo.GetDeviceDiscriminator());
-
-    if (aEndpoint->mDiscoveryRequest.mDiscriminator == deviceInfo.GetDeviceDiscriminator())
-        ConnectDevice(aDevice);
-exit:
-    g_free(debugStr);
 }
 
 /// Update the table of open BLE connections whevener a new device is spotted or its attributes have changed.
@@ -947,8 +854,6 @@ static void UpdateConnectionTable(BluezDevice1 * apDevice, BluezEndpoint & aEndp
 
     if (connection == nullptr && !bluez_device1_get_connected(apDevice) && aEndpoint.mIsCentral)
     {
-        // Check if the new device is the one that the central is trying to connect to.
-        BluezHandleAdvertisementFromDevice(apDevice, &aEndpoint);
         return;
     }
 
@@ -990,54 +895,51 @@ static void BluezHandleNewDevice(BluezDevice1 * device, BluezEndpoint * apEndpoi
     VerifyOrExit(apEndpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
     if (apEndpoint->mIsCentral)
     {
-        BluezHandleAdvertisementFromDevice(device, apEndpoint);
+        return;
     }
-    else
-    {
-        // We need to handle device connection both this function and BluezSignalInterfacePropertiesChanged
-        // When a device is connected for first time, this function will be triggerred.
-        // The future connections for the same device will trigger ``Connect'' property change.
-        // TODO: Factor common code in the two function.
-        BluezConnection * conn;
-        VerifyOrExit(bluez_device1_get_connected(device), ChipLogError(DeviceLayer, "FAIL: device is not connected"));
 
-        conn = static_cast<BluezConnection *>(
-            g_hash_table_lookup(apEndpoint->mpConnMap, g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
-        VerifyOrExit(conn == nullptr,
-                     ChipLogError(DeviceLayer, "FAIL: connection already tracked: conn: %x new device: %s", conn,
-                                  g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
+    // We need to handle device connection both this function and BluezSignalInterfacePropertiesChanged
+    // When a device is connected for first time, this function will be triggerred.
+    // The future connections for the same device will trigger ``Connect'' property change.
+    // TODO: Factor common code in the two function.
+    BluezConnection * conn;
+    VerifyOrExit(bluez_device1_get_connected(device), ChipLogError(DeviceLayer, "FAIL: device is not connected"));
 
-        conn                = g_new0(BluezConnection, 1);
-        conn->mpPeerAddress = g_strdup(bluez_device1_get_address(device));
-        conn->mpDevice      = static_cast<BluezDevice1 *>(g_object_ref(device));
-        conn->mpEndpoint    = apEndpoint;
-        BluezConnectionInit(conn);
-        apEndpoint->mpPeerDevicePath = g_strdup(g_dbus_proxy_get_object_path(G_DBUS_PROXY(device)));
-        ChipLogDetail(DeviceLayer, "Device %s (Path: %s) Connected", conn->mpPeerAddress, apEndpoint->mpPeerDevicePath);
-        g_hash_table_insert(apEndpoint->mpConnMap, g_strdup(g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))), conn);
-    }
+    conn = static_cast<BluezConnection *>(
+        g_hash_table_lookup(apEndpoint->mpConnMap, g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
+    VerifyOrExit(conn == nullptr,
+                 ChipLogError(DeviceLayer, "FAIL: connection already tracked: conn: %x new device: %s", conn,
+                              g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))));
+
+    conn                = g_new0(BluezConnection, 1);
+    conn->mpPeerAddress = g_strdup(bluez_device1_get_address(device));
+    conn->mpDevice      = static_cast<BluezDevice1 *>(g_object_ref(device));
+    conn->mpEndpoint    = apEndpoint;
+    BluezConnectionInit(conn);
+    apEndpoint->mpPeerDevicePath = g_strdup(g_dbus_proxy_get_object_path(G_DBUS_PROXY(device)));
+    ChipLogDetail(DeviceLayer, "Device %s (Path: %s) Connected", conn->mpPeerAddress, apEndpoint->mpPeerDevicePath);
+    g_hash_table_insert(apEndpoint->mpConnMap, g_strdup(g_dbus_proxy_get_object_path(G_DBUS_PROXY(device))), conn);
 
 exit:
     return;
 }
 
-static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, gpointer apClosure)
+static void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject, BluezEndpoint * endpoint)
 {
     // TODO: right now we do not handle addition/removal of adapters
     // Primary focus here is to handle addition of a device
-
-    BluezObject * o          = BLUEZ_OBJECT(aObject);
-    BluezDevice1 * device    = bluez_object_get_device1(o);
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
-    if (device != nullptr)
+    BluezDevice1 * device = bluez_object_get_device1(BLUEZ_OBJECT(aObject));
+    if (device == nullptr)
     {
-        if (BluezIsDeviceOnAdapter(device, endpoint->mpAdapter) == TRUE)
-        {
-            BluezHandleNewDevice(device, endpoint);
-        }
-
-        g_object_unref(device);
+        return;
     }
+
+    if (BluezIsDeviceOnAdapter(device, endpoint->mpAdapter) == TRUE)
+    {
+        BluezHandleNewDevice(device, endpoint);
+    }
+
+    g_object_unref(device);
 }
 
 static void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject, gpointer apClosure)
@@ -1261,10 +1163,11 @@ void EndpointCleanup(BluezEndpoint * apEndpoint)
     }
 }
 
-void BluezObjectsCleanup(BluezEndpoint * apEndpoint)
+int BluezObjectsCleanup(BluezEndpoint * apEndpoint)
 {
     g_object_unref(apEndpoint->mpAdapter);
     EndpointCleanup(apEndpoint);
+    return 0;
 }
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
@@ -1408,12 +1311,11 @@ static void BluezOnNameLost(GDBusConnection * aConn, const gchar * aName, gpoint
 }
 #endif
 
-static void * BluezMainLoop(void * apClosure)
+static int StartupEndpointBindings(BluezEndpoint * endpoint)
 {
     GDBusObjectManager * manager;
-    GError * error           = nullptr;
-    GDBusConnection * conn   = nullptr;
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apClosure);
+    GError * error         = nullptr;
+    GDBusConnection * conn = nullptr;
     VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
 
     conn = g_bus_get_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
@@ -1424,7 +1326,7 @@ static void * BluezMainLoop(void * apClosure)
     else
         endpoint->mpOwningName = g_strdup_printf("C-%04x", getpid() & 0xffff);
 
-    BluezOnBusAcquired(conn, endpoint->mpOwningName, apClosure);
+    BluezOnBusAcquired(conn, endpoint->mpOwningName, endpoint);
 
     manager = g_dbus_object_manager_client_new_sync(
         conn, G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE, BLUEZ_INTERFACE, "/", bluez_object_manager_client_get_proxy_type,
@@ -1436,60 +1338,30 @@ static void * BluezMainLoop(void * apClosure)
 
     bluezObjectsSetup(endpoint);
 
-#if 0
-    // reenable if we want to handle the bluetoothd restart
-    g_signal_connect (manager,
-                      "notify::name-owner",
-                      G_CALLBACK (on_notify_name_owner),
-                      NULL);
-#endif
-    g_signal_connect(manager, "object-added", G_CALLBACK(BluezSignalOnObjectAdded), apClosure);
-    g_signal_connect(manager, "object-removed", G_CALLBACK(BluezSignalOnObjectRemoved), apClosure);
-    g_signal_connect(manager, "interface-proxy-properties-changed", G_CALLBACK(BluezSignalInterfacePropertiesChanged), apClosure);
+    g_signal_connect(manager, "object-added", G_CALLBACK(BluezSignalOnObjectAdded), endpoint);
+    g_signal_connect(manager, "object-removed", G_CALLBACK(BluezSignalOnObjectRemoved), endpoint);
+    g_signal_connect(manager, "interface-proxy-properties-changed", G_CALLBACK(BluezSignalInterfacePropertiesChanged), endpoint);
 
-    ChipLogDetail(DeviceLayer, "TRACE: Bluez mainloop starting %s", __func__);
-    g_main_loop_run(sBluezMainLoop);
-    ChipLogDetail(DeviceLayer, "TRACE: Bluez mainloop stopping %s", __func__);
-
-    BluezObjectsCleanup(endpoint);
+    if (!MainLoop::Instance().SetCleanupFunction(BluezObjectsCleanup, endpoint))
+    {
+        ChipLogError(DeviceLayer, "Failed to schedule cleanup function");
+    }
 
 exit:
     if (error != nullptr)
         g_error_free(error);
-    return nullptr;
+
+    return 0;
 }
 
-bool BluezRunOnBluezThread(int (*aCallback)(void *), void * apClosure)
+static gboolean BluezC2Indicate(ConnectionDataBundle * closure)
 {
-    GMainContext * context = nullptr;
-    const char * msg       = nullptr;
-
-    VerifyOrExit(sBluezMainLoop != nullptr, msg = "FAIL: NULL sBluezMainLoop");
-    VerifyOrExit(g_main_loop_is_running(sBluezMainLoop), msg = "FAIL: sBluezMainLoop not running");
-
-    context = g_main_loop_get_context(sBluezMainLoop);
-    VerifyOrExit(context != nullptr, msg = "FAIL: NULL main context");
-    g_main_context_invoke(context, aCallback, apClosure);
-
-exit:
-    if (msg != nullptr)
-    {
-        ChipLogDetail(DeviceLayer, "%s in %s", msg, __func__);
-    }
-
-    return msg == nullptr;
-}
-
-static gboolean BluezC2Indicate(void * apClosure)
-{
-    ConnectionDataBundle * closure = nullptr;
-    BluezConnection * conn         = nullptr;
-    GError * error                 = nullptr;
+    BluezConnection * conn = nullptr;
+    GError * error         = nullptr;
     GIOStatus status;
     const char * buf;
     size_t len, written;
 
-    closure = static_cast<ConnectionDataBundle *>(apClosure);
     VerifyOrExit(closure != nullptr, ChipLogError(DeviceLayer, "ConnectionDataBundle is NULL in %s", __func__));
 
     conn = closure->mpConn;
@@ -1543,7 +1415,7 @@ bool SendBluezIndication(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBuffe
 
     VerifyOrExit(!apBuf.IsNull(), ChipLogError(DeviceLayer, "apBuf is NULL in %s", __func__));
 
-    success = BluezRunOnBluezThread(BluezC2Indicate, MakeConnectionDataBundle(apConn, apBuf));
+    success = MainLoop::Instance().Schedule(BluezC2Indicate, MakeConnectionDataBundle(apConn, apBuf));
 
 exit:
     return success;
@@ -1577,13 +1449,13 @@ static int CloseBleconnectionCB(void * apAppState)
 
 bool CloseBluezConnection(BLE_CONNECTION_OBJECT apConn)
 {
-    return BluezRunOnBluezThread(CloseBleconnectionCB, apConn);
+    return MainLoop::Instance().RunOnBluezThread(CloseBleconnectionCB, apConn);
 }
 
 CHIP_ERROR StartBluezAdv(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvStart, apEndpoint))
+    if (!MainLoop::Instance().Schedule(BluezAdvStart, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvStart() on CHIPoBluez thread");
@@ -1594,7 +1466,7 @@ CHIP_ERROR StartBluezAdv(BluezEndpoint * apEndpoint)
 CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvStop, apEndpoint))
+    if (!MainLoop::Instance().Schedule(BluezAdvStop, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvStop() on CHIPoBluez thread");
@@ -1605,7 +1477,7 @@ CHIP_ERROR StopBluezAdv(BluezEndpoint * apEndpoint)
 CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezAdvSetup, apEndpoint))
+    if (!MainLoop::Instance().Schedule(BluezAdvSetup, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezAdvertisementSetup() on CHIPoBluez thread");
@@ -1616,7 +1488,7 @@ CHIP_ERROR BluezAdvertisementSetup(BluezEndpoint * apEndpoint)
 CHIP_ERROR BluezGattsAppRegister(BluezEndpoint * apEndpoint)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    if (!BluezRunOnBluezThread(BluezPeripheralRegisterApp, apEndpoint))
+    if (!MainLoop::Instance().Schedule(BluezPeripheralRegisterApp, apEndpoint))
     {
         err = CHIP_ERROR_INCORRECT_STATE;
         ChipLogError(Ble, "Failed to schedule BluezPeripheralRegisterApp() on CHIPoBluez thread");
@@ -1650,15 +1522,11 @@ exit:
     return err;
 }
 
-CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, void *& apEndpoint)
+CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, BluezEndpoint *& apEndpoint)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    bool retval    = false;
-    int pthreadErr = 0;
-    int tmpErrno;
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+    bool retval              = false;
     BluezEndpoint * endpoint = nullptr;
-
-    VerifyOrExit(pipe2(sBluezFD, O_DIRECT) == 0, ChipLogError(DeviceLayer, "FAIL: open pipe in %s", __func__));
 
     // initialize server endpoint
     endpoint = g_new0(BluezEndpoint, 1);
@@ -1678,13 +1546,14 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
         SuccessOrExit(err);
     }
 
-    sBluezMainLoop = g_main_loop_new(nullptr, FALSE);
-    VerifyOrExit(sBluezMainLoop != nullptr, ChipLogError(DeviceLayer, "FAIL: memory alloc in %s", __func__));
+    err = MainLoop::Instance().EnsureStarted();
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start BLE main loop"));
 
-    pthreadErr = pthread_create(&sBluezThread, nullptr, BluezMainLoop, endpoint);
-    tmpErrno   = errno;
-    VerifyOrExit(pthreadErr == 0, ChipLogError(DeviceLayer, "FAIL: pthread_create (%s) in %s", strerror(tmpErrno), __func__));
-    sleep(1);
+    if (!MainLoop::Instance().Schedule(StartupEndpointBindings, endpoint))
+    {
+        ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization");
+        ExitNow();
+    }
 
     retval = TRUE;
 
@@ -1746,7 +1615,7 @@ bool BluezSendWriteRequest(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBuf
 
     VerifyOrExit(!apBuf.IsNull(), ChipLogError(DeviceLayer, "apBuf is NULL in %s", __func__));
 
-    success = BluezRunOnBluezThread(SendWriteRequestImpl, MakeConnectionDataBundle(apConn, apBuf));
+    success = MainLoop::Instance().RunOnBluezThread(SendWriteRequestImpl, MakeConnectionDataBundle(apConn, apBuf));
 
 exit:
     return success;
@@ -1785,10 +1654,8 @@ exit:
         g_error_free(error);
 }
 
-static gboolean SubscribeCharacteristicImpl(void * apConnection)
+static gboolean SubscribeCharacteristicImpl(BluezConnection * connection)
 {
-    BluezConnection * connection = static_cast<BluezConnection *>(apConnection);
-
     VerifyOrExit(connection != nullptr, ChipLogError(DeviceLayer, "BluezConnection is NULL in %s", __func__));
     VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
 
@@ -1800,7 +1667,7 @@ exit:
 
 bool BluezSubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn)
 {
-    return BluezRunOnBluezThread(SubscribeCharacteristicImpl, apConn);
+    return MainLoop::Instance().Schedule(SubscribeCharacteristicImpl, static_cast<BluezConnection *>(apConn));
 }
 
 // BluezUnsubscribeCharacteristic callbacks
@@ -1822,10 +1689,8 @@ exit:
         g_error_free(error);
 }
 
-static gboolean UnsubscribeCharacteristicImpl(void * apConnection)
+static gboolean UnsubscribeCharacteristicImpl(BluezConnection * connection)
 {
-    BluezConnection * connection = static_cast<BluezConnection *>(apConnection);
-
     VerifyOrExit(connection != nullptr, ChipLogError(DeviceLayer, "BluezConnection is NULL in %s", __func__));
     VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
 
@@ -1837,138 +1702,7 @@ exit:
 
 bool BluezUnsubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn)
 {
-    return BluezRunOnBluezThread(UnsubscribeCharacteristicImpl, apConn);
-}
-
-// StartDiscovery callbacks
-
-using DiscoveryTaskArg = std::pair<BluezEndpoint *, BluezDiscoveryRequest>;
-
-void StartDiscoveryDone(GObject * aObject, GAsyncResult * aResult, gpointer apEndpoint)
-{
-    BluezAdapter1 * adapter = BLUEZ_ADAPTER1(aObject);
-    GError * error          = nullptr;
-    gboolean success        = bluez_adapter1_call_start_discovery_finish(adapter, aResult, &error);
-
-    VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: StartDiscovery : %s", error->message));
-    ChipLogDetail(DeviceLayer, "StartDiscovery complete");
-
-exit:
-    if (error != nullptr)
-        g_error_free(error);
-}
-
-static bool CheckIfAlreadyDiscovered(BluezEndpoint & aEndpoint)
-{
-    chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
-
-    for (BluezObject & object : BluezObjectList(&aEndpoint))
-    {
-        BluezDevice1 * device = bluez_object_get_device1(&object);
-        if (device == nullptr || !BluezIsDeviceOnAdapter(device, aEndpoint.mpAdapter))
-            continue;
-
-        if (!BluezGetChipDeviceInfo(*device, deviceInfo))
-            continue;
-
-        if (deviceInfo.GetDeviceDiscriminator() != aEndpoint.mDiscoveryRequest.mDiscriminator)
-            continue;
-
-        UpdateConnectionTable(device, aEndpoint);
-        return true;
-    }
-
-    return false;
-}
-
-static gboolean StartDiscoveryImpl(void * apDiscoveryTaskArg)
-{
-    DiscoveryTaskArg * taskArg = static_cast<DiscoveryTaskArg *>(apDiscoveryTaskArg);
-    BluezEndpoint * endpoint;
-
-    VerifyOrExit(taskArg != nullptr, ChipLogError(DeviceLayer, "taskArg is NULL in %s", __func__));
-    endpoint = taskArg->first;
-
-    VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogError(DeviceLayer, "mpAdapter is NULL in %s", __func__));
-
-    // Bluez may already know the device in which case there's no need to discover it
-    endpoint->mDiscoveryRequest = taskArg->second;
-
-    if (CheckIfAlreadyDiscovered(*endpoint))
-    {
-        ChipLogProgress(DeviceLayer, "Device already discovered");
-        endpoint->mDiscoveryRequest = {};
-        ExitNow();
-    }
-
-    bluez_adapter1_call_start_discovery(endpoint->mpAdapter, nullptr, StartDiscoveryDone, endpoint);
-
-exit:
-    if (taskArg)
-        delete taskArg;
-    return G_SOURCE_REMOVE;
-}
-
-CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, const BluezDiscoveryRequest aRequest)
-{
-    DiscoveryTaskArg * const taskArg = new DiscoveryTaskArg(apEndpoint, aRequest);
-    CHIP_ERROR error                 = CHIP_NO_ERROR;
-
-    if (!BluezRunOnBluezThread(StartDiscoveryImpl, taskArg))
-    {
-        ChipLogError(Ble, "Failed to schedule StartDiscoveryImpl() on CHIPoBluez thread");
-        delete taskArg;
-        error = CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    return error;
-}
-
-// StopDiscovery callbacks
-
-static void StopDiscoveryDone(GObject * aObject, GAsyncResult * aResult, gpointer apEndpoint)
-{
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
-    BluezAdapter1 * adapter  = BLUEZ_ADAPTER1(aObject);
-    GError * error           = nullptr;
-    gboolean success         = bluez_adapter1_call_stop_discovery_finish(adapter, aResult, &error);
-
-    VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
-    endpoint->mDiscoveryRequest = {};
-
-    VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: StopDiscovery : %s", error->message));
-    ChipLogDetail(DeviceLayer, "StopDiscovery complete");
-
-exit:
-    if (error != nullptr)
-        g_error_free(error);
-}
-
-static gboolean StopDiscoveryImpl(void * apEndpoint)
-{
-    BluezEndpoint * endpoint = static_cast<BluezEndpoint *>(apEndpoint);
-
-    VerifyOrExit(endpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
-    VerifyOrExit(endpoint->mpAdapter != nullptr, ChipLogError(DeviceLayer, "mpAdapter is NULL in %s", __func__));
-
-    bluez_adapter1_call_stop_discovery(endpoint->mpAdapter, nullptr, StopDiscoveryDone, apEndpoint);
-
-exit:
-    return G_SOURCE_REMOVE;
-}
-
-CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint)
-{
-    CHIP_ERROR error = CHIP_NO_ERROR;
-
-    if (!BluezRunOnBluezThread(StopDiscoveryImpl, apEndpoint))
-    {
-        ChipLogError(Ble, "Failed to schedule StopDiscoveryImpl() on CHIPoBluez thread");
-        error = CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    return error;
+    return MainLoop::Instance().Schedule(UnsubscribeCharacteristicImpl, static_cast<BluezConnection *>(apConn));
 }
 
 // ConnectDevice callbacks
@@ -1987,13 +1721,12 @@ exit:
         g_error_free(error);
 }
 
-static gboolean ConnectDeviceImpl(void * apDevice)
+static gboolean ConnectDeviceImpl(BluezDevice1 * device)
 {
-    BluezDevice1 * device = static_cast<BluezDevice1 *>(apDevice);
-
     VerifyOrExit(device != nullptr, ChipLogError(DeviceLayer, "device is NULL in %s", __func__));
 
     bluez_device1_call_connect(device, nullptr, ConnectDeviceDone, nullptr);
+    g_object_unref(device);
 
 exit:
     return G_SOURCE_REMOVE;
@@ -2002,10 +1735,12 @@ exit:
 CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
+    g_object_ref(apDevice);
 
-    if (!BluezRunOnBluezThread(ConnectDeviceImpl, apDevice))
+    if (!MainLoop::Instance().Schedule(ConnectDeviceImpl, apDevice))
     {
         ChipLogError(Ble, "Failed to schedule ConnectDeviceImpl() on CHIPoBluez thread");
+        g_object_unref(apDevice);
         error = CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/platform/Linux/bluez/Helper.h
+++ b/src/platform/Linux/bluez/Helper.h
@@ -58,7 +58,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, void *& apEndpoint);
+CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & aBleAdvConfig, BluezEndpoint *& apEndpoint);
 bool BluezRunOnBluezThread(int (*aCallback)(void *), void * apClosure);
 bool SendBluezIndication(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBufferHandle apBuf);
 bool CloseBluezConnection(BLE_CONNECTION_OBJECT apConn);
@@ -73,10 +73,6 @@ bool BluezSendWriteRequest(BLE_CONNECTION_OBJECT apConn, chip::System::PacketBuf
 bool BluezSubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
 /// Unsubscribe from the CHIP TX characteristic on the remote peripheral device
 bool BluezUnsubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
-
-CHIP_ERROR StartDiscovery(BluezEndpoint * apEndpoint, BluezDiscoveryRequest aRequest = {});
-
-CHIP_ERROR StopDiscovery(BluezEndpoint * apEndpoint);
 
 CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);
 

--- a/src/platform/Linux/bluez/MainLoop.cpp
+++ b/src/platform/Linux/bluez/MainLoop.cpp
@@ -1,0 +1,115 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "MainLoop.h"
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include <errno.h>
+#include <pthread.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+MainLoop & MainLoop::Instance()
+{
+    static MainLoop sMainLoop;
+    return sMainLoop;
+}
+
+void * MainLoop::Thread(void * self)
+{
+    MainLoop * loop = reinterpret_cast<MainLoop *>(self);
+
+    ChipLogDetail(DeviceLayer, "TRACE: Bluez mainloop starting %s", __func__);
+    g_main_loop_run(loop->mBluezMainLoop);
+    ChipLogDetail(DeviceLayer, "TRACE: Bluez mainloop stopping %s", __func__);
+
+    if (loop->mCleanup != nullptr)
+    {
+        ChipLogDetail(DeviceLayer, "TRACE: Executing cleanup %s", __func__);
+        loop->mCleanup(loop->mCleanupArgument);
+    }
+
+    return nullptr;
+}
+
+CHIP_ERROR MainLoop::EnsureStarted()
+{
+    if (mBluezMainLoop != nullptr)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int pthreadErr = 0;
+    int tmpErrno;
+
+    mBluezMainLoop = g_main_loop_new(nullptr, FALSE);
+    VerifyOrExit(mBluezMainLoop != nullptr, ChipLogError(DeviceLayer, "FAIL: memory alloc in %s", __func__));
+
+    pthreadErr = pthread_create(&mThread, nullptr, &MainLoop::Thread, reinterpret_cast<void *>(this));
+    tmpErrno   = errno;
+    VerifyOrExit(pthreadErr == 0, ChipLogError(DeviceLayer, "FAIL: pthread_create (%s) in %s", strerror(tmpErrno), __func__));
+
+    while (!g_main_loop_is_running(mBluezMainLoop))
+    {
+        pthread_yield();
+    }
+
+exit:
+
+    if (err != CHIP_NO_ERROR)
+    {
+        if (mBluezMainLoop != nullptr)
+        {
+            g_free(mBluezMainLoop);
+            mBluezMainLoop = nullptr;
+        }
+    }
+
+    return err;
+}
+
+bool MainLoop::RunOnBluezThread(GSourceFunc callback, void * argument)
+{
+    GMainContext * context = nullptr;
+    const char * msg       = nullptr;
+
+    VerifyOrExit(mBluezMainLoop != nullptr, msg = "FAIL: NULL sBluezMainLoop");
+    VerifyOrExit(g_main_loop_is_running(mBluezMainLoop), msg = "FAIL: sBluezMainLoop not running");
+
+    context = g_main_loop_get_context(mBluezMainLoop);
+    VerifyOrExit(context != nullptr, msg = "FAIL: NULL main context");
+    g_main_context_invoke(context, callback, argument);
+
+exit:
+    if (msg != nullptr)
+    {
+        ChipLogDetail(DeviceLayer, "%s in %s", msg, __func__);
+    }
+
+    return msg == nullptr;
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE

--- a/src/platform/Linux/bluez/MainLoop.cpp
+++ b/src/platform/Linux/bluez/MainLoop.cpp
@@ -134,7 +134,7 @@ CHIP_ERROR MainLoop::EnsureStarted()
     Semaphore semaphore;
 
     GMainContext * context = g_main_loop_get_context(mBluezMainLoop);
-    VerifyOrDieWithMsg(context != nullptr, "Unexpected null context on the main loop");
+    VerifyOrDie(context != nullptr);
 
     g_main_context_invoke(context, GSourceFunc(PostSemaphore), &semaphore);
 

--- a/src/platform/Linux/bluez/MainLoop.cpp
+++ b/src/platform/Linux/bluez/MainLoop.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR MainLoop::EnsureStarted()
         return CHIP_NO_ERROR;
     }
 
-    mBluezMainLoop = g_main_loop_new(nullptr, FALSE);
+    mBluezMainLoop = g_main_loop_new(nullptr, TRUE);
     if (mBluezMainLoop == nullptr)
     {
         ChipLogError(DeviceLayer, "FAIL: memory alloc in %s", __func__);
@@ -143,7 +143,6 @@ CHIP_ERROR MainLoop::EnsureStarted()
     g_main_context_invoke(context, GSourceFunc(PostSemaphore), &semaphore);
 
     semaphore.Wait();
-    VerifyOrDie(g_main_loop_is_running(mBluezMainLoop));
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/bluez/MainLoop.cpp
+++ b/src/platform/Linux/bluez/MainLoop.cpp
@@ -134,12 +134,8 @@ CHIP_ERROR MainLoop::EnsureStarted()
     Semaphore semaphore;
 
     GMainContext * context = g_main_loop_get_context(mBluezMainLoop);
-    if (context == nullptr)
-    {
-        ChipLogError(DeviceLayer, "Unexpected null context on the main loop");
-        // bluez loop not cleaned as running thread is already started.
-        return CHIP_ERROR_INTERNAL;
-    }
+    VerifyOrDieWithMsg(context != nullptr, "Unexpected null context on the main loop");
+
     g_main_context_invoke(context, GSourceFunc(PostSemaphore), &semaphore);
 
     semaphore.Wait();

--- a/src/platform/Linux/bluez/MainLoop.cpp
+++ b/src/platform/Linux/bluez/MainLoop.cpp
@@ -119,6 +119,7 @@ CHIP_ERROR MainLoop::EnsureStarted()
     tmpErrno   = errno;
     VerifyOrExit(pthreadErr == 0, ChipLogError(DeviceLayer, "FAIL: pthread_create (%s) in %s", strerror(tmpErrno), __func__));
 
+    // Ensure that the newly created thread starts the main loop
     while (!g_main_loop_is_running(mBluezMainLoop))
     {
         pthread_yield();

--- a/src/platform/Linux/bluez/MainLoop.h
+++ b/src/platform/Linux/bluez/MainLoop.h
@@ -1,0 +1,94 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPError.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include <glib.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/// The main loop provides a thread-based implementation that runs
+/// the GLib main loop.
+///
+/// The main loop is used execute callbacks (e.g. dbus notifications).
+class MainLoop
+{
+public:
+    /// Ensure that a thread with g_main_loop_run is executing.
+    CHIP_ERROR EnsureStarted();
+
+    /// Executes a callback on the underlying main loop.
+    ///
+    /// The main loop MUST have been started already.
+    bool RunOnBluezThread(GSourceFunc closure, void * arg);
+
+    /// Convenience method to require less casts to void*
+    template <class T>
+    bool Schedule(int (*callback)(T *), T * value)
+    {
+        return RunOnBluezThread(G_SOURCE_FUNC(callback), value);
+    }
+
+    /// Schedules a method to be executed after the main loop has finished
+    ///
+    /// A single cleanup method can exist and the main loop has to be running
+    /// to set a cleanup method.
+    template <class T>
+    bool SetCleanupFunction(int (*callback)(T *), T * value)
+    {
+        if (mCleanup != nullptr)
+        {
+            return false;
+        }
+
+        if ((mBluezMainLoop == nullptr) || !g_main_loop_is_running(mBluezMainLoop))
+        {
+            return false;
+        }
+
+        mCleanup         = G_SOURCE_FUNC(callback);
+        mCleanupArgument = static_cast<void *>(value);
+
+        return true;
+    }
+
+    static MainLoop & Instance();
+
+private:
+    MainLoop() {}
+
+    static void * Thread(void * self);
+
+    GMainLoop * mBluezMainLoop = nullptr;
+    pthread_t mThread          = 0;
+
+    // allow a single cleanup method
+    GSourceFunc mCleanup    = nullptr;
+    void * mCleanupArgument = nullptr;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE

--- a/src/platform/Linux/bluez/MainLoop.h
+++ b/src/platform/Linux/bluez/MainLoop.h
@@ -22,6 +22,7 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 #include <glib.h>
+#include <semaphore.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -34,6 +35,7 @@ namespace Internal {
 class MainLoop
 {
 public:
+
     /// Ensure that a thread with g_main_loop_run is executing.
     CHIP_ERROR EnsureStarted();
 
@@ -42,11 +44,24 @@ public:
     /// The main loop MUST have been started already.
     bool RunOnBluezThread(GSourceFunc closure, void * arg);
 
+    /// Executes a callback on the underlying main loop and waits for
+    /// the method to complete.
+    ///
+    /// The main loop MUST have been started already.
+    bool RunOnBluezThreadAndWait(GSourceFunc closure, void * arg);
+
     /// Convenience method to require less casts to void*
     template <class T>
     bool Schedule(int (*callback)(T *), T * value)
     {
         return RunOnBluezThread(G_SOURCE_FUNC(callback), value);
+    }
+
+    /// Convenience method to require less casts to void*
+    template <class T>
+    bool ScheduleAndWait(int (*callback)(T *), T * value)
+    {
+        return RunOnBluezThreadAndWait(G_SOURCE_FUNC(callback), value);
     }
 
     /// Schedules a method to be executed after the main loop has finished

--- a/src/platform/Linux/bluez/MainLoop.h
+++ b/src/platform/Linux/bluez/MainLoop.h
@@ -35,7 +35,6 @@ namespace Internal {
 class MainLoop
 {
 public:
-
     /// Ensure that a thread with g_main_loop_run is executing.
     CHIP_ERROR EnsureStarted();
 

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -45,12 +45,11 @@
 
 #pragma once
 
-#include <platform/CHIPDeviceLayer.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 #include <ble/CHIPBleServiceData.h>
-#include <platform/CHIPDeviceConfig.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
 #include <cstdint>
@@ -59,6 +58,23 @@
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
+
+enum ChipAdvType
+{
+    BLUEZ_ADV_TYPE_CONNECTABLE = 0x01,
+    BLUEZ_ADV_TYPE_SCANNABLE   = 0x02,
+    BLUEZ_ADV_TYPE_DIRECTED    = 0x04,
+
+    BLUEZ_ADV_TYPE_UNDIRECTED_NONCONNECTABLE_NONSCANNABLE = 0,
+    BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_NONSCANNABLE    = BLUEZ_ADV_TYPE_CONNECTABLE,
+    BLUEZ_ADV_TYPE_UNDIRECTED_NONCONNECTABLE_SCANNABLE    = BLUEZ_ADV_TYPE_SCANNABLE,
+    BLUEZ_ADV_TYPE_UNDIRECTED_CONNECTABLE_SCANNABLE       = BLUEZ_ADV_TYPE_CONNECTABLE | BLUEZ_ADV_TYPE_SCANNABLE,
+
+    BLUEZ_ADV_TYPE_DIRECTED_NONCONNECTABLE_NONSCANNABLE = BLUEZ_ADV_TYPE_DIRECTED,
+    BLUEZ_ADV_TYPE_DIRECTED_CONNECTABLE_NONSCANNABLE    = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_CONNECTABLE,
+    BLUEZ_ADV_TYPE_DIRECTED_NONCONNECTABLE_SCANNABLE    = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_SCANNABLE,
+    BLUEZ_ADV_TYPE_DIRECTED_CONNECTABLE_SCANNABLE = BLUEZ_ADV_TYPE_DIRECTED | BLUEZ_ADV_TYPE_CONNECTABLE | BLUEZ_ADV_TYPE_SCANNABLE,
+};
 
 #define BLUEZ_ADDRESS_SIZE 6 ///< BLE address size (in bytes)
 #define BLUEZ_PATH "/org/bluez"
@@ -112,11 +128,6 @@ struct IOChannel
     guint mWatch;
 };
 
-struct BluezDiscoveryRequest
-{
-    uint16_t mDiscriminator;
-};
-
 struct BluezEndpoint
 {
     char * mpOwningName; // Bus owning name
@@ -131,9 +142,9 @@ struct BluezEndpoint
     char * mpServicePath;
 
     // Objects (interfaces) subscibed to by this service
-    GDBusObjectManager * mpObjMgr;
-    BluezAdapter1 * mpAdapter;
-    BluezDevice1 * mpDevice;
+    GDBusObjectManager * mpObjMgr = nullptr;
+    BluezAdapter1 * mpAdapter     = nullptr;
+    BluezDevice1 * mpDevice       = nullptr;
 
     // Objects (interfaces) published by this service
     GDBusObjectManagerServer * mpRoot;
@@ -153,9 +164,6 @@ struct BluezEndpoint
     uint16_t mDuration; ///< Advertisement interval (in ms).
     bool mIsAdvertising;
     char * mpPeerDevicePath;
-
-    // Discovery settings
-    BluezDiscoveryRequest mDiscoveryRequest = {};
 };
 
 struct BluezConnection


### PR DESCRIPTION
 #### Problem
Native C++ device scanning is not implemented nor accessible from python, which does not allow us to verify/script the parsing of discovered devices.

Current discovery is done natively by Android and iOS platforms and a pure python version. However connectivity itself is done by C++ native code which would only be exercised on connect and never on discovery.


 #### Summary of Changes
 This is a merge of several branches developed while the bluez code split was under review. It contains:
 
 - Moved BlueZ main loop to a separate class (rather than inline method) so that it is accessible by other implementations
 - Implemented a 'CHIPDeviceScanner' that can be used both externally and is used internally by the 'connect via BLE' implementation in linux BLEManager
 - Added native handle classes for python for managing native interface calls and doing 'init' for platform-specific stack bits (e.g. memory and device layer initialization required by BLE)
 - Added bindings to the device scanner from python
 - Added more type safety to BlueZ code (less void *, replaced with actual types and avoided casting)
 
 Example usage:
 
 ```
 In [1]: import chip.ble

In [2]: chip.ble.DiscoverAsync(2000, lambda *x: print('Discovered: %r' % (x,)), lambda: print('Done'))
CHIP:DL: Platform main loop started.
CHIP:DL: TRACE: Bluez mainloop starting Thread
CHIP:BLE: BLE scanning through known devices.
CHIP:BLE: BLE initiating scan.

In [3]: CHIP:BLE: Device 38:CB:9F:C4:D5:7A does not look like a CHIP device.
CHIP:BLE: Device 79:1C:AB:8D:B4:1E does not look like a CHIP device.
CHIP:BLE: Device 6E:91:AB:C1:8B:75 does not look like a CHIP device.
CHIP:BLE: Device 53:DA:56:14:DF:2E does not look like a CHIP device.
Discovered: (b'98:F4:AB:6B:1A:FE', 3840, 65279, 9050)
Done
In [3]:
 ```
