### PR TITLE
Fix TI simplelink in unified build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -138,7 +138,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     enable_android_builds = false
 
     # Set this to true to enable TI builds by default.
-    enable_cc13x2_26x2_builds = false
+    enable_ti_simplelink_builds = false
 
     # Set this to true to enable efr32 builds by default.
     enable_efr32_builds = false
@@ -179,8 +179,8 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     enable_linux_lighting_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
 
-    # Build the cc13x2_26x2 lock app example.
-    enable_cc13x2_26x2_lock_app_build = enable_cc13x2_26x2_builds
+    # Build the cc13x2x7_26x2x7 lock app example.
+    enable_cc13x2x7_26x2x7_lock_app_build = enable_ti_simplelink_builds
 
     # Build the efr32 lock app example.
     enable_efr32_lock_app_build = enable_efr32_builds
@@ -240,9 +240,9 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 
-  if (enable_cc13x2_26x2_lock_app_build) {
-    group("cc13x2_26x2_lock_app") {
-      deps = [ "${chip_root}/examples/lock-app/cc13x2_26x2(${chip_root}/config/cc13x2_26x2/toolchain:cc13x2_26x2_lock_app)" ]
+  if (enable_cc13x2x7_26x2x7_lock_app_build) {
+    group("cc13x2x7_26x2x7_lock_app") {
+      deps = [ "${chip_root}/examples/lock-app/cc13x2x7_26x2x7(${chip_root}/config/cc13x2_26x2/toolchain:cc13x2x7_26x2x7_lock_app)" ]
     }
   }
 
@@ -346,8 +346,8 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     if (enable_qpg6100_lock_app_build) {
       deps += [ ":qpg6100_lock_app" ]
     }
-    if (enable_cc13x2_26x2_lock_app_build) {
-      deps += [ ":cc13x2_26x2_lock_app" ]
+    if (enable_cc13x2x7_26x2x7_lock_app_build) {
+      deps += [ ":cc13x2x7_26x2x7_lock_app" ]
     }
   }
 

--- a/config/cc13x2_26x2/toolchain/BUILD.gn
+++ b/config/cc13x2_26x2/toolchain/BUILD.gn
@@ -17,9 +17,9 @@ import("//build_overrides/chip.gni")
 
 import("${build_root}/toolchain/arm_gcc/arm_toolchain.gni")
 
-arm_toolchain("cc13x2_26x2_lock_app") {
+arm_toolchain("cc13x2x7_26x2x7_lock_app") {
   toolchain_args = {
     current_os = "freertos"
-    import("${chip_root}/examples/lock-app/cc13x2_26x2/args.gni")
+    import("${chip_root}/examples/lock-app/cc13x2x7_26x2x7/args.gni")
   }
 }


### PR DESCRIPTION
This broke after e76ed5403 ("CC26X2X7 Initial support of BLE Rendezvous (#4865)"). Fix the build file to use the new paths.

Tested via
`gn gen out/unified --args="target_os=\"all\" enable_ti_simplelink_builds=true ti_simplelink_sdk_root=\"$HOME/ti/simplelink_cc13x2_26x2_sdk_4_40_05_02_eng\" ti_sysconfig_root=\"$HOME/ti/sysconfig_1.7.0\" enable_linux_bridge_app_build=false"`