### PR TITLE
Increase stack size for esp32 unit tests

### DIFF
--- a/scripts/tests/esp32_qemu_tests.sh
+++ b/scripts/tests/esp32_qemu_tests.sh
@@ -68,6 +68,7 @@ run_suite libCoreTests.a
 run_suite libInetLayerTests.a
 run_suite libRetransmitTests.a
 run_suite libSystemLayerTests.a
+run_suite libChipCryptoTests.a
 
 # TODO: Transport layer tests do not link:
 #    - getpid undefined
@@ -80,6 +81,3 @@ run_suite libSystemLayerTests.a
 #    - ArgParser for IPAddresses are not linked in
 #    - std::__throw_bad_alloc() linker errors
 # run_suite libTransportLayerTests.a "-lNetworkTestHelpers -lInetTestHelpers"
-
-# TODO - Fix crypto tests.
-# run_suite libChipCryptoTests.a || true

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -127,7 +127,7 @@ extern "C" void app_main()
         exit(err);
     }
 
-    xTaskCreate(tester_task, "tester", 8192, (void *) NULL, tskIDLE_PRIORITY + 10, NULL);
+    xTaskCreate(tester_task, "tester", 12288, (void *) NULL, tskIDLE_PRIORITY + 10, NULL);
 
     while (1)
     {


### PR DESCRIPTION
#### Problem

Stack overflow running `TestCSR_Gen()` in `src/crypto/tests/CHIPCryptoPALTest.cpp`

#### Summary of Changes

Increase test task stack from 8K to 12K.

Fixes #2712 ChipCryptoTests are failing on esp32 qemu
