### PR TITLE
[python] Add command for Thread provisioning 

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -89,6 +89,10 @@ CHIP_ERROR
 pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::Controller::DeviceCommissioner * devCtrl, const char * ssid,
                                                      const char * password);
 CHIP_ERROR
+pychip_ScriptDevicePairingDelegate_SetThreadCredential(chip::Controller::DeviceCommissioner * devCtrl, int channel, int panId,
+                                                       const char * masterKey);
+
+CHIP_ERROR
 pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(chip::Controller::DeviceCommissioner * devCtrl,
                                                           chip::Controller::DevicePairingDelegate_OnPairingCompleteFunct callback);
 
@@ -197,6 +201,26 @@ pychip_ScriptDevicePairingDelegate_SetWifiCredential(chip::Controller::DeviceCom
     VerifyOrExit(password != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
     sPairingDelegate.SetWifiCredential(ssid, password);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR
+pychip_ScriptDevicePairingDelegate_SetThreadCredential(chip::Controller::DeviceCommissioner * devCtrl, int channel, int panId,
+                                                       const char * masterKeyStr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t masterKey[chip::DeviceLayer::Internal::kThreadMasterKeyLength];
+    (void) devCtrl;
+
+    VerifyOrExit(strlen(masterKeyStr) == 2 * chip::DeviceLayer::Internal::kThreadMasterKeyLength,
+                 err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    for (size_t i = 0; i < chip::DeviceLayer::Internal::kThreadMasterKeyLength; i++)
+        VerifyOrExit(sscanf(&masterKeyStr[2 * i], "%2hhx", &masterKey[i]) == 1, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    sPairingDelegate.SetThreadCredential(channel, panId, masterKey);
 
 exit:
     return err;

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
@@ -28,11 +28,25 @@ void ScriptDevicePairingDelegate::SetWifiCredential(const char * ssid, const cha
 {
     strncpy(mWifiSSID, ssid, sizeof(mWifiSSID));
     strncpy(mWifiPassword, password, sizeof(mWifiPassword));
+    mMode = Mode::Wifi;
+}
+
+void ScriptDevicePairingDelegate::SetThreadCredential(uint8_t channel, uint16_t panId,
+                                                      uint8_t (&masterKey)[chip::DeviceLayer::Internal::kThreadMasterKeyLength])
+{
+    mThreadInfo               = {};
+    mThreadInfo.ThreadChannel = channel;
+    mThreadInfo.ThreadPANId   = panId;
+    memcpy(mThreadInfo.ThreadMasterKey, masterKey, sizeof(masterKey));
+    mMode = Mode::Thread;
 }
 
 void ScriptDevicePairingDelegate::OnNetworkCredentialsRequested(RendezvousDeviceCredentialsDelegate * callback)
 {
-    callback->SendNetworkCredentials(mWifiSSID, mWifiPassword);
+    if (mMode == Mode::Wifi)
+        callback->SendNetworkCredentials(mWifiSSID, mWifiPassword);
+    else
+        callback->SendThreadCredentials(mThreadInfo);
 }
 
 void ScriptDevicePairingDelegate::OnOperationalCredentialsRequested(const char * csr, size_t csr_length,

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.h
@@ -42,6 +42,8 @@ class ScriptDevicePairingDelegate final : public Controller::DevicePairingDelega
 public:
     ~ScriptDevicePairingDelegate() = default;
     void SetWifiCredential(const char * ssid, const char * password);
+    void SetThreadCredential(uint8_t channel, uint16_t panId,
+                             uint8_t (&masterKey)[chip::DeviceLayer::Internal::kThreadMasterKeyLength]);
     void SetKeyExchangeCallback(DevicePairingDelegate_OnPairingCompleteFunct callback);
 
     void OnNetworkCredentialsRequested(RendezvousDeviceCredentialsDelegate * callback) override;
@@ -56,6 +58,16 @@ private:
     char mWifiSSID[chip::DeviceLayer::Internal::kMaxWiFiSSIDLength + 1];
     char mWifiPassword[chip::DeviceLayer::Internal::kMaxWiFiKeyLength];
 
+    // Thread Provisioning Data
+    chip::DeviceLayer::Internal::DeviceNetworkInfo mThreadInfo = {};
+
+    enum class Mode
+    {
+        Wifi,
+        Thread
+    };
+
+    Mode mMode                                                              = Mode::Wifi;
     DevicePairingDelegate_OnPairingCompleteFunct mOnPairingCompleteCallback = nullptr;
 };
 

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -170,6 +170,7 @@ class DeviceMgrCmd(Cmd):
         "zcl",
 
         "set-pairing-wifi-credential",
+        "set-pairing-thread-credential",
     ]
 
     def parseline(self, line):
@@ -441,6 +442,22 @@ class DeviceMgrCmd(Cmd):
             return
 
         print("WiFi credential set")
+
+    def do_setpairingthreadcredential(self, line):
+        """
+        set-pairing-thread-credential <channel> <panid> <masterkey>
+
+        Set Thread credentials used while pairing device
+        """
+        try:
+            args = shlex.split(line)
+            if len(args) == 3:
+                self.devCtrl.SetThreadCredential(int(args[0]), int(args[1], 16), args[2])
+            else:
+                self.do_help("set-pairing-thread-credential")
+        except exceptions.ChipStackException as ex:
+            print(str(ex))
+            return
 
     def do_history(self, line):
         """

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -430,29 +430,32 @@ class DeviceMgrCmd(Cmd):
 
     def do_setpairingwificredential(self, line):
         """
-        set-pairing-wifi-credential
+        set-pairing-wifi-credential <ssid> <password>
 
-        Set WiFi credential for pairing, will sent to device
+        Set WiFi credential to be used while pairing a Wi-Fi device
         """
         try:
             args = shlex.split(line)
-            self.devCtrl.SetWifiCredential(args[0], args[1])
+            if len(args) == 2:
+                self.devCtrl.SetWifiCredential(args[0], args[1])
+                print("WiFi credential set")
+            else:
+                self.do_help("set-pairing-wifi-credential")
         except exceptions.ChipStackException as ex:
             print(str(ex))
             return
-
-        print("WiFi credential set")
 
     def do_setpairingthreadcredential(self, line):
         """
         set-pairing-thread-credential <channel> <panid> <masterkey>
 
-        Set Thread credentials used while pairing device
+        Set Thread credential to be used while pairing a Thread device
         """
         try:
             args = shlex.split(line)
             if len(args) == 3:
                 self.devCtrl.SetThreadCredential(int(args[0]), int(args[1], 16), args[2])
+                print("Thread credential set")
             else:
                 self.do_help("set-pairing-thread-credential")
         except exceptions.ChipStackException as ex:

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -158,6 +158,11 @@ class ChipDeviceController(object):
         if ret != 0:
             raise self._ChipStack.ErrorToException(res)
 
+    def SetThreadCredential(self, channel, panid, masterKey):
+        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetThreadCredential(self.devCtrl, channel, panid, masterKey.encode("utf-8") + b'\0')
+        if ret != 0:
+            raise self._ChipStack.ErrorToException(ret)
+
     # ----- Private Members -----
     def _InitLib(self):
         if self._dmLib is None:


### PR DESCRIPTION
 #### Problem
While we're waiting for Network Provisioning cluster to be used in the commissioning process, we're unable to use the Python CHIP Controller to control Thread devices.

#### Summary of Changes
Add a command for setting Thread settings to be used during the device commissioning process. It is similar to the existing "set-pairing-wifi-credential" command.

To commission a Thread device over Bluetooth LE, run the following commands:
```
  $ ./chip-device-ctrl.py
  > set-pairing-thread-credential 15 1234 00112233445566778899aabbccddeeff
  > connect -ble 3840 12345678 12344321
```

 By the way, fix #4968.
