### PR TITLE
Change note about external SDKs to use cc13x2_26x2

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -238,13 +238,14 @@ all of the target instances. For example:
 gn desc out/unified '//src/controller(//build/toolchain/host:linux_x64_clang)'
 ```
 
-Note: Some builds are disabled by default as they need extra SDKs. For example,
-to add the EFR32 examples to the unified build, download the
-[SDK](https://github.com/SiliconLabs/sdk_support) and add the following build
-arguments:
+Note: Some platforms that can be build as part of the unified build require
+downloading additional SDKs. To add these to the build, the location of the SDK
+installation must be provided as a build argument. For example, to add the
+Simplelink cc13x2_26x2 examples to the unified build, install the
+[SDK](https://ti.com/chip_sdk) and add the following build arguments:
 
 ```
-gn gen out/unified --args='target_os="all" enable_efr32_builds=true efr32_sdk_root="/path/to/sdk" efr32_board="BRD4161A"'
+gn gen out/unified --args="target_os=\"all\" enable_ti_simplelink_builds=true ti_simplelink_sdk_root=\"/path/to/sdk\" ti_sysconfig_root=\"/path/to/sysconfig\""
 ```
 
 ### Getting Help


### PR DESCRIPTION
The EFR32 platform SDK is now retrieved via submodule and therefore
doesn't require a separate download. Change the note about separate SDKs
to a platform that still does: cc13x2_26x2.