### PR TITLE
Rename some IM MessageDef name in code

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -205,7 +205,7 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
             commandPath.GroupId(aCommandParams.GroupId);
         }
 
-        commandPath.NamespacedClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
+        commandPath.ClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
 
         err = commandPath.GetError();
         SuccessOrExit(err);
@@ -233,7 +233,7 @@ exit:
 }
 
 CHIP_ERROR Command::AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
-                                  const chip::ClusterId aNamespacedClusterId)
+                                  const chip::ClusterId aClusterId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Builder statusElementBuilder;

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -120,7 +120,7 @@ public:
                           chip::CommandId aCommandId, uint8_t Flags);
     CHIP_ERROR AddCommand(CommandParams & aCommandParams);
     CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
-                             const chip::ClusterId aNamespacedClusterId);
+                             const chip::ClusterId aClusterId);
     CHIP_ERROR ClearExistingExchangeContext();
 
     CHIP_ERROR Reset();

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -81,7 +81,7 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
     chip::EndpointId endpointId;
 
     ReturnErrorOnFailure(aCommandElement.GetCommandPath(&commandPath));
-    ReturnErrorOnFailure(commandPath.GetNamespacedClusterId(&clusterId));
+    ReturnErrorOnFailure(commandPath.GetClusterId(&clusterId));
     ReturnErrorOnFailure(commandPath.GetCommandId(&commandId));
     ReturnErrorOnFailure(commandPath.GetEndpointId(&endpointId));
 

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -129,7 +129,7 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
         err = aCommandElement.GetCommandPath(&commandPath);
         SuccessOrExit(err);
 
-        err = commandPath.GetNamespacedClusterId(&clusterId);
+        err = commandPath.GetClusterId(&clusterId);
         SuccessOrExit(err);
 
         err = commandPath.GetCommandId(&commandId);

--- a/src/app/MessageDef/AttributePath.cpp
+++ b/src/app/MessageDef/AttributePath.cpp
@@ -99,18 +99,18 @@ CHIP_ERROR AttributePath::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_NamespacedClusterId:
+        case kCsTag_ClusterId:
             // check if this tag has appeared before
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_NamespacedClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_NamespacedClusterId);
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_ClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_ClusterId);
             VerifyOrExit(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
             if (chip::TLV::kTLVType_UnsignedInteger == reader.GetType())
             {
-                chip::ClusterId namespacedClusterId;
-                reader.Get(namespacedClusterId);
-                PRETTY_PRINT("\tNamespacedClusterId = 0x%" PRIx32 ",", namespacedClusterId);
+                chip::ClusterId clusterId;
+                reader.Get(clusterId);
+                PRETTY_PRINT("\tClusterId = 0x%" PRIx32 ",", clusterId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -152,7 +152,7 @@ CHIP_ERROR AttributePath::Parser::CheckSchemaValidity() const
     if (CHIP_END_OF_TLV == err)
     {
         // check for required fields:
-        const uint16_t RequiredFields = (1 << kCsTag_EndpointId) | (1 << kCsTag_NamespacedClusterId);
+        const uint16_t RequiredFields = (1 << kCsTag_EndpointId) | (1 << kCsTag_ClusterId);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -182,9 +182,9 @@ CHIP_ERROR AttributePath::Parser::GetEndpointId(chip::EndpointId * const apEndpo
     return GetUnsignedInteger(kCsTag_EndpointId, apEndpointId);
 }
 
-CHIP_ERROR AttributePath::Parser::GetNamespacedClusterId(chip::ClusterId * const apClusterId) const
+CHIP_ERROR AttributePath::Parser::GetClusterId(chip::ClusterId * const apClusterId) const
 {
-    return GetUnsignedInteger(kCsTag_NamespacedClusterId, apClusterId);
+    return GetUnsignedInteger(kCsTag_ClusterId, apClusterId);
 }
 
 CHIP_ERROR AttributePath::Parser::GetFieldId(uint8_t * const apFieldId) const
@@ -243,12 +243,12 @@ exit:
     return *this;
 }
 
-AttributePath::Builder & AttributePath::Builder::NamespacedClusterId(const chip::ClusterId aClusterId)
+AttributePath::Builder & AttributePath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
 
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NamespacedClusterId), aClusterId);
+    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
     ChipLogFunctError(mError);
 
 exit:

--- a/src/app/MessageDef/AttributePath.h
+++ b/src/app/MessageDef/AttributePath.h
@@ -39,11 +39,11 @@ namespace app {
 namespace AttributePath {
 enum
 {
-    kCsTag_NodeId              = 0,
-    kCsTag_EndpointId          = 1,
-    kCsTag_NamespacedClusterId = 2,
-    kCsTag_FieldId             = 3,
-    kCsTag_ListIndex           = 4,
+    kCsTag_NodeId     = 0,
+    kCsTag_EndpointId = 1,
+    kCsTag_ClusterId  = 2,
+    kCsTag_FieldId    = 3,
+    kCsTag_ListIndex  = 4,
 };
 
 class Parser : public chip::app::Parser
@@ -104,7 +104,7 @@ public:
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetNamespacedClusterId(chip::ClusterId * const apClusterId) const;
+    CHIP_ERROR GetClusterId(chip::ClusterId * const apClusterId) const;
 
     /**
      *  @brief Get a TLVReader for the FieldId. Next() must be called before accessing them.
@@ -171,13 +171,13 @@ public:
     AttributePath::Builder & EndpointId(const chip::EndpointId aEndpointId);
 
     /**
-     *  @brief Inject NamespacedClusterId into the TLV stream.
+     *  @brief Inject ClusterId into the TLV stream.
      *
-     *  @param [in] aNamespacedClusterId NamespacedClusterId for this attribute path
+     *  @param [in] aClusterId ClusterId for this attribute path
      *
      *  @return A reference to *this
      */
-    AttributePath::Builder & NamespacedClusterId(const chip::ClusterId aNamespacedClusterId);
+    AttributePath::Builder & ClusterId(const chip::ClusterId aClusterId);
 
     /**
      *  @brief Inject FieldId into the TLV stream.

--- a/src/app/MessageDef/CommandPath.cpp
+++ b/src/app/MessageDef/CommandPath.cpp
@@ -99,16 +99,16 @@ CHIP_ERROR CommandPath::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_NamespacedClusterId:
+        case kCsTag_ClusterId:
             // check if this tag has appeared before
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_NamespacedClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_NamespacedClusterId);
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_ClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_ClusterId);
             VerifyOrExit(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                chip::ClusterId namespacedClusterId;
-                reader.Get(namespacedClusterId);
-                PRETTY_PRINT("\tNamespacedClusterId = 0x%" PRIx32 ",", namespacedClusterId);
+                chip::ClusterId clusterId;
+                reader.Get(clusterId);
+                PRETTY_PRINT("\tClusterId = 0x%" PRIx32 ",", clusterId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -135,7 +135,7 @@ CHIP_ERROR CommandPath::Parser::CheckSchemaValidity() const
     if (CHIP_END_OF_TLV == err)
     {
         // check for required fields:
-        const uint16_t RequiredFields = (1 << kCsTag_CommandId) | (1 << kCsTag_NamespacedClusterId);
+        const uint16_t RequiredFields = (1 << kCsTag_CommandId) | (1 << kCsTag_ClusterId);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -164,9 +164,9 @@ CHIP_ERROR CommandPath::Parser::GetGroupId(chip::GroupId * const apGroupId) cons
     return GetUnsignedInteger(kCsTag_GroupId, apGroupId);
 }
 
-CHIP_ERROR CommandPath::Parser::GetNamespacedClusterId(chip::ClusterId * const apClusterId) const
+CHIP_ERROR CommandPath::Parser::GetClusterId(chip::ClusterId * const apClusterId) const
 {
-    return GetUnsignedInteger(kCsTag_NamespacedClusterId, apClusterId);
+    return GetUnsignedInteger(kCsTag_ClusterId, apClusterId);
 }
 
 CHIP_ERROR CommandPath::Parser::GetCommandId(chip::CommandId * const apCommandId) const
@@ -219,12 +219,12 @@ exit:
     return *this;
 }
 
-CommandPath::Builder & CommandPath::Builder::NamespacedClusterId(const chip::ClusterId aClusterId)
+CommandPath::Builder & CommandPath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
 
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NamespacedClusterId), aClusterId);
+    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
     ChipLogFunctError(mError);
 
 exit:

--- a/src/app/MessageDef/CommandPath.h
+++ b/src/app/MessageDef/CommandPath.h
@@ -39,10 +39,10 @@ namespace app {
 namespace CommandPath {
 enum
 {
-    kCsTag_EndpointId          = 0,
-    kCsTag_GroupId             = 1,
-    kCsTag_NamespacedClusterId = 2,
-    kCsTag_CommandId           = 3,
+    kCsTag_EndpointId = 0,
+    kCsTag_GroupId    = 1,
+    kCsTag_ClusterId  = 2,
+    kCsTag_CommandId  = 3,
 };
 
 class Parser : public chip::app::Parser
@@ -95,15 +95,15 @@ public:
     CHIP_ERROR GetGroupId(chip::GroupId * const apGroupId) const;
 
     /**
-     *  @brief Get a TLVReader for the NamespacedClusterId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the ClusterId. Next() must be called before accessing them.
      *
-     *  @param [in] apEndpointId    A pointer to NamespacedClusterId
+     *  @param [in] apEndpointId    A pointer to ClusterId
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetNamespacedClusterId(chip::ClusterId * const apNamespacedClusterId) const;
+    CHIP_ERROR GetClusterId(chip::ClusterId * const apClusterId) const;
 
     /**
      *  @brief Get a TLVReader for the CommandId. Next() must be called before accessing them.
@@ -159,18 +159,18 @@ public:
     CommandPath::Builder & GroupId(const chip::GroupId aGroupId);
 
     /**
-     *  @brief Inject NamespacedClusterId into the TLV stream.
+     *  @brief Inject ClusterId into the TLV stream.
      *
-     *  @param [in] aNamespacedClusterId NamespacedClusterId for this command path
+     *  @param [in] aClusterId ClusterId for this command path
      *
      *  @return A reference to *this
      */
-    CommandPath::Builder & NamespacedClusterId(const chip::ClusterId aNamespacedClusterId);
+    CommandPath::Builder & ClusterId(const chip::ClusterId aClusterId);
 
     /**
      *  @brief Inject CommandId into the TLV stream
      *
-     *  @param [in] aCommandId Command Id for NamespacedClusterId for this command path
+     *  @param [in] aCommandId Command Id for ClusterId for this command path
      *
      *  @return A reference to *this
      */

--- a/src/app/MessageDef/EventDataElement.cpp
+++ b/src/app/MessageDef/EventDataElement.cpp
@@ -254,10 +254,10 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_ImportanceLevel:
+        case kCsTag_PriorityLevel:
             // check if this tag has appeared before
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_ImportanceLevel)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_ImportanceLevel);
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_PriorityLevel)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_PriorityLevel);
             VerifyOrExit(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -266,7 +266,7 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
                 err = reader.Get(value);
                 SuccessOrExit(err);
 
-                PRETTY_PRINT("\tImportanceLevel = 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tPriorityLevel = 0x%" PRIx64 ",", value);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -335,7 +335,7 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
                 err = reader.Get(value);
                 SuccessOrExit(err);
 
-                PRETTY_PRINT("\tDeltaUTCTimestamp= 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tDeltaUTCTimestampstamp= 0x%" PRIx64 ",", value);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -352,7 +352,7 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
                 err = reader.Get(value);
                 SuccessOrExit(err);
 
-                PRETTY_PRINT("\tDeltaSystemTimestamp= 0x%" PRIx64 ",", value);
+                PRETTY_PRINT("\tDeltaSystemTimestamp = 0x%" PRIx64 ",", value);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -372,12 +372,12 @@ CHIP_ERROR EventDataElement::Parser::CheckSchemaValidity() const
     }
     PRETTY_PRINT("},");
     PRETTY_PRINT("");
+
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
         // check for required fields:
-        const uint16_t RequiredFields =
-            (1 << kCsTag_EventPath) | (1 << kCsTag_ImportanceLevel) | (1 << kCsTag_Number) | (1 << kCsTag_Data);
+        const uint16_t RequiredFields = (1 << kCsTag_EventPath) | (1 << kCsTag_PriorityLevel) | (1 << kCsTag_Data);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -416,9 +416,9 @@ exit:
     return err;
 }
 
-CHIP_ERROR EventDataElement::Parser::GetImportanceLevel(uint8_t * const apImportanceLevel)
+CHIP_ERROR EventDataElement::Parser::GetPriorityLevel(uint8_t * const apPriorityLevel)
 {
-    return GetUnsignedInteger(kCsTag_ImportanceLevel, apImportanceLevel);
+    return GetUnsignedInteger(kCsTag_PriorityLevel, apPriorityLevel);
 }
 
 CHIP_ERROR EventDataElement::Parser::GetNumber(uint64_t * const apNumber)
@@ -436,12 +436,12 @@ CHIP_ERROR EventDataElement::Parser::GetSystemTimestamp(uint64_t * const apSyste
     return GetUnsignedInteger(kCsTag_SystemTimestamp, apSystemTimestamp);
 }
 
-CHIP_ERROR EventDataElement::Parser::GetDeltaUTCTime(uint64_t * const apDeltaUTCTimestamp)
+CHIP_ERROR EventDataElement::Parser::GetDeltaUTCTimestamp(uint64_t * const apDeltaUTCTimestampstamp)
 {
-    return GetUnsignedInteger(kCsTag_DeltaUTCTimestamp, apDeltaUTCTimestamp);
+    return GetUnsignedInteger(kCsTag_DeltaUTCTimestamp, apDeltaUTCTimestampstamp);
 }
 
-CHIP_ERROR EventDataElement::Parser::GetDeltaSystemTime(uint64_t * const apDeltaSystemTimestamp)
+CHIP_ERROR EventDataElement::Parser::GetDeltaSystemTimestamp(uint64_t * const apDeltaSystemTimestamp)
 {
     return GetUnsignedInteger(kCsTag_DeltaSystemTimestamp, apDeltaSystemTimestamp);
 }
@@ -473,12 +473,12 @@ exit:
     return mEventPathBuilder;
 }
 
-EventDataElement::Builder EventDataElement::Builder::ImportanceLevel(const uint8_t aImportanceLevel)
+EventDataElement::Builder EventDataElement::Builder::PriorityLevel(const uint8_t aPriorityLevel)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
 
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ImportanceLevel), aImportanceLevel);
+    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_PriorityLevel), aPriorityLevel);
     ChipLogFunctError(mError);
 
 exit:
@@ -521,7 +521,7 @@ exit:
     return *this;
 }
 
-EventDataElement::Builder EventDataElement::Builder::DeltaUTCTime(const uint64_t aDeltaUTCTimestamp)
+EventDataElement::Builder EventDataElement::Builder::DeltaUTCTimestamp(const uint64_t aDeltaUTCTimestamp)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
@@ -533,7 +533,7 @@ exit:
     return *this;
 }
 
-EventDataElement::Builder EventDataElement::Builder::DeltaSystemTime(const uint64_t aDeltaSystemTimestamp)
+EventDataElement::Builder EventDataElement::Builder::DeltaSystemTimestamp(const uint64_t aDeltaSystemTimestamp)
 {
     // skip if error has already been set
     SuccessOrExit(mError);

--- a/src/app/MessageDef/EventDataElement.h
+++ b/src/app/MessageDef/EventDataElement.h
@@ -42,7 +42,7 @@ namespace EventDataElement {
 enum
 {
     kCsTag_EventPath            = 0,
-    kCsTag_ImportanceLevel      = 1,
+    kCsTag_PriorityLevel        = 1,
     kCsTag_Number               = 2,
     kCsTag_UTCTimestamp         = 3,
     kCsTag_SystemTimestamp      = 4,
@@ -92,13 +92,13 @@ public:
     /**
      *  @brief Get a TLVReader for the Number. Next() must be called before accessing them.
      *
-     *  @param [in] apImportanceLevel    A pointer to apImportanceLevel
+     *  @param [in] apPriorityLevel    A pointer to apPriorityLevel
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetImportanceLevel(uint8_t * const apImportanceLevel);
+    CHIP_ERROR GetPriorityLevel(uint8_t * const apPriorityLevel);
 
     /**
      *  @brief Get a TLVReader for the Number. Next() must be called before accessing them.
@@ -134,26 +134,26 @@ public:
     CHIP_ERROR GetSystemTimestamp(uint64_t * const apSystemTimestamp);
 
     /**
-     *  @brief Get a TLVReader for the DeltaUTCTime. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the DeltaUTCTimestamp. Next() must be called before accessing them.
      *
-     *  @param [in] apDeltaUTCTimestamp   A pointer to apDeltaUTCTime
+     *  @param [in] apDeltaUTCTimestampstamp   A pointer to apDeltaUTCTimestamp
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetDeltaUTCTime(uint64_t * const apDeltaUTCTime);
+    CHIP_ERROR GetDeltaUTCTimestamp(uint64_t * const apDeltaUTCTimestamp);
 
     /**
-     *  @brief Get a TLVReader for the DeltaSystemTime. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the DeltaSystemTimestamp. Next() must be called before accessing them.
      *
-     *  @param [in] apDeltaSystemTimestamp   A pointer to apDeltaSystemTime
+     *  @param [in] apDeltaSystemTimestamp   A pointer to apDeltaSystemTimestamp
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetDeltaSystemTime(uint64_t * const apDeltaSystemTime);
+    CHIP_ERROR GetDeltaSystemTimestamp(uint64_t * const apDeltaSystemTimestamp);
 
     /**
      *  @brief Get a TLVReader for the Data. Next() must be called before accessing them.
@@ -190,19 +190,19 @@ public:
     EventPath::Builder & CreateEventPathBuilder();
 
     /**
-     *  @brief Inject ImportanceLevel into the TLV stream to indicate the importance level associated with
+     *  @brief Inject PriorityLevel into the TLV stream to indicate the priority level associated with
      *  the cluster that is referenced by the path.
      *
-     *  @param [in] aImportanceLevel This is an integer representation of the importance level.
+     *  @param [in] aPriorityLevel This is an integer representation of the priority level.
      *
      *  @return A reference to *this
      */
-    EventDataElement::Builder ImportanceLevel(const uint8_t aImportanceLevel);
+    EventDataElement::Builder PriorityLevel(const uint8_t aPriorityLevel);
 
     /**
      *  @brief Inject Number into the TLV stream to indicate the number associated with
      *  the cluster that is referenced by the path. The event number is a monotonically increasing number that
-     *  uniquely identifies each emitted event. This number is scoped to the ImportanceLevel.
+     *  uniquely identifies each emitted event. This number is scoped to the PriorityLevel.
      *
      *  @param [in] aNumber The uint64_t variable to reflectt the event number
      *
@@ -231,26 +231,26 @@ public:
     EventDataElement::Builder SystemTimestamp(const uint64_t aSystemTimestamp);
 
     /**
-     *  @brief Inject DeltaUTCTime into the TLV stream.
+     *  @brief Inject DeltaUTCTimestamp into the TLV stream.
      *      This field is present if delta encoding of the UTC timestamp relative to a prior event is desired for compression
      *      reasons. When this field is present, the UTC Timestamp field SHALL be omitted.
      *
-     *  @param [in] aDeltaUTCTime The uint64_t variable to reflect DeltaUTCTime
+     *  @param [in] aDeltaUTCTimestamp The uint64_t variable to reflect DeltaUTCTimestamp
      *
      *  @return A reference to *this
      */
-    EventDataElement::Builder DeltaUTCTime(const uint64_t aDeltaUTCTime);
+    EventDataElement::Builder DeltaUTCTimestamp(const uint64_t aDeltaUTCTimestamp);
 
     /**
      *  @brief Inject DeltaSystemTimestamp into the TLV stream.
      *  This field is present if delta encoding of the System timestamp relative to a prior event is desired for compression
      * reasons. When this field is present, the System Timestamp field SHALL be omitted.
      *
-     *  @param [in] DeltaSystemTimestamp The uint64_t variable to reflect DeltaSystemTime
+     *  @param [in] DeltaSystemTimestamp The uint64_t variable to reflect DeltaSystemTimestamp
      *
      *  @return A reference to *this
      */
-    EventDataElement::Builder DeltaSystemTime(const uint64_t aDeltaSystemTime);
+    EventDataElement::Builder DeltaSystemTimestamp(const uint64_t aDeltaSystemTimestamp);
 
     /**
      *  @brief Mark the end of this EventDataElement

--- a/src/app/MessageDef/EventPath.cpp
+++ b/src/app/MessageDef/EventPath.cpp
@@ -99,17 +99,17 @@ CHIP_ERROR EventPath::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_NamespacedClusterId:
+        case kCsTag_ClusterId:
             // check if this tag has appeared before
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_NamespacedClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_NamespacedClusterId);
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_ClusterId)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_ClusterId);
             VerifyOrExit(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
             {
-                chip::ClusterId namespacedClusterId;
-                reader.Get(namespacedClusterId);
-                PRETTY_PRINT("\tNamespacedClusterId = 0x%" PRIx32 ",", namespacedClusterId);
+                chip::ClusterId clusterId;
+                reader.Get(clusterId);
+                PRETTY_PRINT("\tClusterId = 0x%" PRIx32 ",", clusterId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -139,7 +139,7 @@ CHIP_ERROR EventPath::Parser::CheckSchemaValidity() const
     if (CHIP_END_OF_TLV == err)
     {
         // check for required fields:
-        const uint16_t RequiredFields = (1 << kCsTag_EndpointId) | (1 << kCsTag_NamespacedClusterId);
+        const uint16_t RequiredFields = (1 << kCsTag_EndpointId) | (1 << kCsTag_ClusterId);
 
         if ((TagPresenceMask & RequiredFields) == RequiredFields)
         {
@@ -169,9 +169,9 @@ CHIP_ERROR EventPath::Parser::GetEndpointId(chip::EndpointId * const apEndpointI
     return GetUnsignedInteger(kCsTag_EndpointId, apEndpointID);
 }
 
-CHIP_ERROR EventPath::Parser::GetNamespacedClusterId(chip::ClusterId * const apClusterId) const
+CHIP_ERROR EventPath::Parser::GetClusterId(chip::ClusterId * const apClusterId) const
 {
-    return GetUnsignedInteger(kCsTag_NamespacedClusterId, apClusterId);
+    return GetUnsignedInteger(kCsTag_ClusterId, apClusterId);
 }
 
 CHIP_ERROR EventPath::Parser::GetEventId(chip::EventId * const apEventId) const
@@ -224,12 +224,12 @@ exit:
     return *this;
 }
 
-EventPath::Builder & EventPath::Builder::NamespacedClusterId(const chip::ClusterId aClusterId)
+EventPath::Builder & EventPath::Builder::ClusterId(const chip::ClusterId aClusterId)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
 
-    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_NamespacedClusterId), aClusterId);
+    mError = mpWriter->Put(chip::TLV::ContextTag(kCsTag_ClusterId), aClusterId);
     ChipLogFunctError(mError);
 
 exit:

--- a/src/app/MessageDef/EventPath.h
+++ b/src/app/MessageDef/EventPath.h
@@ -39,10 +39,10 @@ namespace app {
 namespace EventPath {
 enum
 {
-    kCsTag_NodeId              = 0,
-    kCsTag_EndpointId          = 1,
-    kCsTag_NamespacedClusterId = 2,
-    kCsTag_EventId             = 3,
+    kCsTag_NodeId     = 0,
+    kCsTag_EndpointId = 1,
+    kCsTag_ClusterId  = 2,
+    kCsTag_EventId    = 3,
 };
 
 class Parser : public chip::app::Parser
@@ -95,15 +95,15 @@ public:
     CHIP_ERROR GetEndpointId(chip::EndpointId * const apEndpointId) const;
 
     /**
-     *  @brief Get a TLVReader for the NamespacedClusterId. Next() must be called before accessing them.
+     *  @brief Get a TLVReader for the ClusterId. Next() must be called before accessing them.
      *
-     *  @param [in] apNamespacedClusterId    A pointer to apNamespacedClusterId
+     *  @param [in] apClusterId    A pointer to apClusterId
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetNamespacedClusterId(chip::ClusterId * const apNamespacedClusterId) const;
+    CHIP_ERROR GetClusterId(chip::ClusterId * const apClusterId) const;
 
     /**
      *  @brief Get a TLVReader for the EventId. Next() must be called before accessing them.
@@ -159,18 +159,18 @@ public:
     EventPath::Builder & EndpointId(const chip::EndpointId aEndpointId);
 
     /**
-     *  @brief Inject NamespacedClusterId into the TLV stream.
+     *  @brief Inject ClusterId into the TLV stream.
      *
-     *  @param [in] aNamespacedClusterId NamespacedClusterId for this event path
+     *  @param [in] aClusterId ClusterId for this event path
      *
      *  @return A reference to *this
      */
-    EventPath::Builder & NamespacedClusterId(const chip::ClusterId aNamespacedClusterId);
+    EventPath::Builder & ClusterId(const chip::ClusterId aClusterId);
 
     /**
      *  @brief Inject EventId into the TLV stream.
      *
-     *  @param [in] aEventId NamespacedClusterId for this event path
+     *  @param [in] aEventId ClusterId for this event path
      *
      *  @return A reference to *this
      */

--- a/src/app/MessageDef/ReportData.cpp
+++ b/src/app/MessageDef/ReportData.cpp
@@ -75,16 +75,16 @@ CHIP_ERROR ReportData::Parser::CheckSchemaValidity() const
 
         switch (chip::TLV::TagNumFromTag(reader.GetTag()))
         {
-        case kCsTag_RequestResponse:
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_RequestResponse)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_RequestResponse);
+        case kCsTag_SuppressResponse:
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_SuppressResponse)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_SuppressResponse);
             VerifyOrExit(chip::TLV::kTLVType_Boolean == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                bool RequestResponse;
-                err = reader.Get(RequestResponse);
+                bool SuppressResponse;
+                err = reader.Get(SuppressResponse);
                 SuccessOrExit(err);
-                PRETTY_PRINT("\tRequestResponse = %s, ", RequestResponse ? "true" : "false");
+                PRETTY_PRINT("\tSuppressResponse = %s, ", SuppressResponse ? "true" : "false");
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -149,16 +149,16 @@ CHIP_ERROR ReportData::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case kCsTag_IsLastReport:
-            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_IsLastReport)), err = CHIP_ERROR_INVALID_TLV_TAG);
-            TagPresenceMask |= (1 << kCsTag_IsLastReport);
+        case kCsTag_MoreChunkedMessages:
+            VerifyOrExit(!(TagPresenceMask & (1 << kCsTag_MoreChunkedMessages)), err = CHIP_ERROR_INVALID_TLV_TAG);
+            TagPresenceMask |= (1 << kCsTag_MoreChunkedMessages);
             VerifyOrExit(chip::TLV::kTLVType_Boolean == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
-                bool isLastReport;
-                err = reader.Get(isLastReport);
+                bool moreChunkedMessages;
+                err = reader.Get(moreChunkedMessages);
                 SuccessOrExit(err);
-                PRETTY_PRINT("\tisLastReport = %s, ", isLastReport ? "true" : "false");
+                PRETTY_PRINT("\tMoreChunkedMessages = %s, ", moreChunkedMessages ? "true" : "false");
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -182,9 +182,9 @@ exit:
 }
 #endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
-CHIP_ERROR ReportData::Parser::GetRequestResponse(bool * const apRequestResponse) const
+CHIP_ERROR ReportData::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {
-    return GetSimpleValue(kCsTag_RequestResponse, chip::TLV::kTLVType_Boolean, apRequestResponse);
+    return GetSimpleValue(kCsTag_SuppressResponse, chip::TLV::kTLVType_Boolean, apSuppressResponse);
 }
 
 CHIP_ERROR ReportData::Parser::GetSubscriptionId(uint64_t * const apSubscriptionId) const
@@ -249,9 +249,9 @@ exit:
     return err;
 }
 
-CHIP_ERROR ReportData::Parser::GetIsLastReport(bool * const apIsLastReport) const
+CHIP_ERROR ReportData::Parser::GetMoreChunkedMessages(bool * const apMoreChunkedMessages) const
 {
-    return GetSimpleValue(kCsTag_IsLastReport, chip::TLV::kTLVType_Boolean, apIsLastReport);
+    return GetSimpleValue(kCsTag_MoreChunkedMessages, chip::TLV::kTLVType_Boolean, apMoreChunkedMessages);
 }
 
 CHIP_ERROR ReportData::Builder::Init(chip::TLV::TLVWriter * const apWriter)
@@ -259,15 +259,14 @@ CHIP_ERROR ReportData::Builder::Init(chip::TLV::TLVWriter * const apWriter)
     return InitAnonymousStructure(apWriter);
 }
 
-ReportData::Builder & ReportData::Builder::RequestResponse(const bool aRequestResponse)
+ReportData::Builder & ReportData::Builder::SuppressResponse(const bool aSuppressResponse)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
-
-    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_RequestResponse), aRequestResponse);
-    ChipLogFunctError(mError);
+    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_SuppressResponse), aSuppressResponse);
 
 exit:
+    ChipLogFunctError(mError);
     return *this;
 }
 
@@ -319,12 +318,12 @@ exit:
     return mEventDataListBuilder;
 }
 
-ReportData::Builder & ReportData::Builder::IsLastReport(const bool aIsLastReport)
+ReportData::Builder & ReportData::Builder::MoreChunkedMessages(const bool aMoreChunkedMessages)
 {
     // skip if error has already been set
     SuccessOrExit(mError);
 
-    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_IsLastReport), aIsLastReport);
+    mError = mpWriter->PutBoolean(chip::TLV::ContextTag(kCsTag_MoreChunkedMessages), aMoreChunkedMessages);
     ChipLogFunctError(mError);
 
 exit:

--- a/src/app/MessageDef/ReportData.h
+++ b/src/app/MessageDef/ReportData.h
@@ -43,12 +43,12 @@ namespace app {
 namespace ReportData {
 enum
 {
-    kCsTag_RequestResponse     = 0,
+    kCsTag_SuppressResponse    = 0,
     kCsTag_SubscriptionId      = 1,
     kCsTag_AttributeStatusList = 2,
     kCsTag_AttributeDataList   = 3,
     kCsTag_EventDataList       = 4,
-    kCsTag_IsLastReport        = 5,
+    kCsTag_MoreChunkedMessages = 5,
 };
 
 class Parser : public chip::app::Parser
@@ -79,19 +79,20 @@ public:
     CHIP_ERROR CheckSchemaValidity() const;
 
     /**
-     *  @brief Check whether this message needs request response. Next() must be called before accessing them.
+     *  @brief Check whether a response (a StatusReponse specifically) is to be sent back to the request.
+     *  Next() must be called before accessing them.
      *
-     *  @param [in] apRequestResponse    A pointer to apRequestResponse
+     *  @param [in] apSuppressResponse    A pointer to apSuppressResponse
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetRequestResponse(bool * const apRequestResponse) const;
+    CHIP_ERROR GetSuppressResponse(bool * const apSuppressResponse) const;
 
     /**
      *  @brief Get Subscription Id. Next() must be called before accessing them.
      *
-     *  @param [in] apSubscriptionId    A pointer to apIsLastReport
+     *  @param [in] apSubscriptionId    A pointer to apSubscriptionId
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
@@ -132,14 +133,14 @@ public:
     CHIP_ERROR GetEventDataList(EventList::Parser * const apEventDataList) const;
 
     /**
-     *  @brief Check whether this message is last report. Next() must be called before accessing them.
+     *  @brief Check whether there are more chunked messages in a transaction. Next() must be called before accessing them.
      *
-     *  @param [in] apIsLastReport    A pointer to apIsLastReport
+     *  @param [in] apMoreChunkedMessages   A pointer to apMoreChunkedMessages
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element
      */
-    CHIP_ERROR GetIsLastReport(bool * const apIsLastReport) const;
+    CHIP_ERROR GetMoreChunkedMessages(bool * const apMoreChunkedMessages) const;
 };
 
 class Builder : public chip::app::Builder
@@ -155,14 +156,14 @@ public:
     CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter);
 
     /**
-     *  @brief Inject RequestResponse into the TLV stream to indicate whether a response (a StatusReponse specifically)
+     *  @brief Inject SuppressResponse into the TLV stream to indicate whether a response (a StatusResponse specifically)
      *  is to be sent back to the request.
      *
-     *  @param [in] aRequestResponse The boolean variable to indicate if request response is needed.
+     *  @param [in] aSuppressResponse The boolean variable to indicate if request response is needed.
      *
      *  @return A reference to *this
      */
-    ReportData::Builder & RequestResponse(const bool aRequestResponse);
+    ReportData::Builder & SuppressResponse(const bool aSuppressResponse);
 
     /**
      *  @brief Inject subscription id into the TLV stream, This field contains the Subscription ID
@@ -199,12 +200,11 @@ public:
     EventList::Builder & CreateEventDataListBuilder();
 
     /**
-     *  @brief This flag is set to ‘true’ when this is the last ReportDataRequest message
-     *  in a transaction and there are no more Changes to be conveyed.
-     *  @param [in] aIsLastReport The boolean variable to indicate if it is LastReport
+     *  @brief This flag is set to ‘true’ when there are more chunked messages in a transaction.
+     *  @param [in] aMoreChunkedMessages The boolean variable to indicate if there are more chunked messages in a transaction.
      *  @return A reference to *this
      */
-    ReportData::Builder & IsLastReport(const bool aIsLastReport);
+    ReportData::Builder & MoreChunkedMessages(const bool aMoreChunkedMessages);
 
     /**
      *  @brief Mark the end of this ReportData

--- a/src/app/MessageDef/StatusElement.cpp
+++ b/src/app/MessageDef/StatusElement.cpp
@@ -151,19 +151,19 @@ CHIP_ERROR StatusElement::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
         }
-        else if (!(TagPresenceMask & (1 << kCsTag_NamespacedClusterId)))
+        else if (!(TagPresenceMask & (1 << kCsTag_ClusterId)))
         {
-            TagPresenceMask |= (1 << kCsTag_NamespacedClusterId);
+            TagPresenceMask |= (1 << kCsTag_ClusterId);
 
             VerifyOrExit(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
             {
-                chip::ClusterId namespacedClusterId;
-                err = reader.Get(namespacedClusterId);
+                chip::ClusterId clusterId;
+                err = reader.Get(clusterId);
                 SuccessOrExit(err);
 
-                PRETTY_PRINT("\tNamespacedClusterId = 0x%" PRIx32 ",", namespacedClusterId);
+                PRETTY_PRINT("\tClusterId = 0x%" PRIx32 ",", clusterId);
             }
 #endif // CHIP_DETAIL_LOGGING
         }
@@ -210,7 +210,7 @@ CHIP_ERROR StatusElement::Builder::Init(chip::TLV::TLVWriter * const apWriter, c
 
 StatusElement::Builder & StatusElement::Builder::EncodeStatusElement(const uint16_t aGeneralCode, const uint32_t aProtocolId,
                                                                      const uint16_t aStatusElement,
-                                                                     const chip::ClusterId aNamespacedClusterId)
+                                                                     const chip::ClusterId aClusterId)
 {
     uint64_t tag = chip::TLV::AnonymousTag;
 
@@ -225,7 +225,7 @@ StatusElement::Builder & StatusElement::Builder::EncodeStatusElement(const uint1
     mError = mpWriter->Put(tag, aStatusElement);
     SuccessOrExit(mError);
 
-    mError = mpWriter->Put(tag, aNamespacedClusterId);
+    mError = mpWriter->Put(tag, aClusterId);
     SuccessOrExit(mError);
 
 exit:

--- a/src/app/MessageDef/StatusElement.h
+++ b/src/app/MessageDef/StatusElement.h
@@ -40,10 +40,10 @@ namespace app {
 namespace StatusElement {
 enum
 {
-    kCsTag_GeneralCode         = 1,
-    kCsTag_ProtocolId          = 2,
-    kCsTag_ProtocolCode        = 3,
-    kCsTag_NamespacedClusterId = 4
+    kCsTag_GeneralCode  = 1,
+    kCsTag_ProtocolId   = 2,
+    kCsTag_ProtocolCode = 3,
+    kCsTag_ClusterId    = 4
 };
 
 class Parser : public ListParser
@@ -74,19 +74,19 @@ public:
     CHIP_ERROR CheckSchemaValidity() const;
 
     /**
-    `* Read the GeneralCode, ProtocolId, ProtocolCode, NamespacedClusterId
+    `* Read the GeneralCode, ProtocolId, ProtocolCode, ClusterId
      *
      * @param[out]   apGeneralCode     Pointer to the storage for the GeneralCode
      * @param[out]   apProtocolId     Pointer to the storage for the ProtocolId
      * @param[out]   apProtocolCode   Pointer to the storage for the ProtocolCode
-     * @param[out]   apNamespacedClusterId     Pointer to the storage for the NamespacedClusterId
+     * @param[out]   apClusterId     Pointer to the storage for the ClusterId
      *
      * @return       CHIP_ERROR codes returned by chip::TLV objects. CHIP_END_OF_TLV if either
      *               element is missing. CHIP_ERROR_WRONG_TLV_TYPE if the elements are of the wrong
      *               type.
      */
     CHIP_ERROR DecodeStatusElement(uint16_t * apGeneralCode, uint32_t * apProtocolId, uint16_t * apProtocolCode,
-                                   chip::ClusterId * apNamespacedClusterId) const;
+                                   chip::ClusterId * apClusterId) const;
 };
 
 class Builder : public ListBuilder
@@ -113,19 +113,19 @@ public:
     CHIP_ERROR Init(chip::TLV::TLVWriter * const apWriter, const uint8_t aContextTagToUse);
 
     /**
-    `* Read the GeneralCode, ProtocolId, ProtocolCode, NamespacedClusterId
+    `* Read the GeneralCode, ProtocolId, ProtocolCode, ClusterId
      *
      * @param[in]   aGeneralCode    General status code
      * @param[in]   aProtocolId     A protocol ID (32-bit integer composed of a 16-bit vendor id and 16-bit Scoped id)
      * @param[in]   aProtocolCode   16-bit protocol-specific error code
-     * @param[in]   aNamespacedClusterId      Cluster Id for ZCL
+     * @param[in]   aClusterId      Cluster Id for ZCL
      *
      * @return       CHIP_ERROR codes returned by chip::TLV objects. CHIP_END_OF_TLV if either
      *               element is missing. CHIP_ERROR_WRONG_TLV_TYPE if the elements are of the wrong
      *               type.
      */
     StatusElement::Builder & EncodeStatusElement(const uint16_t aGeneralCode, const uint32_t aProtocolId,
-                                                 const uint16_t aProtocolCode, const chip::ClusterId aNamespacedClusterId);
+                                                 const uint16_t aProtocolCode, const chip::ClusterId aClusterId);
 
     /**
      *  @brief Mark the end of this StatusElement

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -68,7 +68,7 @@ CHIP_ERROR DebugPrettyPrint(const chip::System::PacketBufferHandle & aMsgBuf)
 void BuildAttributePath(nlTestSuite * apSuite, AttributePath::Builder & aAttributePathBuilder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    aAttributePathBuilder.NodeId(1).EndpointId(2).NamespacedClusterId(3).FieldId(4).ListIndex(5).EndOfAttributePath();
+    aAttributePathBuilder.NodeId(1).EndpointId(2).ClusterId(3).FieldId(4).ListIndex(5).EndOfAttributePath();
     err = aAttributePathBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
@@ -76,12 +76,12 @@ void BuildAttributePath(nlTestSuite * apSuite, AttributePath::Builder & aAttribu
 void ParseAttributePath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 {
     AttributePath::Parser attributePathParser;
-    CHIP_ERROR err                      = CHIP_NO_ERROR;
-    chip::NodeId nodeId                 = 1;
-    chip::EndpointId endpointId         = 2;
-    chip::ClusterId namespacedClusterId = 3;
-    uint8_t fieldId                     = 4;
-    uint16_t listIndex                  = 5;
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    chip::NodeId nodeId         = 1;
+    chip::EndpointId endpointId = 2;
+    chip::ClusterId clusterId   = 3;
+    uint8_t fieldId             = 4;
+    uint16_t listIndex          = 5;
 
     err = attributePathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -95,8 +95,8 @@ void ParseAttributePath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = attributePathParser.GetEndpointId(&endpointId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && endpointId == 2);
 
-    err = attributePathParser.GetNamespacedClusterId(&namespacedClusterId);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && namespacedClusterId == 3);
+    err = attributePathParser.GetClusterId(&clusterId);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && clusterId == 3);
 
     err = attributePathParser.GetFieldId(&fieldId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && fieldId == 4);
@@ -131,18 +131,18 @@ void ParseAttributePathList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
 void BuildEventPath(nlTestSuite * apSuite, EventPath::Builder & aEventPathBuilder)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    aEventPathBuilder.NodeId(1).EndpointId(2).NamespacedClusterId(3).EventId(4).EndOfEventPath();
+    aEventPathBuilder.NodeId(1).EndpointId(2).ClusterId(3).EventId(4).EndOfEventPath();
     err = aEventPathBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 
 void ParseEventPath(nlTestSuite * apSuite, EventPath::Parser & aEventPathParser)
 {
-    CHIP_ERROR err                      = CHIP_NO_ERROR;
-    chip::NodeId nodeId                 = 1;
-    chip::EndpointId endpointId         = 2;
-    chip::ClusterId namespacedClusterId = 3;
-    chip::EventId eventId               = 4;
+    CHIP_ERROR err              = CHIP_NO_ERROR;
+    chip::NodeId nodeId         = 1;
+    chip::EndpointId endpointId = 2;
+    chip::ClusterId clusterId   = 3;
+    chip::EventId eventId       = 4;
 
     err = aEventPathParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -153,8 +153,8 @@ void ParseEventPath(nlTestSuite * apSuite, EventPath::Parser & aEventPathParser)
     err = aEventPathParser.GetEndpointId(&endpointId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && endpointId == 2);
 
-    err = aEventPathParser.GetNamespacedClusterId(&namespacedClusterId);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && namespacedClusterId == 3);
+    err = aEventPathParser.GetClusterId(&clusterId);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && clusterId == 3);
 
     err = aEventPathParser.GetEventId(&eventId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && eventId == 4);
@@ -184,7 +184,7 @@ void ParseEventPathList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
 void BuildCommandPath(nlTestSuite * apSuite, CommandPath::Builder & aCommandPathBuilder)
 {
-    aCommandPathBuilder.EndpointId(1).NamespacedClusterId(3).CommandId(4).EndOfCommandPath();
+    aCommandPathBuilder.EndpointId(1).ClusterId(3).CommandId(4).EndOfCommandPath();
     NL_TEST_ASSERT(apSuite, aCommandPathBuilder.GetError() == CHIP_NO_ERROR);
 }
 
@@ -192,9 +192,9 @@ void ParseCommandPath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandPath::Parser commandPathParser;
-    chip::EndpointId endpointId         = 0;
-    chip::ClusterId namespacedClusterId = 0;
-    chip::CommandId commandId           = 0;
+    chip::EndpointId endpointId = 0;
+    chip::ClusterId clusterId   = 0;
+    chip::CommandId commandId   = 0;
 
     err = commandPathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -205,8 +205,8 @@ void ParseCommandPath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = commandPathParser.GetEndpointId(&endpointId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && endpointId == 1);
 
-    err = commandPathParser.GetNamespacedClusterId(&namespacedClusterId);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && namespacedClusterId == 3);
+    err = commandPathParser.GetClusterId(&clusterId);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && clusterId == 3);
 
     err = commandPathParser.GetCommandId(&commandId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && commandId == 4);
@@ -220,7 +220,12 @@ void BuildEventDataElement(nlTestSuite * apSuite, EventDataElement::Builder & aE
     NL_TEST_ASSERT(apSuite, eventPathBuilder.GetError() == CHIP_NO_ERROR);
     BuildEventPath(apSuite, eventPathBuilder);
 
-    aEventDataElementBuilder.ImportanceLevel(2).Number(3).UTCTimestamp(4).SystemTimestamp(5).DeltaUTCTime(6).DeltaSystemTime(7);
+    aEventDataElementBuilder.PriorityLevel(2)
+        .Number(3)
+        .UTCTimestamp(4)
+        .SystemTimestamp(5)
+        .DeltaUTCTimestamp(6)
+        .DeltaSystemTimestamp(7);
     err = aEventDataElementBuilder.GetError();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     // Construct test event data
@@ -243,13 +248,13 @@ void BuildEventDataElement(nlTestSuite * apSuite, EventDataElement::Builder & aE
 
 void ParseEventDataElement(nlTestSuite * apSuite, EventDataElement::Parser & aEventDataElementParser)
 {
-    CHIP_ERROR err           = CHIP_NO_ERROR;
-    uint8_t importanceLevel  = 0;
-    uint64_t number          = 0;
-    uint64_t uTCTimestamp    = 0;
-    uint64_t systemTimestamp = 0;
-    uint64_t deltaUTCTime    = 0;
-    uint64_t deltaSystemTime = 0;
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    uint8_t importanceLevel       = 0;
+    uint64_t number               = 0;
+    uint64_t uTCTimestamp         = 0;
+    uint64_t systemTimestamp      = 0;
+    uint64_t deltaUTCTimestamp    = 0;
+    uint64_t deltaSystemTimestamp = 0;
 
     err = aEventDataElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -260,7 +265,7 @@ void ParseEventDataElement(nlTestSuite * apSuite, EventDataElement::Parser & aEv
             err = aEventDataElementParser.GetEventPath(&eventPath);
             NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         }
-        err = aEventDataElementParser.GetImportanceLevel(&importanceLevel);
+        err = aEventDataElementParser.GetPriorityLevel(&importanceLevel);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && importanceLevel == 2);
         err = aEventDataElementParser.GetNumber(&number);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && number == 3);
@@ -268,10 +273,10 @@ void ParseEventDataElement(nlTestSuite * apSuite, EventDataElement::Parser & aEv
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && uTCTimestamp == 4);
         err = aEventDataElementParser.GetSystemTimestamp(&systemTimestamp);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && systemTimestamp == 5);
-        err = aEventDataElementParser.GetDeltaUTCTime(&deltaUTCTime);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && deltaUTCTime == 6);
-        err = aEventDataElementParser.GetDeltaSystemTime(&deltaSystemTime);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && deltaSystemTime == 7);
+        err = aEventDataElementParser.GetDeltaUTCTimestamp(&deltaUTCTimestamp);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && deltaUTCTimestamp == 6);
+        err = aEventDataElementParser.GetDeltaSystemTimestamp(&deltaSystemTimestamp);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && deltaSystemTimestamp == 7);
 
         {
             chip::TLV::TLVReader reader;
@@ -329,17 +334,16 @@ void ParseStatusElement(nlTestSuite * apSuite, StatusElement::Parser & aStatusEl
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Parser StatusElementParser;
 
-    uint16_t generalCode                = 0;
-    uint32_t protocolId                 = 0;
-    uint16_t protocolCode               = 0;
-    chip::ClusterId namespacedClusterId = 0;
+    uint16_t generalCode      = 0;
+    uint32_t protocolId       = 0;
+    uint16_t protocolCode     = 0;
+    chip::ClusterId clusterId = 0;
 
     err = aStatusElementParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = aStatusElementParser.DecodeStatusElement(&generalCode, &protocolId, &protocolCode, &namespacedClusterId);
-    NL_TEST_ASSERT(apSuite,
-                   err == CHIP_NO_ERROR && generalCode == 1 && protocolId == 2 && protocolCode == 3 && namespacedClusterId == 4);
+    err = aStatusElementParser.DecodeStatusElement(&generalCode, &protocolId, &protocolCode, &clusterId);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && generalCode == 1 && protocolId == 2 && protocolCode == 3 && clusterId == 4);
 }
 
 void BuildAttributeStatusElement(nlTestSuite * apSuite, AttributeStatusElement::Builder & aAttributeStatusElementBuilder)
@@ -597,7 +601,7 @@ void BuildReportData(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
     err = reportDataBuilder.Init(&aWriter);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    reportDataBuilder.RequestResponse(1).SubscriptionId(2);
+    reportDataBuilder.SuppressResponse(true).SubscriptionId(2);
     NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
 
     AttributeStatusList::Builder attributeStatusList = reportDataBuilder.CreateAttributeStatusListBuilder();
@@ -612,7 +616,7 @@ void BuildReportData(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)
     NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
     BuildEventList(apSuite, eventList);
 
-    reportDataBuilder.IsLastReport(6);
+    reportDataBuilder.MoreChunkedMessages(true);
     NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
 
     reportDataBuilder.EndOfReportData();
@@ -624,19 +628,19 @@ void ParseReportData(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     CHIP_ERROR err = CHIP_NO_ERROR;
     ReportData::Parser reportDataParser;
 
-    bool requestResponse    = false;
+    bool suppressResponse   = false;
     uint64_t subscriptionId = 0;
     AttributeStatusList::Parser attributeStatusListParser;
     AttributeDataList::Parser attributeDataListParser;
     EventList::Parser eventListParser;
-    bool isLastReport = false;
+    bool moreChunkedMessages = false;
     reportDataParser.Init(aReader);
 
     err = reportDataParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = reportDataParser.GetRequestResponse(&requestResponse);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && requestResponse);
+    err = reportDataParser.GetSuppressResponse(&suppressResponse);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && suppressResponse);
 
     err = reportDataParser.GetSubscriptionId(&subscriptionId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && subscriptionId == 2);
@@ -650,8 +654,8 @@ void ParseReportData(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = reportDataParser.GetEventDataList(&eventListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = reportDataParser.GetIsLastReport(&isLastReport);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && isLastReport);
+    err = reportDataParser.GetMoreChunkedMessages(&moreChunkedMessages);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && moreChunkedMessages);
 }
 
 void BuildInvokeCommand(nlTestSuite * apSuite, chip::TLV::TLVWriter & aWriter)


### PR DESCRIPTION
Problems:
Need to align with IM encoding spec regarding naming

Summary of Changes
-- Rename related words following  ClusterId, DeltaUTCTimestamp, PriorityLevel, MoreChunkedMessages,SuppressResponse in spec
