### PR TITLE
Fix Platform::New to return nullptr on failure

### DIFF
--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -165,7 +165,12 @@ extern void MemoryFree(void * p);
 template <typename T, typename... Args>
 inline T * New(Args &&... args)
 {
-    return new (MemoryAlloc(sizeof(T))) T(std::forward<Args>(args)...);
+    void * p = MemoryAlloc(sizeof(T));
+    if (p != nullptr)
+    {
+        return new (p) T(std::forward<Args>(args)...);
+    }
+    return nullptr;
 }
 
 /**


### PR DESCRIPTION
#### Problem

`Platform::New()` uses placement `new` into a possibly-null pointer.

#### Summary of Changes

Check the return value of `MemoryAlloc` before using it.

Fixes #4998 platform::New will crash or do other bad things on allocation failure
