### PR TITLE
Add GetRemainingFreeLength

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -1774,6 +1774,12 @@ public:
     uint32_t GetLengthWritten() const { return mLenWritten; }
 
     /**
+     * Returns the total remaining number of bytes for current tlv writer
+     *
+     * @return the total remaining number of bytes.
+     */
+    uint32_t GetRemainingFreeLength() const { return mRemainingLen; }
+    /**
      * The profile id of tags that should be encoded in implicit form.
      *
      * When a writer is asked to encode a new element, if the profile id of the tag associated with the
@@ -2202,7 +2208,6 @@ class DLL_EXPORT TLVBackingStore
 {
 public:
     virtual ~TLVBackingStore() {}
-
     /**
      * A function to provide a backing store's initial start position and data length to a reader.
      *

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -1344,9 +1344,13 @@ void CheckSimpleWriteRead(nlTestSuite * inSuite, void * inContext)
     uint8_t buf[2048];
     TLVWriter writer;
     TLVReader reader;
+    uint32_t remainingFreedLen;
 
     writer.Init(buf, sizeof(buf));
     writer.ImplicitProfileId = TestProfile_2;
+
+    remainingFreedLen = writer.GetRemainingFreeLength();
+    NL_TEST_ASSERT(inSuite, sizeof(buf) == remainingFreedLen);
 
     WriteEncoding1(inSuite, writer);
 


### PR DESCRIPTION
Problems:
we need GetRemainingFreeLength to check the remaning length of tlv
buffer in im eventing feature.

SummaryOfChanges:
-- Add GetRemainingFreeLength to get the total remaining number of bytes
for current tlv writer.