### PR TITLE
Add ability to redirect CHIP logs to a callback and add python log callback integration

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -43,6 +43,7 @@ shared_library("ChipDeviceCtrl") {
     "ChipDeviceController-ScriptDevicePairingDelegate.h",
     "ChipDeviceController-StorageDelegate.cpp",
     "ChipDeviceController-StorageDelegate.h",
+    "chip/logging/LoggingRedirect.cpp",
     "chip/native/StackInit.cpp",
   ]
 
@@ -82,6 +83,9 @@ pw_python_action("python") {
         "chip/ChipUtility.py",
         "chip/__init__.py",
         "chip/exceptions/__init__.py",
+        "chip/logging/__init__.py",
+        "chip/logging/library_handle.py",
+        "chip/logging/types.py",
         "chip/native/__init__.py",
         "chip/tlv/__init__.py",
       ]

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -107,21 +107,23 @@ try:
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
 
-    requiredPackages = []
+    requiredPackages = [
+        "ipython",
+        "coloredlogs",
+    ]
 
-    requiredPackages.append('ipython')
 
     if platform.system() == 'Darwin':
         requiredPackages.append('pyobjc')
-    
+
     if platform.system() == 'Linux':
         requiredPackages.append('dbus-python')
         requiredPackages.append('pygobject')
-    
+
     #
     # Build the chip package...
     #
-     
+
     # Invoke the setuptools 'bdist_wheel' command to generate a wheel containing
     # the CHIP python packages, shared libraries and scripts.
     setup(
@@ -142,6 +144,7 @@ try:
             'chip',
             'chip.ble',
             'chip.exceptions',
+            'chip.logging',
             'chip.native',
             'chip.tlv',
         ],

--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -19,15 +19,30 @@
 
 from IPython import embed
 import chip
+import chip.logging
+import coloredlogs
+import logging
 
 def main():
-    # The chip import at the top level will be visible in the ipython REPL.
+    # The chip imports at the top level will be visible in the ipython REPL.
+
+    coloredlogs.install(level='DEBUG')
+    chip.logging.RedirectToPythonLogging()
+
+    # trace/debug logging is not friendly to an interactive console. Only keep errors.
+    logging.getLogger().setLevel(logging.ERROR)
+
     embed(header = '''
 Welcome to the CHIP python REPL utilty.
 
 Usage examples:
 
 import chip.ble
+
+######## Enable detailed logging if needed #########
+
+import logging
+logging.getLogger().setLevel(logging.DEBUG)
 
 ######## List available BLE adapters #########
 print(chip.ble.GetAdapters())

--- a/src/controller/python/chip/logging/LoggingRedirect.cpp
+++ b/src/controller/python/chip/logging/LoggingRedirect.cpp
@@ -1,0 +1,56 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdio.h>
+#include <support/logging/CHIPLogging.h>
+
+namespace {
+
+constexpr size_t kMaxLogMessageLength = 256;
+
+using PythonLogCallback = void (*)(uint8_t category, const char * module, const char * message);
+
+PythonLogCallback sPythonLogCallback;
+
+void NativeLoggingCallback(const char * module, uint8_t category, const char * msg, va_list args)
+{
+    if (sPythonLogCallback == nullptr)
+    {
+        return;
+    }
+    char buffer[kMaxLogMessageLength];
+    vsnprintf(buffer, sizeof(buffer), msg, args);
+    buffer[sizeof(buffer) - 1] = 0;
+
+    sPythonLogCallback(category, module, buffer);
+}
+
+} // namespace
+
+extern "C" void pychip_logging_set_callback(PythonLogCallback callback)
+{
+    if (callback == nullptr)
+    {
+        chip::Logging::SetLogRedirectCallback(nullptr);
+        sPythonLogCallback = callback;
+    }
+    else
+    {
+        sPythonLogCallback = callback;
+        chip::Logging::SetLogRedirectCallback(NativeLoggingCallback);
+    }
+}

--- a/src/controller/python/chip/logging/__init__.py
+++ b/src/controller/python/chip/logging/__init__.py
@@ -1,0 +1,53 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from chip.logging.library_handle import _GetLoggingLibraryHandle
+from chip.logging.types import LogRedirectCallback_t
+import logging
+
+
+# Defines match support/logging/Constants.h (LogCategory enum)
+ERROR_CATEGORY_NONE = 0
+ERROR_CATEGORY_ERROR = 1
+ERROR_CATEGORY_PROGRESS = 2
+ERROR_CATEGORY_DETAIL = 3
+
+
+@LogRedirectCallback_t
+def _RedirectToPythonLogging(category, module, message):
+
+    module = module.decode('utf-8')
+    message = message.decode('utf-8')
+
+    logger = logging.getLogger('chip.%s' % module)
+
+    if category == ERROR_CATEGORY_ERROR:
+        logger.error("%s", message)
+    elif category == ERROR_CATEGORY_PROGRESS:
+        logger.info("%s", message)
+    elif category == ERROR_CATEGORY_DETAIL:
+        logger.debug("%s", message)
+    else:
+        # All logs are expected to have some reasonable category. This treats
+        # unknonw/None as critical.
+        logging.critical("%s", message)
+
+
+def RedirectToPythonLogging():
+    """Redireects CHIP logging to python logging module."""
+
+    handle = _GetLoggingLibraryHandle()
+    handle.pychip_logging_set_callback(_RedirectToPythonLogging)

--- a/src/controller/python/chip/logging/library_handle.py
+++ b/src/controller/python/chip/logging/library_handle.py
@@ -1,0 +1,39 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import chip.native
+import ctypes
+from ctypes import c_void_p
+from chip.logging.types import LogRedirectCallback_t
+
+
+def _GetLoggingLibraryHandle() -> ctypes.CDLL:
+  """ Get the native library handle with logging method initialization.
+
+    Retreives the CHIP native library handle and attaches signatures to
+    native methods.
+    """
+
+  handle = chip.native.GetLibraryHandle()
+
+  # Uses one of the type decorators as an indicator for everything being
+  # initialized. 
+  if not handle.pychip_logging_set_callback.argtypes:
+    setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+
+    setter.Set('pychip_logging_set_callback', c_void_p, [LogRedirectCallback_t])
+
+  return handle

--- a/src/controller/python/chip/logging/types.py
+++ b/src/controller/python/chip/logging/types.py
@@ -1,0 +1,20 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from ctypes import CFUNCTYPE, py_object, c_char_p, c_uint8
+
+# Log callback: void(category, module, message)
+LogRedirectCallback_t = CFUNCTYPE(None, c_uint8, c_char_p, c_char_p)

--- a/src/lib/support/logging/CHIPLogging.h
+++ b/src/lib/support/logging/CHIPLogging.h
@@ -67,6 +67,10 @@
 namespace chip {
 namespace Logging {
 
+using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, const char * msg, va_list args);
+
+void SetLogRedirectCallback(LogRedirectCallback_t callback);
+
 void LogV(uint8_t module, uint8_t category, const char * msg, va_list args);
 void Log(uint8_t module, uint8_t category, const char * msg, ...);
 


### PR DESCRIPTION
 #### Problem
Python scripting cannot easily capture logs (and generally log redirects do not seem possible)

 #### Summary of Changes
Add the ability to redirect CHIP Logging to a callback, implement such a log redirect in python.