### PR TITLE
Fix KVS assert failure on EFR examples

### DIFF
--- a/examples/persistent-storage/efr32/BUILD.gn
+++ b/examples/persistent-storage/efr32/BUILD.gn
@@ -41,11 +41,6 @@ efr32_sdk("sdk") {
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
-  defines = [
-    "CHIP_KVS_SECTOR_COUNT=4",
-    "CHIP_KVS_BASE_SECTOR_INDEX=((FLASH_SIZE/FLASH_PAGE_SIZE)-(CHIP_KVS_SECTOR_COUNT))",
-  ]
-
   if (is_debug) {
     defines += [ "BUILD_RELEASE=0" ]
   } else {

--- a/examples/persistent-storage/efr32/ldscripts/efr32-persistent_storage-example-MG12P.ld
+++ b/examples/persistent-storage/efr32/ldscripts/efr32-persistent_storage-example-MG12P.ld
@@ -1,0 +1,288 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/***************************************************************************//**
+ * Linker script for Silicon Labs EFR32MG12P devices
+ * @version 5.7.2
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1048576
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 262144
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __Vectors_End
+ *   __Vectors_Size
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    __Vectors_End = .;
+    __Vectors_Size = __Vectors_End - __Vectors;
+    __end__ = .;
+
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    KEEP(*(.application_properties))
+	  KEEP(*(.gecko_configuration))
+	  KEEP(*(.xo_configuration))
+    KEEP(*(.gatt_header))
+    KEEP(*(.gatt_data))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+
+
+  /* To copy multiple ROM to RAM sections,
+   * uncomment .copy.table section and,
+   * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+  /*
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG (__data_end__ - __data_start__)
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG (__data2_end__ - __data2_start__)
+    __copy_table_end__ = .;
+  } > FLASH
+  */
+
+  /* To clear multiple BSS sections,
+   * uncomment .zero.table section and,
+   * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+  /*
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG (__bss_end__ - __bss_start__)
+    LONG (__bss2_start__)
+    LONG (__bss2_end__ - __bss2_start__)
+    __zero_table_end__ = .;
+  } > FLASH
+  */
+
+  __etext = .;
+
+  /*******************************************************************/
+  /* Define flash block for BLE-simee & chip-nvm3                    */
+  /* simee: 9000H (36k) bytes for BLE nvm3                           */
+  /* chipNvm3_section: 4000H (16k) bytes for chip nvm3.              */
+  /* 8K is reserved for OpenThread's NVM which is mapped directly at */
+  /* the top of flash                                                */
+  /*******************************************************************/
+
+  OPENTHREAD_NVM_SIZE = 8192;
+
+  .nvm_dummy (DSECT):
+  {
+    __nvm3_dummy_begin = .;
+    . = ALIGN (8192);
+    __nvm3_dummy_simee = .;
+    KEEP(*(.simee));
+    . = ALIGN (8192);
+    __nvm3_dummy_chip = .;
+    KEEP(*(chipNvm3_section));
+    . = ALIGN (8192);
+    . += OPENTHREAD_NVM_SIZE;
+    . = ALIGN (8192);
+  } > FLASH
+
+  /* Set NVM to end of FLASH */
+  __nvm3Base = LENGTH(FLASH) - SIZEOF(.nvm_dummy) + (__nvm3_dummy_simee - __nvm3_dummy_begin);
+  __chipNvm3Base = LENGTH(FLASH) - SIZEOF(.nvm_dummy) + (__nvm3_dummy_chip - __nvm3_dummy_begin);
+
+
+  /*******************************************************************/
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data*)
+    . = ALIGN (4);
+    PROVIDE (__ram_func_section_start = .);
+    *(.ram)
+    PROVIDE (__ram_func_section_end = .);
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM
+
+  .heap (COPY):
+  {
+    __HeapBase = .;
+    __end__ = .;
+    end = __end__;
+    _end = __end__;
+    __HeapLimit = .;
+  } > RAM
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+  .stack_dummy (COPY):
+  {
+    KEEP(*(.stack*))
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+
+  /* Check if FLASH usage exceeds FLASH size */
+  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT((__etext + SIZEOF(.data)) <= __nvm3Base, "FLASH memory overlapped with NVM section.")
+}

--- a/examples/persistent-storage/efr32/ldscripts/efr32-persistent_storage-example-MG21.ld
+++ b/examples/persistent-storage/efr32/ldscripts/efr32-persistent_storage-example-MG21.ld
@@ -1,0 +1,288 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/***************************************************************************//**
+ * Linker script for Silicon Labs EFR32MG21 devices
+ * @version 5.7.2
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2018 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1048576 - 8192  /* 8K is reserved at top of flash on MG21 */
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 98304
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __Vectors_End
+ *   __Vectors_Size
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.vectors))
+    __Vectors_End = .;
+    __Vectors_Size = __Vectors_End - __Vectors;
+    __end__ = .;
+
+    *(.text*)
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    KEEP(*(.application_properties))
+	KEEP(*(.gecko_configuration))
+	KEEP(*(.xo_configuration))
+    KEEP(*(.gatt_header))
+    KEEP(*(.gatt_data))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+
+
+    KEEP(*(.eh_frame*))
+  } > FLASH
+
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+
+
+  /* To copy multiple ROM to RAM sections,
+   * uncomment .copy.table section and,
+   * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+  /*
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG (__data_end__ - __data_start__)
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG (__data2_end__ - __data2_start__)
+    __copy_table_end__ = .;
+  } > FLASH
+  */
+
+  /* To clear multiple BSS sections,
+   * uncomment .zero.table section and,
+   * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+  /*
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    LONG (__bss_start__)
+    LONG (__bss_end__ - __bss_start__)
+    LONG (__bss2_start__)
+    LONG (__bss2_end__ - __bss2_start__)
+    __zero_table_end__ = .;
+  } > FLASH
+  */
+
+  __etext = .;
+
+  /*******************************************************************/
+  /* Define flash block for BLE-simee & CHIP-nvm3                    */
+  /* simee: 9000H (36k) bytes for BLE nvm3                           */
+  /* chipNvm3_section: 4000H (16k) bytes for CHIP nvm3.              */
+  /* 8K is reserved for OpenThread's NVM which is mapped directly at */
+  /* the top of flash                                                */
+  /*******************************************************************/
+
+  OPENTHREAD_NVM_SIZE = 8192;
+
+  .nvm_dummy (DSECT):
+  {
+    __nvm3_dummy_begin = .;
+    . = ALIGN (8192);
+    __nvm3_dummy_simee = .;
+    KEEP(*(.simee));
+    . = ALIGN (8192);
+    __nvm3_dummy_chip = .;
+    KEEP(*(chipNvm3_section));
+    . = ALIGN (8192);
+    . += OPENTHREAD_NVM_SIZE;
+    . = ALIGN (8192);
+  } > FLASH
+
+  /* Set NVM to end of FLASH */
+  __nvm3Base = LENGTH(FLASH) - SIZEOF(.nvm_dummy) + (__nvm3_dummy_simee - __nvm3_dummy_begin);
+  __nvm3ChipBase = LENGTH(FLASH) - SIZEOF(.nvm_dummy) + (__nvm3_dummy_chip - __nvm3_dummy_begin);
+
+
+  /*******************************************************************/
+
+  .data : AT (__etext)
+  {
+    __data_start__ = .;
+    *(vtable)
+    *(.data*)
+    . = ALIGN (4);
+    PROVIDE (__ram_func_section_start = .);
+    *(.ram)
+    PROVIDE (__ram_func_section_end = .);
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM
+
+  .heap (COPY):
+  {
+    __HeapBase = .;
+    __end__ = .;
+    end = __end__;
+    _end = __end__;
+    __HeapLimit = .;
+  } > RAM
+
+  /* .stack_dummy section doesn't contains any symbols. It is only
+   * used for linker to calculate size of stack sections, and assign
+   * values to stack symbols later */
+  .stack_dummy (COPY):
+  {
+    KEEP(*(.stack*))
+  } > RAM
+
+  /* Set stack top to end of RAM, and stack limit move down by
+   * size of stack_dummy section */
+  __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+  __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+  PROVIDE(__stack = __StackTop);
+
+  /* Check if data + heap + stack exceeds RAM limit */
+  ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+
+  /* Check if FLASH usage exceeds FLASH size */
+  ASSERT( LENGTH(FLASH) >= (__etext + SIZEOF(.data)), "FLASH memory overflowed !")
+  ASSERT((__etext + SIZEOF(.data)) <= __nvm3Base, "FLASH memory overlapped with NVM section.")
+}

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -131,6 +131,8 @@ template("efr32_sdk") {
       "${efr32_mcu}=1",
       "${efr32_board}=1",
       "SL_SUPRESS_DEPRECATION_WARNINGS_SDK_3_1",
+      "CHIP_KVS_SECTOR_COUNT=4",
+      "CHIP_KVS_BASE_SECTOR_INDEX=((FLASH_SIZE/FLASH_PAGE_SIZE)-(CHIP_KVS_SECTOR_COUNT))",
     ]
 
     defines += board_defines


### PR DESCRIPTION
 #### Problem
Running the EFR lighting or lock example fails the following assert :

`assertion "CHIP_KVS_AVAILABLE" failed: file "../../../examples/lighting-app/efr32/third_party/connectedhomeip/src/platform/EFR32/KeyValueStoreManagerImpl.h", line 167, function: CHIP_ERROR chip::DeviceLayer::PersistedStorage::KeyValueStoreManagerImpl::_Get(const char*, void*, size_t, size_t*, size_t) const`

The persitent-storage example is missing linker files for MG12 and MG21 MCU

 #### Summary of Changes
Add the needed KVS defines to enable KVS usage for all EFR examples
Add missing linker files for the persistent_storage example

Based of changes in active PR from Rob Oliver for fixes in EFR KVS implementation files
[Fix persistent storage example on EFR32 #5030](https://github.com/project-chip/connectedhomeip/pull/5030)

Fixes #5053 