### PR TITLE
Replace common.h with full path to header

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server-user.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-user.cpp
@@ -39,7 +39,7 @@
 
 #include "af-event.h"
 #include "af.h"
-#include "common.h"
+#include "app/util/common.h"
 #include "door-lock-server.h"
 #include "time-util.h"
 

--- a/src/app/clusters/identify/identify.cpp
+++ b/src/app/clusters/identify/identify.cpp
@@ -48,13 +48,12 @@
 
 // this file contains all the common includes for clusters in the util
 #include <app/util/af.h>
+#include <app/util/common.h>
 
 #include "gen/attribute-id.h"
 #include "gen/attribute-type.h"
 #include "gen/cluster-id.h"
 #include "gen/command-id.h"
-
-#include "common.h"
 
 using namespace chip;
 

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -24,11 +24,10 @@
  *
  */
 
-#include "common.h"
-
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
 #include <app/InteractionModelEngine.h>
+#include <app/tests/integration/common.h>
 #include <core/CHIPCore.h>
 #include <platform/CHIPDeviceLayer.h>
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -24,11 +24,10 @@
  *
  */
 
-#include "common.h"
-
 #include "app/InteractionModelEngine.h"
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
+#include <app/tests/integration/common.h>
 #include <core/CHIPCore.h>
 #include <platform/CHIPDeviceLayer.h>
 

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -24,7 +24,7 @@
 
 #include <errno.h>
 
-#include "common.h"
+#include <app/tests/integration/common.h>
 #include <core/CHIPCore.h>
 #include <core/CHIPTLVDebug.hpp>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -88,14 +88,13 @@
 // Service discovery library
 //#include "service-discovery.h"
 
-#include "common.h"
-
 // determines the number of in-clusters and out-clusters based on defines
 // in config.h
 #include "af-main.h"
 
 //#include "app/framework/security/af-security.h"
 //#include "app/framework/security/crypto-state.h"
+#include "app/util/common.h"
 #include "attribute-storage.h"
 #include "attribute-table.h"
 #include "config.h"

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -41,7 +41,7 @@
 
 #include "attribute-storage.h"
 #include "af.h"
-#include "common.h"
+#include "app/util/common.h"
 
 #include "gen/attribute-type.h"
 #include "gen/callback.h"

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -42,13 +42,12 @@
  ******************************************************************************/
 
 // this file contains all the common includes for clusters in the zcl-util
-#include "common.h"
 
 #include "attribute-storage.h"
 
 // for pulling in defines dealing with EITHER server or client
 #include "af-main.h"
-
+#include "app/util/common.h"
 #include "gen/callback.h"
 
 #ifdef EMBER_AF_PLUGIN_REPORTING

--- a/src/app/util/client-api.cpp
+++ b/src/app/util/client-api.cpp
@@ -39,7 +39,7 @@
  ******************************************************************************/
 
 #include "client-api.h"
-#include "common.h"
+#include "app/util/common.h"
 #include "util.h"
 #include <stdarg.h>
 

--- a/src/app/util/process-cluster-message.cpp
+++ b/src/app/util/process-cluster-message.cpp
@@ -40,7 +40,7 @@
  ******************************************************************************/
 
 // this file contains all the common includes for clusters in the zcl-util
-#include "common.h"
+#include "app/util/common.h"
 
 // for pulling in defines dealing with EITHER server or client
 #include "af-main.h"

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -40,9 +40,9 @@
  ******************************************************************************/
 
 #include "af.h"
-#include "common.h"
 
 #include <app/clusters/ias-zone-client/ias-zone-client.h>
+#include <app/util/common.h>
 
 #ifdef EMBER_AF_PLUGIN_REPORTING
 #include <app/reporting/reporting.h>

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -43,7 +43,7 @@
 #include "af-event.h"
 #include "af-main.h"
 #include "af.h"
-#include "common.h"
+#include "app/util/common.h"
 
 #include "gen/attribute-id.h"
 #include "gen/attribute-type.h"


### PR DESCRIPTION
This prevents accidental include of other libaries' common.h files.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

`#include "common.h"` may cause accidental inclusion of other libraries' common.h file.

 #### Summary of Changes

Replace the include with the full path to the file.