### PR TITLE
[ESP32] Replace ESP_IF_WIFI_* with WIFI_IF_*

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -102,7 +102,7 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    return esp_wifi_get_mac(ESP_IF_WIFI_STA, buf);
+    return esp_wifi_get_mac(WIFI_IF_STA, buf);
 }
 
 bool ConfigurationManagerImpl::_CanFactoryReset()

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -116,7 +116,7 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
         wifi_config_t stationConfig;
 
         memset(&stationConfig, 0, sizeof(stationConfig));
-        esp_wifi_set_config(ESP_IF_WIFI_STA, &stationConfig);
+        esp_wifi_set_config(WIFI_IF_STA, &stationConfig);
 
         SystemLayer.ScheduleWork(DriveStationState, NULL);
         SystemLayer.ScheduleWork(DriveAPState, NULL);
@@ -360,7 +360,7 @@ CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWifiStatsCounters(void)
     uint16_t freq;
     uint16_t bssid;
 
-    err = esp_wifi_get_config(ESP_IF_WIFI_STA, &wifiConfig);
+    err = esp_wifi_get_config(WIFI_IF_STA, &wifiConfig);
     if (err != ESP_OK)
     {
         ChipLogError(DeviceLayer, "esp_wifi_get_config() failed: %s", ErrorStr(err));
@@ -424,7 +424,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
             memcpy(wifiConfig.sta.password, CONFIG_DEFAULT_WIFI_PASSWORD, strlen(CONFIG_DEFAULT_WIFI_PASSWORD) + 1);
             wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
             wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
-            err                        = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifiConfig);
+            err                        = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
             if (err != ESP_OK)
             {
                 ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", chip::ErrorStr(err));
@@ -875,10 +875,10 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     wifiConfig.ap.max_connection  = CHIP_DEVICE_CONFIG_WIFI_AP_MAX_STATIONS;
     wifiConfig.ap.beacon_interval = CHIP_DEVICE_CONFIG_WIFI_AP_BEACON_INTERVAL;
     ChipLogProgress(DeviceLayer, "Configuring WiFi AP: SSID %s, channel %u", wifiConfig.ap.ssid, wifiConfig.ap.channel);
-    err = esp_wifi_set_config(ESP_IF_WIFI_AP, &wifiConfig);
+    err = esp_wifi_set_config(WIFI_IF_AP, &wifiConfig);
     if (err != ESP_OK)
     {
-        ChipLogError(DeviceLayer, "esp_wifi_set_config(ESP_IF_WIFI_AP) failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_wifi_set_config(WIFI_IF_AP) failed: %s", chip::ErrorStr(err));
     }
     SuccessOrExit(err);
 

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR ESP32Utils::IsAPEnabled(bool & apEnabled)
 bool ESP32Utils::IsStationProvisioned(void)
 {
     wifi_config_t stationConfig;
-    return (esp_wifi_get_config(ESP_IF_WIFI_STA, &stationConfig) == ERR_OK && stationConfig.sta.ssid[0] != 0);
+    return (esp_wifi_get_config(WIFI_IF_STA, &stationConfig) == ERR_OK && stationConfig.sta.ssid[0] != 0);
 }
 
 CHIP_ERROR ESP32Utils::IsStationConnected(bool & connected)
@@ -234,7 +234,7 @@ CHIP_ERROR ESP32Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & net
     CHIP_ERROR err = CHIP_NO_ERROR;
     wifi_config_t stationConfig;
 
-    err = esp_wifi_get_config(ESP_IF_WIFI_STA, &stationConfig);
+    err = esp_wifi_get_config(WIFI_IF_STA, &stationConfig);
     SuccessOrExit(err);
 
     VerifyOrExit(stationConfig.sta.ssid[0] != 0, err = CHIP_ERROR_INCORRECT_STATE);
@@ -290,7 +290,7 @@ CHIP_ERROR ESP32Utils::SetWiFiStationProvision(const Internal::DeviceNetworkInfo
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 
     // Configure the ESP WiFi interface.
-    err = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifiConfig);
+    err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
     if (err != ESP_OK)
     {
         ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", chip::ErrorStr(err));
@@ -310,7 +310,7 @@ CHIP_ERROR ESP32Utils::ClearWiFiStationProvision(void)
 
     // Clear the ESP WiFi station configuration.
     memset(&stationConfig, 0, sizeof(stationConfig));
-    esp_wifi_set_config(ESP_IF_WIFI_STA, &stationConfig);
+    esp_wifi_set_config(WIFI_IF_STA, &stationConfig);
 
     return err;
 }

--- a/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
+++ b/src/platform/ESP32/NetworkProvisioningServerImpl.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR NetworkProvisioningServerImpl::GetWiFiStationProvision(NetworkInfo & 
 
     netInfo.Reset();
 
-    err = esp_wifi_get_config(ESP_IF_WIFI_STA, &stationConfig);
+    err = esp_wifi_get_config(WIFI_IF_STA, &stationConfig);
     SuccessOrExit(err);
 
     VerifyOrExit(stationConfig.sta.ssid[0] != 0, err = CHIP_ERROR_INCORRECT_STATE);
@@ -173,7 +173,7 @@ CHIP_ERROR NetworkProvisioningServerImpl::SetWiFiStationProvision(const NetworkI
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 
     // Configure the ESP WiFi interface.
-    err = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifiConfig);
+    err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
     if (err != ESP_OK)
     {
         ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", chip::ErrorStr(err));
@@ -198,7 +198,7 @@ CHIP_ERROR NetworkProvisioningServerImpl::ClearWiFiStationProvision(void)
 
     // Clear the ESP WiFi station configuration.
     memset(&stationConfig, 0, sizeof(stationConfig));
-    esp_wifi_set_config(ESP_IF_WIFI_STA, &stationConfig);
+    esp_wifi_set_config(WIFI_IF_STA, &stationConfig);
 
     // Clear the persisted WiFi station security type.
     ConfigurationMgrImpl().UpdateWiFiStationSecurityType(kWiFiSecurityType_NotSpecified);

--- a/src/platform/ESP32/ServiceProvisioning.cpp
+++ b/src/platform/ESP32/ServiceProvisioning.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR SetWiFiStationProvisioning(const char * ssid, const char * key)
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 
     // Configure the ESP WiFi interface.
-    err = esp_wifi_set_config(ESP_IF_WIFI_STA, &wifiConfig);
+    err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
     if (err != ESP_OK)
     {
         ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", chip::ErrorStr(err));


### PR DESCRIPTION
 #### Problem

`esp_wifi_*` apis accepts `wifi_interface_t` enums rather than `esp_interface_t` enums.

On build systems with more strict type checks, these enums cannot be used interchangeably.

 #### Summary of Changes

Use `WIFI_IF_*` enums with the correct type instead.
