### PR TITLE
[Thread] Support Thread network provisioning using Thread operational dataset TLV

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -78,6 +78,7 @@ public:
 
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
+    CHIP_ERROR SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
     CHIP_ERROR SetThreadEnabled(bool val);
 
 private:
@@ -235,6 +236,11 @@ inline CHIP_ERROR ThreadStackManager::GetThreadProvision(Internal::DeviceNetwork
 inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo)
 {
     return static_cast<ImplClass *>(this)->_SetThreadProvision(netInfo);
+}
+
+inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen)
+{
+    return static_cast<ImplClass *>(this)->_SetThreadProvision(operationalDataset, operationalDatasetLen);
 }
 
 inline void ThreadStackManager::ErasePersistentInfo()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -78,7 +78,7 @@ public:
 
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
-    CHIP_ERROR SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
+    CHIP_ERROR SetThreadProvision(const uint8_t * operationalDataset, size_t operationalDatasetLen);
     CHIP_ERROR SetThreadEnabled(bool val);
 
 private:
@@ -238,7 +238,7 @@ inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const Internal::DeviceN
     return static_cast<ImplClass *>(this)->_SetThreadProvision(netInfo);
 }
 
-inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen)
+inline CHIP_ERROR ThreadStackManager::SetThreadProvision(const uint8_t * operationalDataset, size_t operationalDatasetLen)
 {
     return static_cast<ImplClass *>(this)->_SetThreadProvision(operationalDataset, operationalDatasetLen);
 }

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -174,6 +174,19 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const Internal::DeviceNet
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen)
+{
+    mOperationalDatasetTlv = std::vector<uint8_t>(operationalDataset, operationalDataset + operationalDatasetLen);
+
+    // post an event alerting other subsystems about change in provisioning state
+    ChipDeviceEvent event;
+    event.Type                                           = DeviceEventType::kServiceProvisioningChange;
+    event.ServiceProvisioningChange.IsServiceProvisioned = true;
+    PlatformMgr().PostEvent(&event);
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials)
 {
     netInfo = mNetworkInfo;
@@ -222,39 +235,48 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
 
     if (val)
     {
-        std::vector<uint8_t> masterkey(std::begin(mNetworkInfo.ThreadMasterKey), std::end(mNetworkInfo.ThreadMasterKey));
-        std::vector<uint8_t> pskc;
-        uint64_t extPanId    = UINT64_MAX;
-        uint32_t channelMask = UINT32_MAX;
-
-        if (mNetworkInfo.FieldPresent.ThreadExtendedPANId)
+        if (mOperationalDatasetTlv.size() > 0)
         {
-            extPanId = 0;
-            for (size_t i = 0; i < extPanId; i++)
+            SuccessOrExit(error = mThreadApi->SetActiveDatasetTlvs(mOperationalDatasetTlv));
+            SuccessOrExit(error = mThreadApi->Attach(
+                              [](ClientError result) { ChipLogProgress(DeviceLayer, "Thread attach result %d", result); }));
+        }
+        else
+        {
+            std::vector<uint8_t> masterkey(std::begin(mNetworkInfo.ThreadMasterKey), std::end(mNetworkInfo.ThreadMasterKey));
+            std::vector<uint8_t> pskc;
+            uint64_t extPanId    = UINT64_MAX;
+            uint32_t channelMask = UINT32_MAX;
+
+            if (mNetworkInfo.FieldPresent.ThreadExtendedPANId)
             {
-                extPanId <<= CHAR_BIT;
-                extPanId |= mNetworkInfo.ThreadExtendedPANId[i];
+                extPanId = 0;
+                for (size_t i = 0; i < extPanId; i++)
+                {
+                    extPanId <<= CHAR_BIT;
+                    extPanId |= mNetworkInfo.ThreadExtendedPANId[i];
+                }
             }
-        }
-        if (mNetworkInfo.FieldPresent.ThreadPSKc)
-        {
-            pskc = std::vector<uint8_t>(std::begin(mNetworkInfo.ThreadPSKc), std::end(mNetworkInfo.ThreadPSKc));
-        }
-        if (mNetworkInfo.ThreadChannel != Internal::kThreadChannel_NotSpecified)
-        {
-            channelMask = 1 << mNetworkInfo.ThreadChannel;
-        }
+            if (mNetworkInfo.FieldPresent.ThreadPSKc)
+            {
+                pskc = std::vector<uint8_t>(std::begin(mNetworkInfo.ThreadPSKc), std::end(mNetworkInfo.ThreadPSKc));
+            }
+            if (mNetworkInfo.ThreadChannel != Internal::kThreadChannel_NotSpecified)
+            {
+                channelMask = 1 << mNetworkInfo.ThreadChannel;
+            }
 
-        if (mNetworkInfo.FieldPresent.ThreadMeshPrefix)
-        {
-            std::array<uint8_t, Internal::kThreadMeshPrefixLength> prefix;
+            if (mNetworkInfo.FieldPresent.ThreadMeshPrefix)
+            {
+                std::array<uint8_t, Internal::kThreadMeshPrefixLength> prefix;
 
-            std::copy(std::begin(mNetworkInfo.ThreadMeshPrefix), std::end(mNetworkInfo.ThreadMeshPrefix), std::begin(prefix));
-            SuccessOrExit(error = mThreadApi->SetMeshLocalPrefix(prefix));
+                std::copy(std::begin(mNetworkInfo.ThreadMeshPrefix), std::end(mNetworkInfo.ThreadMeshPrefix), std::begin(prefix));
+                SuccessOrExit(error = mThreadApi->SetMeshLocalPrefix(prefix));
+            }
+
+            mThreadApi->Attach(mNetworkInfo.ThreadNetworkName, mNetworkInfo.ThreadPANId, extPanId, masterkey, pskc, channelMask,
+                               [](ClientError result) { ChipLogProgress(DeviceLayer, "Thread attach result %d", result); });
         }
-
-        mThreadApi->Attach(mNetworkInfo.ThreadNetworkName, mNetworkInfo.ThreadPANId, extPanId, masterkey, pskc, channelMask,
-                           [](ClientError result) { ChipLogProgress(DeviceLayer, "Thread attach result %d", result); });
     }
     else
     {

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -174,7 +174,7 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const Internal::DeviceNet
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen)
+CHIP_ERROR ThreadStackManagerImpl::_SetThreadProvision(const uint8_t * operationalDataset, size_t operationalDatasetLen)
 {
     mOperationalDatasetTlv = std::vector<uint8_t>(operationalDataset, operationalDataset + operationalDatasetLen);
 
@@ -238,8 +238,10 @@ CHIP_ERROR ThreadStackManagerImpl::_SetThreadEnabled(bool val)
         if (mOperationalDatasetTlv.size() > 0)
         {
             SuccessOrExit(error = mThreadApi->SetActiveDatasetTlvs(mOperationalDatasetTlv));
-            SuccessOrExit(error = mThreadApi->Attach(
-                              [](ClientError result) { ChipLogProgress(DeviceLayer, "Thread attach result %d", result); }));
+            SuccessOrExit(error = mThreadApi->Attach([](ClientError result) {
+                // ThreadDevcieRoleChangedHandler should take care of this, so we don't emit another event.
+                ChipLogProgress(DeviceLayer, "Thread attach result %d", result);
+            }));
         }
         else
         {

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -50,6 +50,8 @@ public:
 
     CHIP_ERROR _SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
 
+    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
+
     void _ErasePersistentInfo();
 
     bool _IsThreadProvisioned();

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -50,7 +50,7 @@ public:
 
     CHIP_ERROR _SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
 
-    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
+    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, size_t operationalDatasetLen);
 
     void _ErasePersistentInfo();
 

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <thread>
+#include <vector>
 
 #include "platform/internal/CHIPDeviceLayerInternal.h"
 
@@ -103,6 +104,7 @@ private:
 
     std::unique_ptr<otbr::DBus::ThreadApiDBus> mThreadApi;
     UniqueDBusConnection mConnection;
+    std::vector<uint8_t> mOperationalDatasetTlv;
     Internal::DeviceNetworkInfo mNetworkInfo;
     bool mAttached;
     std::thread mDBusEventLoop;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -278,9 +278,10 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvis
     otOperationalDatasetTlvs datasetTlv;
 
     VerifyOrReturnError(operationalDatasetLen <= sizeof(datasetTlv.mTlvs), CHIP_ERROR_MESSAGE_TOO_LONG);
-
+    // Just a check, what if we have updated the thread spec and dataset can be larger?
+    static_assert(sizeof(datasetTlv.mTlvs) <= UINT8_MAX);
     memcpy(datasetTlv.mTlvs, operationalDataset, operationalDatasetLen);
-    datasetTlv.mLength = operationalDatasetLen;
+    datasetTlv.mLength = static_cast<uint8_t>(operationalDatasetLen);
 
     // Set the dataset as the active dataset for the node.
     Impl()->LockThreadStack();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -272,13 +272,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvis
 
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvision(const uint8_t * operationalDataset,
-                                                                                    uint32_t operationalDatasetLen)
+                                                                                    size_t operationalDatasetLen)
 {
     otError otErr = OT_ERROR_FAILED;
     otOperationalDatasetTlvs datasetTlv;
 
     VerifyOrReturnError(operationalDatasetLen <= sizeof(datasetTlv.mTlvs), CHIP_ERROR_MESSAGE_TOO_LONG);
-    // Just a check, what if we have updated the thread spec and dataset can be larger?
+    // A compile time check to avoid misbehavior if the openthread implementation changed over time.
     static_assert(sizeof(datasetTlv.mTlvs) <= UINT8_MAX);
     memcpy(datasetTlv.mTlvs, operationalDataset, operationalDatasetLen);
     datasetTlv.mLength = static_cast<uint8_t>(operationalDatasetLen);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -69,6 +69,7 @@ protected:
     bool _IsThreadAttached(void);
     CHIP_ERROR _GetThreadProvision(DeviceNetworkInfo & netInfo, bool includeCredentials);
     CHIP_ERROR _SetThreadProvision(const DeviceNetworkInfo & netInfo);
+    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
     void _ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -69,7 +69,7 @@ protected:
     bool _IsThreadAttached(void);
     CHIP_ERROR _GetThreadProvision(DeviceNetworkInfo & netInfo, bool includeCredentials);
     CHIP_ERROR _SetThreadProvision(const DeviceNetworkInfo & netInfo);
-    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, uint32_t operationalDatasetLen);
+    CHIP_ERROR _SetThreadProvision(const uint8_t * operationalDataset, size_t operationalDatasetLen);
     void _ErasePersistentInfo(void);
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We does not use TLV for network provisioning in thread, we should support it.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add TLV support in SetThreadProvisioning

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5039 

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
