### PR TITLE
Fix src/app/server config propagation

### DIFF
--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -24,8 +24,6 @@ config("includes") {
   include_dirs = [
     ".",
     "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
   ]
 }
 
@@ -41,10 +39,6 @@ executable("chip-tool-server") {
     defines = [ "BUILD_RELEASE=0" ]
   } else {
     defines = [ "BUILD_RELEASE=1" ]
-  }
-
-  if (chip_app_use_interaction_model) {
-    defines += [ "CHIP_APP_USE_INTERACTION_MODEL" ]
   }
 
   public_configs = [ ":includes" ]

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -15,6 +15,16 @@
 import("//build_overrides/chip.gni")
 import("${chip_root}/src/app/common_flags.gni")
 
+config("server_config") {
+  defines = []
+
+  if (chip_app_use_interaction_model) {
+    defines += [ "CHIP_APP_USE_INTERACTION_MODEL" ]
+  }
+
+  include_dirs = [ "." ]
+}
+
 static_library("server") {
   output_name = "libCHIPAppServer"
 
@@ -27,6 +37,8 @@ static_library("server") {
     "Server.h",
   ]
 
+  public_configs = [ ":server_config" ]
+
   public_deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/lib/mdns",
@@ -35,10 +47,4 @@ static_library("server") {
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport",
   ]
-
-  defines = []
-
-  if (chip_app_use_interaction_model) {
-    defines += [ "CHIP_APP_USE_INTERACTION_MODEL" ]
-  }
 }


### PR DESCRIPTION
Currently lighting-app manually adds include paths and #defines for
src/app/server. This is not desirable as such duplicates can easily get
out of sync. Fix the library to propagate its configuration to reverse
deps via a new config target.

As a general rule needing to duplicate include paths or defines of your
dependencies is a sign of improperly specified build files.