### PR TITLE
Rename Linux examples to their directory prefixed by "chip-"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,7 @@
             "name": "LightingApp (Linux)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/out/lighting-app/chip-tool-server",
+            "program": "${workspaceFolder}/out/lighting-app/chip-lighting-app",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -28,7 +28,7 @@ config("includes") {
   ]
 }
 
-executable("all-clusters-server") {
+executable("chip-all-clusters-app") {
   sources = [ "main.cpp" ]
 
   if (is_debug) {
@@ -48,5 +48,5 @@ executable("all-clusters-server") {
 }
 
 group("linux") {
-  deps = [ ":all-clusters-server" ]
+  deps = [ ":chip-all-clusters-app" ]
 }

--- a/examples/all-clusters-app/linux/Dockerfile
+++ b/examples/all-clusters-app/linux/Dockerfile
@@ -17,7 +17,7 @@
 
 from generic_node_image
 RUN apt-get install -y libglib2.0
-COPY out/debug/chip-tool-all-clusters-server /usr/bin/
+COPY out/debug/chip-all-clusters-app /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "server"]

--- a/examples/all-clusters-app/linux/entrypoint.sh
+++ b/examples/all-clusters-app/linux/entrypoint.sh
@@ -26,4 +26,4 @@ ot-ctl panid 0x1234
 ot-ctl ifconfig up
 ot-ctl thread start
 
-chip-tool-all-clusters-server
+chip-all-clusters-app

--- a/examples/bridge-app/linux/BUILD.gn
+++ b/examples/bridge-app/linux/BUILD.gn
@@ -27,7 +27,7 @@ config("includes") {
   ]
 }
 
-executable("bridge-app-server") {
+executable("chip-bridge-app") {
   sources = [
     "LightingManager.cpp",
     "Options.cpp",
@@ -52,5 +52,5 @@ executable("bridge-app-server") {
 }
 
 group("linux") {
-  deps = [ ":bridge-app-server" ]
+  deps = [ ":chip-bridge-app" ]
 }

--- a/examples/bridge-app/linux/Dockerfile
+++ b/examples/bridge-app/linux/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
-COPY out/debug/chip-tool-server /usr/bin/
+COPY out/debug/chip-bridge-app /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "server"]

--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -84,9 +84,9 @@ Raspberry Pi Desktop 20.10 (aarch64)**
         -   Run Linux Bridge Example App
 
                   $ cd ~/connectedhomeip/examples/bridge-app/linux
-                  $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
+                  $ sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
                   # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-tool-server --ble-device 1
+                  $ sudo out/debug/chip-bridge-app --ble-device 1
 
         -   Test the device using ChipDeviceController on your laptop /
             workstation etc.

--- a/examples/bridge-app/linux/entrypoint.sh
+++ b/examples/bridge-app/linux/entrypoint.sh
@@ -9,4 +9,4 @@ ot-ctl panid 0x1234
 ot-ctl ifconfig up
 ot-ctl thread start
 
-chip-tool-server
+chip-bridge-app

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -29,7 +29,7 @@ config("includes") {
   ]
 }
 
-executable("chip-tool-server") {
+executable("chip-lighting-app") {
   sources = [
     "LightingManager.cpp",
     "Options.cpp",
@@ -58,5 +58,5 @@ executable("chip-tool-server") {
 }
 
 group("linux") {
-  deps = [ ":chip-tool-server" ]
+  deps = [ ":chip-lighting-app" ]
 }

--- a/examples/lighting-app/linux/Dockerfile
+++ b/examples/lighting-app/linux/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
-COPY out/debug/chip-tool-server /usr/bin/
+COPY out/debug/chip-lighting-app /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "server"]

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -84,9 +84,9 @@ Raspberry Pi Desktop 20.10 (aarch64)**
         -   Run Linux Lighting Example App
 
                   $ cd ~/connectedhomeip/examples/lighting-app/linux
-                  $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
+                  $ sudo out/debug/chip-lighting-app --ble-device [bluetooth device number]
                   # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-tool-server --ble-device 1
+                  $ sudo out/debug/chip-lighting-app --ble-device 1
 
         -   Test the device using ChipDeviceController on your laptop /
             workstation etc.

--- a/examples/lighting-app/linux/entrypoint.sh
+++ b/examples/lighting-app/linux/entrypoint.sh
@@ -9,4 +9,4 @@ ot-ctl panid 0x1234
 ot-ctl ifconfig up
 ot-ctl thread start
 
-chip-tool-server --thread
+chip-lighting-app --thread

--- a/examples/tv-app/linux/BUILD.gn
+++ b/examples/tv-app/linux/BUILD.gn
@@ -28,7 +28,7 @@ config("includes") {
   ]
 }
 
-executable("tv-server") {
+executable("chip-tv-app") {
   sources = [ "main.cpp" ]
 
   if (is_debug) {
@@ -48,5 +48,5 @@ executable("tv-server") {
 }
 
 group("linux") {
-  deps = [ ":tv-server" ]
+  deps = [ ":chip-tv-app" ]
 }

--- a/examples/tv-app/linux/Dockerfile
+++ b/examples/tv-app/linux/Dockerfile
@@ -17,7 +17,7 @@
 
 from generic_node_image
 RUN apt-get install -y libglib2.0
-COPY out/debug/chip-tool-tv-server /usr/bin/
+COPY out/debug/chip-tv-app /usr/bin/
 COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh", "server"]

--- a/examples/tv-app/linux/README.md
+++ b/examples/tv-app/linux/README.md
@@ -84,9 +84,9 @@ Desktop 20.10 (aarch64)**
         -   Run TV Example App
 
                   $ cd ~/connectedhomeip/examples/tv-app/linux
-                  $ sudo out/debug/chip-tool-server --ble-device [bluetooth device number]
+                  $ sudo out/debug/chip-tv-app --ble-device [bluetooth device number]
                   # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-tool-server --ble-device 1
+                  $ sudo out/debug/chip-tv-app --ble-device 1
 
         -   Test the device using ChipDeviceController on your laptop /
             workstation etc.

--- a/examples/tv-app/linux/entrypoint.sh
+++ b/examples/tv-app/linux/entrypoint.sh
@@ -26,4 +26,4 @@ ot-ctl panid 0x1234
 ot-ctl ifconfig up
 ot-ctl thread start
 
-chip-tool-tv-server
+chip-tv-app


### PR DESCRIPTION
The binary names used on Linux are inconsistent and confusing. For
example, the name "chip-tool-server" is shared between the lighting &
bridge sample binaries. These names don't indicate which sample they
are, and the samples have little to do with "chip-tool".

Rename these executables to the same name as their containing directory,
prefixed by "chip". The shell example already follows this pattern.