### PR TITLE
Remove objcopy from ti_simplelink_executable

### DIFF
--- a/third_party/ti_simplelink_sdk/ti_simplelink_executable.gni
+++ b/third_party/ti_simplelink_sdk/ti_simplelink_executable.gni
@@ -17,11 +17,6 @@ import("//build_overrides/build.gni")
 import("${build_root}/toolchain/flashable_executable.gni")
 
 template("ti_simplelink_executable") {
-  # we really only need the ELF
-  objcopy_image_name = invoker.output_name + ".hex"
-  objcopy_image_format = "ihex"
-  objcopy = "arm-none-eabi-objcopy"
-
   flashable_executable(target_name) {
     forward_variables_from(invoker, "*")
   }


### PR DESCRIPTION
The preceding comment says we don't actually need the image in ihex
format. So don't produce it.