### PR TITLE
Fix and enable warnings -Wunreachable-code

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -157,6 +157,7 @@ config("strict_warnings") {
     "-Wall",
     "-Wextra",
     "-Wshadow",
+    "-Wunreachable-code",
   ]
 
   cflags_cc = [ "-Wnon-virtual-dtor" ]

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -51,7 +51,8 @@ NodeId GetCurrentNodeId()
     // mdns advertises a single node id as parameter.
 
     // Search for one admin pariing and use its node id.
-    for (auto pairing = GetGlobalAdminPairingTable().cbegin(); pairing != GetGlobalAdminPairingTable().cend(); pairing++)
+    auto pairing = GetGlobalAdminPairingTable().cbegin();
+    if (pairing != GetGlobalAdminPairingTable().cend())
     {
         ChipLogProgress(Discovery, "Found admin paring for admin %" PRIX64 ", node %" PRIX64, pairing->GetAdminId(),
                         pairing->GetNodeId());

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -315,7 +315,7 @@ void emberAfStackDown(void)
     // (Issue 77101) Also don't clear the table if the stack has gone down as a
     // a result of losing its parent or some other transient state where a future
     // rejoin is expected to get us back online.
-    if (false
+    if ((false)
         // emberStackIsPerformingRejoin() == false
         // && emberNetworkState() == EMBER_NO_NETWORK
     )

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -28,6 +28,7 @@
 #include "AndroidDeviceControllerWrapper.h"
 
 #include <app/chip-zcl-zpro-codec.h>
+#include <atomic>
 #include <ble/BleUUID.h>
 #include <controller/CHIPDeviceController_deprecated.h>
 #include <jni.h>
@@ -1048,13 +1049,16 @@ void * IOThreadMain(void * arg)
     sJVM->AttachCurrentThreadAsDaemon((void **) &env, (void *) &attachArgs);
 #endif
 
+    // Set to true to quit the loop. This is currently unused.
+    std::atomic<bool> quit;
+
     ChipLogProgress(Controller, "IO thread starting");
 
     // Lock the stack to prevent collisions with Java threads.
     pthread_mutex_lock(&sStackLock);
 
     // Loop until we are told to exit.
-    while (true)
+    while (!quit.load(std::memory_order_relaxed))
     {
         numFDs = 0;
         FD_ZERO(&readFDs);

--- a/src/system/tests/TestSystemObject.cpp
+++ b/src/system/tests/TestSystemObject.cpp
@@ -87,12 +87,9 @@ private:
 #if CHIP_SYSTEM_CONFIG_POSIX_LOCKING
     unsigned int mDelay;
 
-    enum
-    {
-        kNumThreads         = 16,
-        kLoopIterations     = 100000,
-        kMaxDelayIterations = 3
-    };
+    static constexpr int kNumThreads         = 16;
+    static constexpr int kLoopIterations     = 100000;
+    static constexpr int kMaxDelayIterations = 3;
 
     void Delay(volatile unsigned int & aAccumulator);
     static void * CheckConcurrencyThread(void * aContext);

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -133,7 +133,7 @@ void AdminPairingTable::Reset()
 {
     for (size_t i = 0; i < CHIP_CONFIG_MAX_DEVICE_ADMINS; i++)
     {
-        return mStates[i].Reset();
+        mStates[i].Reset();
     }
 }
 


### PR DESCRIPTION
- Fix or remove loops that run at most once
- Add a quit variable in Android IO thread; otherwise the code after the
  loop is [more obviously] unreachable.
- Don't use enums as test parameters that can only be changed by editing
  the test. Perhaps we shouldn't have these at all, but static constexpr
  triggers no diagnostics.
