### PR TITLE
Use bool instead of uint8_t for requiresCustomFlow

### DIFF
--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -138,7 +138,7 @@ public:
     uint8_t version;
     uint16_t vendorID;
     uint16_t productID;
-    uint8_t requiresCustomFlow;
+    bool requiresCustomFlow;
     RendezvousInformationFlags rendezvousInformation;
     uint16_t discriminator;
     uint32_t setUpPINCode;


### PR DESCRIPTION
 #### Problem
The requiresCustomFlow field of the SetupPayload class is defined as an uint_8, which may introduce an unspecified behaviour since the specification only specify values for 0 and 1. And the code to validate the payload does not enforce check the value is 0 or 1 since it is assumed to be a boolean.

Not enforcing it to be either 0 or 1 may ends up in vendors relying on it for generating QRCode and ends up in undefined behavior in the future.

 #### Summary of Changes
 * Use `bool` instead of `uint8_t` for `requiresCustomFlow` definition
 
 Fixes #937