### PR TITLE
Removal of %h/%hh specifiers - not supported in newlib-nano printf

### DIFF
--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -57,7 +57,7 @@ void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, b
     if (buffer != nullptr && length > 0)
     {
         constexpr uint16_t kBufferSize = CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
-        const char * perByteFormatStr  = withSpace ? "%02hhX " : "%02hhX";
+        const char * perByteFormatStr  = withSpace ? "%02X " : "%02X";
         const uint8_t perByteCharCount = withSpace ? 3 : 2;
         const uint16_t bytesPerBuffer  = static_cast<uint16_t>((kBufferSize - 1) / perByteCharCount);
         char result[kBufferSize];

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -950,7 +950,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_JoinerStart(voi
         discerner.mLength = 12;
         discerner.mValue  = discriminator;
 
-        ChipLogProgress(DeviceLayer, "Joiner Discerner: %hu", discriminator);
+        ChipLogProgress(DeviceLayer, "Joiner Discerner: %u", discriminator);
         otJoinerSetDiscerner(mOTInst, &discerner);
     }
 


### PR DESCRIPTION
Problem:
newlib-nano printf - selected as default for arm + freertos compilation.
does not support the specifier resulting in unusable logging.

Solution:
Removing the isolated use-cases of %h/%hh specifiers.