### PR TITLE
Disable optional rotating device ID for QPG6100

### DIFF
--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -32,6 +32,11 @@ chip_inet_config_enable_dns_resolver = false
 
 chip_build_tests = false
 
+# GH #4224
+# Lifetime counter keyId not available in ConfigurationManager
+# Disabling feature awaiting path into ConfigurationManager
+chip_enable_rotating_device_id = false
+
 openthread_external_mbedtls = mbedtls_target
 openthread_project_core_config_file = "openthread-core-qpg6100-config.h"
 openthread_core_config_platform_check_file =


### PR DESCRIPTION
Problem:
Rotating device ID - tracked in GH #4224, was enabled by default in PR #4362 
However, the implementation of the counter has no link to the ConfigurationManager keys.
Our NVM implementation asserts on this as the PersistedLifeTimeCounter is an unknown KeyId.

Solution:
Disabling optional rotating device ID feature until decision on clean path into ConfigurationManager is made.
Discussion under original GH issue:
https://github.com/project-chip/connectedhomeip/issues/4224#issuecomment-788283107