### PR TITLE
Use RFC specified values for min-mDNS time to live

### DIFF
--- a/src/lib/mdns/minimal/records/ResourceRecord.h
+++ b/src/lib/mdns/minimal/records/ResourceRecord.h
@@ -31,11 +31,7 @@ namespace Minimal {
 class ResourceRecord
 {
 public:
-    static constexpr uint32_t kTtlHourInSeconds = 3600;
-    static constexpr uint32_t kTtlDayInSeconds  = 24 * kTtlHourInSeconds;
-    static constexpr uint32_t kTtlYearInSeconds = 365 * kTtlDayInSeconds;
-
-    static constexpr uint32_t kDefaultTtl = 10 * kTtlYearInSeconds;
+    static constexpr uint32_t kDefaultTtl = 120; // 2 minutes
 
     virtual ~ResourceRecord() {}
 

--- a/src/lib/mdns/minimal/records/Txt.h
+++ b/src/lib/mdns/minimal/records/Txt.h
@@ -27,7 +27,7 @@ namespace Minimal {
 class TxtResourceRecord : public ResourceRecord
 {
 public:
-    static constexpr uint64_t kDefaultTtl = 10;
+    static constexpr uint64_t kDefaultTtl = 4500; // 75 minutes
 
     TxtResourceRecord(const FullQName & qName, const char ** entries, size_t entryCount) :
         ResourceRecord(QType::TXT, qName), mEntries(entries), mEntryCount(entryCount)

--- a/src/lib/mdns/minimal/records/tests/TestResourceRecord.cpp
+++ b/src/lib/mdns/minimal/records/tests/TestResourceRecord.cpp
@@ -172,14 +172,14 @@ void ErrorsOutOnSmallBuffers(nlTestSuite * inSuite, void * inContext)
 
     const uint8_t expectedOutput[] = {
         //
-        3,    'f',  'o',  'o',  // QNAME part: foo
-        3,    'b',  'a',  'r',  // QNAME part: bar
-        0,                      // QNAME ends
-        0,    255,              // QType ANY (totally fake)
-        0,    1,                // QClass IN
-        0x12, 0xcc, 0x03, 0x00, // TTL
-        0,    8,                // data size
-        's',  'o',  'm',  'e',  'd', 'a', 't', 'a',
+        3,   'f', 'o', 'o', // QNAME part: foo
+        3,   'b', 'a', 'r', // QNAME part: bar
+        0,                  // QNAME ends
+        0,   255,           // QType ANY (totally fake)
+        0,   1,             // QClass IN
+        0,   0,   0,   120, // TTL
+        0,   8,             // data size
+        's', 'o', 'm', 'e', 'd', 'a', 't', 'a',
     };
 
     header.Clear();


### PR DESCRIPTION
The TXT records are expiring after 10 seconds which is too low, and the
others expire after years which is too high. Use spec recommended values
of 75 minutes for TXT records and 2 minutes for all other records.