### PR TITLE
Fix secure channel after removing node IDs from rendezvous

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -179,7 +179,9 @@ void RendezvousSession::OnSessionEstablished()
     {
         ChipLogError(Ble, "Missing node id in rendezvous parameters. Node ID is required until opcerts are implemented");
     }
-    mPairingSession.PeerConnection().SetPeerNodeId(mParams.GetRemoteNodeId().ValueOr(kUndefinedNodeId));
+
+    const auto defaultPeerNodeId = mParams.IsController() ? kTestDeviceNodeId : kTestControllerNodeId;
+    mPairingSession.PeerConnection().SetPeerNodeId(mParams.GetRemoteNodeId().ValueOr(defaultPeerNodeId));
 
     CHIP_ERROR err = mSecureSessionMgr->NewPairing(
         Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),


### PR DESCRIPTION
 #### Problem
After merging #4945, CHIP Python Controller is able to pair an accessory device successfully, but then the accessory is unable to decrypt ZCL messages. The reason is that the PR dropped usage of node IDs (in PASE session) which are necessary to identify a correct encryption key.

 #### Summary of Changes
When nodeIDs are missing in CHIP messages use correct defaults to store encryption keys exchanged during the rendezvous session.

 Fixes #5016