### PR TITLE
[nrfconnect] Escape GN arguments coming from CMake

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -46,50 +46,31 @@ list(APPEND CHIP_CFLAGS_CC)
 # CHIP libraries that the application should be linked with
 list(APPEND CHIP_LIBRARIES)
 
-# GN meta-build system arguments in the form of 'key1 = value1\nkey2 = value2...' string
-string(APPEND CHIP_GN_ARGS)
-
-# C/C++ compiler flags which should not be forwarded to CHIP
-# build system (e.g. because CHIP configures them on its own)
-set(CHIP_CFLAG_EXCLUDES 
-    "-fno-asynchronous-unwind-tables"
-    "-fno-common"
-    "-fno-defer-pop"
-    "-fno-reorder-functions"
-    "-ffunction-sections"
-    "-fdata-sections"
-    "-g*"
-    "-O*"
-    "-W*"
-)
+# GN meta-build system arguments passed to the make_gn_args.py script
+list(APPEND CHIP_GN_ARGS)
 
 # ==============================================================================
 # Helper macros
 # ==============================================================================
 
 macro(chip_gn_arg_import FILE)
-    string(APPEND CHIP_GN_ARGS "import(\"${FILE}\")\n")
+    list(APPEND CHIP_GN_ARGS --module "${FILE}")
 endmacro()
 
 macro(chip_gn_arg_string ARG STRING)
-    string(APPEND CHIP_GN_ARGS "${ARG} = \"${STRING}\"\n")
+    list(APPEND CHIP_GN_ARGS --arg-string "${ARG}" "${STRING}")
 endmacro()
 
 macro(chip_gn_arg_bool ARG BOOLEAN)
     if (${BOOLEAN})
-        string(APPEND CHIP_GN_ARGS "${ARG} = true\n")
+        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "true")
     else()
-        string(APPEND CHIP_GN_ARGS "${ARG} = false\n")
+        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "false")
     endif()
 endmacro()
 
 macro(chip_gn_arg_cflags ARG CFLAGS)
-    set(CFLAG_EXCLUDES "[")
-    foreach(cflag ${CHIP_CFLAG_EXCLUDES})
-        string(APPEND CFLAG_EXCLUDES "\"${cflag}\", ")
-    endforeach()
-    string(APPEND CFLAG_EXCLUDES "]")
-    string(APPEND CHIP_GN_ARGS "${ARG} = filter_exclude(string_split(\"${CFLAGS}\"), ${CFLAG_EXCLUDES})\n")
+    list(APPEND CHIP_GN_ARGS --arg-cflags "${ARG}" "${CFLAGS}")
 endmacro()
 
 # ==============================================================================
@@ -217,8 +198,6 @@ chip_gn_arg_cflags("target_cflags_cc"                       ${CHIP_CFLAGS_CC})
 chip_gn_arg_string("zephyr_ar"                              ${CMAKE_AR})
 chip_gn_arg_string("zephyr_cc"                              ${CMAKE_C_COMPILER})
 chip_gn_arg_string("zephyr_cxx"                             ${CMAKE_CXX_COMPILER})
-chip_gn_arg_string("chip_project_config_include"            "${CHIP_PROJECT_CONFIG}")
-chip_gn_arg_string("chip_system_project_config_include"     "${CHIP_PROJECT_CONFIG}")
 chip_gn_arg_bool  ("is_debug"                               CONFIG_DEBUG)
 chip_gn_arg_bool  ("chip_enable_openthread"                 CONFIG_NET_L2_OPENTHREAD)
 chip_gn_arg_bool  ("chip_inet_config_enable_ipv4"           CONFIG_NET_IPV4)
@@ -229,24 +208,28 @@ chip_gn_arg_bool  ("chip_inet_config_enable_dns_resolver"   CONFIG_CHIP_BUILD_TE
 chip_gn_arg_bool  ("chip_build_libshell"                    CONFIG_CHIP_LIB_SHELL)
 chip_gn_arg_bool  ("chip_build_pw_rpc_lib"                  CONFIG_CHIP_PW_RPC)
 
+if (CHIP_PROJECT_CONFIG)
+    chip_gn_arg_string("chip_project_config_include"        ${CHIP_PROJECT_CONFIG})
+    chip_gn_arg_string("chip_system_project_config_include" ${CHIP_PROJECT_CONFIG})
+endif()
+
 if (BOARD STREQUAL "native_posix")
     chip_gn_arg_string("target_cpu" "x86")
 elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
 endif()
 
-file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/args.gn CONTENT ${CHIP_GN_ARGS})
-
 # ==============================================================================
 # Define 'chip-gn' target that builds CHIP library(ies) with GN build system
 # ==============================================================================
-
 ExternalProject_Add(
     chip-gn
     PREFIX                  ${CMAKE_CURRENT_BINARY_DIR}
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
-    CONFIGURE_COMMAND       ${GN_EXECUTABLE}
+    CONFIGURE_COMMAND       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
+                                ${CHIP_GN_ARGS} > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
+                            ${GN_EXECUTABLE}
                                 --root=${CHIP_ROOT}
                                 --root-target=${GN_ROOT_TARGET}
                                 --dotfile=${GN_ROOT_TARGET}/.gn
@@ -255,6 +238,7 @@ ExternalProject_Add(
     BUILD_COMMAND           ninja
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
+    CONFIGURE_ALWAYS        TRUE
     BUILD_ALWAYS            TRUE
     USES_TERMINAL_CONFIGURE TRUE
     USES_TERMINAL_BUILD     TRUE

--- a/config/nrfconnect/chip-module/make_gn_args.py
+++ b/config/nrfconnect/chip-module/make_gn_args.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import re
+import sys
+
+GN_SPECIAL_CHARACTERS = r'(["$\\])'
+GN_CFLAG_EXCLUDES = [
+    '-fno-asynchronous-unwind-tables',
+    '-fno-common',
+    '-fno-defer-pop',
+    '-fno-reorder-functions',
+    '-ffunction-sections',
+    '-fdata-sections',
+    '-g*',
+    '-O*',
+    '-W*',
+]
+
+def escape_strings(gn_args):
+    return [[key, re.sub(GN_SPECIAL_CHARACTERS, r'\\\1', value)] for key, value in gn_args]
+
+def write_gn_args(args):
+    if args.module:
+        sys.stdout.write('import("{}")\n'.format(args.module))
+
+    for key, value in args.arg:
+        sys.stdout.write('{} = {}\n'.format(key, value))
+
+    for key, value in args.arg_string:
+        sys.stdout.write('{} = "{}"\n'.format(key, value))
+
+    cflag_excludes = ', '.join(['"{}"'.format(exclude) for exclude in GN_CFLAG_EXCLUDES])
+
+    for key, value in args.arg_cflags:
+        sys.stdout.write('{} = filter_exclude(string_split("{}"), [{}])\n'.format(key, value, cflag_excludes))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--module', action='store')
+    parser.add_argument('--arg', action='append', nargs=2, default=[])
+    parser.add_argument('--arg-string', action='append', nargs=2, default=[])
+    parser.add_argument('--arg-cflags', action='append', nargs=2, default=[])
+    args = parser.parse_args()
+    args.arg_string = escape_strings(args.arg_string)
+    args.arg_cflags = escape_strings(args.arg_cflags)
+    write_gn_args(args)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
 #### Problem
CMake flags that are passed to GN and contain GN special characters like `"`, `\` and `$` are not escaped and break the build.

 #### Summary of Changes
Provide a dedicated Python script since some of the GN arguments are calculated using CMake generator
expressions which are only evaluated in the build phase, so the escaping can't be fully done in CMake alone.

 Fixes #5063