### PR TITLE
Add kProtocol_SetupPayload to Protocols.h and use it for the setup pa…

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -138,47 +138,27 @@ CHIP_ERROR QRCodeSetupPayloadGenerator::generateTLVFromOptionalData(SetupPayload
 
     TLV::TLVWriter rootWriter;
     rootWriter.Init(tlvDataStart, maxLen);
-    rootWriter.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
 
-    // The cost (in bytes) of the top-level container is amortized as soon as there is at least 4 optionals elements.
-    if ((optionalData.size() + optionalExtensionData.size()) >= 4)
+    TLV::TLVWriter innerStructureWriter;
+
+    err = rootWriter.OpenContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, innerStructureWriter);
+    SuccessOrExit(err);
+
+    for (OptionalQRCodeInfo info : optionalData)
     {
-
-        TLV::TLVWriter innerStructureWriter;
-
-        err = rootWriter.OpenContainer(TLV::ProfileTag(rootWriter.ImplicitProfileId, kTag_QRCodeExensionDescriptor),
-                                       TLV::kTLVType_Structure, innerStructureWriter);
-        SuccessOrExit(err);
-
-        for (OptionalQRCodeInfo info : optionalData)
-        {
-            err = writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info);
-            SuccessOrExit(err);
-        }
-
-        for (OptionalQRCodeInfoExtension info : optionalExtensionData)
-        {
-            err = writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info);
-            SuccessOrExit(err);
-        }
-
-        err = rootWriter.CloseContainer(innerStructureWriter);
+        err = writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info);
         SuccessOrExit(err);
     }
-    else
-    {
-        for (OptionalQRCodeInfo info : optionalData)
-        {
-            err = writeTag(rootWriter, TLV::ProfileTag(rootWriter.ImplicitProfileId, info.tag), info);
-            SuccessOrExit(err);
-        }
 
-        for (OptionalQRCodeInfoExtension info : optionalExtensionData)
-        {
-            err = writeTag(rootWriter, TLV::ProfileTag(rootWriter.ImplicitProfileId, info.tag), info);
-            SuccessOrExit(err);
-        }
+    for (OptionalQRCodeInfoExtension info : optionalExtensionData)
+    {
+        err = writeTag(innerStructureWriter, TLV::ContextTag(info.tag), info);
+        SuccessOrExit(err);
     }
+
+    err = rootWriter.CloseContainer(innerStructureWriter);
+    SuccessOrExit(err);
+
     err = rootWriter.Finalize();
     SuccessOrExit(err);
 

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -266,24 +266,20 @@ CHIP_ERROR QRCodeSetupPayloadParser::parseTLVFields(SetupPayload & outPayload, u
     }
     TLV::TLVReader rootReader;
     rootReader.Init(tlvDataStart, static_cast<uint32_t>(tlvDataLengthInBytes));
-    rootReader.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
-    err                          = rootReader.Next();
+    err = rootReader.Next();
     SuccessOrExit(err);
 
-    if (rootReader.GetType() == TLV::kTLVType_Structure)
+    if (rootReader.GetType() != TLV::kTLVType_Structure)
     {
-        TLV::TLVReader innerStructureReader;
-        err = openTLVContainer(rootReader, TLV::kTLVType_Structure,
-                               TLV::ProfileTag(rootReader.ImplicitProfileId, kTag_QRCodeExensionDescriptor), innerStructureReader);
-        SuccessOrExit(err);
-        err = innerStructureReader.Next();
-        SuccessOrExit(err);
-        err = retrieveOptionalInfos(outPayload, innerStructureReader);
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    else
-    {
-        err = retrieveOptionalInfos(outPayload, rootReader);
-    }
+
+    TLV::TLVReader innerStructureReader;
+    err = openTLVContainer(rootReader, TLV::kTLVType_Structure, TLV::AnonymousTag, innerStructureReader);
+    SuccessOrExit(err);
+    err = innerStructureReader.Next();
+    SuccessOrExit(err);
+    err = retrieveOptionalInfos(outPayload, innerStructureReader);
 
     if (err == CHIP_END_OF_TLV)
     {

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -51,8 +51,7 @@ const int kManualSetupLongCodeCharLength  = 20;
 const int kManualSetupVendorIdCharLength  = 5;
 const int kManualSetupProductIdCharLength = 5;
 
-const uint8_t kSerialNumberTag               = 128;
-const uint32_t kTag_QRCodeExensionDescriptor = 0x00;
+const uint8_t kSerialNumberTag = 128;
 
 // The largest value of the 12-bit Payload discriminator
 const uint16_t kMaxDiscriminatorValue = 0xFFF;

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -127,24 +127,6 @@ inline bool CompareBinary(SetupPayload & payload, std::string & expectedBinary)
     return (expectedBinary == resultBinary);
 }
 
-inline bool CompareBinaryLength(SetupPayload & payload, size_t expectedTLVLengthInBytes)
-{
-    std::string result;
-    uint8_t optionalInfo[kDefaultBufferSizeInBytes];
-
-    SetupPayload basePayload = GetDefaultPayload();
-    QRCodeSetupPayloadGenerator baseGenerator(basePayload);
-    baseGenerator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
-    std::string baseBinary = toBinaryRepresentation(result);
-
-    QRCodeSetupPayloadGenerator generator(payload);
-    generator.payloadBase41Representation(result, optionalInfo, sizeof(optionalInfo));
-
-    std::string resultBinary      = toBinaryRepresentation(result);
-    size_t resultTLVLengthInBytes = (resultBinary.size() - baseBinary.size()) / 8;
-    return (expectedTLVLengthInBytes == resultTLVLengthInBytes);
-}
-
 inline bool CheckWriteRead(SetupPayload & inPayload)
 {
     SetupPayload outPayload;

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -224,31 +224,6 @@ void TestOptionalDataWriteSmallBuffer(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 
-void TestPayloadBinary(nlTestSuite * inSuite, void * inContext)
-{
-    SetupPayload payload = GetDefaultPayload();
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 0));
-
-    payload.addOptionalVendorData(kOptionalDefaultStringTag, "1");
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 5));
-    payload.removeOptionalVendorData(kOptionalDefaultStringTag);
-
-    payload.addOptionalVendorData(1, kOptionalDefaultIntValue);
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 4));
-
-    payload.addOptionalVendorData(2, kOptionalDefaultIntValue);
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 8));
-
-    payload.addOptionalVendorData(3, kOptionalDefaultIntValue);
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 12));
-
-    payload.addOptionalVendorData(4, kOptionalDefaultIntValue);
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 16));
-
-    payload.addOptionalVendorData(5, kOptionalDefaultIntValue);
-    NL_TEST_ASSERT(inSuite, CompareBinaryLength(payload, 19));
-}
-
 // Test Suite
 
 /**
@@ -270,7 +245,6 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test Optional Read Vendor Int",    TestOptionalDataReadVendorInt),
     NL_TEST_DEF("Test Optional Read",               TestOptionalDataRead),
     NL_TEST_DEF("Test Optional Tag Values",         TestOptionalTagValues),
-    NL_TEST_DEF("Test Payload Binary",              TestPayloadBinary),
 
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
…yload instead of kProtocol_ServiceProvisioning

 #### Problem

The TLV implicit profile used into `src/setup_payload` is wrong.

 #### Summary of Changes
 * Add `kProtocol_SetupPayload` to `Protocols.h`
 * Replace the 2 occurrences of `kProtocol_ServiceProvisioning` inside `src/setup_payload` with `kProtocol_SetupPayload`

 Fixes #1133 