### PR TITLE
Let Txt records use the default ttl from the base class instead of 10s

### DIFF
--- a/src/lib/mdns/minimal/records/Txt.h
+++ b/src/lib/mdns/minimal/records/Txt.h
@@ -27,27 +27,19 @@ namespace Minimal {
 class TxtResourceRecord : public ResourceRecord
 {
 public:
-    static constexpr uint64_t kDefaultTtl = 10;
-
     TxtResourceRecord(const FullQName & qName, const char ** entries, size_t entryCount) :
         ResourceRecord(QType::TXT, qName), mEntries(entries), mEntryCount(entryCount)
-    {
-        SetTtl(kDefaultTtl);
-    }
+    {}
 
     template <size_t N>
     TxtResourceRecord(const FullQName & qName, const char * (&entries)[N]) :
         ResourceRecord(QType::TXT, qName), mEntries(entries), mEntryCount(N)
-    {
-        SetTtl(kDefaultTtl);
-    }
+    {}
 
     // A FullQName is a holder of a string array.
     TxtResourceRecord(const FullQName & qName, FullQName entries) :
         ResourceRecord(QType::TXT, qName), mEntries(entries.names), mEntryCount(entries.nameCount)
-    {
-        SetTtl(kDefaultTtl);
-    }
+    {}
 
 protected:
     bool WriteData(chip::Encoding::BigEndian::BufferWriter & out) const override


### PR DESCRIPTION
 #### Problem
TXT record TTL for minMdns is 10s.
ResourceRecord already has a TTL, so we may as well use it (plus 10s is too short for mdns clients that are capable of caching, like avahi).

 #### Summary of Changes
Drops TXT record default ttl - resourcerecord default will be used.