### PR TITLE
Fix Issues building and running python controller on MacOS

### DIFF
--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -24,9 +24,9 @@ Follow [BUILDING.md](/docs/BUILDING.md) to setup CHIP on your platform.
 Genrally, once build dependencies are satisfied you can build the `python`
 target.
 
--  If you are on MacOS BigSur(11.x) set this export before running the script
-   `export MACOSX_DEPLOYMENT_TARGET=10.16`
-   to prevent ".whl is not a supported wheel on this platform." when trying to install it
+-   If you are on MacOS BigSur(11.x) set this export before running the script
+    `export MACOSX_DEPLOYMENT_TARGET=10.16` to prevent ".whl is not a supported
+    wheel on this platform." when trying to install it
 
 Use `scripts/build_python.sh` or run something equivalent to:
 

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -24,6 +24,10 @@ Follow [BUILDING.md](/docs/BUILDING.md) to setup CHIP on your platform.
 Genrally, once build dependencies are satisfied you can build the `python`
 target.
 
+-  If you are on MacOS BigSur(11.x) set this export before running the script
+   `export MACOSX_DEPLOYMENT_TARGET=10.16`
+   to prevent ".whl is not a supported wheel on this platform." when trying to install it
+
 Use `scripts/build_python.sh` or run something equivalent to:
 
 ```sh
@@ -139,6 +143,26 @@ chip-device-ctrl > set-pairing-wifi-credential TestAP TestPassword
 
 ```
 chip-device-ctrl > connect -ble 1383 12345678
+```
+
+## Thread Secure Session provisioning
+
+1. Run CHIP Device Controller
+
+```
+sudo chip-device-ctrl
+```
+
+2. Set Thread credentials
+
+```
+set-pairing-thread-credential <channel> <pan id[HEX]> <master_key>
+```
+
+3. BLE Connect to the device
+
+```
+connect -ble <discriminator> <setup pin code> [<nodeid>]
 ```
 
 ## IP Secure Session Establishment

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -110,6 +110,9 @@ try:
     requiredPackages = []
 
     requiredPackages.append('ipython')
+
+    if platform.system() == 'Darwin':
+        requiredPackages.append('pyobjc')
     
     if platform.system() == 'Linux':
         requiredPackages.append('dbus-python')


### PR DESCRIPTION
 #### Problem
Installing the built .whl on macOs BigSur(11.x) fails with error:
`ERROR: chip-0.0-cp38-cp38-macosx_11_0_x86_64.whl is not a supported wheel on this platform.`

Running the chip-device-ctrl fails due to a missing python module.
```
chip-device-ctrl 
Traceback (most recent call last):
 File "/Users/GitHub/connectedhomeip/out/python_env/bin/chip-device-ctrl", line 65, in <module>
  from chip.ChipCoreBluetoothMgr import CoreBluetoothManager as BleManager
 File "/Users/GitHub/connectedhomeip/out/python_env/lib/python3.8/site-packages/chip/ChipCoreBluetoothMgr.py", line 28, in <module>
  from Foundation import *
ModuleNotFoundError: No module named 'Foundation'
```

 #### Summary of Changes
add required install of `pyobjc` package in `build-chip-wheel.py`, when on Darwin system, to run the python controller

update python controler readme:
- Mention for needed environement VAR `export MACOSX_DEPLOYMENT_TARGET=10.16` when running on MacOS BigSur to build the controller whl
- Thread credential provision commands

