### PR TITLE
Fix docker build errors

### DIFF
--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -4,7 +4,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 # Setup the ESP-IDF
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y python \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y python libgcrypt20-dev \
     && mkdir -p /opt/espressif \
     && cd /opt/espressif \
     && git clone --progress -b release/v4.2 https://github.com/espressif/esp-idf.git \

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -10,7 +10,6 @@ COPY --from=esp32 /opt/espressif/qemu /opt/espressif/qemu
 COPY --from=nrf /opt/NordicSemiconductor/nRF5_tools /opt/NordicSemiconductor/nRF5_tools
 COPY --from=nrf /opt/NordicSemiconductor/nrfconnect /opt/NordicSemiconductor/nrfconnect
 COPY --from=nrf /opt/ARM-software/gcc-arm-none-eabi-9-2019-q4-major /opt/ARM-software/gcc-arm-none-eabi-9-2019-q4-major
-COPY --from=efr32 /opt/SiliconLabs/sdk_support /opt/SiliconLabs/sdk_support
 COPY --from=android /opt/android/sdk /opt/android/sdk
 COPY --from=android /opt/android/android-ndk-r21b /opt/android/android-ndk-r21b
 ENV IDF_PATH=/opt/espressif/esp-idf/


### PR DESCRIPTION
 #### Problem
Docker build errors:
  - esp32 needs gcrypt header
  - sdk_support not available in efr32 anymore (was moved to repoo)

 #### Summary of Changes
Updated dockerfiles and I was able to push the latest version.
