### PR TITLE
Update qemu dockerfile 

### DIFF
--- a/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
@@ -4,9 +4,10 @@ FROM connectedhomeip/chip-build-esp32:${VERSION}
 # Setup QEMU emulator for ESP32 platform
 RUN set -x \
     && mkdir -p /opt/espressif \
-    && git clone --progress https://github.com/espressif/qemu.git /opt/espressif/qemu \
+    && git clone --progress --depth 1 --branch esp-develop-20210220 https://github.com/espressif/qemu.git /opt/espressif/qemu-src \
+    && mkdir -p /opt/espressif/qemu \
     && (cd /opt/espressif/qemu \
-    && ./configure --target-list=xtensa-softmmu --enable-debug --enable-sanitizers --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
+    && ../qemu-src/configure --target-list=xtensa-softmmu --enable-debug --enable-sanitizers --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
     && make -j8) \
     && : # last line
 


### PR DESCRIPTION
 #### Problem
QEMU checkout was using master and it stopped supporting in-source builds (separate `build` directory is created).

 #### Summary of Changes
 
 Pin QEMU checkout to a fixed tag so this does not happen again
Perform an out of source build (checkout in a `-src` directory).

