### PR TITLE
Update chip-tool zapt to align with src/app/zap-templates

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -60,6 +60,14 @@ static void OnInt16sAttributeResponse(void * context, int16_t value)
     command->SetCommandExitStatus(true);
 }
 
+static void OnInt64uAttributeResponse(void * context, uint64_t value)
+{
+    ChipLogProgress(chipTool, "Int64u attribute Response: %" PRIu64, value);
+
+    ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
+    command->SetCommandExitStatus(true);
+}
+
 {{#all_user_clusters}}
 {{#if (isClient side) }}
 {{#if (user_cluster_has_enabled_command name side)}}
@@ -117,7 +125,7 @@ public:
 
         chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
         cluster.Associate(device, endpointId);
-        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isByteString type)}} reinterpret_cast<uint8_t*>(m{{asCamelCased label false}}), static_cast<uint32_t>(strlen(m{{asCamelCased label false}})){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_server_cluster_command_arguments}});
+        return cluster.{{asCamelCased name false}}(onSuccessCallback->Cancel(), onFailureCallback->Cancel(){{#chip_server_cluster_command_arguments}}, {{#if (isByteString type)}} reinterpret_cast<char*>(m{{asCamelCased label false}}){{else}}m{{asCamelCased label false}}{{/if}}{{/chip_server_cluster_command_arguments}});
     }
 
 private:


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Once I run
./scripts/tools/zap_regen_all.py && ./gn_build.sh

Got the following error:
I../../third_party/lwip/repo/lwip/src/include -I../../src/lwip/include -I../../src/setup_payload -I../../third_party/inipp/repo/inipp -c ../../examples/chip-tool/main.cpp -o standalone/obj/examples/chip-tool/chip-tool.main.cpp.o
In file included from ../../examples/chip-tool/main.cpp:21:
../../examples/chip-tool/commands/clusters/Commands.h:4682:264: error: too many arguments to function call, expected 6, have 8
        return cluster.SetFabric(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),  reinterpret_cast<uint8_t*>(mFabricId), static_cast<uint32_t>(strlen(mFabricId)),  reinterpret_cast<uint8_t*>(mFabricSecret), static_cast<uint32_t>(strlen(mFabricSecret)), mBreadcrumb, mTimeoutMs);
               ~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                       ^~~~~~~~~~~~~~~~~~~~~~~
../../src/controller/CHIPClusters.h:338:5: note: 'SetFabric' declared here
    CHIP_ERROR SetFabric(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback, char * fabricId, char * fabricSecret, uint64_t breadcrumb, uint32_t timeoutMs);

The problem is chip-tool zapt translates type "byteString" to following two arguments:
 "reinterpret_cast<uint8_t*>(arg), static_cast<uint32_t>(strlen(arg))"

This is not aligned with src/app/zap-templates, if we can take arg length with strlen, then it seems the length argument is not necessary.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Update chip-tool zapt to align with src/app/zap-templates

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->

 #### Test
 ./scripts/tools/zap_regen_all.py && ./gn_build.sh
 All builds passed