### PR TITLE
[mdns] fix esp32 mdns publish error with platform implementation

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -20,6 +20,7 @@
 #include <core/Optional.h>
 #include <mdns/Advertiser.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/ConfigurationManager.h>
 #include <support/ReturnMacros.h>
 #include <support/logging/CHIPLogging.h>
 #include <transport/AdminPairingTable.h>
@@ -66,7 +67,6 @@ NodeId GetCurrentNodeId()
 /// Set MDNS operational advertisement
 CHIP_ERROR AdvertiseOperational()
 {
-
     uint64_t fabricId;
 
     if (DeviceLayer::ConfigurationMgr().GetFabricId(fabricId) != CHIP_NO_ERROR)
@@ -131,6 +131,18 @@ CHIP_ERROR AdvertiseCommisioning()
 void StartServer()
 {
     CHIP_ERROR err = chip::Mdns::ServiceAdvertiser::Instance().Start(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
+
+    // TODO: advertise this only when really operational once we support both
+    // operational and commisioning advertising is supported.
+    if (DeviceLayer::ConfigurationMgr().IsFullyProvisioned())
+    {
+        err = app::Mdns::AdvertiseOperational();
+    }
+    else
+    {
+        err = app::Mdns::AdvertiseCommisioning();
+    }
+
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Discovery, "Failed to start mDNS server: %s", chip::ErrorStr(err));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -532,20 +532,6 @@ void InitServer(AppDelegate * delegate)
 #endif
     }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-    // TODO: advertise this only when really operational once we support both
-    // operational and commisioning advertising is supported.
-    if (ConfigurationMgr().IsFullyProvisioned())
-    {
-        err = app::Mdns::AdvertiseOperational();
-    }
-    else
-    {
-        err = app::Mdns::AdvertiseCommisioning();
-    }
-    SuccessOrExit(err);
-#endif
-
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -150,7 +150,7 @@ public:
     virtual ~ServiceAdvertiser() {}
 
     /// Starts the advertiser. Items 'Advertised' will become visible.
-    /// May be called before OR after Advertise() calls.
+    /// Must be called before Advertise() calls.
     virtual CHIP_ERROR Start(chip::Inet::InetLayer * inetLayer, uint16_t port) = 0;
 
     /// Advertises the CHIP node as an operational node

--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -30,12 +30,6 @@ namespace Mdns {
 class DiscoveryImplPlatform : public ServiceAdvertiser, public Resolver
 {
 public:
-    /**
-     * This method initializes the publisher.
-     *
-     */
-    CHIP_ERROR Init();
-
     CHIP_ERROR Start(Inet::InetLayer * inetLayer, uint16_t port) override;
 
     /// Advertises the CHIP node as an operational node


### PR DESCRIPTION
 #### Problem
The mdns module cannot be initialized until the ESP32 is connected to
the wifi network.

 #### Summary of Changes

* Fix various build errors and warnings
* Move mdns initialization to `Start()`
* Advertise CHIP services in the server until the advertiser has been
  started

fixes https://github.com/project-chip/connectedhomeip/issues/5076
