### PR TITLE
Typo. MdnsAsnycReturnCallback -> MdnsAsyncReturnCallback

### DIFF
--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -95,7 +95,7 @@ using MdnsResolveCallback = void (*)(void * context, MdnsService * result, CHIP_
  */
 using MdnsBrowseCallback = void (*)(void * context, MdnsService * services, size_t servicesSize, CHIP_ERROR error);
 
-using MdnsAsnycReturnCallback = void (*)(void * context, CHIP_ERROR error);
+using MdnsAsyncReturnCallback = void (*)(void * context, CHIP_ERROR error);
 
 /**
  * This function intializes the mdns module
@@ -108,7 +108,7 @@ using MdnsAsnycReturnCallback = void (*)(void * context, CHIP_ERROR error);
  * @retval Error code     The initialization fails
  *
  */
-CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context);
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context);
 
 /**
  * This function sets the host name for services.

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -37,7 +37,7 @@ static constexpr size_t kMaxResults     = 20;
 namespace chip {
 namespace Mdns {
 
-CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context)
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     esp_err_t espError;

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -326,7 +326,7 @@ void Poller::Process(const fd_set & readFdSet, const fd_set & writeFdSet, const 
     }
 }
 
-CHIP_ERROR MdnsAvahi::Init(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context)
+CHIP_ERROR MdnsAvahi::Init(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int avahiError   = 0;
@@ -737,7 +737,7 @@ void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet)
     MdnsAvahi::GetInstance().GetPoller().Process(readFdSet, writeFdSet, errorFdSet);
 }
 
-CHIP_ERROR ChipMdnsInit(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context)
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
 {
     return MdnsAvahi::GetInstance().Init(initCallback, errorCallback, context);
 }

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -100,7 +100,7 @@ public:
     MdnsAvahi(const MdnsAvahi &) = delete;
     MdnsAvahi & operator=(const MdnsAvahi &) = delete;
 
-    CHIP_ERROR Init(MdnsAsnycReturnCallback initCallback, MdnsAsnycReturnCallback errorCallback, void * context);
+    CHIP_ERROR Init(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context);
     CHIP_ERROR SetHostname(const char * hostname);
     CHIP_ERROR PublishService(const MdnsService & service);
     CHIP_ERROR StopPublish();
@@ -148,8 +148,8 @@ private:
                               const char * host_name, const AvahiAddress * address, uint16_t port, AvahiStringList * txt,
                               AvahiLookupResultFlags flags, void * userdata);
 
-    MdnsAsnycReturnCallback mInitCallback;
-    MdnsAsnycReturnCallback mErrorCallback;
+    MdnsAsyncReturnCallback mInitCallback;
+    MdnsAsyncReturnCallback mErrorCallback;
     void * mAsyncReturnContext;
 
     std::set<std::string> mPublishedServices;


### PR DESCRIPTION
 #### Problem

`MdnsAsnycReturnCallback` -> `MdnsAsyncReturnCallback`
