### PR TITLE
[linux] mNodeId->mAdapterId for BLE on linux

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -171,11 +171,11 @@ uint16_t BLEManagerImpl::_NumConnections()
     return numCons;
 }
 
-CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aNodeId, bool aIsCentral)
+CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
 {
     CHIP_ERROR err                  = CHIP_NO_ERROR;
     mBLEAdvConfig.mpBleName         = mDeviceName;
-    mBLEAdvConfig.mNodeId           = aNodeId;
+    mBLEAdvConfig.mAdapterId        = aAdapterId;
     mBLEAdvConfig.mMajor            = 1;
     mBLEAdvConfig.mMinor            = 1;
     mBLEAdvConfig.mVendorId         = 1;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -40,7 +40,7 @@ void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
 struct BLEAdvConfig
 {
     char * mpBleName;
-    uint32_t mNodeId;
+    uint32_t mAdapterId;
     uint8_t mMajor;
     uint8_t mMinor;
     uint16_t mVendorId;
@@ -89,7 +89,7 @@ class BLEManagerImpl final : public BLEManager,
     friend BLEManager;
 
 public:
-    CHIP_ERROR ConfigureBle(uint32_t aNodeId, bool aIsCentral);
+    CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
 
     // Driven by BlueZ IO
     static void HandleNewConnection(BLE_CONNECTION_OBJECT conId);

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -980,7 +980,7 @@ static void bluezObjectsSetup(BluezEndpoint * apEndpoint)
 
     VerifyOrExit(apEndpoint != nullptr, ChipLogError(DeviceLayer, "endpoint is NULL in %s", __func__));
 
-    expectedPath = g_strdup_printf("%s/hci%d", BLUEZ_PATH, apEndpoint->mNodeId);
+    expectedPath = g_strdup_printf("%s/hci%d", BLUEZ_PATH, apEndpoint->mAdapterId);
     objects      = g_dbus_object_manager_get_objects(apEndpoint->mpObjMgr);
 
     for (l = objects; l != nullptr && apEndpoint->mpAdapter == nullptr; l = l->next)
@@ -1507,7 +1507,7 @@ CHIP_ERROR ConfigureBluezAdv(BLEAdvConfig & aBleAdvConfig, BluezEndpoint * apEnd
 
     apEndpoint->mpAdapterName     = g_strdup(aBleAdvConfig.mpBleName);
     apEndpoint->mpAdvertisingUUID = g_strdup(aBleAdvConfig.mpAdvertisingUUID);
-    apEndpoint->mNodeId           = aBleAdvConfig.mNodeId;
+    apEndpoint->mAdapterId        = aBleAdvConfig.mAdapterId;
     apEndpoint->mType             = aBleAdvConfig.mType;
     apEndpoint->mDuration         = aBleAdvConfig.mDuration;
     apEndpoint->mDuration         = aBleAdvConfig.mDuration;

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -156,7 +156,7 @@ struct BluezEndpoint
 
     // map device path to the connection
     GHashTable * mpConnMap;
-    uint32_t mNodeId;
+    uint32_t mAdapterId;
     bool mIsCentral;
     char * mpAdvertisingUUID;
     chip::Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The Linux ble manager is using mNodeId, which is confusing.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Rename it to mAdapterId. Only Linux platform is affected.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
