### PR TITLE
[zephyr] Fix logging long integers

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -20,6 +20,7 @@ menuconfig CHIP
 	select CPLUSPLUS
 	imply LIB_CPLUSPLUS
 	imply REQUIRES_FULL_LIBC
+	imply CBPRINTF_LIBC_SUBSTS
 	imply POSIX_API if !ARCH_POSIX
 	imply EVENTFD if !ARCH_POSIX
 	imply REBOOT

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -7,8 +7,7 @@
 
 #include <kernel.h>
 #include <logging/log.h>
-
-#include <cstdio>
+#include <sys/cbprintf.h>
 
 LOG_MODULE_REGISTER(chip, LOG_LEVEL_DBG);
 
@@ -36,7 +35,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
 
-    snprintf(formattedMsg, sizeof(formattedMsg), "%u [%s]", k_uptime_get_32(), module);
+    snprintfcb(formattedMsg, sizeof(formattedMsg), "%u [%s]", k_uptime_get_32(), module);
 
     // -2 to ensure at least one byte available for vsnprintf below.
     formattedMsg[sizeof(formattedMsg) - 2] = 0;
@@ -44,7 +43,7 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     size_t prefixLen = strlen(formattedMsg);
 
     // Append the log message.
-    vsnprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, msg, v);
+    vsnprintfcb(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, msg, v);
 
     // Invoke the Zephyr logging library to log the message.
     //


### PR DESCRIPTION
 #### Problem
"Nano" implementation of the newlib libc for ARM can't correctly process "%llu", "%llx" and other long-int format specifiers. 

 #### Summary of Changes
Replace snprintf functions from libc with substitutes provided by Zephyr itself.