### PR TITLE
remove use of <iterator>

### DIFF
--- a/src/lib/mdns/minimal/responders/QueryResponder.h
+++ b/src/lib/mdns/minimal/responders/QueryResponder.h
@@ -164,8 +164,8 @@ class QueryResponderIterator
 {
 public:
     using value_type = QueryResponderRecord;
-    using pointer = QueryResponderRecord*;
-    using reference = QueryResponderRecord&;
+    using pointer    = QueryResponderRecord *;
+    using reference  = QueryResponderRecord &;
 
     QueryResponderIterator() : mCurrent(nullptr), mRemaining(0) {}
     QueryResponderIterator(QueryResponderRecordFilter * recordFilter, Internal::QueryResponderInfo * pos, size_t size) :

--- a/src/lib/mdns/minimal/responders/QueryResponder.h
+++ b/src/lib/mdns/minimal/responders/QueryResponder.h
@@ -22,8 +22,6 @@
 
 #include <inet/InetLayer.h>
 
-#include <iterator>
-
 namespace mdns {
 namespace Minimal {
 
@@ -162,9 +160,13 @@ private:
 
 /// Iterates over an array of QueryResponderRecord items, providing only 'valid' ones, where
 /// valid is based on the provided filter.
-class QueryResponderIterator : public std::iterator<std::input_iterator_tag, QueryResponderRecord>
+class QueryResponderIterator
 {
 public:
+    using value_type = QueryResponderRecord;
+    using pointer = QueryResponderRecord*;
+    using reference = QueryResponderRecord&;
+
     QueryResponderIterator() : mCurrent(nullptr), mRemaining(0) {}
     QueryResponderIterator(QueryResponderRecordFilter * recordFilter, Internal::QueryResponderInfo * pos, size_t size) :
         mFilter(recordFilter), mCurrent(pos), mRemaining(size)

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <core/CHIPPersistentStorageDelegate.h>
-#include <iterator>
 #include <support/DLLUtil.h>
 #include <transport/raw/MessageHeader.h>
 
@@ -115,9 +114,13 @@ private:
 /**
  * Iterates over valid admins within a list
  */
-class ConstAdminIterator : public std::iterator<std::forward_iterator_tag, const AdminPairingInfo>
+class ConstAdminIterator
 {
 public:
+    using value_type = AdminPairingInfo;
+    using pointer = AdminPairingInfo*;
+    using reference = AdminPairingInfo&;
+
     ConstAdminIterator(const AdminPairingInfo * start, size_t index, size_t maxSize) :
         mStart(start), mIndex(index), mMaxSize(maxSize)
     {

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -118,8 +118,8 @@ class ConstAdminIterator
 {
 public:
     using value_type = AdminPairingInfo;
-    using pointer = AdminPairingInfo*;
-    using reference = AdminPairingInfo&;
+    using pointer    = AdminPairingInfo *;
+    using reference  = AdminPairingInfo &;
 
     ConstAdminIterator(const AdminPairingInfo * start, size_t index, size_t maxSize) :
         mStart(start), mIndex(index), mMaxSize(maxSize)


### PR DESCRIPTION
#### Problem

`<iterator>` includes `<iostream>` which includes `<locale>`,
which breaks the K32W build and could lead to size increases.

`<iterator>` is only used for `std::iterator<>`, which is
deprecated in C++17.

#### Summary of Changes

Replace uses of `std::iterator<>`.

Fixes #5060 - remove use of `<iterator>`
