### PR TITLE
Fix various issues from a code review of PR #4932.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -88,12 +88,12 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     VerifyOrReturnError(state != nullptr, CHIP_ERROR_NOT_CONNECTED);
 
     // If a group message is to be transmitted to a destination node whose message counter is unknown.
-    if (ChipKeyId::IsAppGroupKey(state->GetLocalKeyID()) && !state->isPeerMsgCounterSynced())
+    if (ChipKeyId::IsAppGroupKey(state->GetLocalKeyID()) && !state->IsPeerMsgCounterSynced())
     {
         MessageCounterSyncMgr * messageCounterSyncMgr = mExchangeMgr->GetMessageCounterSyncMgr();
         VerifyOrReturnError(messageCounterSyncMgr != nullptr, CHIP_ERROR_INTERNAL);
 
-        // Queue the message as need for sync with destination node.
+        // Queue the message as needed for sync with destination node.
         err = messageCounterSyncMgr->AddToRetransmissionTable(protocolId, msgType, sendFlags, std::move(msgBuf), this);
         ReturnErrorOnFailure(err);
 

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -223,6 +223,11 @@ private:
     bool MatchExchange(SecureSessionHandle session, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader);
 
     CHIP_ERROR StartResponseTimer();
+
+    /**
+     * A subset of SendMessage functionality that does not perform message
+     * counter sync for group keys.
+     */
     CHIP_ERROR SendMessageImpl(uint16_t protocolId, uint8_t msgType, System::PacketBufferHandle msgBuf, const SendFlags & sendFlags,
                                Transport::PeerConnectionState * state = nullptr);
     void CancelResponseTimer();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -206,7 +206,7 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(uint32_t protocolId, int16_t msgType)
     return CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER;
 }
 
-bool ExchangeManager::isMsgCounterSyncMessage(const PayloadHeader & payloadHeader) const
+bool ExchangeManager::IsMsgCounterSyncMessage(const PayloadHeader & payloadHeader)
 {
     if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncReq) ||
         payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp))
@@ -231,12 +231,12 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     UnsolicitedMessageHandler * matchingUMH = nullptr;
     bool sendAckAndCloseExchange            = false;
 
-    if (!isMsgCounterSyncMessage(payloadHeader) && packetHeader.IsPeerGroupMsgIdNotSynchronized())
+    if (!IsMsgCounterSyncMessage(payloadHeader) && packetHeader.IsPeerGroupMsgIdNotSynchronized())
     {
         Transport::PeerConnectionState * state = mSessionMgr->GetPeerConnectionState(session);
         VerifyOrReturn(state != nullptr);
 
-        // Queue the message as need for sync with destination node.
+        // Queue the message as needed for sync with destination node.
         err = mMessageCounterSyncMgr.AddToReceiveTable(packetHeader, payloadHeader, session, std::move(msgBuf));
         VerifyOrReturn(err == CHIP_NO_ERROR);
 
@@ -254,7 +254,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         }
 
         // After the message that triggers message counter synchronization is stored, and a message counter
-        // synchronization exchange is initiated, we need to return immeidately and re-process the original message
+        // synchronization exchange is initiated, we need to return immediately and re-process the original message
         // when the synchronization is completed.
 
         return;

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -173,7 +173,8 @@ public:
 
     /**
      * @brief
-     *   Called when a cached group message is received.
+     *   Called when a cached group message that was waiting for message counter
+     *   sync shold be reprocessed.
      *
      * @param packetHeader  The message header
      * @param payloadHeader The payload header
@@ -225,7 +226,7 @@ private:
     CHIP_ERROR RegisterUMH(uint32_t protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(uint32_t protocolId, int16_t msgType);
 
-    bool isMsgCounterSyncMessage(const PayloadHeader & payloadHeader) const;
+    static bool IsMsgCounterSyncMessage(const PayloadHeader & payloadHeader);
 
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * msgLayer) override;
 

--- a/src/messaging/MessageCounterSync.h
+++ b/src/messaging/MessageCounterSync.h
@@ -76,7 +76,7 @@ public:
                                         System::PacketBufferHandle msgBuf, Messaging::ExchangeContext * exchangeContext);
 
     /**
-     *  Add a CHIP message into the cache table to queue the incomming messages that trigger message counter synchronization
+     *  Add a CHIP message into the cache table to queue the incoming messages that trigger message counter synchronization
      * protocol for re-processing.
      *
      *  @param[in]    packetHeader     The message header for the received message.
@@ -98,12 +98,13 @@ private:
      *    This class is part of the CHIP Message Counter Synchronization Protocol and is used
      *    to keep track of a CHIP messages to be transmitted to a destination node whose message
      *    counter is unknown. The message would be retransmitted from this table after message
-     *    synchronization is completed.
+     *    counter synchronization is completed.
      *
      */
     struct RetransTableEntry
     {
-        ExchangeContext * exchangeContext; /**< The ExchangeContext for the stored CHIP message. */
+        ExchangeContext * exchangeContext; /**< The ExchangeContext for the stored CHIP message.
+                                                Non-null if and only if this entry is in use. */
         System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the CHIP message. */
         SendFlags sendFlags;               /**< Flags set by the application for the CHIP message being sent. */
         uint16_t protocolId;               /**< The protocol identifier of the CHIP message to be sent. */
@@ -115,17 +116,19 @@ private:
      *
      *  @brief
      *    This class is part of the CHIP Message Counter Synchronization Protocol and is used
-     *    to keep track of a CHIP messages to be transmitted to a destination node whose message
-     *    counter is unknown. The message would be retransmitted from this table after message
-     *    synchronization is completed.
+     *    to keep track of a CHIP messages to be reprocessed whose source's
+     *    message counter is unknown. The message is reprocessed after message
+     *    counter synchronization is completed.
      *
      */
     struct ReceiveTableEntry
     {
-        PacketHeader packetHeader;         /**< The ExchangeContext for the stored CHIP message. */
-        PayloadHeader payloadHeader;       /**< Flags set by the application for the CHIP message being sent. */
-        SecureSessionHandle session;       /**< The protocol identifier of the CHIP message to be sent. */
-        System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the CHIP message. */
+        PacketHeader packetHeader;         /**< The packet header for the message. */
+        PayloadHeader payloadHeader;       /**< The payload header for the message. */
+        SecureSessionHandle session;       /**< The secure session the message was received on. */
+        System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding
+                                                the message data. This is non-null if and only
+                                                if this entry is in use. */
     };
 
     Messaging::ExchangeManager * mExchangeMgr; // [READ ONLY] Associated Exchange Manager object.
@@ -133,7 +136,7 @@ private:
     // MessageCounterSyncProtocol cache table to queue the outging messages that trigger message counter synchronization protocol.
     RetransTableEntry mRetransTable[CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS];
 
-    // MessageCounterSyncProtocol cache table to queue the incomming messages that trigger message counter synchronization protocol.
+    // MessageCounterSyncProtocol cache table to queue the incoming messages that trigger message counter synchronization protocol.
     ReceiveTableEntry mReceiveTable[CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS];
 
     void RetransPendingGroupMsgs(NodeId peerNodeId);

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -64,7 +64,7 @@ public:
     void SetTransport(Transport::Base * transport) { mTransport = transport; }
     Transport::Base * GetTransport() { return mTransport; }
 
-    bool isPeerMsgCounterSynced() { return (mPeerMessageIndex != kUndefinedMessageIndex); }
+    bool IsPeerMsgCounterSynced() { return (mPeerMessageIndex != kUndefinedMessageIndex); }
     void SetPeerMessageIndex(uint32_t id) { mPeerMessageIndex = id; }
 
     NodeId GetPeerNodeId() const { return mPeerNodeId; }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -345,7 +345,7 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         state->SetPeerAddress(peerAddress);
     }
 
-    if (!state->isPeerMsgCounterSynced())
+    if (!state->IsPeerMsgCounterSynced())
     {
         // For all control messages, the first authenticated message counter from an unsynchronized peer is trusted
         // and used to seed subsequent message counter based replay protection.


### PR DESCRIPTION
* Methods with lowercase first letters in names.
* Mis-spellings in comments.
* IsMsgCounterSyncMessage can be static; it does not use exchange manager state.
* Clarify some comments
* Fix some completely copy-pasted-wrong comments.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Various issues in the code that landed in #4932.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

