### PR TITLE
Fix build_python.sh on Mac without requiring coreutils

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -18,6 +18,10 @@
 
 set -e
 
+_normpath() {
+    python -c "import os.path; print(os.path.normpath('$@'))"
+}
+
 echo_green() {
     echo -e "\033[0;32m$*\033[0m"
 }
@@ -30,7 +34,7 @@ echo_bold_white() {
     echo -e "\033[1;37m$*\033[0m"
 }
 
-CHIP_ROOT=$(realpath "$(dirname "$0")/..")
+CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/python_lib"
 ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 
@@ -51,11 +55,9 @@ source "$ENVIRONMENT_ROOT"/bin/activate
 "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade pip
 "$ENVIRONMENT_ROOT"/bin/pip install "$OUTPUT_ROOT"/controller/python/chip-*.whl
 
-RELATIVE_ENVIRONMENT_ROOT=$(realpath --relative-to "$PWD" "$ENVIRONMENT_ROOT")
-
 echo ""
 echo_green "Compilation completed and WHL package installed in: "
-echo_blue "  $RELATIVE_ENVIRONMENT_ROOT"
+echo_blue "  $ENVIRONMENT_ROOT"
 echo ""
 echo_green "To use please run:"
-echo_bold_white "  source $RELATIVE_ENVIRONMENT_ROOT/bin/activate"
+echo_bold_white "  source $ENVIRONMENT_ROOT/bin/activate"

--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -1,4 +1,5 @@
 pip-tools
+virtualenv
 
 # esp-idf
 pyelftools>=0.22
@@ -16,6 +17,9 @@ requests>=2.24.0
 wheel==0.34.2
 dbus-python; sys_platform == 'linux'
 pgi; sys_platform == 'linux'
+pyobjc-core; sys_platform == 'darwin'
+pyobjc-framework-cocoa; sys_platform == 'darwin'
+pyobjc-framework-corebluetooth; sys_platform == 'darwin'
 
 # mobly tests
 portpicker
@@ -31,6 +35,8 @@ psutil >= 5.7.3
 
 # pigweed
 ipython
+appnope; sys_platform == 'darwin'
+appdirs; sys_platform == 'darwin'
 coloredlogs
 watchdog
 protobuf

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,11 +4,19 @@
 #
 #    pip-compile requirements.in
 #
+appdirs==1.4.4 ; sys_platform == "darwin"
+    # via
+    #   -r requirements.in
+    #   virtualenv
+appnope==0.1.2 ; sys_platform == "darwin"
+    # via
+    #   -r requirements.in
+    #   ipython
 backcall==0.2.0
     # via ipython
 certifi==2020.12.5
     # via requests
-cffi==1.14.4
+cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
@@ -20,14 +28,18 @@ colorama==0.4.4
     # via west
 coloredlogs==15.0
     # via -r requirements.in
-cryptography==3.4.4
+cryptography==3.4.6
     # via -r requirements.in
 dbus-python==1.2.16 ; sys_platform == "linux"
     # via -r requirements.in
 decorator==4.4.2
     # via ipython
+distlib==0.3.1
+    # via virtualenv
 docopt==0.6.2
     # via pykwalify
+filelock==3.0.12
+    # via virtualenv
 future==0.18.2
     # via
     #   -r requirements.in
@@ -40,7 +52,7 @@ intelhex==2.3.0
     # via -r requirements.in
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.20.0
+ipython==7.21.0
     # via -r requirements.in
 jedi==0.18.0
     # via ipython
@@ -64,9 +76,9 @@ portpicker==1.3.1
     # via
     #   -r requirements.in
     #   mobly
-prompt-toolkit==3.0.15
+prompt-toolkit==3.0.16
     # via ipython
-protobuf==3.14.0
+protobuf==3.15.5
     # via -r requirements.in
 psutil==5.8.0
     # via
@@ -78,10 +90,21 @@ pycparser==2.20
     # via cffi
 pyelftools==0.27
     # via -r requirements.in
-pygments==2.7.4
+pygments==2.8.0
     # via ipython
 pykwalify==1.8.0
     # via west
+pyobjc-core==7.1 ; sys_platform == "darwin"
+    # via
+    #   -r requirements.in
+    #   pyobjc-framework-cocoa
+    #   pyobjc-framework-corebluetooth
+pyobjc-framework-cocoa==7.1 ; sys_platform == "darwin"
+    # via
+    #   -r requirements.in
+    #   pyobjc-framework-corebluetooth
+pyobjc-framework-corebluetooth==7.1 ; sys_platform == "darwin"
+    # via -r requirements.in
 pyparsing==2.3.1
     # via
     #   -r requirements.in
@@ -100,19 +123,22 @@ requests==2.25.1
     # via -r requirements.in
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
-ruamel.yaml==0.16.12
+ruamel.yaml==0.16.13
     # via pykwalify
 six==1.15.0
     # via
     #   protobuf
     #   python-dateutil
+    #   virtualenv
 timeout-decorator==0.5.0
     # via mobly
 traitlets==5.0.5
     # via ipython
 urllib3==1.26.3
     # via requests
-watchdog==1.0.2
+virtualenv==20.4.2
+    # via -r requirements.in
+watchdog==2.0.2
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -114,7 +114,7 @@ try:
 
 
     if platform.system() == 'Darwin':
-        requiredPackages.append('pyobjc')
+        requiredPackages.append('pyobjc-framework-corebluetooth')
 
     if platform.system() == 'Linux':
         requiredPackages.append('dbus-python')


### PR DESCRIPTION
Just use python to normalize paths. It's actually not critical to
normalize, but provides cleaner output.

Don't use absolute paths in the guts of the script and then relativize.
We should use relative paths in the build, not absolute - absolute paths
contains uninteresting bits like the name of the logged in user. Those
may end up in logs or even build artifacts which isn't desirable.

Narrow the python module's deps to just corebluetooth, not every single
framework that pyobjc supports. Add them to our requirements so
bootstrapping fetches them into the build env and pip cache.