### PR TITLE
Add ReadClient and ReaderHandler and interactionModelDelegate

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -78,6 +78,8 @@ static_library("app") {
     "MessageDef/ReportData.h",
     "MessageDef/StatusElement.cpp",
     "MessageDef/StatusElement.h",
+    "ReadClient.cpp",
+    "ReadHandler.cpp",
     "decoder.cpp",
     "encoder.cpp",
   ]

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -35,6 +35,7 @@ CHIP_ERROR Command::Init(Messaging::ExchangeManager * apExchangeMgr)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Error if already initialized.
+    VerifyOrExit(apExchangeMgr != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mpExchangeMgr == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
@@ -57,7 +58,7 @@ CHIP_ERROR Command::Reset()
     if (mCommandMessageBuf.IsNull())
     {
         // TODO: Calculate the packet buffer size
-        mCommandMessageBuf = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLength);
+        mCommandMessageBuf = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
         VerifyOrExit(!mCommandMessageBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
     }
 
@@ -141,7 +142,7 @@ exit:
 
 chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
 {
-    mCommandDataBuf = chip::System::PacketBufferHandle::New(chip::app::kMaxSecureSduLength);
+    mCommandDataBuf = chip::System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
     if (mCommandDataBuf.IsNull())
     {
         ChipLogDetail(DataManagement, "Unable to allocate packet buffer");

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR CommandHandler::SendCommandResponse()
     err = FinalizeCommandsMessage();
     SuccessOrExit(err);
 
-    VerifyOrExit(mpExchangeCtx != NULL, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandResponse, std::move(mCommandMessageBuf),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
     SuccessOrExit(err);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -44,7 +44,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
     mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
     VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
-    mpExchangeCtx->SetResponseTimeout(kImMesssageTimeout);
+    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::InvokeCommandRequest, std::move(mCommandMessageBuf),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
@@ -92,7 +92,6 @@ void CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExchangeCon
 
 exit:
     Reset();
-    return;
 }
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -1,0 +1,82 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the delegate the SDK consumer needs to implement to receive notifications from the interaction model.
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+class ReadClient;
+struct EventPathParams;
+
+/**
+ * @brief
+ *   This class defines the API for a delegate that an SDK consumer can use to interface with the interaction model.
+ */
+class InteractionModelDelegate
+{
+public:
+    /**
+     * Notification that the interaction model has received a list of events in response to a Read request and that list
+     * of events needs to be processed.
+     * @param[in]  apExchangeContext   An exchange context that represents the exchange the Report Data came in on.
+     *                                 This can be used to recover the NodeId of the node that sent the Report Data.
+     *                                 It is managed externally and should not be closed by the SDK consumer.
+     * @param[in]  apEventListReader  TLV reader positioned at the list that contains the events.  The
+     *                                implementation of EventStreamReceived is expected to call Next() on the reader to
+     *                                advance it to the first element of the list, then process the elements from beginning to the
+     *                                end. The callee is expected to consume all events.
+     *
+     * @retval  # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
+     */
+    virtual CHIP_ERROR EventStreamReceived(const Messaging::ExchangeContext * apExchangeContext, TLV::TLVReader * apEventListReader)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    /**
+     * Notification that the last message for a Report Data action for the given ReadClient has been received and processed.
+     * @param[in]  apReadClient   A current readClient which can identify the read to the consumer, particularly during
+     *                            multiple read interactions
+     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
+     */
+    virtual CHIP_ERROR ReportProcessed(const ReadClient * apReadClient) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * Notification that a read attempt encountered an asynchronous failure.
+     * @param[in]  apReadClient   A current readClient which can identify the read to the consumer, particularly during
+     *                            multiple read interactions
+     * @param[in]  aError         A error that could be CHIP_ERROR_TIMEOUT when read client fails to receive, or other error when
+     *                            fail to process report data.
+     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
+     */
+    virtual CHIP_ERROR ReportError(const ReadClient * apReadClient, CHIP_ERROR aError) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    virtual ~InteractionModelDelegate() = default;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,12 +23,11 @@
  *
  */
 
-#include <cinttypes>
-
+#include "InteractionModelEngine.h"
 #include "Command.h"
 #include "CommandHandler.h"
 #include "CommandSender.h"
-#include "InteractionModelEngine.h"
+#include <cinttypes>
 
 namespace chip {
 namespace app {
@@ -41,29 +40,12 @@ InteractionModelEngine * InteractionModelEngine::GetInstance()
     return &sInteractionModelEngine;
 }
 
-void InteractionModelEngine::SetEventCallback(void * apAppState, EventCallback aEventCallback)
-{
-    mpAppState     = apAppState;
-    mEventCallback = aEventCallback;
-}
-
-void InteractionModelEngine::DefaultEventHandler(EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam)
-{
-    IgnoreUnusedVariable(aInParam);
-    IgnoreUnusedVariable(aOutParam);
-
-    ChipLogDetail(DataManagement, "%s event: %d", __func__, aEvent);
-}
-
-CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr)
+CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    // Error if already initialized.
-    if (mpExchangeMgr != nullptr)
-        return CHIP_ERROR_INCORRECT_STATE;
-
     mpExchangeMgr = apExchangeMgr;
+    mpDelegate    = apDelegate;
 
     err = mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::kProtocol_InteractionModel, this);
     SuccessOrExit(err);
@@ -74,27 +56,41 @@ exit:
 
 void InteractionModelEngine::Shutdown()
 {
-    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS; ++i)
+    for (auto & commandSender : mCommandSenderObjs)
     {
-        mCommandHandlerObjs[i].Shutdown();
+        commandSender.Shutdown();
+    }
+
+    for (auto & commandHandler : mCommandHandlerObjs)
+    {
+        commandHandler.Shutdown();
+    }
+
+    for (auto & readClient : mReadClients)
+    {
+        readClient.Shutdown();
+    }
+
+    for (auto & readHandler : mReadHandlers)
+    {
+        readHandler.Shutdown();
     }
 }
 
-CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apComandSender)
+CHIP_ERROR InteractionModelEngine::NewCommandSender(CommandSender ** const apCommandSender)
 {
-    CHIP_ERROR err  = CHIP_ERROR_NO_MEMORY;
-    *apComandSender = nullptr;
+    CHIP_ERROR err   = CHIP_ERROR_NO_MEMORY;
+    *apCommandSender = nullptr;
 
-    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS; ++i)
+    for (auto & commandSender : mCommandSenderObjs)
     {
-        if (mCommandHandlerObjs[i].IsFree())
+        if (commandSender.IsFree())
         {
-            *apComandSender = &mCommandSenderObjs[i];
-            err             = mCommandSenderObjs[i].Init(mpExchangeMgr);
-            SuccessOrExit(err);
+            *apCommandSender = &commandSender;
+            err              = commandSender.Init(mpExchangeMgr);
             if (CHIP_NO_ERROR != err)
             {
-                *apComandSender = nullptr;
+                *apCommandSender = nullptr;
                 ExitNow();
             }
             break;
@@ -105,7 +101,28 @@ exit:
     return err;
 }
 
-void InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+CHIP_ERROR InteractionModelEngine::NewReadClient(ReadClient ** const apReadClient)
+{
+    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+
+    for (auto & readClient : mReadClients)
+    {
+        if (readClient.IsFree())
+        {
+            *apReadClient = &readClient;
+            err           = readClient.Init(mpExchangeMgr, mpDelegate);
+            if (CHIP_NO_ERROR != err)
+            {
+                *apReadClient = nullptr;
+            }
+            return err;
+        }
+    }
+
+    return err;
+}
+
+void InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                                               const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -116,51 +133,32 @@ void InteractionModelEngine::OnUnknownMsgType(Messaging::ExchangeContext * apEc,
     // err = SendStatusReport(ec, kChipProfile_Common, kStatus_UnsupportedMessage);
     // SuccessOrExit(err);
 
-    apEc->Close();
-    apEc = NULL;
+    apExchangeContext->Close();
+    apExchangeContext = nullptr;
 
     ChipLogFunctError(err);
 
-    if (NULL != apEc)
+    // Todo: Fix the below check after the above status report is implemented.
+    if (nullptr != apExchangeContext)
     {
-        apEc->Abort();
-        apEc = NULL;
+        apExchangeContext->Abort();
     }
 }
 
-void InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
-                                                    const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload)
+void InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext * apExchangeContext,
+                                                    const PacketHeader & aPacketHeader, const PayloadHeader & aPayloadHeader,
+                                                    System::PacketBufferHandle aPayload)
 {
-    CHIP_ERROR err                 = CHIP_NO_ERROR;
-    CommandHandler * commandServer = nullptr;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (nullptr != mEventCallback)
+    for (auto & commandHandler : mCommandHandlerObjs)
     {
-        InEventParam inParam;
-        OutEventParam outParam;
-        inParam.Clear();
-        outParam.Clear();
-        outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing = true;
-        inParam.mIncomingInvokeCommandRequest.mpPacketHeader             = &aPacketHeader;
-
-        mEventCallback(mpAppState, kEvent_OnIncomingInvokeCommandRequest, inParam, outParam);
-
-        if (!outParam.mIncomingInvokeCommandRequest.mShouldContinueProcessing)
+        if (commandHandler.IsFree())
         {
-            ChipLogDetail(DataManagement, "Command not allowed");
-            ExitNow();
-        }
-    }
-
-    for (size_t i = 0; i < CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS; ++i)
-    {
-        if (mCommandHandlerObjs[i].IsFree())
-        {
-            commandServer = &mCommandHandlerObjs[i];
-            err           = commandServer->Init(mpExchangeMgr);
+            err = commandHandler.Init(mpExchangeMgr);
             SuccessOrExit(err);
-            commandServer->OnMessageReceived(apEc, aPacketHeader, aPayloadHeader, std::move(aPayload));
-            apEc = nullptr;
+            commandHandler.OnMessageReceived(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+            apExchangeContext = nullptr;
             break;
         }
     }
@@ -168,23 +166,56 @@ void InteractionModelEngine::OnInvokeCommandRequest(Messaging::ExchangeContext *
 exit:
     ChipLogFunctError(err);
 
-    if (nullptr != apEc)
+    if (nullptr != apExchangeContext)
     {
-        apEc->Abort();
-        apEc = NULL;
+        apExchangeContext->Abort();
     }
 }
 
-void InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+void InteractionModelEngine::OnReadRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    ChipLogDetail(DataManagement, "Receive Read request");
+
+    for (auto & readHandler : mReadHandlers)
+    {
+        if (readHandler.IsFree())
+        {
+            err = readHandler.Init(mpDelegate);
+            SuccessOrExit(err);
+            err = readHandler.OnReadRequest(apExchangeContext, std::move(aPayload));
+            SuccessOrExit(err);
+            apExchangeContext = nullptr;
+            break;
+        }
+    }
+
+exit:
+    ChipLogFunctError(err);
+
+    if (nullptr != apExchangeContext)
+    {
+        apExchangeContext->Abort();
+    }
+}
+
+void InteractionModelEngine::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                                                const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload)
 {
     if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::InvokeCommandRequest))
     {
-        OnInvokeCommandRequest(apEc, aPacketHeader, aPayloadHeader, std::move(aPayload));
+
+        OnInvokeCommandRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
+    }
+    else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReadRequest))
+    {
+        OnReadRequest(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
     }
     else
     {
-        OnUnknownMsgType(apEc, aPacketHeader, aPayloadHeader, std::move(aPayload));
+        OnUnknownMsgType(apExchangeContext, aPacketHeader, aPayloadHeader, std::move(aPayload));
     }
 }
 
@@ -206,5 +237,9 @@ DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aComman
         "Default DispatchSingleClusterCommand is called, this should be replaced by actual dispatched for cluster commands");
 }
 
+uint16_t InteractionModelEngine::GetReadClientArrayIndex(const ReadClient * const apReadClient) const
+{
+    return static_cast<uint16_t>(apReadClient - mReadClients);
+}
 } // namespace app
 } // namespace chip

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,11 +25,8 @@
 
 #pragma once
 
-#ifndef _CHIP_INTERACTION_MODEL_ENGINE_H
-#define _CHIP_INTERACTION_MODEL_ENGINE_H
-
+#include <app/MessageDef/ReportData.h>
 #include <core/CHIPCore.h>
-#include <map>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
@@ -43,17 +40,21 @@
 #include <app/Command.h>
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
+#include <app/InteractionModelDelegate.h>
+#include <app/ReadClient.h>
+#include <app/ReadHandler.h>
 
-#define CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS 1
-#define CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS 1
+#define CHIP_MAX_NUM_COMMAND_HANDLER 1
+#define CHIP_MAX_NUM_COMMAND_SENDER 1
+#define CHIP_MAX_NUM_READ_CLIENT 1
+#define CHIP_MAX_NUM_READ_HANDLER 1
+#define CHIP_MAX_REPORTS_IN_FLIGHT 1
 
 namespace chip {
 namespace app {
 
-constexpr size_t kMaxSecureSduLength  = 1024;
-constexpr uint32_t kImMesssageTimeout = 20;
-
-typedef void (*CommandCbFunct)(chip::TLV::TLVReader & aReader, Command * apCommandObj);
+constexpr size_t kMaxSecureSduLengthBytes = 1024;
+constexpr uint32_t kImMessageTimeoutMsec  = 3000;
 
 /**
  * @class InteractionModelEngine
@@ -65,69 +66,8 @@ typedef void (*CommandCbFunct)(chip::TLV::TLVReader & aReader, Command * apComma
 class InteractionModelEngine : public Messaging::ExchangeDelegate
 {
 public:
-    enum EventID
-    {
-        kEvent_OnIncomingInvokeCommandRequest =
-            0, ///< Called when an incoming invoke command request has arrived before applying commands..
-    };
-
     /**
-     * Incoming parameters sent with events generated directly from this component
-     *
-     */
-    union InEventParam
-    {
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
-        struct
-        {
-            const PacketHeader * mpPacketHeader; ///< A pointer to the message information for the request
-        } mIncomingInvokeCommandRequest;
-    };
-
-    /**
-     * Outgoing parameters sent with events generated directly from this component
-     *
-     */
-    union OutEventParam
-    {
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
-
-        struct
-        {
-            bool mShouldContinueProcessing; ///< Set to true if update is allowed.
-        } mIncomingInvokeCommandRequest;
-    };
-
-    /**
-     * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
-     *
-     * @param[in]  apAppState    A pointer to application layer supplied state object
-     * @param[in]  aEvent       A function pointer for event call back
-     * @param[in]  aInParam     A const reference to the input parameter for this event
-     * @param[out] aOutParam    A reference to the output parameter for this event
-     */
-    typedef void (*EventCallback)(void * apAppState, EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
-
-    /**
-     * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
-     *
-     * @param[in]  apAppState  		A pointer to application layer supplied state object
-     * @param[in]  aEventCallback  	A function pointer for event call back
-     */
-    void SetEventCallback(void * apAppState, EventCallback aEventCallback);
-
-    /**
-     * @brief This is the default event handler to be called by application layer for any ignored or unrecognized event
-     *
-     * @param[in]  aEvent       A function pointer for event call back
-     * @param[in]  aInParam     A const reference to the input parameter for this event
-     * @param[out] aOutParam    A reference to the output parameter for this event
-     */
-    static void DefaultEventHandler(EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
-
-    /**
-     * @brief Retrieve the singleton DataManagement Engine. Note this function should be implemented by the
-     *  adoption layer.
+     * @brief Retrieve the singleton Interaction Model Engine.
      *
      *  @return  A pointer to the shared InteractionModel Engine
      *
@@ -136,33 +76,76 @@ public:
 
     InteractionModelEngine(void);
 
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr);
+    /**
+     *  Initialize the InteractionModel Engine.
+     *
+     *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
+     *  @param[in]    apDelegate       InteractionModelDelegate set by application.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
+     *          kState_NotInitialized.
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
 
     void Shutdown();
 
-    CHIP_ERROR DeregisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
-                                               Command::CommandRoleId aCommandRoleId);
-    CHIP_ERROR RegisterClusterCommandHandler(chip::ClusterId aClusterId, chip::CommandId aCommandId,
-                                             Command::CommandRoleId aCommandRoleId, CommandCbFunct aDispatcher);
-
     Messaging::ExchangeManager * GetExchangeManager(void) const { return mpExchangeMgr; };
 
-    CHIP_ERROR NewCommandSender(CommandSender ** const apComandSender);
+    /**
+     *  Retrieve a CommandSender that the SDK consumer can use to send a set of commands.  If the call succeeds,
+     *  the consumer is responsible for calling Shutdown() on the CommandSender once it's done using it.
+     *
+     *  @param[out]    apCommandSender    A pointer to the CommandSender object.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE If there is no CommandSender available
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR NewCommandSender(CommandSender ** const apCommandSender);
+
+    /**
+     *  Retrieve a ReadClient that the SDK consumer can use to send do a read.  If the call succeeds, the consumer
+     *  is responsible for calling Shutdown() on the ReadClient once it's done using it.
+     *
+     *  @param[out]    apReadClient    A pointer to the ReadClient object.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE If there is no ReadClient available
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient);
+
+    /**
+     *  Get read client index in mReadClients
+     *
+     *  @param[in]    apReadClient    A pointer to a read client object.
+     *
+     *  @retval  the index in mReadClients array
+     */
+    uint16_t GetReadClientArrayIndex(const ReadClient * const apReadClient) const;
 
 private:
-    void OnUnknownMsgType(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+    void OnUnknownMsgType(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
-    void OnInvokeCommandRequest(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+    void OnInvokeCommandRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                                 const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
-    void OnMessageReceived(Messaging::ExchangeContext * apEc, const PacketHeader & aPacketHeader,
+    void OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                            const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
     void OnResponseTimeout(Messaging::ExchangeContext * ec);
 
+    /**
+     * Called when Interaction Model receives a Read Request message.  Errors processing
+     * the Read Request are handled entirely within this function.
+     */
+    void OnReadRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                       const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
+
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    void * mpAppState                          = nullptr;
-    EventCallback mEventCallback;
-    CommandHandler mCommandHandlerObjs[CHIP_MAX_NUM_COMMAND_HANDLER_OBJECTS];
-    CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER_OBJECTS];
+    InteractionModelDelegate * mpDelegate      = nullptr;
+    CommandHandler mCommandHandlerObjs[CHIP_MAX_NUM_COMMAND_HANDLER];
+    CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER];
+    ReadClient mReadClients[CHIP_MAX_NUM_READ_CLIENT];
+    ReadHandler mReadHandlers[CHIP_MAX_NUM_READ_HANDLER];
 };
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
@@ -170,5 +153,3 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
 } // namespace app
 } // namespace chip
-
-#endif //_CHIP_INTERACTION_MODEL_ENGINE_H

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1,0 +1,244 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the initiator side of a CHIP Read Interaction.
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/ReadClient.h>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR ReadClient::Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // Error if already initialized.
+    VerifyOrExit(apExchangeMgr != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpExchangeMgr == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    mpExchangeMgr = apExchangeMgr;
+    mpExchangeCtx = nullptr;
+    mpDelegate    = apDelegate;
+    mState        = ClientState::Initialized;
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+void ReadClient::Shutdown()
+{
+    ClearExistingExchangeContext();
+    mpExchangeMgr = nullptr;
+    mpDelegate    = nullptr;
+    MoveToState(ClientState::Uninitialized);
+}
+
+const char * ReadClient::GetStateStr() const
+{
+#if CHIP_DETAIL_LOGGING
+    switch (mState)
+    {
+    case ClientState::Uninitialized:
+        return "UNINIT";
+    case ClientState::Initialized:
+        return "INIT";
+    case ClientState::AwaitingResponse:
+        return "AwaitingResponse";
+    }
+#endif // CHIP_DETAIL_LOGGING
+    return "N/A";
+}
+
+void ReadClient::MoveToState(const ClientState aTargetState)
+{
+    mState = aTargetState;
+    ChipLogDetail(DataManagement, "Client[%u] moving to [%s]", InteractionModelEngine::GetInstance()->GetReadClientArrayIndex(this),
+                  GetStateStr());
+}
+
+CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, EventPathParams * apEventPathParamsList,
+                                       size_t aEventPathParamsListSize)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle msgBuf;
+    ChipLogDetail(DataManagement, "%s: Client[%u] [%5.5s]", __func__,
+                  InteractionModelEngine::GetInstance()->GetReadClientArrayIndex(this), GetStateStr());
+    VerifyOrExit(ClientState::Initialized == mState, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    {
+        System::PacketBufferTLVWriter writer;
+        ReadRequest::Builder request;
+
+        msgBuf = System::PacketBufferHandle::New(kMaxSecureSduLengthBytes);
+        VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+        writer.Init(std::move(msgBuf));
+
+        err = request.Init(&writer);
+        SuccessOrExit(err);
+
+        if (aEventPathParamsListSize != 0 && apEventPathParamsList != nullptr)
+        {
+            // TODO: fill to construct event paths
+        }
+        request.EndOfReadRequest();
+        SuccessOrExit(request.GetError());
+
+        err = writer.Finalize(&msgBuf);
+        SuccessOrExit(err);
+    }
+
+    mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
+
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReadRequest, std::move(msgBuf),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse));
+    SuccessOrExit(err);
+    MoveToState(ClientState::AwaitingResponse);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+void ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                                   const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::ReportData),
+                 err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+    err = ProcessReportData(std::move(aPayload));
+
+exit:
+    ChipLogFunctError(err);
+    if (err != CHIP_NO_ERROR && mpDelegate != nullptr)
+    {
+        mpDelegate->ReportError(this, err);
+    }
+    ClearExistingExchangeContext();
+    MoveToState(ClientState::Initialized);
+    return;
+}
+
+CHIP_ERROR ReadClient::ClearExistingExchangeContext()
+{
+    if (mpExchangeCtx != nullptr)
+    {
+        mpExchangeCtx->Abort();
+        mpExchangeCtx = nullptr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    ReportData::Parser report;
+
+    bool isEventListPresent  = false;
+    bool suppressResponse    = false;
+    bool moreChunkedMessages = false;
+
+    System::PacketBufferTLVReader reader;
+
+    reader.Init(std::move(aPayload));
+    reader.Next();
+
+    err = report.Init(reader);
+    SuccessOrExit(err);
+
+    err = report.CheckSchemaValidity();
+    SuccessOrExit(err);
+
+    err = report.GetSuppressResponse(&suppressResponse);
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    SuccessOrExit(err);
+
+    err = report.GetMoreChunkedMessages(&moreChunkedMessages);
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    SuccessOrExit(err);
+
+    {
+        EventList::Parser eventList;
+
+        err = report.GetEventDataList(&eventList);
+        if (CHIP_NO_ERROR == err)
+        {
+            isEventListPresent = true;
+        }
+        else if (CHIP_END_OF_TLV == err)
+        {
+            isEventListPresent = false;
+            err                = CHIP_NO_ERROR;
+        }
+        SuccessOrExit(err);
+
+        if (isEventListPresent && nullptr != mpDelegate && !moreChunkedMessages)
+        {
+            chip::TLV::TLVReader eventListReader;
+            eventList.GetReader(&eventListReader);
+            err = mpDelegate->EventStreamReceived(mpExchangeCtx, &eventListReader);
+            SuccessOrExit(err);
+        }
+    }
+
+    if (!suppressResponse)
+    {
+        // TODO: Add status report support and correspond handler in ReadHandler, particular for situation when there
+        // are multiple reports
+    }
+    if (nullptr != mpDelegate && !moreChunkedMessages)
+    {
+        err = mpDelegate->ReportProcessed(this);
+    }
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+void ReadClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
+{
+    ChipLogProgress(DataManagement, "Time out! failed to receive report data from Exchange: %d",
+                    apExchangeContext->GetExchangeId());
+    ClearExistingExchangeContext();
+    MoveToState(ClientState::Initialized);
+    if (nullptr != mpDelegate)
+    {
+        mpDelegate->ReportError(this, CHIP_ERROR_TIMEOUT);
+    }
+}
+}; // namespace app
+}; // namespace chip

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -1,0 +1,127 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines read client for a CHIP Interaction Data model
+ *
+ */
+
+#pragma once
+
+#include <app/InteractionModelDelegate.h>
+#include <app/MessageDef/ReadRequest.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+/**
+ *  @class ReadClient
+ *
+ *  @brief The read client represents the initiator side of a Read Interaction, and is responsible
+ *  for generating one Read Request for a particular set of attributes and/or events, and handling the Report Data response.
+ *
+ */
+class ReadClient : public Messaging::ExchangeDelegate
+{
+public:
+    /**
+     *  Shut down the Client. This terminates this instance of the object and releases
+     *  all held resources.  The object must not be used after Shutdown() is called.
+     *
+     *  SDK consumer can choose when to shut down the ReadClient.
+     *  The ReadClient will never shut itself down, unless the overall InteractionModelEngine is shut down.
+     */
+    void Shutdown();
+
+    /**
+     *  Send a Read Request.  There can be one Read Request outstanding on a given ReadClient.
+     *  If SendReadRequest returns success, no more Read Requests can be sent on this ReadClient
+     *  until the corresponding InteractionModelDelegate::ReportProcessed or InteractionModelDelegate::ReportError
+     *  call happens with guarantee.
+     *
+     *  @param[in]    aNodeId    Node Id
+     *  @param[in]    aAdminId   Admin ID
+     *  @param[in]    apEventPathParamsList       a list of event paths the read client is interested in
+     *  @param[in]    aEventPathParamsListSize    Number of event paths in apEventPathParamsList
+     *  @retval #others fail to send read request
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, EventPathParams * apEventPathParamsList,
+                               size_t aEventPathParamsListSize);
+
+private:
+    friend class TestReadInteraction;
+    friend class InteractionModelEngine;
+
+    enum class ClientState
+    {
+        Uninitialized = 0, //< The client has not been initialized
+        Initialized,       //< The client has been initialized and is ready for a SendReadRequest
+        AwaitingResponse,  //< The client has sent out the read request message
+    };
+
+    /**
+     *  Initialize the client object. Within the lifetime
+     *  of this instance, this method is invoked once after object
+     *  construction until a call to Shutdown is made to terminate the
+     *  instance.
+     *
+     *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
+     *  @param[in]    apDelegate       InteractionModelDelegate set by application.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
+
+    virtual ~ReadClient() = default;
+
+    void OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
+                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+
+    /**
+     *  Check if current read client is being used
+     *
+     */
+    bool IsFree() const { return mState == ClientState::Uninitialized; };
+
+    void MoveToState(const ClientState aTargetState);
+    CHIP_ERROR ProcessReportData(System::PacketBufferHandle aPayload);
+    CHIP_ERROR ClearExistingExchangeContext();
+    const char * GetStateStr() const;
+
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    InteractionModelDelegate * mpDelegate      = nullptr;
+    ClientState mState                         = ClientState::Uninitialized;
+};
+
+}; // namespace app
+}; // namespace chip

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -1,0 +1,180 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines read handler for a CHIP Interaction Data model
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/EventPath.h>
+#include <app/ReadHandler.h>
+
+namespace chip {
+namespace app {
+CHIP_ERROR ReadHandler::Init(InteractionModelDelegate * apDelegate)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    // Error if already initialized.
+    VerifyOrExit(apDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    mpExchangeCtx     = nullptr;
+    mpDelegate        = apDelegate;
+    mSuppressResponse = true;
+    mGetToAllEvents   = true;
+    MoveToState(HandlerState::Initialized);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+void ReadHandler::Shutdown()
+{
+    ClearExistingExchangeContext();
+    MoveToState(HandlerState::Uninitialized);
+    mpDelegate = nullptr;
+}
+
+CHIP_ERROR ReadHandler::ClearExistingExchangeContext()
+{
+    if (mpExchangeCtx != nullptr)
+    {
+        mpExchangeCtx->Abort();
+        mpExchangeCtx = nullptr;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ReadHandler::OnReadRequest(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferHandle response;
+
+    mpExchangeCtx = apExchangeContext;
+
+    err = ProcessReadRequest(std::move(aPayload));
+    SuccessOrExit(err);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogFunctError(err);
+        Shutdown();
+    }
+
+    return err;
+}
+
+CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
+                                     Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
+    SuccessOrExit(err);
+
+    // Todo: Once status report support is added, we would shutdown only when there is error or when this is last chunk of report
+exit:
+    Shutdown();
+    return err;
+}
+
+CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferTLVReader reader;
+
+    ReadRequest::Parser readRequestParser;
+    EventPathList::Parser eventPathListParser;
+    TLV::TLVReader eventPathListReader;
+
+    reader.Init(std::move(aPayload));
+
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = readRequestParser.Init(reader);
+    SuccessOrExit(err);
+
+    err = readRequestParser.CheckSchemaValidity();
+    SuccessOrExit(err);
+
+    err = readRequestParser.GetEventPathList(&eventPathListParser);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    else
+    {
+        SuccessOrExit(err);
+        eventPathListParser.GetReader(&eventPathListReader);
+
+        while (CHIP_NO_ERROR == (err = eventPathListReader.Next()))
+        {
+            VerifyOrExit(TLV::AnonymousTag == eventPathListReader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+
+            EventPath::Parser eventPath;
+
+            err = eventPath.Init(eventPathListReader);
+            SuccessOrExit(err);
+            // TODO: Pass event path to report engine to generate report with interested events
+        }
+    }
+
+    // if we have exhausted this container
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+const char * ReadHandler::GetStateStr() const
+{
+#if CHIP_DETAIL_LOGGING
+    switch (mState)
+    {
+    case HandlerState::Uninitialized:
+        return "Uninitialized";
+
+    case HandlerState::Initialized:
+        return "Initialized";
+
+    case HandlerState::Reportable:
+        return "Reportable";
+    }
+#endif // CHIP_DETAIL_LOGGING
+    return "N/A";
+}
+
+void ReadHandler::MoveToState(const HandlerState aTargetState)
+{
+    mState = aTargetState;
+    ChipLogDetail(DataManagement, "IM RH moving to [%s]", GetStateStr());
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -1,0 +1,129 @@
+/*
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *     This file defines read handler for a CHIP Interaction Data model
+ *
+ */
+
+#pragma once
+
+#include <app/InteractionModelDelegate.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/DLLUtil.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+/**
+ *  @class ReadHandler
+ *
+ *  @brief The read handler is responsible for processing a read request, asking the attribute/event store
+ *         for the relevant data, and sending a reply.
+ *
+ */
+class ReadHandler
+{
+public:
+    /**
+     *  Initialize the ReadHandler. Within the lifetime
+     *  of this instance, this method is invoked once after object
+     *  construction until a call to Shutdown is made to terminate the
+     *  instance.
+     *
+     *  @param[in]    apDelegate       InteractionModelDelegate set by application.
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
+     *          kState_NotInitialized.
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR Init(InteractionModelDelegate * apDelegate);
+
+    /**
+     *  Shut down the ReadHandler. This terminates this instance
+     *  of the object and releases all held resources.
+     *
+     */
+    void Shutdown();
+    /**
+     *  Process a read request.  Parts of the processing may end up being asynchronous, but the ReadHandler
+     *  guarantees that it will call Shutdown on itself when processing is done (including if OnReadRequest
+     *  returns an error).
+     *
+     *  @param[in]    apExchangeContext    A pointer to the ExchangeContext.
+     *  @param[in]    aPayload             A payload that has read request data
+     *
+     *  @retval #Others If fails to process read request
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR OnReadRequest(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle aPayload);
+
+    /**
+     *  Send ReportData to initiator
+     *
+     *  @param[in]    aPayload             A payload that has read request data
+     *
+     *  @retval #Others If fails to send report data
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    CHIP_ERROR SendReportData(System::PacketBufferHandle aPayload);
+
+    bool IsFree() const { return mState == HandlerState::Uninitialized; }
+
+    virtual ~ReadHandler() = default;
+
+private:
+    enum class HandlerState
+    {
+        Uninitialized = 0, //< The handler has not been initialized
+        Initialized,       //< The handler has been initialized and is ready
+        Reportable,        //< The handler has received read request and is waiting for the data to send to be available
+    };
+
+    CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle aPayload);
+
+    void MoveToState(const HandlerState aTargetState);
+
+    const char * GetStateStr() const;
+    CHIP_ERROR ClearExistingExchangeContext();
+
+    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    InteractionModelDelegate * mpDelegate      = nullptr;
+
+    // Don't need the response for report data if true
+    bool mSuppressResponse;
+
+    // Retrieve all events
+    bool mGetToAllEvents;
+
+    // Current Handler state
+    HandlerState mState;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -21,7 +21,10 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libAppTests"
 
-  test_sources = [ "TestMessageDef.cpp" ]
+  test_sources = [
+    "TestMessageDef.cpp",
+    "TestReadInteraction.cpp",
+  ]
 
   cflags = [ "-Wconversion" ]
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1,0 +1,190 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Read Interaction
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/PASESession.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+
+#include <nlunit-test.h>
+
+namespace chip {
+SecureSessionMgr gSessionManager;
+Messaging::ExchangeManager gExchangeManager;
+TransportMgr<Transport::UDP> gTransportManager;
+const Transport::AdminId gAdminId = 0;
+
+namespace app {
+class TestReadInteraction
+{
+public:
+    static void TestReadClient(nlTestSuite * apSuite, void * apContext);
+    static void TestReadHandler(nlTestSuite * apSuite, void * apContext);
+
+private:
+    static void GenerateReportData(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload);
+};
+
+void TestReadInteraction::GenerateReportData(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferTLVWriter writer;
+    writer.Init(std::move(aPayload));
+
+    ReportData::Builder reportDataBuilder;
+
+    err = reportDataBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    reportDataBuilder.SuppressResponse(true);
+    NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
+
+    reportDataBuilder.MoreChunkedMessages(false);
+    NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
+
+    reportDataBuilder.EndOfReportData();
+    NL_TEST_ASSERT(apSuite, reportDataBuilder.GetError() == CHIP_NO_ERROR);
+
+    err = writer.Finalize(&aPayload);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+void TestReadInteraction::TestReadClient(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    app::ReadClient readClient;
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    err                            = readClient.Init(&gExchangeManager, nullptr);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = readClient.SendReadRequest(kTestDeviceNodeId, gAdminId, nullptr, 0);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    GenerateReportData(apSuite, apContext, buf);
+
+    err = readClient.ProcessReportData(std::move(buf));
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    readClient.Shutdown();
+}
+
+void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    app::ReadHandler readHandler;
+    System::PacketBufferTLVWriter writer;
+    System::PacketBufferHandle reportDatabuf  = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    System::PacketBufferHandle readRequestbuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    ReadRequest::Builder readRequestBuilder;
+    readHandler.Init(nullptr);
+
+    GenerateReportData(apSuite, apContext, reportDatabuf);
+    err = readHandler.SendReportData(std::move(reportDatabuf));
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
+
+    writer.Init(std::move(readRequestbuf));
+    err = readRequestBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    readRequestBuilder.EventNumber(1);
+    NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
+    readRequestBuilder.EndOfReadRequest();
+    NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
+    err = writer.Finalize(&readRequestbuf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = readHandler.OnReadRequest(nullptr, std::move(readRequestbuf));
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, nullptr, &admins);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(chip::kTestDeviceNodeId, &chip::gTransportManager, &chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+        {
+                NL_TEST_DEF("CheckReadClient", chip::app::TestReadInteraction::TestReadClient),
+                NL_TEST_DEF("CheckReadHandler", chip::app::TestReadInteraction::TestReadHandler),
+                NL_TEST_SENTINEL()
+        };
+// clang-format on
+} // namespace
+
+int TestEventLogging()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "InteractionMessage",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestEventLogging)

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -40,17 +40,20 @@
 #define IM_CLIENT_PORT (CHIP_PORT + 1)
 
 namespace {
+// Max value for the number of message request sent.
+constexpr size_t kMaxCommandMessageCount = 3;
+constexpr size_t kMaxReadMessageCount    = 0;
 
-// Max value for the number of command request sent.
-constexpr size_t kMaxCommandCount = 3;
-
-// The CHIP Command interval time in milliseconds.
-constexpr int32_t gCommandInterval = 1000;
+// The CHIP Message interval time in milliseconds.
+constexpr int32_t gMessageInterval = 1000;
 
 constexpr chip::Transport::AdminId gAdminId = 0;
 
 // The CommandSender object.
 chip::app::CommandSender * gpCommandSender = nullptr;
+
+// The ReadClient object.
+chip::app::ReadClient * gpReadClient = nullptr;
 
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 
@@ -59,11 +62,15 @@ chip::SecureSessionMgr gSessionManager;
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Command was attempted to be sent.
-uint64_t gLastCommandTime = 0;
+uint64_t gLastMessageTime = 0;
 
 // True, if the CommandSender is waiting for an CommandResponse
 // after sending an CommandRequest, false otherwise.
 bool gWaitingForCommandResp = false;
+
+// True, if the ReadClient is waiting for an Report Data
+// after sending an ReadRequest, false otherwise.
+bool gWaitingForReadResp = false;
 
 // Count of the number of CommandRequests sent.
 uint64_t gCommandCount = 0;
@@ -71,18 +78,24 @@ uint64_t gCommandCount = 0;
 // Count of the number of CommandResponses received.
 uint64_t gCommandRespCount = 0;
 
-bool CommandIntervalExpired(void)
+// Count of the number of CommandRequests sent.
+uint64_t gReadCount = 0;
+
+// Count of the number of CommandResponses received.
+uint64_t gReadRespCount = 0;
+
+bool MessageIntervalExpired(void)
 {
     uint64_t now = chip::System::Timer::GetCurrentEpoch();
 
-    return (now >= gLastCommandTime + gCommandInterval);
+    return (now >= gLastMessageTime + gMessageInterval);
 }
 
 CHIP_ERROR SendCommandRequest(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    gLastCommandTime = chip::System::Timer::GetCurrentEpoch();
+    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
@@ -135,6 +148,30 @@ exit:
     return err;
 }
 
+CHIP_ERROR SendReadRequest(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
+
+    printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+
+    err = gpReadClient->SendReadRequest(chip::kTestDeviceNodeId, gAdminId, nullptr, 0);
+    SuccessOrExit(err);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        gWaitingForReadResp = true;
+        gReadCount++;
+    }
+    else
+    {
+        printf("Send read request failed, err: %s\n", chip::ErrorStr(err));
+    }
+exit:
+    return err;
+}
+
 CHIP_ERROR EstablishSecureSession()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -152,7 +189,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         printf("Establish secure session failed, err: %s\n", chip::ErrorStr(err));
-        gLastCommandTime = chip::System::Timer::GetCurrentEpoch();
+        gLastMessageTime = chip::System::Timer::GetCurrentEpoch();
     }
     else
     {
@@ -161,6 +198,38 @@ exit:
 
     return err;
 }
+
+void HandleReadComplete()
+{
+    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+    uint32_t transitTime = respTime - gLastMessageTime;
+
+    gWaitingForReadResp = false;
+    gReadRespCount++;
+
+    printf("Read Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gReadRespCount, gReadCount,
+           static_cast<double>(gReadRespCount) * 100 / gReadCount, static_cast<double>(transitTime) / 1000);
+}
+
+class MockInteractionModelApp : public chip::app::InteractionModelDelegate
+{
+public:
+    CHIP_ERROR EventStreamReceived(const chip::Messaging::ExchangeContext * apExchangeContext,
+                                   chip::TLV::TLVReader * apEventListReader) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR ReportProcessed(const chip::app::ReadClient * apReadClient) override
+    {
+        HandleReadComplete();
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR ReportError(const chip::app::ReadClient * apReadClient, CHIP_ERROR aError) override
+    {
+        printf("ReportError with err %d", aError);
+        return CHIP_NO_ERROR;
+    }
+};
 
 } // namespace
 
@@ -176,7 +245,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     }
 
     uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
-    uint32_t transitTime = respTime - gLastCommandTime;
+    uint32_t transitTime = respTime - gLastMessageTime;
 
     if (aReader.GetLength() != 0)
     {
@@ -194,6 +263,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    MockInteractionModelApp mockDelegate;
     chip::Transport::AdminPairingTable admins;
     chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestControllerNodeId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
@@ -223,7 +293,7 @@ int main(int argc, char * argv[])
     err = gExchangeManager.Init(chip::kTestControllerNodeId, &gTransportManager, &gSessionManager);
     SuccessOrExit(err);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager);
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);
     SuccessOrExit(err);
 
     // Start the CHIP connection to the CHIP im responder.
@@ -233,18 +303,21 @@ int main(int argc, char * argv[])
     err = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&gpCommandSender);
     SuccessOrExit(err);
 
+    err = chip::app::InteractionModelEngine::GetInstance()->NewReadClient(&gpReadClient);
+    SuccessOrExit(err);
+
     // Connection has been established. Now send the CommandRequests.
-    for (unsigned int i = 0; i < kMaxCommandCount; i++)
+    for (unsigned int i = 0; i < kMaxCommandMessageCount; i++)
     {
         err = SendCommandRequest();
         if (err != CHIP_NO_ERROR)
         {
-            printf("Send request failed: %s\n", chip::ErrorStr(err));
-            break;
+            printf("Send command request failed: %s\n", chip::ErrorStr(err));
+            goto exit;
         }
 
-        // Wait for response until the Command interval.
-        while (!CommandIntervalExpired())
+        // Wait for response until the Message interval.
+        while (!MessageIntervalExpired())
         {
             DriveIO();
         }
@@ -252,8 +325,32 @@ int main(int argc, char * argv[])
         // Check if expected response was received.
         if (gWaitingForCommandResp)
         {
-            printf("No response received\n");
+            printf("Invoke Command: No response received\n");
             gWaitingForCommandResp = false;
+        }
+    }
+
+    // Connection has been established. Now send the ReadRequests.
+    for (unsigned int i = 0; i < kMaxReadMessageCount; i++)
+    {
+        err = SendReadRequest();
+        if (err != CHIP_NO_ERROR)
+        {
+            printf("Send read request failed: %s\n", chip::ErrorStr(err));
+            goto exit;
+        }
+
+        // Wait for response until the Message interval.
+        while (!MessageIntervalExpired())
+        {
+            DriveIO();
+        }
+
+        // Check if expected response was received.
+        if (gWaitingForReadResp)
+        {
+            printf("read request: No response received\n");
+            gWaitingForReadResp = false;
         }
     }
 
@@ -262,11 +359,17 @@ int main(int argc, char * argv[])
     ShutdownChip();
 
 exit:
-    if ((err != CHIP_NO_ERROR) || (gCommandRespCount != kMaxCommandCount))
+    if (err != CHIP_NO_ERROR || (gCommandRespCount != kMaxCommandMessageCount))
     {
         printf("ChipCommandSender failed: %s\n", chip::ErrorStr(err));
         exit(EXIT_FAILURE);
     }
 
+    if (err != CHIP_NO_ERROR || (gReadRespCount != kMaxReadMessageCount))
+    {
+        printf("ChipReadClient failed: %s\n", chip::ErrorStr(err));
+        exit(EXIT_FAILURE);
+    }
+    printf("Test success \n");
     return EXIT_SUCCESS;
 }

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -20,18 +20,19 @@
  *      This file implements a chip-im-responder, for the
  *      CHIP Interaction Data Model Protocol.
  *
- *      Currently it provides simple command handler with sample cluster and command
+ *      Currently it provides simple command and read handler with sample cluster
  *
  */
 
-#include "app/InteractionModelEngine.h"
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
+#include <app/InteractionModelEngine.h>
 #include <app/tests/integration/common.h>
 #include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
 #include <platform/CHIPDeviceLayer.h>
-
-#include "InteractionModelEngine.h"
 #include <support/ErrorStr.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/PASESession.h>
@@ -40,7 +41,6 @@
 
 namespace chip {
 namespace app {
-
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {
@@ -97,8 +97,6 @@ exit:
 } // namespace chip
 
 namespace {
-
-// The CommandHandler object
 chip::TransportMgr<chip::Transport::UDP> gTransportManager;
 chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
@@ -127,7 +125,7 @@ int main(int argc, char * argv[])
     err = gExchangeManager.Init(chip::kTestDeviceNodeId, &gTransportManager, &gSessionManager);
     SuccessOrExit(err);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager);
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);
     SuccessOrExit(err);
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
@@ -142,7 +140,7 @@ exit:
 
     if (err != CHIP_NO_ERROR)
     {
-        printf("CommandHandler failed, err:%s\n", chip::ErrorStr(err));
+        printf("IM responder failed, err:%s\n", chip::ErrorStr(err));
         exit(EXIT_FAILURE);
     }
 

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -35,5 +35,6 @@ typedef uint16_t AttributeId;
 typedef uint16_t GroupId;
 typedef uint8_t CommandId;
 typedef uint16_t EventId;
+typedef uint64_t EventNumber;
 typedef uint64_t DataVersion;
 } // namespace chip


### PR DESCRIPTION
Problem:
Need read client to send IM read request and process report and read handler to process
read request, need interaction model delegate to notify zcl the actions
in corresponse for particular IM callback.

Summary of Changes:
-- Add read client to send IM read request and process report.
-- Add read handler to process read request
-- Add interaction model delgate to notify when each IM event stream is received and
all reports have been received and so on.

Note: This is PR splited from large PR #4800 