### PR TITLE
Fix up the python wheel tags on Mac

### DIFF
--- a/build/config/arm.gni
+++ b/build/config/arm.gni
@@ -14,7 +14,8 @@
 
 import("//build_overrides/build.gni")
 
-if (current_cpu == "arm" || current_cpu == "arm64") {
+if ((current_cpu == "arm" || current_cpu == "arm64") &&
+    (current_os != "mac" && current_os != "ios")) {
   declare_args() {
     # Build file to import for ARM defaults.
     arm_platform_config = ""

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -18,16 +18,17 @@ import("//build_overrides/pigweed.gni")
 import("${build_root}/config/compiler/compiler.gni")
 import("${build_root}/config/target.gni")
 
+if (current_os == "mac") {
+  import("${build_root}/config/mac/mac_sdk.gni")
+}
+
 declare_args() {
   # Enable -Werror. This can be disabled if using a different compiler
   # with unfixed or unsupported wanings.
   treat_warnings_as_errors = true
 }
 
-_is_embedded_arm = current_os != "ios" && current_os != "mac_os" &&
-                   (current_cpu == "arm" || current_cpu == "arm64")
-
-if (_is_embedded_arm) {
+if (current_cpu == "arm" || current_cpu == "arm64") {
   import("${build_root}/config/arm.gni")
 } else if (current_cpu == "x86" || current_cpu == "x86_64") {
   import("${build_root}/config/x86.gni")
@@ -45,7 +46,14 @@ config("debug_default") {
 
 config("abi_default") {
   cflags = []
-  if (_is_embedded_arm) {
+  if (current_os == "mac") {
+    cflags += [
+      "-target",
+      mac_target_triple,
+    ]
+  } else if (current_os == "ios") {
+    # iOS ABI currently set by chip_xcode_build_connector.sh
+  } else if (current_cpu == "arm" || current_cpu == "arm64") {
     if (arm_arch != "") {
       cflags += [ "-march=${arm_arch}" ]
     }
@@ -92,6 +100,7 @@ config("abi_default") {
       ]
     }
   }
+  asmflags = cflags
   ldflags = cflags
 }
 

--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2020 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Utility script to genertae the python tag + the abi tag + platform tag for a Python
+_mac_deployment_target = "10.15"
 
-try:
-  from setuptools import pep425tags
-except ImportError:
-  from wheel import pep425tags
+if (current_cpu == "arm64") {
+  _mac_deployment_target = "11.0"
+}
 
-try:
-  platform_tag = pep425tags.get_platform(None)
-except TypeError:
-  platform_tag = pep425tags.get_platform()
+declare_args() {
+  # OS X version to target when compiling.
+  mac_deployment_target = _mac_deployment_target
+}
 
-print(pep425tags.get_abbr_impl() + pep425tags.get_impl_ver() + "-" +
-      pep425tags.get_abi_tag() + "-" + platform_tag)
+if (current_cpu == "x64") {
+  mac_target_arch = "x86_64"
+} else {
+  mac_target_arch = current_cpu
+}
+
+mac_target_triple = "${mac_target_arch}-apple-macos${mac_deployment_target}"

--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -13,7 +13,7 @@ pyelftools>=0.22
 requests>=2.24.0
 
 # device controller wheel package
-wheel==0.34.2
+wheel
 dbus-python; sys_platform == 'linux'
 pgi; sys_platform == 'linux'
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -118,7 +118,7 @@ wcwidth==0.2.5
     # via prompt-toolkit
 west==0.9.0
     # via -r requirements.in
-wheel==0.34.2
+wheel==0.36.2
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -22,6 +22,10 @@ import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${dir_pw_unit_test}/test.gni")
 
+if (current_os == "mac") {
+  import("${build_root}/config/mac/mac_sdk.gni")
+}
+
 config("controller_wno_deprecate") {
   cflags = [ "-Wno-deprecated-declarations" ]
 }
@@ -148,6 +152,22 @@ pw_python_action("python") {
 
   _dist_dir = "${root_out_dir}/controller/python"
 
+  if (current_cpu == "x64") {
+    cpu_tag = "x86_64"
+  } else {
+    cpu_tag = current_cpu
+  }
+
+  if (current_os == "mac") {
+    platform_tag = "macosx_" + string_replace(mac_deployment_target, ".", "_")
+  } else {
+    platform_tag = current_os
+  }
+
+  platform_tag = platform_tag + "_" + cpu_tag
+
+  tags = "cp37-abi3-" + platform_tag
+
   args = [
     "--package_name",
     "chip",
@@ -159,15 +179,12 @@ pw_python_action("python") {
     rebase_path(_dist_dir, root_build_dir),
     "--manifest",
     rebase_path(_py_manifest_file, root_build_dir),
+    "--plat-name",
+    platform_tag,
   ]
 
   public_deps = [ ":ChipDeviceCtrl" ]
 
-  pythontags = exec_script("${chip_root}/build/chip/python_gen_tags.py",
-                           [],
-                           "list lines",
-                           [])
-  pythontagsStr = string_join("", pythontags)
-  output_name = "chip-0.0-$pythontagsStr.whl"
+  output_name = "chip-0.0-${tags}.whl"
   outputs = [ "${_dist_dir}/$output_name" ]
 }

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -39,6 +39,7 @@ parser.add_argument('--build_number', default='0.0', help='configure the chip bu
 parser.add_argument('--build_dir', help='directory to build in')
 parser.add_argument('--dist_dir', help='directory to place distribution in')
 parser.add_argument('--manifest', help='list of files to package')
+parser.add_argument('--plat-name', help='platform name to embed in generated filenames')
 
 args = parser.parse_args()
 
@@ -167,7 +168,9 @@ try:
         options={
             'bdist_wheel':{
                 'universal':False,
-                'dist_dir':distDir         # Place the generated .whl in the dist directory.
+                'dist_dir':distDir,         # Place the generated .whl in the dist directory.
+                'py_limited_api':'cp37',
+                'plat_name':args.plat_name,
             },
             'egg_info':{
                 'egg_base':tmpDir           # Place the .egg-info subdirectory in the tmp directory.


### PR DESCRIPTION
Fix up the python wheel tags on Mac

- Choose the deployment target explicitly since so we can tag the wheel
  with the right version. Defaults to 10.15 on x64 and 11.0 on arm64,
  but configurable via the mac_deployment_target build argument.

- Switch to stable ABI "cp37-abi3". Actually, we don't care about the
  Python ABI, because we don't include any python headers. It should
  really be something like "py3-none" but there doesn't appear to be a
  way to achieve that. So the next best thing is to say we're on the
  stable ABI for a recent version.

- Remove `python_gen_tags.py`, since we don't need it anymore, and
  relax the wheel dependency since this script was relying on some
  implementation details of that package.

This is not runtime tested on M1, but cross compiles for ARM64 - just
set `target_cpu="arm64" chip_crypto="mbedtls"` in the build arguments.
