### PR TITLE
Remove unused include src/app/gen include directory

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -18,7 +18,6 @@ import("common_flags.gni")
 
 config("app_config") {
   include_dirs = [
-    "gen",
     "util",
     ".",
     "${target_gen_dir}/include",


### PR DESCRIPTION
This was removed way back in dcecc8a3 ("Remove Silicon Labs dotdot code,
since it's not used anymore. (#2006)").