### PR TITLE
Fix generation with chip_with_lwip=false

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -20,6 +20,7 @@ import("//build_overrides/nlio.gni")
 import("//build_overrides/nlunit_test.gni")
 import("//build_overrides/pigweed.gni")
 
+import("//src/lwip/lwip.gni")
 import("//src/platform/device.gni")
 import("$dir_pw_build/python.gni")
 
@@ -70,7 +71,6 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/shell",
       "${chip_root}/src/lib/support",
-      "${chip_root}/src/lwip:all",
       "${chip_root}/src/messaging",
       "${chip_root}/src/protocols",
       "${chip_root}/src/setup_payload",
@@ -88,6 +88,10 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
     if (chip_build_tests) {
       deps += [ "//src:tests" ]
+    }
+
+    if (chip_with_lwip) {
+      deps += [ "${chip_root}/src/lwip:all" ]
     }
 
     if (chip_build_tools) {


### PR DESCRIPTION
This fixes the following error if LwIP is removed from the build:

```
ERROR at //src/lwip/BUILD.gn:23:1: Assertion failed.
assert(chip_with_lwip)
^-----
See //BUILD.gn:73:7: which caused the file to be included.
	"${chip_root}/src/lwip:all",
	^--------------------------
```

The problem is just that we're not checking `chip_with_lwip` at the top
level.