### PR TITLE
Move CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE to CHIPDeviceBuildConfig.h

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -28,10 +28,6 @@ config("includes") {
   ]
 
   defines = [ "CHIP_HAVE_CONFIG_H=1" ]
-
-  if (chip_device_platform == "linux" || chip_device_platform == "darwin") {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_ble}" ]
-  }
 }
 
 if (chip_build_tests) {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -71,6 +71,10 @@ if (chip_device_platform != "none") {
       "OPENTHREAD_CONFIG_ENABLE_TOBLE=false",
     ]
 
+    if (chip_device_platform == "linux" || chip_device_platform == "darwin") {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_ble}" ]
+    }
+
     if (chip_enable_mdns) {
       defines += [ "CHIP_DEVICE_CONFIG_ENABLE_MDNS=1" ]
     }


### PR DESCRIPTION
We've moved almost all configuration to generated files, not compiler
command lines. Move `CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE` too, which was
added to the command line more recently.