### PR TITLE
Document querying of include_dirs et al.

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -307,6 +307,17 @@ To find dependency paths:
 gn path out/host //src/transport/tests:tests //src/system
 ```
 
+To list useful information for linking against libCHIP:
+
+```
+gn desc out/host //src/lib include_dirs
+gn desc out/host //src/lib defines
+gn desc out/host //src/lib outputs
+
+# everything as JSON
+gn desc out/host //src/lib --format=json
+```
+
 ## Maintaining CHIP
 
 If you make any change to the GN build system, the next build will regenerate


### PR DESCRIPTION
e.g.,

```
gn desc out/host //src/lib --format=json | jq '
  {include_dirs: [.[] | .include_dirs? | select(. != null)] | flatten | sort | unique,
   defines: [.[] | .defines? | select(. != null)] | flatten | sort | unique,
   outputs: [.[] | .outputs? | select(. != null) ] | flatten | sort | unique}'
```
shows the most important information for building successfuly against
libCHIP regardless of application build system:

```
{
  "include_dirs": [ 
    "//config/standalone/",
    "//out/host/gen/",
    "//out/host/gen/include/",
    "//out/host/gen/src/app/include/",
    "//src/",
    "//src/app/",
    "//src/app/server/",
    "//src/app/util/",
    "//src/include/",
    "//src/lib/",
    "//src/setup_payload/",
    "//third_party/inipp/repo/inipp/",
    "//third_party/nlassert/repo/include/",
    "//third_party/nlfaultinjection/repo/include/",
    "//third_party/nlio/repo/include/"
  ],
  "defines": [ 
    "CHIP_HAVE_CONFIG_H=1"
  ],
  "outputs": [ 
    "//out/host/lib/libCHIP.a"
  ] 
} 
```

We should still reduce the number of include directories as this is
unnecessarily many.