### PR TITLE
[esp32] use -std=gnu++14 rather than -std=c++14

### DIFF
--- a/examples/all-clusters-app/esp32/Makefile
+++ b/examples/all-clusters-app/esp32/Makefile
@@ -26,7 +26,7 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
                         $(PROJECT_PATH)/../../common/QRCode \
                         $(PROJECT_PATH)/../../common/screen-framework \
 
-CXXFLAGS += -std=c++14 -Os -DLWIP_IPV6_SCOPES=0
+CXXFLAGS += -std=gnu++14 -Os -DLWIP_IPV6_SCOPES=0
 CPPFLAGS += -Os -DLWIP_IPV6_SCOPES=0 -DCHIP_HAVE_CONFIG_H
 CFLAGS += -Os -DLWIP_IPV6_SCOPES=0
 

--- a/examples/temperature-measurement-app/esp32/Makefile
+++ b/examples/temperature-measurement-app/esp32/Makefile
@@ -26,7 +26,7 @@ EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32
                         $(PROJECT_PATH)/../../common/QRCode \
                         $(PROJECT_PATH)/../../common/screen-framework \
 
-CXXFLAGS += -std=c++14 -Os -DLWIP_IPV6_SCOPES=0
+CXXFLAGS += -std=gnu++14 -Os -DLWIP_IPV6_SCOPES=0
 CPPFLAGS += -Os -DLWIP_IPV6_SCOPES=0 -DCHIP_HAVE_CONFIG_H
 CFLAGS += -Os -DLWIP_IPV6_SCOPES=0
 


### PR DESCRIPTION
ESP-IDF has a macro expansion issue for ``__VA_RAGS__ `` when gnu compiler
extension is disabled.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The esp32 build fails with xtensa-esp32-elf-c++ 8.4.0 because of https://github.com/espressif/esp-idf/issues/5897

 #### Summary of Changes

Use -std=gnu++14 instead.

Fixes https://github.com/project-chip/connectedhomeip/issues/5211
