### PR TITLE
Implement CMake build for ESP32

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -1,0 +1,158 @@
+#
+#   Copyright (c) 2021 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# The compile flags written args.gn come from chip.c and chip.cpp.
+# Any build specifications (include dirs, compile flags, definitions, etc)
+# that is set in the component will be reflected in
+# the output args.gn. By default, all components inherit build-level
+# specifications stored as idf-build-properties as done in
+# tools/cmake/build.cmake.
+#
+# Adding REQUIRES/PRIV_REQUIRES will also propagate the
+# appropriate build specifications from the required component.
+idf_build_get_property(idf_path IDF_PATH)
+
+if(NOT CHIP_ROOT)
+    get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../.. REALPATH)
+endif()
+
+idf_component_register(SRCS chip.c chip.cpp
+                       PRIV_REQUIRES freertos lwip bt mdns mbedtls)
+
+# Override some build specifications
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
+set(CMAKE_BUILD_TYPE MinSizeRel)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
+
+# Prepare initial args file (lacking compile flags)
+# This will be saved as args.gn.in
+set(chip_gn_args "import(\"//args.gni\")\n")
+
+macro(chip_gn_arg_append arg val)
+    string(APPEND chip_gn_args "${arg} = ${val}\n")
+endmacro()
+
+chip_gn_arg_append("esp32_ar"              "\"${CMAKE_AR}\"")
+chip_gn_arg_append("esp32_cc"              "\"${CMAKE_C_COMPILER}\"")
+chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
+chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
+
+if(CONFIG_ENABLE_PW_RPC)
+    chip_gn_arg_append("chip_build_pw_rpc_lib"              "true")
+    chip_gn_arg_append("pw_log_BACKEND"                     "true")
+    chip_gn_arg_append("pw_assert_BACKEND"                  "true")
+    chip_gn_arg_append("pw_sys_io_BACKEND"                  "true")
+    chip_gn_arg_append("dir_pw_third_party_nanopb"          "true")
+endif()
+
+set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
+file(GENERATE OUTPUT "${args_gn_input}" CONTENT "${chip_gn_args}")
+
+# This generates the final args.in file to be fed to
+# CHIP build using GN build system. The necessary compile_commands.json
+# and args.gn.in input file should exist by the time this is invoked,
+# since these requirements ar generated at the parent project's
+# GENERATE phase.
+idf_build_get_property(idf_ver IDF_VER)
+set(filter_out "-DHAVE_CONFIG_H" "-DIDF_VER=\\\"${idf_ver}\\\"" )
+
+# CMake adds config include dir relative to build directory.
+# Make sure full path is given to CHIP build.
+list(APPEND filter_out "-Iconfig")
+idf_build_get_property(config_dir CONFIG_DIR)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-I${config_dir}")
+
+if(filter_out)
+    set(filter_arg "--filter-out=${filter_out}")
+endif()
+
+set(args_gn "${CMAKE_CURRENT_BINARY_DIR}/args.gn")
+add_custom_command(OUTPUT "${args_gn}"
+                   COMMAND ${python} 
+                           ${CMAKE_CURRENT_LIST_DIR}/create_args_gn.py 
+                           "${CMAKE_BINARY_DIR}"
+                           "${idf_path}"
+                           "${CMAKE_CURRENT_LIST_DIR}/chip.c"
+                           "${CMAKE_CURRENT_LIST_DIR}/chip.cpp"
+                           "${args_gn_input}"
+                           "${args_gn}"
+                           "${filter_arg}"
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                   DEPENDS "${CMAKE_BINARY_DIR}/compile_commands.json"
+                   VERBATIM)
+
+add_custom_target(args_gn DEPENDS "${args_gn}")
+
+# CHIP build as an external project.
+find_program(GN_EXECUTABLE gn)
+if (${GN_EXECUTABLE} STREQUAL GN_EXECUTABLE-NOTFOUND)
+    message(FATAL_ERROR "The 'gn' command was not found. Make sure you have GN installed."
+                        "Or have followed necessary build preparations stated in BUILDING.md.")
+endif()
+
+set(GN_ROOT_TARGET ${CHIP_ROOT}/config/esp32)
+
+externalproject_add(
+    chip_gn
+    SOURCE_DIR              ${CHIP_ROOT}
+    BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
+    CONFIGURE_COMMAND       gn --root=${GN_ROOT_TARGET} gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
+    BUILD_COMMAND           ninja
+    INSTALL_COMMAND         ""
+    BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
+    WORKING_DIRECTORY       ${CMAKE_CURRENT_LIST_DIR}
+    DEPENDS                 args_gn
+    BUILD_ALWAYS            1
+)
+
+idf_component_get_property(freertos_dir freertos COMPONENT_DIR)
+
+# ESP-IDF components usually need 'freertos/<header.h>', while
+# CHIP might include do 'header.h'.
+target_include_directories(${COMPONENT_LIB} PRIVATE
+    "${freertos_dir}/include/freertos")
+
+target_include_directories(${COMPONENT_LIB} INTERFACE
+    "${CHIP_ROOT}/src/platform/ESP32"
+    "${CHIP_ROOT}/src/include/"
+    "${CHIP_ROOT}/src/lib"
+    "${CHIP_ROOT}/src/"
+    "${CHIP_ROOT}/src/system"
+    "${CHIP_ROOT}/third_party/nlassert/repo/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/gen/third_party/connectedhomeip/src/app/include"
+    "${CMAKE_CURRENT_BINARY_DIR}/gen/include"
+)
+
+idf_component_get_property(bt_lib bt COMPONENT_LIB)
+idf_component_get_property(esp32_mbedtls_lib esp32_mbedtls COMPONENT_LIB)
+
+set(chip_libraries "-lCHIP")
+
+if(CONFIG_ENABLE_PW_RPC)
+    list(APPEND chip_libraries "-lPwRpc")
+endif()
+
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-L${CMAKE_CURRENT_BINARY_DIR}/lib")
+target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group 
+                                                ${chip_libraries}
+                                                $<TARGET_FILE:${bt_lib}> -lbtdm_app 
+                                                $<TARGET_FILE:mbedcrypto> $<TARGET_FILE:${esp32_mbedtls_lib}> 
+                                                -Wl,--end-group)
+
+# Make the component dependent on our CHIP build
+add_dependencies(${COMPONENT_LIB} chip_gn)

--- a/config/esp32/components/chip/chip.c
+++ b/config/esp32/components/chip/chip.c
@@ -1,0 +1,1 @@
+// Empty file

--- a/config/esp32/components/chip/chip.cpp
+++ b/config/esp32/components/chip/chip.cpp
@@ -1,0 +1,1 @@
+// Empty file

--- a/config/esp32/components/chip/create_args_gn.py
+++ b/config/esp32/components/chip/create_args_gn.py
@@ -1,0 +1,78 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2018 Nest Labs, Inc.
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Component makefile for building CHIP within the ESP32 ESP-IDF environment.
+#
+
+import json
+import os
+import argparse
+import re
+
+# Parse the build's compile_commands.json to generate
+# final args file for CHIP build.
+
+argparser = argparse.ArgumentParser()
+
+argparser.add_argument("build_dir")
+argparser.add_argument("idf_path")
+argparser.add_argument("c_file")
+argparser.add_argument("cpp_file")
+argparser.add_argument("input")
+argparser.add_argument("output")
+argparser.add_argument("--filter-out")
+
+args = argparser.parse_args()
+
+compile_commands_path = os.path.join(args.build_dir, "compile_commands.json")
+
+with open(compile_commands_path) as compile_commands_json:
+    compile_commands = json.load(compile_commands_json)
+
+    def get_compile_flags(src_file):
+        compile_command = list(map(lambda res: res["command"],
+                               filter(lambda cmd: cmd["file"] == src_file, compile_commands)))
+
+        if len(compile_command) != 1:
+            raise Exception("Failed to resolve compile flags for %s", src_file)
+
+        compile_command = compile_command[0]
+        # Trim compiler, input and output
+        compile_flags = compile_command.split()[1:-4]
+
+        replace = "-I%s" % args.idf_path
+        replace_with = "-isystem%s" % args.idf_path
+
+        compile_flags = list(map(lambda f: ('"%s"' % f).replace(replace, replace_with), compile_flags))
+
+        if args.filter_out:
+            filter_out = list(map(lambda f: ('"%s"' % f), args.filter_out.split(';')))
+            compile_flags = [c for c in compile_flags if c not in filter_out]
+
+        return compile_flags
+
+    c_flags = get_compile_flags(args.c_file)
+    cpp_flags = get_compile_flags(args.cpp_file)
+
+    with open(args.input) as args_input:
+        with open(args.output, "w") as args_output:
+            args_output.write(args_input.read())
+
+            args_output.write("target_cflags_c = [%s]" % ', '.join(c_flags))
+            args_output.write("\n")
+            args_output.write("target_cflags_cc = [%s]" % ', '.join(cpp_flags))

--- a/config/esp32/components/esp32_mbedtls/CMakeLists.txt
+++ b/config/esp32/components/esp32_mbedtls/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS hkdf.c
+                       INCLUDE_DIRS .
+                       PRIV_REQUIRES mbedtls)

--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -1,0 +1,34 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+#
+# This is a project Makefile. It is assumed the directory this Makefile resides in is a
+# project subdirectory.
+#
+
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
+    "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components"
+    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
+    "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework"
+)
+
+project(chip-all-clusters-app)

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -1,0 +1,51 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      Component makefile for the ESP32 demo application.
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+idf_component_register(PRIV_INCLUDE_DIRS 
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/nlio/repo/include"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
+                      "${CMAKE_CURRENT_LIST_DIR}/include"
+                      SRC_DIRS
+                      "${CMAKE_CURRENT_LIST_DIR}"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/gen"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/on-off-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/level-control"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/barrier-control-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/color-control-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/temperature-measurement-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/scenes"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/door-lock-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ias-zone-server"
+                      #${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ias-zone-client
+                      PRIV_REQUIRES chip QRCode tft spidriver bt screen-framework)
+
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")

--- a/examples/common/QRCode/CMakeLists.txt
+++ b/examples/common/QRCode/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "repo/c/qrcodegen.c"
+                       INCLUDE_DIRS "repo/c")
+
+target_compile_options(${COMPONENT_LIB} PRIVATE "-Wno-unknown-pragmas")

--- a/examples/common/screen-framework/CMakeLists.txt
+++ b/examples/common/screen-framework/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(SRCS "Display.cpp" 
+                            "ScreenManager.cpp" 
+                            "Screen.cpp" 
+                            "ListScreen.cpp"
+                       INCLUDE_DIRS "include")


### PR DESCRIPTION
 #### Problem

Currently, ESP32 CHIP examples can only be built with Make, despite ESP-IDF having support for CMake
since v3.3.

 #### Summary of Changes

Enables support for building with CMake. Tested to build `all-clusters-app/esp32`. Might need some more work for other examples, which can be based on work done here.

 Fixes #4779
