### PR TITLE
Match MACOSX_DEPLOYMENT_TARGET with mac python build.

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -22,6 +22,21 @@ _normpath() {
     python -c "import os.path; print(os.path.normpath('$@'))"
 }
 
+_ensure_darwin_deployment_target() {
+    if [[ `uname` != "Darwin" ]]; then
+        return
+    fi
+
+    # Only override the deployment target if not set
+    if [[ -n "${MACOSX_DEPLOYMENT_TARGET}" ]]; then
+        return
+    fi
+
+    # This matches the deployment target for the current python binary.
+    # platform.platform is of the form 'macOS-10.16-x86_64-i386-64bit'
+    export MACOSX_DEPLOYMENT_TARGET=`python -c "import platform; print(platform.platform().split('-')[1])"`
+}
+
 echo_green() {
     echo -e "\033[0;32m$*\033[0m"
 }
@@ -40,6 +55,11 @@ ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
+
+# Deployment target set only post activate, to ensure the right
+# python binary is used.
+_ensure_darwin_deployment_target
+
 
 # Generates ninja files
 gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT"

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -60,7 +60,6 @@ source "$CHIP_ROOT/scripts/activate.sh"
 # python binary is used.
 _ensure_darwin_deployment_target
 
-
 # Generates ninja files
 gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT"
 


### PR DESCRIPTION
 #### Problem
Default mac build of python library (and chip-repl) does not work with the python used by 
our build environment because the default build target is too new.

#5202 resolves things a bit more. This is limited change just for the build_python.sh script.

 #### Summary of Changes
 Setup MACOSX_DEPLOYMENT_TARGET to match the current python binary.
