### PR TITLE
Fix segfault when running python controller on mac 

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -292,7 +292,6 @@ namespace DeviceLayer {
 
 - (void)stop
 {
-    dispatch_source_cancel(_timer);
     [self stopScanning];
     [self disconnect];
     _centralManager = nil;
@@ -313,7 +312,7 @@ namespace DeviceLayer {
     if (!_centralManager) {
         return;
     }
-
+    dispatch_source_cancel(_timer);
     [_centralManager stopScan];
 }
 


### PR DESCRIPTION
 #### Problem
Running chip-device-ctrl on macOS, The Secure Rendez-vous and Thread provision completes succesfully but a segfault happens around 50 seconds after the BLE connection is auto-closed. 

 #### Summary of Changes
Move a the timer cancel to the function stopScanning. The timer expired and called back `onConnectionError(_appState, BLE_ERROR_APP_CLOSED_CONNECTION);` when the BLE transport object was already released and connection was closed.

fixes #5182

