### PR TITLE
[nrfconnect] Don't add test pairing on startup

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -356,7 +356,11 @@ void AppTask::StartThreadHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != THREAD_START_BUTTON)
         return;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (AddTestPairing() != CHIP_NO_ERROR)
+    {
+        LOG_ERR("Failed to add test pairing");
+    }
+
     if (!chip::DeviceLayer::ConnectivityMgr().IsThreadProvisioned())
     {
         StartDefaultThreadNetwork();
@@ -366,7 +370,6 @@ void AppTask::StartThreadHandler(AppEvent * aEvent)
     {
         LOG_INF("Device is commissioned to a Thread network.");
     }
-#endif
 }
 
 void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)

--- a/examples/lighting-app/nrfconnect/main/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/nrfconnect/main/include/CHIPProjectConfig.h
@@ -30,4 +30,3 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
-#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1

--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -63,7 +63,6 @@ int main(void)
         goto exit;
     }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     LOG_INF("Init Thread stack");
     ret = ThreadStackMgr().InitThreadStack();
     if (ret != CHIP_NO_ERROR)
@@ -78,7 +77,6 @@ int main(void)
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         goto exit;
     }
-#endif
 
     ret = GetAppTask().StartApp();
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -358,7 +358,11 @@ void AppTask::StartThreadHandler(AppEvent * aEvent)
     if (aEvent->ButtonEvent.PinNo != THREAD_START_BUTTON)
         return;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (AddTestPairing() != CHIP_NO_ERROR)
+    {
+        LOG_ERR("Failed to add test pairing");
+    }
+
     if (!chip::DeviceLayer::ConnectivityMgr().IsThreadProvisioned())
     {
         StartDefaultThreadNetwork();
@@ -368,7 +372,6 @@ void AppTask::StartThreadHandler(AppEvent * aEvent)
     {
         LOG_INF("Device is commissioned to a Thread network.");
     }
-#endif
 }
 
 void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)

--- a/examples/lock-app/nrfconnect/main/include/CHIPProjectConfig.h
+++ b/examples/lock-app/nrfconnect/main/include/CHIPProjectConfig.h
@@ -30,4 +30,3 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
-#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1

--- a/examples/lock-app/nrfconnect/main/main.cpp
+++ b/examples/lock-app/nrfconnect/main/main.cpp
@@ -59,7 +59,6 @@ int main()
         goto exit;
     }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     LOG_INF("Init Thread stack");
     ret = ThreadStackMgr().InitThreadStack();
     if (ret != CHIP_NO_ERROR)
@@ -74,7 +73,6 @@ int main()
         LOG_ERR("ConnectivityMgr().SetThreadDeviceType() failed");
         goto exit;
     }
-#endif
 
     ret = GetAppTask().StartApp();
 

--- a/examples/shell/nrfconnect/CHIPProjectConfig.h
+++ b/examples/shell/nrfconnect/CHIPProjectConfig.h
@@ -30,7 +30,6 @@
 // Use a default pairing code if one hasn't been provisioned in flash.
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
-#define CHIP_DEVICE_CONFIG_USE_TEST_PAIRING 1
 
 // Enable support functions for parsing command-line arguments
 #define CHIP_CONFIG_ENABLE_ARG_PARSER 1

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -37,6 +37,8 @@ using DemoTransportMgr = chip::TransportMgr<chip::Transport::UDP>;
  */
 void InitServer(AppDelegate * delegate = nullptr);
 
+CHIP_ERROR AddTestPairing();
+
 chip::Transport::AdminPairingTable & GetGlobalAdminPairingTable();
 
 namespace chip {

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -197,6 +197,8 @@ public:
     {
         return ConstAdminIterator(mStates, CHIP_CONFIG_MAX_DEVICE_ADMINS, CHIP_CONFIG_MAX_DEVICE_ADMINS);
     }
+    ConstAdminIterator begin() const { return cbegin(); }
+    ConstAdminIterator end() const { return cend(); }
 
 private:
     AdminPairingInfo mStates[CHIP_CONFIG_MAX_DEVICE_ADMINS];


### PR DESCRIPTION
 #### Problem
The initialization of nRF Connect applications differed from other platforms. That is, nRF Connect examples would add the test pairing automatically even if rendezvous was not bypassed and the behaviour might lead to certain issues in the rendezvous flow

 #### Summary of Changes
Remove the discrepancy and add the test pairing only if the "test mode" button is pressed".
Remove unnecessary `#ifdef`s from the examples.