### PR TITLE
Use peer encryption key ID in message header while sending message

### DIFF
--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -71,11 +71,7 @@ public:
 
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        // We need to change the peerKeyId to local Key Id to be received by itself.
-        PacketHeader tmpHeader = header;
-
-        tmpHeader.SetEncryptionKeyID(kTestLocalGroupKeyId);
-        HandleMessageReceived(tmpHeader, address, std::move(msgBuf));
+        HandleMessageReceived(header, address, std::move(msgBuf));
 
         return CHIP_NO_ERROR;
     }

--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -238,21 +238,15 @@ public:
     }
 
     /**
-     * Get a peer connection state given a peer Node Id, local Node Id and Peer's Encryption Key Id.
+     * Get a peer connection state given the local Encryption Key Id.
      *
-     * @param nodeId is the connection to find (based on nodeId). Note that initial connections
-     *        do not have a node id set. Use this if you know the node id should be set.
-     * @param localNodeId The connection must correspond to the given local node ID.
-     * @param admins List of administrators that have commissioned this device.
-     * @param peerKeyId Encryption key ID used by the peer node.
+     * @param keyId Encryption key ID assigned by the local node.
      * @param begin If a member of the pool, will start search from the next item. Can be nullptr to search from start.
      *
      * @return the state found, nullptr if not found
      */
     CHECK_RETURN_VALUE
-    PeerConnectionState * FindPeerConnectionState(Optional<NodeId> nodeId, NodeId localNodeId,
-                                                  Transport::AdminPairingTable * admins, uint16_t peerKeyId,
-                                                  PeerConnectionState * begin)
+    PeerConnectionState * FindPeerConnectionState(uint16_t keyId, PeerConnectionState * begin)
     {
         PeerConnectionState * state = nullptr;
         PeerConnectionState * iter  = &mStates[0];
@@ -270,15 +264,11 @@ public:
             {
                 continue;
             }
-            AdminPairingInfo * adminInfo = admins->FindAdmin(iter->GetAdminId());
-            if (adminInfo != nullptr && adminInfo->GetNodeId() == localNodeId &&
-                (peerKeyId == kAnyKeyId || iter->GetPeerKeyID() == peerKeyId))
+
+            if (iter->GetLocalKeyID() == keyId)
             {
-                if (!nodeId.HasValue() || iter->GetPeerNodeId() == kUndefinedNodeId || iter->GetPeerNodeId() == nodeId.Value())
-                {
-                    state = iter;
-                    break;
-                }
+                state = iter;
+                break;
             }
         }
         return state;

--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
     packetHeader
         .SetSourceNodeId(localNodeId) //
         .SetMessageId(msgId)          //
-        .SetEncryptionKeyID(state->GetLocalKeyID());
+        .SetEncryptionKeyID(state->GetPeerKeyID());
 
     if (state->GetPeerNodeId() != kUndefinedNodeId)
     {


### PR DESCRIPTION
 #### Problem
We are currently using sender's encryption key ID while sending encrypted messages. As per CHIP spec, the receiver's encryption key ID shall be used in the message header. This allows receiver to use just the key ID (allocated by the receiving node) to lookup the connection information. 

 #### Summary of Changes
1. Use peer's (receiver's) key ID when sending a message.
2. On receiving the message, match the key ID to local key ID in existing connections.
