### PR TITLE
Replace semaphores with dispatch semaphore for apple

### DIFF
--- a/src/controller/python/chip/internal/ChipThreadWork.cpp
+++ b/src/controller/python/chip/internal/ChipThreadWork.cpp
@@ -44,6 +44,7 @@ struct WorkData
     sem_t done;
 
     WorkData() { sem_init(&done, 0 /* shared */, 0); }
+    ~WorkData() { sem_destroy(&done); }
     void Post() { sem_post(&done); }
     void Wait() { sem_wait(&done); }
 #endif

--- a/src/controller/python/chip/internal/ChipThreadWork.cpp
+++ b/src/controller/python/chip/internal/ChipThreadWork.cpp
@@ -16,9 +16,15 @@
  */
 
 #include "ChipThreadWork.h"
+
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+#else
 #include <semaphore.h>
+#endif
 
 #include <platform/CHIPDeviceLayer.h>
+
 
 namespace chip {
 namespace python {
@@ -27,11 +33,20 @@ namespace {
 struct WorkData
 {
     WorkCallback callback;
+#ifdef __APPLE__
+    dispatch_semaphore_t done;
+
+    WorkData() { done = dispatch_semaphore_create(0); }
+    ~WorkData() { dispatch_release(done); }
+    void Post() { dispatch_semaphore_signal(done); }
+    void Wait() { dispatch_semaphore_wait(done, DISPATCH_TIME_FOREVER); }
+#else
     sem_t done;
 
     WorkData() { sem_init(&done, 0 /* shared */, 0); }
     void Post() { sem_post(&done); }
     void Wait() { sem_wait(&done); }
+#endif
 };
 
 void PerformWork(intptr_t arg)

--- a/src/controller/python/chip/internal/ChipThreadWork.cpp
+++ b/src/controller/python/chip/internal/ChipThreadWork.cpp
@@ -25,7 +25,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-
 namespace chip {
 namespace python {
 namespace {


### PR DESCRIPTION
 #### Problem

sem_init does not work on darwin (unnamed semaphores are not supported).

 #### Summary of Changes
Use dispatch semaphores on darwin platforms.