### PR TITLE
Add missing include <inttypes.h>

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -17,6 +17,8 @@
 
 #include "Mdns.h"
 
+#include <inttypes.h>
+
 #include <core/Optional.h>
 #include <mdns/Advertiser.h>
 #include <platform/CHIPDeviceLayer.h>


### PR DESCRIPTION
This fixes a compile error with certain stdlibs:

```
app/server/Mdns.cpp:57:69: error: expected ')'
        ChipLogProgress(Discovery, "Found admin paring for admin %" PRIX64 ", node %" PRIX64, pairing->GetAdminId(),
```