### PR TITLE
[TE1]: Enable echo protocol in lighting app for secure channel test

### DIFF
--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -48,6 +48,12 @@ Raspberry Pi Desktop 20.10 (aarch64)**
 >
 >     gn gen out/debug --args='chip_bypass_rendezvous=false'
 
+> If you want to test Echo protocol, please disable Rendezvous and enable Echo
+> handler
+>
+>     gn gen out/debug --args='chip_bypass_rendezvous=true chip_app_use_echo=true'
+>     ninja -C out/debug
+
 -   Prerequisites
 
     1. A Raspberry Pi 4 board

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 declare_args() {
-  # Temporary flag for new interaction model engine, set it to true to enable
+  # Temporary flag for interaction model and echo protocols, set it to true to enable
+  chip_app_use_echo = false
   chip_app_use_interaction_model = false
 }

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -22,6 +22,10 @@ config("server_config") {
     defines += [ "CHIP_APP_USE_INTERACTION_MODEL" ]
   }
 
+  if (chip_app_use_echo) {
+    defines += [ "CHIP_APP_USE_ECHO" ]
+  }
+
   include_dirs = [ "." ]
 }
 
@@ -29,6 +33,8 @@ static_library("server") {
   output_name = "libCHIPAppServer"
 
   sources = [
+    "EchoHandler.cpp",
+    "EchoHandler.h",
     "Mdns.cpp",
     "Mdns.h",
     "QRCodeUtil.cpp",
@@ -46,6 +52,7 @@ static_library("server") {
     "${chip_root}/src/lib/mdns",
     "${chip_root}/src/messaging",
     "${chip_root}/src/platform",
+    "${chip_root}/src/protocols",
     "${chip_root}/src/setup_payload",
     "${chip_root}/src/transport",
   ]

--- a/src/app/server/EchoHandler.cpp
+++ b/src/app/server/EchoHandler.cpp
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *   This file implements the handler for echo messages.
+ */
+
+#include <app/server/EchoHandler.h>
+
+#include <protocols/echo/Echo.h>
+#include <support/ErrorStr.h>
+
+namespace {
+
+// The EchoServer object.
+chip::Protocols::Echo::EchoServer gEchoServer;
+
+/**
+ * Callback handler when a CHIP EchoRequest is received.
+ *
+ * @param [in] ec      The exchange context holding the incoming message.
+ * @param [in] payload The buffer holding the message.  This function guarantees
+ *                     that it will free the buffer before returning.
+ *
+ */
+void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle payload)
+{
+    ChipLogProgress(AppServer, "Echo Request, len=%u ... sending response.\n", payload->DataLength());
+}
+
+} // namespace
+
+CHIP_ERROR InitEchoHandler(chip::Messaging::ExchangeManager * exchangeMgr)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = gEchoServer.Init(exchangeMgr);
+    SuccessOrExit(err);
+
+    // Arrange to get a callback whenever an Echo Request is received.
+    gEchoServer.SetEchoRequestReceived(HandleEchoRequestReceived);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "EchoServer failed, err:%s\n", chip::ErrorStr(err));
+    }
+
+    return err;
+}

--- a/src/app/server/EchoHandler.h
+++ b/src/app/server/EchoHandler.h
@@ -1,0 +1,33 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *   This file defines the API for the handler for echo messages.
+ */
+
+#pragma once
+
+#include <messaging/ExchangeMgr.h>
+#include <system/SystemPacketBuffer.h>
+
+/**
+ * Register an unsolicited message handler for Echo protocol to be ready to process
+ * Echo messages.
+ *
+ */
+CHIP_ERROR InitEchoHandler(chip::Messaging::ExchangeManager * exchangeMgr);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
This is requested by TE1, TSG has chosen lighting app as the accessory for test setup. Currently, lighting-app does not support Echo protocol which is used for CRMP testing. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Enable echo protocol in lighting app for secure channel test

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5235

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
