### PR TITLE
[chip-tool] stringstream gives wrong results when converting int8_t a…

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -155,12 +155,23 @@ bool Command::InitArgument(size_t argIndex, const char * argValue)
 
     case ArgumentType::Number_int8: {
         int8_t * value = reinterpret_cast<int8_t *>(arg.value);
-        std::stringstream ss(argValue);
-        ss >> *value;
 
-        int64_t min     = arg.min;
-        int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
-        isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
+        // stringstream treats int8_t as char, which is not what we want here.
+        int16_t tmpValue;
+        std::stringstream ss(argValue);
+        ss >> tmpValue;
+        if (chip::CanCastTo<int8_t>(tmpValue))
+        {
+            *value = static_cast<int8_t>(tmpValue);
+
+            int64_t min     = arg.min;
+            int64_t max     = chip::CanCastTo<int64_t>(arg.max) ? static_cast<int64_t>(arg.max) : INT64_MAX;
+            isValidArgument = (!ss.fail() && ss.eof() && *value >= min && *value <= max);
+        }
+        else
+        {
+            isValidArgument = false;
+        }
         break;
     }
 


### PR DESCRIPTION
…rguments

 #### Problem

If there is a `writable` `INT8S` attribute for a given cluster, `chip-tool` is unable to write to it because `stringstream` considers `int8_t` types as `char`. 

 #### Summary of Changes
 * Apply the same kind of "fix" than for `uint8_t`
 