### PR TITLE
Add BleConnectionDelegate::CancelConnection to stop scanning when ren…

### DIFF
--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -53,6 +53,9 @@ public:
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
     // out of a peripheral discriminator.
     virtual void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) = 0;
+
+    // Call this function to stop the connection
+    virtual BLE_ERROR CancelConnection() = 0;
 };
 
 } /* namespace Ble */

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -368,6 +368,23 @@ exit:
     return err;
 }
 
+BLE_ERROR BleLayer::CancelBleIncompleteConnection()
+{
+    BLE_ERROR err = BLE_NO_ERROR;
+
+    VerifyOrExit(mState == kState_Initialized, err = BLE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mConnectionDelegate != nullptr, err = BLE_ERROR_INCORRECT_STATE);
+
+    err = mConnectionDelegate->CancelConnection();
+    if (err == BLE_ERROR_NOT_IMPLEMENTED)
+    {
+        ChipLogError(Ble, "BleConnectionDelegate::CancelConnection is not implemented.");
+    }
+
+exit:
+    return err;
+}
+
 BLE_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose)
 {
     *retEndPoint = nullptr;

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -267,6 +267,7 @@ public:
     BLE_ERROR NewBleConnection(void * appState, uint16_t connDiscriminator,
                                BleConnectionDelegate::OnConnectionCompleteFunct onConnectionComplete,
                                BleConnectionDelegate::OnConnectionErrorFunct onConnectionError);
+    BLE_ERROR CancelBleIncompleteConnection();
     BLE_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
 
     chip::System::Error ScheduleWork(chip::System::Layer::TimerCompleteFunct aComplete, void * aAppState)

--- a/src/controller/java/AndroidBleConnectionDelegate.cpp
+++ b/src/controller/java/AndroidBleConnectionDelegate.cpp
@@ -26,3 +26,8 @@ void AndroidBleConnectionDelegate::NewConnection(chip::Ble::BleLayer * bleLayer,
         newConnectionCb(bleLayer->mAppState, connDiscriminator);
     }
 }
+
+BLE_ERROR AndroidBleConnectionDelegate::CancelConnection()
+{
+    return BLE_ERROR_NOT_IMPLEMENTED;
+}

--- a/src/controller/java/AndroidBleConnectionDelegate.h
+++ b/src/controller/java/AndroidBleConnectionDelegate.h
@@ -26,6 +26,7 @@ class AndroidBleConnectionDelegate : public chip::Ble::BleConnectionDelegate
 {
 public:
     void NewConnection(chip::Ble::BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator);
+    BLE_ERROR CancelConnection();
 
     void SetNewConnectionCallback(NotifyNewConnectionAvailable cb) { newConnectionCb = cb; }
 

--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -27,6 +27,7 @@ class BleConnectionDelegateImpl : public Ble::BleConnectionDelegate
 {
 public:
     virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator);
+    virtual BLE_ERROR CancelConnection();
 };
 
 } // namespace Internal

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -58,14 +58,24 @@ constexpr uint64_t kScanningTimeoutInSeconds = 60;
 namespace chip {
 namespace DeviceLayer {
     namespace Internal {
+        BleConnection * ble;
+
         void BleConnectionDelegateImpl::NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t deviceDiscriminator)
         {
             ChipLogProgress(Ble, "%s", __FUNCTION__);
-            BleConnection * ble = [[BleConnection alloc] initWithDiscriminator:deviceDiscriminator];
+            ble = [[BleConnection alloc] initWithDiscriminator:deviceDiscriminator];
             [ble setBleLayer:bleLayer];
             ble.appState = appState;
             ble.onConnectionComplete = OnConnectionComplete;
             ble.onConnectionError = OnConnectionError;
+        }
+
+        BLE_ERROR BleConnectionDelegateImpl::CancelConnection()
+        {
+            ChipLogProgress(Ble, "%s", __FUNCTION__);
+            [ble stop];
+            ble = nil;
+            return BLE_NO_ERROR;
         }
     } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -691,6 +691,11 @@ void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const u
     PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));
 }
 
+BLE_ERROR BLEManagerImpl::CancelConnection()
+{
+    return BLE_ERROR_NOT_IMPLEMENTED;
+}
+
 void BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate)
 {
     ChipDeviceEvent event;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -150,6 +150,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    BLE_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate
     void OnDeviceScanned(BluezDevice1 * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override;

--- a/src/transport/BLE.h
+++ b/src/transport/BLE.h
@@ -80,8 +80,8 @@ public:
 
 private:
     CHIP_ERROR InitInternal(BLE_CONNECTION_OBJECT connObj);
-    CHIP_ERROR DelegateConnection(uint16_t connDiscriminator);
     void SetupEvents(Ble::BLEEndPoint * endPoint);
+    void ClearState();
 
     /**
      * @brief


### PR DESCRIPTION
…dezvous is aborted

 #### Problem

Once `BLEConnectionDelegate::NewConnection` has been called there is no explicit method to stop it. In the case of `darwin`, the BLE scanning continues in the background and it crashes the stack once it the complete or error callback is called...

 #### Summary of Changes
 * Add `BleConnectionDelegate::CancelConnection`
 
 Fixes #4339