### PR TITLE
CHIP does not build with chip_config_network_layer_ble = false

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -168,7 +168,9 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
+#ifdef CONFIG_NETWORK_BLE
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
+#endif
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -168,7 +168,9 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
+#ifdef CONFIG_NETWORK_BLE
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
+#endif
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
 

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -123,6 +123,19 @@ try:
     #
     # Build the chip package...
     #
+    packages=[
+            'chip',
+            'chip.configuration',
+            'chip.exceptions',
+            'chip.internal',
+            'chip.logging',
+            'chip.native',
+            'chip.tlv',
+    ]
+
+    if os.path.isdir(os.path.join(tmpDir, 'chip', 'ble')):
+      packages += ['chip.ble']
+      packages += ['chip.ble.commissioning']
 
     # Invoke the setuptools 'bdist_wheel' command to generate a wheel containing
     # the CHIP python packages, shared libraries and scripts.
@@ -140,17 +153,7 @@ try:
             'Programming Language :: Python :: 3',
         ],
         python_requires='>=2.7',
-        packages=[
-            'chip',
-            'chip.ble',
-            'chip.ble.commissioning',
-            'chip.configuration',
-            'chip.exceptions',
-            'chip.internal',
-            'chip.logging',
-            'chip.native',
-            'chip.tlv',
-        ],
+        packages=packages,
         package_dir={
             '':tmpDir,                      # By default, look in the tmp directory for packages/modules to be included.
         },

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -234,11 +234,10 @@ extern "C" uint32_t pychip_internal_Commissioner_BleConnectForPairing(chip::Cont
     chip::python::ChipMainThreadScheduleAndWait([&]() {
         chip::RendezvousParameters params;
 
-        params.SetDiscriminator(discriminator)
-            .SetSetupPINCode(pinCode)
-            .SetRemoteNodeId(remoteNodeId)
-            .SetBleLayer(chip::DeviceLayer::ConnectivityMgr().GetBleLayer())
-            .SetPeerAddress(chip::Transport::PeerAddress::BLE());
+        params.SetDiscriminator(discriminator).SetSetupPINCode(pinCode).SetRemoteNodeId(remoteNodeId);
+#if CONFIG_NETWORK_LAYER_BLE
+        params.SetBleLayer(chip::DeviceLayer::ConnectivityMgr().GetBleLayer()).SetPeerAddress(chip::Transport::PeerAddress::BLE());
+#endif
 
         err = commissioner->PairDevice(remoteNodeId, params);
     });

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/src/ble/ble.gni")
 
 declare_args() {
   # Device platform layer: cc13x2_26x2, darwin, efr32, esp32, external, freertos, linux, nrfconnect, k32w, qpg6100, none.
@@ -41,8 +42,9 @@ declare_args() {
 
   # Enable ble support.
   chip_enable_ble =
-      chip_device_platform == "linux" || chip_device_platform == "darwin" ||
-      chip_device_platform == "cc13x2_26x2"
+      chip_config_network_layer_ble &&
+      (chip_device_platform == "linux" || chip_device_platform == "darwin" ||
+       chip_device_platform == "cc13x2_26x2")
 
   chip_enable_mdns =
       chip_device_platform == "linux" || chip_device_platform == "esp32"


### PR DESCRIPTION
 #### Problem

If `chip_config_network_layer_ble` is set to `false` CHIP does not build anymore.

 #### Summary of Changes
 * Fix the build issues with `chip_config_network_layer_ble = false`
 * Force `chip_enable_ble` to be set to `false` if `chip_config_network_layer_ble` is set to `false` since it depends on the underlying BLE layer.