### PR TITLE
GenericPlatformManagerImpl_POSIX.cpp should not depends on src/platfo…

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -31,7 +31,7 @@
 // Include the non-inline definitions for the GenericPlatformManagerImpl<> template,
 // from which the GenericPlatformManagerImpl_POSIX<> template inherits.
 #if CHIP_DEVICE_CONFIG_ENABLE_MDNS
-#include <platform/Linux/MdnsImpl.h>
+#include "lib/mdns/platform/Mdns.h"
 #endif
 #include <platform/internal/GenericPlatformManagerImpl.cpp>
 
@@ -46,6 +46,15 @@
 #include <unistd.h>
 
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+namespace chip {
+namespace Mdns {
+void UpdateMdnsDataset(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout);
+void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet);
+} // namespace Mdns
+} // namespace chip
+#endif
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/MdnsImpl.h
+++ b/src/platform/Linux/MdnsImpl.h
@@ -158,9 +158,5 @@ private:
     Poller mPoller;
 };
 
-void UpdateMdnsDataset(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet, int & maxFd, timeval & timeout);
-
-void ProcessMdns(fd_set & readFdSet, fd_set & writeFdSet, fd_set & errorFdSet);
-
 } // namespace Mdns
 } // namespace chip


### PR DESCRIPTION
…rm/Linux


 #### Problem
 
While trying to play with `mdns` on macOS, I found out that `GenericPlatformManagerImpl_POSIX.cpp` depends on `src/platform/Linux`.

 #### Summary of Changes
 * Moves some `mdns` specific definitions from `src/platform/Linux/mdns.h` to `GenericPlatformManagerImpl_POSIX.cpp`.
