### PR TITLE
Raise kMaxEndPoints from 10 to 30 to accomodate some OSes

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -302,7 +302,7 @@ private:
 
     FullQName GetCommisioningTextEntries(const CommissionAdvertisingParameters & params);
 
-    static constexpr size_t kMaxEndPoints           = 10;
+    static constexpr size_t kMaxEndPoints           = 30;
     static constexpr size_t kMaxRecords             = 16;
     static constexpr size_t kMaxAllocatedResponders = 16;
     static constexpr size_t kMaxAllocatedQNameData  = 8;


### PR DESCRIPTION
 #### Problem
 While trying to play with `mdns` on macOS, I found out that `kMaxEndPoints` is too small for the number of interfaces I have. I don't know how `10` has been chosen, but I'm raising it to `30` to make it compatible with system with much more interfaces.

 #### Summary of Changes
  * Raise `kMaxEndPoints` from `10` to `30` in `Advertiser_ImplMinimalMdns.cpp`