### PR TITLE
Register CHIP core error formatter to translate error code to text

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -49,6 +49,9 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
 
     mMsgLayerWasActive = false;
 
+    // Arrange for CHIP core errors to be translated to text
+    RegisterCHIPLayerErrorFormatter();
+
     // Arrange for Device Layer errors to be translated to text.
     RegisterDeviceLayerErrorFormatter();
 


### PR DESCRIPTION
 #### Problem

Very often while developing I see CHIP error code without text. Seems like `RegisterCHIPLayerErrorFormatter` is not called and so the formatter for core errors is not registered...

 #### Summary of Changes
  * Call `RegisterCHIPLayerErrorFormatter` from `GenericPlatformManagerImpl.cpp`