### PR TITLE
ESP32: Add a comment in all-clusters-app Makefile and CMakeLists.txt

### DIFF
--- a/examples/all-clusters-app/esp32/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/CMakeLists.txt
@@ -24,6 +24,7 @@
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+# The list of extra component dirs must be in sync with that in all-clusters-app/esp32/Makefile
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components"

--- a/examples/all-clusters-app/esp32/Makefile
+++ b/examples/all-clusters-app/esp32/Makefile
@@ -21,6 +21,7 @@
 
 PROJECT_NAME := chip-all-clusters-app
 
+# The list of extra component dirs must be in sync with that in all-clusters-app/esp32/CMakeLists.txt
 EXTRA_COMPONENT_DIRS += $(PROJECT_PATH)/third_party/connectedhomeip/config/esp32/components \
                         $(PROJECT_PATH)/../../common/m5stack-tft/repo/components \
                         $(PROJECT_PATH)/../../common/QRCode \

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -18,6 +18,7 @@
 #      Component makefile for the ESP32 demo application.
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+# The list of src and include dirs must be in sync with that in all-clusters-app/esp32/main/component.mk
 idf_component_register(PRIV_INCLUDE_DIRS 
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app"
@@ -35,8 +36,11 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/level-control"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/barrier-control-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/color-control-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/content-launch-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/media-playback-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/temperature-measurement-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/scenes"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"

--- a/examples/all-clusters-app/esp32/main/component.mk
+++ b/examples/all-clusters-app/esp32/main/component.mk
@@ -21,6 +21,7 @@
 
 COMPONENT_DEPENDS := chip QRCode tft spidriver
 
+# The list of src and include dirs must be in sync with that in all-clusters-app/esp32/main/CMakeLists.txt
 COMPONENT_SRCDIRS :=                                                                \
   .                                                                                 \
   ../third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/gen  \


### PR DESCRIPTION
We now support CMake in addition to automake. Add a comment so that either of the builds do not break.
