### PR TITLE
Remove mDefaultAdvDelegate in RendezvousParameters.h

### DIFF
--- a/src/transport/RendezvousParameters.h
+++ b/src/transport/RendezvousParameters.h
@@ -102,6 +102,8 @@ public:
         return *this;
     }
 
+    bool HasAdvertisementDelegate() const { return mAdvDelegate != nullptr; }
+
     const RendezvousAdvertisementDelegate * GetAdvertisementDelegate() const { return mAdvDelegate; }
 
     RendezvousParameters & SetAdvertisementDelegate(RendezvousAdvertisementDelegate * delegate)
@@ -140,8 +142,7 @@ private:
     PASEVerifier mPASEVerifier;
     bool mHasPASEVerifier = false;
 
-    RendezvousAdvertisementDelegate mDefaultAdvDelegate;
-    RendezvousAdvertisementDelegate * mAdvDelegate = &mDefaultAdvDelegate;
+    RendezvousAdvertisementDelegate * mAdvDelegate = nullptr;
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer               = nullptr;

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -52,6 +52,9 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params, Transpor
     VerifyOrReturnError(sessionMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(admin != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mParams.HasSetupPINCode() || mParams.HasPASEVerifier(), CHIP_ERROR_INVALID_ARGUMENT);
+#if CONFIG_NETWORK_LAYER_BLE
+    VerifyOrReturnError(mParams.HasAdvertisementDelegate(), CHIP_ERROR_INVALID_ARGUMENT);
+#endif
 
     mSecureSessionMgr = sessionMgr;
     mAdmin            = admin;
@@ -289,7 +292,10 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
             mDelegate->OnRendezvousComplete();
         }
 
-        mParams.GetAdvertisementDelegate()->RendezvousComplete();
+        if (mParams.HasAdvertisementDelegate())
+        {
+            mParams.GetAdvertisementDelegate()->RendezvousComplete();
+        }
 
         // Release the admin, as the rendezvous is complete.
         mAdmin = nullptr;
@@ -305,7 +311,10 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
         ReleasePairingSessionHandle();
 
         // Disable rendezvous advertisement
-        mParams.GetAdvertisementDelegate()->StopAdvertisement();
+        if (mParams.HasAdvertisementDelegate())
+        {
+            mParams.GetAdvertisementDelegate()->StopAdvertisement();
+        }
         if (mTransport)
         {
             // Free the transport


### PR DESCRIPTION
 #### Problem

`mDefaultAdvDelegate` address is assigned to `mAdvDelegate` and is beeing copied into `RendezvousSession::Init` (https://github.com/project-chip/connectedhomeip/blob/master/src/transport/RendezvousSession.cpp#L49)
But if the caller does not hold the `RendezvousParameters` object, `mDefaultAdvDelegate` is released and `RendezvousSession` is not aware of it so it will continue to use it.

This PR removes `mDefaultAdvDelegate` so the caller is responsible for setting and maintaining the `RendezvousAdvertisementDelegate` if any.

 #### Summary of Changes
 * Remove `mDefaultAdvDelegate` and add a method to check if there is a delegate instead