### PR TITLE
[ble/linux] Attempt to set "BR/EDR Not Supported" flag.

### DIFF
--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -161,7 +161,12 @@ static BluezLEAdvertisement1 * BluezAdvertisingCreate(BluezEndpoint * apEndpoint
     bluez_leadvertisement1_set_service_data(adv, serviceData);
     // empty data
 
+    // Setting "Discoverable" to False on the adapter and to True on the advertisement convinces
+    // Bluez to set "BR/EDR Not Supported" flag. Bluez doesn't provide API to do that explicitly
+    // and the flag is necessary to force using LE transport.
     bluez_leadvertisement1_set_discoverable(adv, (apEndpoint->mType & BLUEZ_ADV_TYPE_SCANNABLE) ? TRUE : FALSE);
+    if (apEndpoint->mType & BLUEZ_ADV_TYPE_SCANNABLE)
+        bluez_leadvertisement1_set_discoverable_timeout(adv, UINT16_MAX);
 
     // advertising name corresponding to the PID and object path, for debug purposes
     bluez_leadvertisement1_set_local_name(adv, localName);
@@ -1017,10 +1022,10 @@ static void bluezObjectsSetup(BluezEndpoint * apEndpoint)
     VerifyOrExit(apEndpoint->mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL apEndpoint->mpAdapter in %s", __func__));
     bluez_adapter1_set_powered(apEndpoint->mpAdapter, TRUE);
 
-    // with BLE we are discoverable only when advertising so this can be
-    // set once on init
-    bluez_adapter1_set_discoverable_timeout(apEndpoint->mpAdapter, 0);
-    bluez_adapter1_set_discoverable(apEndpoint->mpAdapter, TRUE);
+    // Setting "Discoverable" to False on the adapter and to True on the advertisement convinces
+    // Bluez to set "BR/EDR Not Supported" flag. Bluez doesn't provide API to do that explicitly
+    // and the flag is necessary to force using LE transport.
+    bluez_adapter1_set_discoverable(apEndpoint->mpAdapter, FALSE);
 
 exit:
     g_list_free_full(objects, g_object_unref);


### PR DESCRIPTION
 #### Problem
When CHIP application is run on hardware with dual mode Bluetooth adapter (e.g. RPi adapter supports both BR/EDR
and Low Energy) we need to convince a controller device to use the LE transport. Otherwise, the communication fails.

 #### Summary of Changes
Set "BR/EDR Not Supported" flag in advertisement packets. Unfortunately, Bluez doesn't provide an explicit way to do
it but it contains the following code which sets the flag when "Discoverable" attribute is only enabled on the
advertisement object and not on the adapter object:
```
/* Set BR/EDR Not Supported if adapter is not discoverable but the
 * instance is.
 */
if ((flags & (BT_AD_FLAG_GENERAL | BT_AD_FLAG_LIMITED)) &&
    !btd_adapter_get_discoverable(client->manager->adapter))
  flags |= BT_AD_FLAG_NO_BREDR;
```
Take advantage of the logic to make the "BR/EDR Not Supported" flag show up in the advertisement packets.

Tested that with the fix I can perform rendezvous between Python CHIP Controller on a linux machine and Lighting Example on RPi4 without the need to turning off BR/EDR on the RPi.

 Should fix #5010