### PR TITLE
Fix minor docstring typo

### DIFF
--- a/src/controller/python/chip/ChipBleBase.py
+++ b/src/controller/python/chip/ChipBleBase.py
@@ -30,7 +30,7 @@ import shlex
 class ChipBleBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def scan(self, line):
-        """ API to initiatae BLE scanning for -t user_timeout seconds."""
+        """ API to initiate BLE scanning for -t user_timeout seconds."""
         return
 
     @abc.abstractmethod


### PR DESCRIPTION
Fixing a minor docstring typo in CHIP Python BLE base code.