### PR TITLE
Add verification of the range of integer values for TLVReader.

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -806,6 +806,8 @@ protected:
     CHIP_ERROR ReadData(uint8_t * buf, uint32_t len);
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
     TLVElementType ElementType() const;
+
+   CHIP_ERROR Get(uint64_t & v, bool& isSigned) const;
 };
 
 /**

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<int8_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint8_t>(v64));
     return err;
 }
@@ -150,7 +150,7 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<int16_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint16_t>(v64));
     return err;
 }
@@ -161,7 +161,7 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<int32_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint32_t>(v64));
     return err;
 }
@@ -172,7 +172,7 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<int64_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(v64);
     return err;
 }
@@ -183,7 +183,7 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<uint8_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint8_t>(v64);
     return err;
 }
@@ -194,7 +194,7 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<uint16_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint16_t>(v64);
     return err;
 }
@@ -205,7 +205,7 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<uint32_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint32_t>(v64);
     return err;
 }
@@ -215,7 +215,7 @@ CHIP_ERROR TLVReader::Get(uint64_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<uint64_t>(tlv_isSigned, v), CHIP_ERROR_WRONG_TLV_TYPE);
     return err;
 }
 

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<int8_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint8_t>(v64));
     return err;
 }
@@ -150,7 +150,7 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<int16_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint16_t>(v64));
     return err;
 }
@@ -161,7 +161,7 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<int32_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(static_cast<uint32_t>(v64));
     return err;
 }
@@ -172,7 +172,7 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<int64_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = CastToSigned(v64);
     return err;
 }
@@ -183,7 +183,7 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<uint8_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint8_t>(v64);
     return err;
 }
@@ -194,7 +194,7 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<uint16_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint16_t>(v64);
     return err;
 }
@@ -205,7 +205,7 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v64, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<uint32_t>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v64), CHIP_ERROR_WRONG_TLV_TYPE);
     v = static_cast<uint32_t>(v64);
     return err;
 }
@@ -215,7 +215,7 @@ CHIP_ERROR TLVReader::Get(uint64_t & v)
     bool tlv_isSigned = false;
 
     CHIP_ERROR err = Get(v, tlv_isSigned);
-    ReturnErrorCodeIf(!TLVTypeValid<uint64_t>(tlv_isSigned, v), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorCodeIf(!TLVTypeValid<typeof(v)>(tlv_isSigned, v), CHIP_ERROR_WRONG_TLV_TYPE);
     return err;
 }
 


### PR DESCRIPTION
#### Problem
 Currently, TVLReader's method `Get` does not validate sizes of requested integers. In case when the size is less than size of TVL field, incorrect value is returned to caller; no error condition is indicated.

#### Summary of Changes
 Size validation is added, error conditions are handled properly.

 Fixes #5152 
