### PR TITLE
Revert #1341 since AddCHIPoBLEConnectionHandler is not needed anymore

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -166,9 +166,6 @@ public:
 
     // CHIPoBLE service methods
     Ble::BleLayer * GetBleLayer();
-    typedef void (*BleConnectionReceivedFunct)(Ble::BLEEndPoint * endpoint);
-    void AddCHIPoBLEConnectionHandler(BleConnectionReceivedFunct handler);
-    void RemoveCHIPoBLEConnectionHandler();
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsBLEAdvertisingEnabled();
@@ -445,16 +442,6 @@ inline bool ConnectivityManager::HaveServiceConnectivityViaThread()
 inline Ble::BleLayer * ConnectivityManager::GetBleLayer()
 {
     return static_cast<ImplClass *>(this)->_GetBleLayer();
-}
-
-inline void ConnectivityManager::AddCHIPoBLEConnectionHandler(BleConnectionReceivedFunct handler)
-{
-    return static_cast<ImplClass *>(this)->_AddCHIPoBLEConnectionHandler(handler);
-}
-
-inline void ConnectivityManager::RemoveCHIPoBLEConnectionHandler()
-{
-    return static_cast<ImplClass *>(this)->_RemoveCHIPoBLEConnectionHandler();
 }
 
 inline ConnectivityManager::CHIPoBLEServiceMode ConnectivityManager::GetCHIPoBLEServiceMode()

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_BLE.h
@@ -52,8 +52,6 @@ public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
     Ble::BleLayer * _GetBleLayer();
-    void _AddCHIPoBLEConnectionHandler(ConnectivityManager::BleConnectionReceivedFunct handler);
-    void _RemoveCHIPoBLEConnectionHandler();
     ConnectivityManager::CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(ConnectivityManager::CHIPoBLEServiceMode val);
     bool _IsBLEAdvertisingEnabled();
@@ -77,21 +75,6 @@ template <class ImplClass>
 inline Ble::BleLayer * GenericConnectivityManagerImpl_BLE<ImplClass>::_GetBleLayer()
 {
     return BLEMgr().GetBleLayer();
-}
-
-template <class ImplClass>
-inline void GenericConnectivityManagerImpl_BLE<ImplClass>::_AddCHIPoBLEConnectionHandler(
-    ConnectivityManager::BleConnectionReceivedFunct handler)
-{
-    Ble::BleLayer * bleLayer           = BLEMgr().GetBleLayer();
-    bleLayer->OnChipBleConnectReceived = handler;
-}
-
-template <class ImplClass>
-inline void GenericConnectivityManagerImpl_BLE<ImplClass>::_RemoveCHIPoBLEConnectionHandler()
-{
-    Ble::BleLayer * bleLayer           = BLEMgr().GetBleLayer();
-    bleLayer->OnChipBleConnectReceived = nullptr;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoBLE.h
@@ -53,8 +53,6 @@ public:
     // ===== Methods that implement the ConnectivityManager abstract interface.
 
     Ble::BleLayer * _GetBleLayer(void);
-    void _AddCHIPoBLEConnectionHandler(ConnectivityManager::BleConnectionReceivedFunct handler);
-    void _RemoveCHIPoBLEConnectionHandler(void);
     ConnectivityManager::CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(ConnectivityManager::CHIPoBLEServiceMode val);
     bool _IsBLEAdvertisingEnabled(void);
@@ -76,15 +74,6 @@ inline Ble::BleLayer * GenericConnectivityManagerImpl_NoBLE<ImplClass>::_GetBleL
 {
     return nullptr;
 }
-
-template <class ImplClass>
-inline void GenericConnectivityManagerImpl_NoBLE<ImplClass>::_AddCHIPoBLEConnectionHandler(
-    ConnectivityManager::BleConnectionReceivedFunct handler)
-{}
-
-template <class ImplClass>
-inline void GenericConnectivityManagerImpl_NoBLE<ImplClass>::_RemoveCHIPoBLEConnectionHandler(void)
-{}
 
 template <class ImplClass>
 inline ConnectivityManager::CHIPoBLEServiceMode GenericConnectivityManagerImpl_NoBLE<ImplClass>::_GetCHIPoBLEServiceMode(void)


### PR DESCRIPTION

 #### Problem

This PR reverts #1341 since the change that has been introduced there is not needed anymore.
For references the changes was the addition of 2 methods to allow the esp32 to intercept new BLE connections.
 * `AddCHIPoBLEConnectionHandler`
 * `RemoveCHIPoBLEConnectionHandler`

 #### Summary of Changes
 * Revert #1341