### PR TITLE
[controller] Don't release admin on failed rendezvous

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -210,6 +210,8 @@ CHIP_ERROR DeviceController::Shutdown()
         mTransportMgr = nullptr;
     }
 
+    mAdmins.ReleaseAdminId(mAdminId);
+
     ReleaseAllDevices();
     return CHIP_NO_ERROR;
 }

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -322,17 +322,9 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
             mTransport = nullptr;
         }
 
-        if (CHIP_NO_ERROR != err)
+        if (CHIP_NO_ERROR != err && mDelegate != nullptr)
         {
-            if (mAdmin != nullptr)
-            {
-                mAdmin->Reset();
-            }
-
-            if (mDelegate)
-            {
-                mDelegate->OnRendezvousError(err);
-            }
+            mDelegate->OnRendezvousError(err);
         }
         break;
 


### PR DESCRIPTION
 #### Problem
Admin ID is released on failed rendezvous session although it's only assigned once during the device controller initialization. As a result, it's impossible to pair another device if the previous rendezvous returned an error.

 #### Summary of Changes
Release the admin on the device controller shutdown, instead. 