### PR TITLE
Remove note about MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -24,10 +24,6 @@ Follow [BUILDING.md](/docs/BUILDING.md) to setup CHIP on your platform.
 Genrally, once build dependencies are satisfied you can build the `python`
 target.
 
--   If you are on MacOS BigSur(11.x) set this export before running the script
-    `export MACOSX_DEPLOYMENT_TARGET=10.16` to prevent ".whl is not a supported
-    wheel on this platform." when trying to install it
-
 Use `scripts/build_python.sh` or run something equivalent to:
 
 ```sh


### PR DESCRIPTION
This should no longer be needed and in fact has no effect, since we
pass the same information via the `-target` option to the toolchain
based on the `mac_deployment_target` argument.