### PR TITLE
Making names unique in workflows, and disabling builds for restyled

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -19,9 +19,8 @@ on:
     pull_request:
 
 jobs:
-    build:
-        name: Build
-
+    android:
+        name: Build Android
         strategy:
             matrix:
                 type: [arm, arm64, x64]
@@ -32,6 +31,7 @@ jobs:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build-android:latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ jobs:
             BUILD_ORG: connectedhomeip
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build:latest

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -19,10 +19,11 @@ on:
     pull_request:
 
 jobs:
-    build:
+    cirque:
         name: Cirque
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
 # need to run with privilege, which isn't supported by job.XXX.contaner
 #  https://github.com/actions/container-action/issues/2

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -19,13 +19,14 @@ on:
     pull_request:
 
 jobs:
-    build:
+    doxygen:
         name: Build Doxygen
         runs-on: ubuntu-20.04
+        if: github.actor != 'restyled-io'
 
         steps:
-            - name: "Print Ref"
-              run: echo ${{github.ref}}
+            - name: "Print Actor"
+              run: echo ${{github.actor}}
             - name: Checkout
               uses: actions/checkout@v2
               with:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -26,6 +26,7 @@ jobs:
             BUILD_TYPE: gn_efr32
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build-efr32:latest

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -27,6 +27,7 @@ jobs:
             BUILD_TYPE: esp32
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build-esp32:latest

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -19,7 +19,7 @@ on:
     pull_request:
 
 jobs:
-    linux-standalone:
+    linux_standalone:
         name: Linux Standalone
 
         env:
@@ -28,6 +28,7 @@ jobs:
             BUILD_ORG: connectedhomeip
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build:latest

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -25,6 +25,7 @@ jobs:
             BUILD_TYPE: nrfconnect
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build-nrf-platform:latest

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -25,6 +25,7 @@ jobs:
             BUILD_TYPE: gn_qpg6100
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build:latest

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -19,13 +19,14 @@ on:
     pull_request:
 
 jobs:
-    examples:
+    qemu:
         name: ESP32
 
         env:
             BUILD_TYPE: esp32-qemu
 
         runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io'
 
         container:
             image: connectedhomeip/chip-build-esp32-qemu:latest

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -19,8 +19,9 @@ on:
     pull_request:
 
 jobs:
-    build:
+    unit_tests:
         name: Unit / Interation Tests
+        if: github.actor != 'restyled-io'
 
         strategy:
             matrix:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -19,10 +19,11 @@ on:
     pull_request:
 
 jobs:
-    templates:
+    zap_templates:
         name: ZAP templates generation
 
         runs-on: ubuntu-18.04
+        if: github.actor != 'restyled-io'
 
         steps:
             - name: Checkout


### PR DESCRIPTION
 #### Problem
Our queue times are getting higher, and this will stop restyled from adding to that. 

Separately, there's a great tool that allows GitHub Actions to run locally: https://github.com/nektos/

A detail here, is it requires names of workflows to be unique, so I made them as such :)