### PR TITLE
Revert "Expand use of type-safe `BitFlags` and `enum class`. (#5232)"

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -152,10 +152,18 @@ chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
     return mCommandDataWriter;
 }
 
-CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpointId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
-                               chip::CommandId aCommandId, BitFlags<CommandPathFlags> aFlags)
+CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
+                               chip::CommandId aCommandId, uint8_t aFlags)
 {
-    CommandParams commandParams(aEndpointId, aGroupId, aClusterId, aCommandId, aFlags);
+    CommandParams commandParams;
+
+    memset(&commandParams, 0, sizeof(CommandParams));
+
+    commandParams.EndpointId = aEndpintId;
+    commandParams.GroupId    = aGroupId;
+    commandParams.ClusterId  = aClusterId;
+    commandParams.CommandId  = aCommandId;
+    commandParams.Flags      = aFlags;
 
     return AddCommand(commandParams);
 }
@@ -183,12 +191,12 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
         CommandDataElement::Builder commandDataElement =
             mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
         CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
-        if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
+        if (aCommandParams.Flags & kCommandPathFlag_EndpointIdValid)
         {
             commandPath.EndpointId(aCommandParams.EndpointId);
         }
 
-        if (aCommandParams.Flags.Has(CommandPathFlags::kGroupIdValid))
+        if (aCommandParams.Flags & kCommandPathFlag_GroupIdValid)
         {
             commandPath.GroupId(aCommandParams.GroupId);
         }

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,6 @@
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
-#include <support/BitFlags.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
 #include <support/logging/CHIPLogging.h>
@@ -60,30 +59,24 @@ public:
         Sending,           //< The invoke command message  has sent out the invoke command
     };
 
-    enum class CommandPathFlags : uint8_t
-    {
-        kEndpointIdValid = 0x01, /**< Set when the EndpointId field is valid */
-        kGroupIdValid    = 0x02, /**< Set when the GroupId field is valid */
-    };
-
     /**
      * Encapsulates arguments to be passed into SendCommand().
      *
      */
     struct CommandParams
     {
-        CommandParams(chip::EndpointId endpointId, chip::GroupId groupId, chip::ClusterId clusterId, chip::CommandId commandId,
-                      const BitFlags<CommandPathFlags> & flags) :
-            EndpointId(endpointId),
-            GroupId(groupId), ClusterId(clusterId), CommandId(commandId), Flags(flags)
-        {}
-
         chip::EndpointId EndpointId;
         chip::GroupId GroupId;
         chip::ClusterId ClusterId;
         chip::CommandId CommandId;
-        BitFlags<CommandPathFlags> Flags;
+        uint8_t Flags;
     };
+
+    enum CommandPathFlags
+    {
+        kCommandPathFlag_EndpointIdValid = 0x0001, /**< Set when the EndpointId field is valid */
+        kCommandPathFlag_GroupIdValid    = 0x0002, /**< Set when the GroupId field is valid */
+    } CommandPathFlags;
 
     /**
      *  Initialize the Command object. Within the lifetime
@@ -117,7 +110,7 @@ public:
 
     chip::TLV::TLVWriter & CreateCommandDataElementTLVWriter();
     CHIP_ERROR AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
-                          chip::CommandId aCommandId, BitFlags<CommandPathFlags> Flags);
+                          chip::CommandId aCommandId, uint8_t Flags);
     CHIP_ERROR AddCommand(CommandParams & aCommandParams);
     CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
                              const chip::ClusterId aClusterId);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ CHIP_ERROR SendCommandRequest(void)
                                                         kTestGroupId,    // GroupId
                                                         kTestClusterId,  // ClusterId
                                                         kTestCommandId,  // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
 
     // Add command data here
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                                                         kTestGroupId,    // GroupId
                                                         kTestClusterId,  // ClusterId
                                                         kTestCommandId,  // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
 
     // Add command data here
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -73,7 +73,7 @@ bool IMEmberAfSendDefaultResponseWithCallback(EmberAfStatus status)
                                                              0, // GroupId
                                                              imCompatibilityEmberApsFrame.clusterId,
                                                              imCompatibilityEmberAfCluster.commandId,
-                                                             (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                                             (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
 
     chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
     chip::TLV::TLVWriter writer  = currentCommandObject->CreateCommandDataElementTLVWriter();

--- a/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
@@ -26,7 +26,7 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
 (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, k{{asCamelCased name false}}CommandId,
-                                         (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                         (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer  = ZCLcommand->CreateCommandDataElementTLVWriter();

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2014-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,26 +107,26 @@ public:
 
 private:
     // Private data members:
-    enum class ConnectionStateFlag : uint8_t
+    enum ConnectionStateFlags
     {
-        kAutoClose                = 0x01, // End point should close underlying BLE conn on BTP close.
-        kCapabilitiesConfReceived = 0x02, // GATT confirmation received for sent capabilities req/resp.
-        kCapabilitiesMsgReceived  = 0x04, // Capabilities request or response message received.
-        kDidBeginSubscribe        = 0x08, // GATT subscribe request sent; must unsubscribe on close.
-        kStandAloneAckInFlight    = 0x10, // Stand-alone ack in flight, awaiting GATT confirmation.
-        kGattOperationInFlight    = 0x20  // GATT write, indication, subscribe, or unsubscribe in flight,
-                                          // awaiting GATT confirmation.
+        kConnState_AutoClose                = 0x01, // End point should close underlying BLE conn on BTP close.
+        kConnState_CapabilitiesConfReceived = 0x02, // GATT confirmation received for sent capabilities req/resp.
+        kConnState_CapabilitiesMsgReceived  = 0x04, // Capabilities request or response message received.
+        kConnState_DidBeginSubscribe        = 0x08, // GATT subscribe request sent; must unsubscribe on close.
+        kConnState_StandAloneAckInFlight    = 0x10, // Stand-alone ack in flight, awaiting GATT confirmation.
+        kConnState_GattOperationInFlight    = 0x20  // GATT write, indication, subscribe, or unsubscribe in flight,
+                                                    // awaiting GATT confirmation.
     };
 
-    enum class TimerStateFlag : uint8_t
+    enum TimerStateFlags
     {
-        kConnectTimerRunning           = 0x01, // BTP connect completion timer running.
-        kReceiveConnectionTimerRunning = 0x02, // BTP receive connection completion timer running.
-        kAckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
-        kSendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
-        kUnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
+        kTimerState_ConnectTimerRunning           = 0x01, // BTP connect completion timer running.
+        kTimerState_ReceiveConnectionTimerRunning = 0x02, // BTP receive connection completion timer running.
+        kTimerState_AckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
+        kTimerState_SendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
+        kTimerState_UnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
 #if CHIP_ENABLE_CHIPOBLE_TEST
-        kUnderTestTimerRunnung = 0x80 // running throughput Tx test
+        kTimerState_UnderTestTimerRunnung = 0x80 // running throughput Tx test
 #endif
     };
 
@@ -147,8 +147,8 @@ private:
 
     BtpEngine mBtpEngine;
     BleRole mRole;
-    BitFlags<ConnectionStateFlag> mConnStateFlags;
-    BitFlags<TimerStateFlag> mTimerStateFlags;
+    uint8_t mConnStateFlags;
+    uint8_t mTimerStateFlags;
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -55,10 +55,10 @@ static inline void IncSeqNum(SequenceNumber_t & a_seq_num)
     a_seq_num = static_cast<SequenceNumber_t>(0xff & ((a_seq_num) + 1));
 }
 
-static inline bool DidReceiveData(BitFlags<BtpEngine::HeaderFlags> rx_flags)
+static inline bool DidReceiveData(uint8_t rx_flags)
 {
-    return rx_flags.HasAny(BtpEngine::HeaderFlags::kStartMessage, BtpEngine::HeaderFlags::kContinueMessage,
-                           BtpEngine::HeaderFlags::kEndMessage);
+    return (GetFlag(rx_flags, BtpEngine::kHeaderFlag_StartMessage) || GetFlag(rx_flags, BtpEngine::kHeaderFlag_ContinueMessage) ||
+            GetFlag(rx_flags, BtpEngine::kHeaderFlag_EndMessage));
 }
 
 static void PrintBufDebug(const System::PacketBufferHandle & buf)
@@ -213,7 +213,7 @@ BLE_ERROR BtpEngine::EncodeStandAloneAck(const PacketBufferHandle & data)
     characteristic = data->Start();
 
     // Since there's no preexisting message payload, we can write BTP header without adjusting data start pointer.
-    characteristic[0] = static_cast<uint8_t>(HeaderFlags::kFragmentAck);
+    characteristic[0] = kHeaderFlag_FragmentAck;
 
     // Acknowledge most recently received sequence number.
     characteristic[1] = GetAndRecordRxAckSeqNum();
@@ -245,8 +245,8 @@ exit:
 BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle data, SequenceNumber_t & receivedAck,
                                                   bool & didReceiveAck)
 {
-    BLE_ERROR err = BLE_NO_ERROR;
-    BitFlags<HeaderFlags> rx_flags;
+    BLE_ERROR err    = BLE_NO_ERROR;
+    uint8_t rx_flags = 0;
     // BLE data uses little-endian byte order.
     Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
 
@@ -255,15 +255,15 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
     mRxCharCount++;
 
     // Get header flags, always in first byte.
-    VerifyOrExit(reader.Read8(rx_flags.RawStorage()).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
+    VerifyOrExit(reader.Read8(&rx_flags).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
 #if CHIP_ENABLE_CHIPOBLE_TEST
-    if (rx_flags.Has(HeaderFlags::kCommandMessage))
+    if (GetFlag(rx_flags, kHeaderFlag_CommandMessage))
         SetRxPacketType(kType_Control);
     else
         SetRxPacketType(kType_Data);
 #endif
 
-    didReceiveAck = rx_flags.Has(HeaderFlags::kFragmentAck);
+    didReceiveAck = GetFlag(rx_flags, kHeaderFlag_FragmentAck);
 
     // Get ack number, if any.
     if (didReceiveAck)
@@ -309,7 +309,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
         Encoding::LittleEndian::Reader startReader(data->Start(), data->DataLength());
 
         // Verify StartMessage header flag set.
-        VerifyOrExit(rx_flags.Has(HeaderFlags::kStartMessage), err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
+        VerifyOrExit(rx_flags & kHeaderFlag_StartMessage, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         VerifyOrExit(startReader.Read16(&mRxLength).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
 
@@ -328,10 +328,10 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
     else if (mRxState == kState_InProgress)
     {
         // Verify StartMessage header flag NOT set, since we're in the middle of receiving a message.
-        VerifyOrExit(!rx_flags.Has(HeaderFlags::kStartMessage), err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
+        VerifyOrExit((rx_flags & kHeaderFlag_StartMessage) == 0, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         // Verify ContinueMessage or EndMessage header flag set.
-        VerifyOrExit(rx_flags.HasAny(HeaderFlags::kContinueMessage, HeaderFlags::kEndMessage),
+        VerifyOrExit((rx_flags & kHeaderFlag_ContinueMessage) || (rx_flags & kHeaderFlag_EndMessage),
                      err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         // Add received fragment to reassembled message buffer.
@@ -348,7 +348,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
         ExitNow();
     }
 
-    if (rx_flags.Has(HeaderFlags::kEndMessage))
+    if (rx_flags & kHeaderFlag_EndMessage)
     {
         // Trim remainder, if any, of the received packet buffer based on sender-specified length of reassembled message.
         int padding = mRxBuf->DataLength() - mRxLength;
@@ -372,7 +372,7 @@ exit:
         mRxState = kState_Error;
 
         // Dump protocol engine state, plus header flags and received data length.
-        ChipLogError(Ble, "HandleCharacteristicReceived failed, err = %d, rx_flags = %u", err, rx_flags.Raw());
+        ChipLogError(Ble, "HandleCharacteristicReceived failed, err = %d, rx_flags = %u", err, rx_flags);
         if (didReceiveAck)
         {
             ChipLogError(Ble, "With rx'd ack = %u", receivedAck);
@@ -457,16 +457,17 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         characteristic -= header_size;
         mTxBuf->SetStart(characteristic);
         uint8_t cursor = 1; // first position past header flags byte
-        BitFlags<HeaderFlags> headerFlags(HeaderFlags::kStartMessage);
+
+        characteristic[0] = kHeaderFlag_StartMessage;
 
 #if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
-            headerFlags.Set(HeaderFlags::kCommandMessage);
+            SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
 #endif
 
         if (send_ack)
         {
-            headerFlags.Set(HeaderFlags::kFragmentAck);
+            SetFlag(characteristic[0], kHeaderFlag_FragmentAck, true);
             characteristic[cursor++] = GetAndRecordRxAckSeqNum();
             ChipLogDebugBtpEngine(Ble, "===> encoded piggybacked ack, ack_num = %u", characteristic[cursor - 1]);
         }
@@ -479,7 +480,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         {
             mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
-            headerFlags.Set(HeaderFlags::kEndMessage);
+            SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
             mTxState = kState_Complete;
             mTxPacketCount++;
         }
@@ -489,7 +490,6 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
             mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
-        characteristic[0] = headerFlags.Raw();
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send first fragment:");
         PrintBufDebug(data);
     }
@@ -510,16 +510,16 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         mTxBuf->SetStart(characteristic);
         uint8_t cursor = 1; // first position past header flags byte
 
-        BitFlags<HeaderFlags> headerFlags(HeaderFlags::kContinueMessage);
+        characteristic[0] = kHeaderFlag_ContinueMessage;
 
 #if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
-            headerFlags.Set(HeaderFlags::kCommandMessage);
+            SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
 #endif
 
         if (send_ack)
         {
-            headerFlags.Set(HeaderFlags::kFragmentAck);
+            SetFlag(characteristic[0], kHeaderFlag_FragmentAck, true);
             characteristic[cursor++] = GetAndRecordRxAckSeqNum();
             ChipLogDebugBtpEngine(Ble, "===> encoded piggybacked ack, ack_num = %u", characteristic[cursor - 1]);
         }
@@ -530,7 +530,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         {
             mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
-            headerFlags.Set(HeaderFlags::kEndMessage);
+            SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
             mTxState = kState_Complete;
             mTxPacketCount++;
         }
@@ -540,7 +540,6 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
             mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
-        characteristic[0] = headerFlags.Raw();
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send additional fragment:");
         PrintBufDebug(mTxBuf);
     }

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -87,17 +87,16 @@ public:
         kState_Error      = 3
     } State_t; // [READ-ONLY] Current state
 
-    // Masks for BTP fragment header flag bits.
-    enum class HeaderFlags : uint8_t
+    enum
     {
-        kStartMessage    = 0x01,
-        kContinueMessage = 0x02,
-        kEndMessage      = 0x04,
-        kFragmentAck     = 0x08,
+        kHeaderFlag_StartMessage    = 0x01,
+        kHeaderFlag_ContinueMessage = 0x02,
+        kHeaderFlag_EndMessage      = 0x04,
+        kHeaderFlag_FragmentAck     = 0x08,
 #if CHIP_ENABLE_CHIPOBLE_TEST
-        kCommandMessage = 0x10,
+        kHeaderFlag_CommandMessage = 0x10,
 #endif
-    };
+    }; // Masks for BTP fragment header flag bits.
 
     static const uint16_t sDefaultFragmentSize;
     static const uint16_t sMaxFragmentSize;
@@ -130,10 +129,7 @@ public:
     inline SequenceNumber_t SetRxPacketSeq(SequenceNumber_t seq) { return (mRxPacketSeq = seq); }
     inline SequenceNumber_t TxPacketSeq() { return mTxPacketSeq; }
     inline SequenceNumber_t RxPacketSeq() { return mRxPacketSeq; }
-    inline bool IsCommandPacket(const PacketBufferHandle & p)
-    {
-        return BitFlags<HeaderFlags>(*(p->Start())).Has(HeaderFlags::kCommandMessage);
-    }
+    inline bool IsCommandPacket(const PacketBufferHandle & p) { return GetFlag(*(p->Start()), kHeaderFlag_CommandMessage); }
     inline void PushPacketTag(const PacketBufferHandle & p, PacketType_t type)
     {
         p->SetStart(p->Start() - sizeof(type));

--- a/src/controller/CHIPClusters.cpp
+++ b/src/controller/CHIPClusters.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -148,7 +148,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -227,7 +227,7 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -257,7 +257,7 @@ CHIP_ERROR BasicCluster::ResetToFactoryDefaults(Callback::Cancelable * onSuccess
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kResetToFactoryDefaultsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -319,7 +319,7 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -360,7 +360,7 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -416,7 +416,7 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -458,7 +458,7 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -502,7 +502,7 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -542,7 +542,7 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -583,7 +583,7 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -626,7 +626,7 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -667,7 +667,7 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -710,7 +710,7 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -753,7 +753,7 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -794,7 +794,7 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -838,7 +838,7 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -886,7 +886,7 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -929,7 +929,7 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -971,7 +971,7 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1610,7 +1610,7 @@ CHIP_ERROR ContentLaunchCluster::LaunchContent(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchContentCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1640,7 +1640,7 @@ CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallb
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchURLCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1687,7 +1687,7 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1717,7 +1717,7 @@ CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1748,7 +1748,7 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1781,7 +1781,7 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1814,7 +1814,7 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1847,7 +1847,7 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1883,7 +1883,7 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1919,7 +1919,7 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1952,7 +1952,7 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1985,7 +1985,7 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2018,7 +2018,7 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2051,7 +2051,7 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2084,7 +2084,7 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2120,7 +2120,7 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2155,7 +2155,7 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2189,7 +2189,7 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2229,7 +2229,7 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2269,7 +2269,7 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2309,7 +2309,7 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2345,7 +2345,7 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2391,7 +2391,7 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2431,7 +2431,7 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2464,7 +2464,7 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2556,7 +2556,7 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2594,7 +2594,7 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2626,7 +2626,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetFabric(Callback::Cancelable * onSucce
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2707,7 +2707,7 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2742,7 +2742,7 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2778,7 +2778,7 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2813,7 +2813,7 @@ CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2844,7 +2844,7 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2877,7 +2877,7 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2996,7 +2996,7 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3028,7 +3028,7 @@ CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3091,7 +3091,7 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3131,7 +3131,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3172,7 +3172,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3208,7 +3208,7 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3244,7 +3244,7 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3286,7 +3286,7 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3324,7 +3324,7 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3358,7 +3358,7 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3475,7 +3475,7 @@ CHIP_ERROR MediaPlaybackCluster::FastForwardRequest(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kFastForwardRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3505,7 +3505,7 @@ CHIP_ERROR MediaPlaybackCluster::NextRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kNextRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3535,7 +3535,7 @@ CHIP_ERROR MediaPlaybackCluster::PauseRequest(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPauseRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3565,7 +3565,7 @@ CHIP_ERROR MediaPlaybackCluster::PlayRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPlayRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3595,7 +3595,7 @@ CHIP_ERROR MediaPlaybackCluster::PreviousRequest(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPreviousRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3625,7 +3625,7 @@ CHIP_ERROR MediaPlaybackCluster::RewindRequest(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRewindRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3656,7 +3656,7 @@ CHIP_ERROR MediaPlaybackCluster::SkipBackwardRequest(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipBackwardRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3687,7 +3687,7 @@ CHIP_ERROR MediaPlaybackCluster::SkipForwardRequest(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipForwardRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3718,7 +3718,7 @@ CHIP_ERROR MediaPlaybackCluster::StartOverRequest(Callback::Cancelable * onSucce
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStartOverRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3748,7 +3748,7 @@ CHIP_ERROR MediaPlaybackCluster::StopRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopRequestCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3805,7 +3805,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3844,7 +3844,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3885,7 +3885,7 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3924,7 +3924,7 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3963,7 +3963,7 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3998,7 +3998,7 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4037,7 +4037,7 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4077,7 +4077,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4116,7 +4116,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4172,7 +4172,7 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4202,7 +4202,7 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4232,7 +4232,7 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4301,7 +4301,7 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4347,7 +4347,7 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4380,7 +4380,7 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4418,7 +4418,7 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4451,7 +4451,7 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4486,7 +4486,7 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4521,7 +4521,7 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -143,7 +143,8 @@ void ChipCertificateSet::Clear()
     mCertCount = 0;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipCertLen,
+                                        BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     TLVReader reader;
@@ -160,7 +161,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     ASN1Writer writer; // ASN1Writer is used to encode TBS portion of the certificate for the purpose of signature
@@ -191,7 +192,8 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeF
 
         // Verify the cert has both the Subject Key Id and Authority Key Id extensions present.
         // Only certs with both these extensions are supported for the purposes of certificate validation.
-        VerifyOrExit(cert->mCertFlags.HasAll(CertFlags::kExtPresent_SubjectKeyId, CertFlags::kExtPresent_AuthKeyId),
+        VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_SubjectKeyId) &&
+                         cert->mCertFlags.Has(CertFlags::kExtPresent_AuthKeyId),
                      err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
         // Verify the cert was signed with ECDSA-SHA256. This is the only signature algorithm currently supported.
@@ -246,7 +248,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen,
+                                         BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     TLVReader reader;
@@ -272,7 +275,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     uint8_t initialCertCount = mCertCount;
@@ -460,7 +463,7 @@ exit:
 }
 
 CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, ValidationContext & context,
-                                            BitFlags<CertValidateFlags> validateFlags, uint8_t depth)
+                                            BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth)
 {
     CHIP_ERROR err               = CHIP_NO_ERROR;
     ChipCertificateData * caCert = nullptr;
@@ -496,19 +499,19 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
     {
         // If a set of desired key usages has been specified, verify that the key usage extension exists
         // in the certificate and that the corresponding usages are supported.
-        if (context.mRequiredKeyUsages.HasAny())
+        if (context.mRequiredKeyUsages.Raw() != 0)
         {
             VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_KeyUsage) &&
-                             cert->mKeyUsageFlags.HasAll(context.mRequiredKeyUsages),
+                             cert->mKeyUsageFlags.Has(context.mRequiredKeyUsages.Raw()),
                          err = CHIP_ERROR_CERT_USAGE_NOT_ALLOWED);
         }
 
         // If a set of desired key purposes has been specified, verify that the extended key usage extension
         // exists in the certificate and that the corresponding purposes are supported.
-        if (context.mRequiredKeyPurposes.HasAny())
+        if (context.mRequiredKeyPurposes.Raw() != 0)
         {
             VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_ExtendedKeyUsage) &&
-                             cert->mKeyPurposeFlags.HasAll(context.mRequiredKeyPurposes),
+                             cert->mKeyPurposeFlags.Has(context.mRequiredKeyPurposes.Raw()),
                          err = CHIP_ERROR_CERT_USAGE_NOT_ALLOWED);
         }
 
@@ -574,8 +577,8 @@ exit:
 }
 
 CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId,
-                                             ValidationContext & context, BitFlags<CertValidateFlags> validateFlags, uint8_t depth,
-                                             ChipCertificateData *& cert)
+                                             ValidationContext & context, BitFlags<uint8_t, CertValidateFlags> validateFlags,
+                                             uint8_t depth, ChipCertificateData *& cert)
 {
     CHIP_ERROR err;
 
@@ -643,9 +646,9 @@ void ChipCertificateData::Clear()
     mPubKeyCurveOID = 0;
     mPubKeyAlgoOID  = 0;
     mSigAlgoOID     = 0;
-    mCertFlags.ClearAll();
-    mKeyUsageFlags.ClearAll();
-    mKeyPurposeFlags.ClearAll();
+    mCertFlags.SetRaw(0);
+    mKeyUsageFlags.SetRaw(0);
+    mKeyPurposeFlags.SetRaw(0);
     mPathLenConstraint = 0;
     mCertType          = kCertType_NotSpecified;
     mSignature.R       = nullptr;
@@ -660,9 +663,9 @@ void ValidationContext::Reset()
     mEffectiveTime = 0;
     mTrustAnchor   = nullptr;
     mSigningCert   = nullptr;
-    mRequiredKeyUsages.ClearAll();
-    mRequiredKeyPurposes.ClearAll();
-    mValidateFlags.ClearAll();
+    mRequiredKeyUsages.SetRaw(0);
+    mRequiredKeyPurposes.SetRaw(0);
+    mValidateFlags.SetRaw(0);
     mRequiredCertType = kCertType_NotSpecified;
 }
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -241,22 +241,22 @@ struct ChipCertificateData
 
     void Clear();
 
-    ChipDN mSubjectDN;                          /**< Certificate Subject DN. */
-    ChipDN mIssuerDN;                           /**< Certificate Issuer DN. */
-    CertificateKeyId mSubjectKeyId;             /**< Certificate Subject public key identifier. */
-    CertificateKeyId mAuthKeyId;                /**< Certificate Authority public key identifier. */
-    uint32_t mNotBeforeTime;                    /**< Certificate validity: Not Before field. */
-    uint32_t mNotAfterTime;                     /**< Certificate validity: Not After field. */
-    const uint8_t * mPublicKey;                 /**< Pointer to the certificate public key. */
-    uint8_t mPublicKeyLen;                      /**< Certificate public key length. */
-    uint16_t mPubKeyCurveOID;                   /**< Public key Elliptic Curve CHIP OID. */
-    uint16_t mPubKeyAlgoOID;                    /**< Public key algorithm CHIP OID. */
-    uint16_t mSigAlgoOID;                       /**< Certificate signature algorithm CHIP OID. */
-    BitFlags<CertFlags> mCertFlags;             /**< Certificate data flags. */
-    BitFlags<KeyUsageFlags> mKeyUsageFlags;     /**< Certificate key usage extensions flags. */
-    BitFlags<KeyPurposeFlags> mKeyPurposeFlags; /**< Certificate extended key usage extensions flags. */
-    uint8_t mPathLenConstraint;                 /**< Basic constraint: path length. */
-    uint8_t mCertType;                          /**< Certificate type. */
+    ChipDN mSubjectDN;                                   /**< Certificate Subject DN. */
+    ChipDN mIssuerDN;                                    /**< Certificate Issuer DN. */
+    CertificateKeyId mSubjectKeyId;                      /**< Certificate Subject public key identifier. */
+    CertificateKeyId mAuthKeyId;                         /**< Certificate Authority public key identifier. */
+    uint32_t mNotBeforeTime;                             /**< Certificate validity: Not Before field. */
+    uint32_t mNotAfterTime;                              /**< Certificate validity: Not After field. */
+    const uint8_t * mPublicKey;                          /**< Pointer to the certificate public key. */
+    uint8_t mPublicKeyLen;                               /**< Certificate public key length. */
+    uint16_t mPubKeyCurveOID;                            /**< Public key Elliptic Curve CHIP OID. */
+    uint16_t mPubKeyAlgoOID;                             /**< Public key algorithm CHIP OID. */
+    uint16_t mSigAlgoOID;                                /**< Certificate signature algorithm CHIP OID. */
+    BitFlags<uint16_t, CertFlags> mCertFlags;            /**< Certificate data flags. */
+    BitFlags<uint16_t, KeyUsageFlags> mKeyUsageFlags;    /**< Certificate key usage extensions flags. */
+    BitFlags<uint8_t, KeyPurposeFlags> mKeyPurposeFlags; /**< Certificate extended key usage extensions flags. */
+    uint8_t mPathLenConstraint;                          /**< Basic constraint: path length. */
+    uint8_t mCertType;                                   /**< Certificate type. */
     struct
     {
         const uint8_t * R; /**< Pointer to the R element of the signature, encoded as ASN.1 DER Integer. */
@@ -275,16 +275,16 @@ struct ChipCertificateData
  */
 struct ValidationContext
 {
-    uint32_t mEffectiveTime;                        /**< Current CHIP Epoch UTC time. */
-    const ChipCertificateData * mTrustAnchor;       /**< Pointer to the Trust Anchor Certificate data structure. */
-    const ChipCertificateData * mSigningCert;       /**< Pointer to the Signing Certificate data structure. */
-    BitFlags<KeyUsageFlags> mRequiredKeyUsages;     /**< Key usage extensions that should be present in the
-                                                       validated certificate. */
-    BitFlags<KeyPurposeFlags> mRequiredKeyPurposes; /**< Extended Key usage extensions that should be present
-                                                       in the validated certificate. */
-    BitFlags<CertValidateFlags> mValidateFlags;     /**< Certificate validation flags, specifying how a certificate
-                                                       should be validated. */
-    uint8_t mRequiredCertType;                      /**< Required certificate type. */
+    uint32_t mEffectiveTime;                                 /**< Current CHIP Epoch UTC time. */
+    const ChipCertificateData * mTrustAnchor;                /**< Pointer to the Trust Anchor Certificate data structure. */
+    const ChipCertificateData * mSigningCert;                /**< Pointer to the Signing Certificate data structure. */
+    BitFlags<uint16_t, KeyUsageFlags> mRequiredKeyUsages;    /**< Key usage extensions that should be present in the
+                                                                validated certificate. */
+    BitFlags<uint8_t, KeyPurposeFlags> mRequiredKeyPurposes; /**< Extended Key usage extensions that should be present
+                                                                in the validated certificate. */
+    BitFlags<uint8_t, CertValidateFlags> mValidateFlags;     /**< Certificate validation flags, specifying how a certificate
+                                                                should be validated. */
+    uint8_t mRequiredCertType;                               /**< Required certificate type. */
 
     void Reset();
 };
@@ -350,7 +350,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificate into set.
@@ -363,7 +363,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCert(chip::TLV::TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCert(chip::TLV::TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificates into set.
@@ -377,7 +377,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificates into set.
@@ -391,7 +391,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCerts(chip::TLV::TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCerts(chip::TLV::TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Add trusted anchor key to the certificate set.
@@ -505,7 +505,7 @@ private:
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId, ValidationContext & context,
-                             BitFlags<CertValidateFlags> validateFlags, uint8_t depth, ChipCertificateData *& cert);
+                             BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth, ChipCertificateData *& cert);
 
     /**
      * @brief Validate CHIP certificate.
@@ -518,7 +518,7 @@ private:
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR ValidateCert(const ChipCertificateData * cert, ValidationContext & context,
-                            BitFlags<CertValidateFlags> validateFlags, uint8_t depth);
+                            BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth);
 };
 
 /**

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -363,7 +363,8 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                 VerifyOrExit(keyUsageBits <= UINT16_MAX, err = ASN1_ERROR_INVALID_ENCODING);
 
                 // Check that only supported flags are set.
-                BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
+                BitFlags<uint16_t, KeyUsageFlags> keyUsageFlags;
+                keyUsageFlags.SetRaw(static_cast<uint16_t>(keyUsageBits));
                 VerifyOrExit(keyUsageFlags.HasOnly(
                                  KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation, KeyUsageFlags::kKeyEncipherment,
                                  KeyUsageFlags::kDataEncipherment, KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign,

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -382,6 +382,7 @@ static CHIP_ERROR DecodeConvertKeyUsageExtension(TLVReader & reader, ASN1Writer 
 {
     CHIP_ERROR err;
     uint64_t keyUsageBits;
+    BitFlags<uint16_t, KeyUsageFlags> keyUsageFlags;
 
     certData.mCertFlags.Set(CertFlags::kExtPresent_KeyUsage);
 
@@ -394,18 +395,16 @@ static CHIP_ERROR DecodeConvertKeyUsageExtension(TLVReader & reader, ASN1Writer 
 
     VerifyOrExit(keyUsageBits <= UINT16_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
-    {
-        BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
-        VerifyOrExit(keyUsageFlags.HasOnly(KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation,
-                                           KeyUsageFlags::kKeyEncipherment, KeyUsageFlags::kDataEncipherment,
-                                           KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign, KeyUsageFlags::kCRLSign,
-                                           KeyUsageFlags::kEncipherOnly, KeyUsageFlags::kEncipherOnly),
-                     err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+    keyUsageFlags.SetRaw(static_cast<uint16_t>(keyUsageBits));
+    VerifyOrExit(keyUsageFlags.HasOnly(KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation,
+                                       KeyUsageFlags::kKeyEncipherment, KeyUsageFlags::kDataEncipherment,
+                                       KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign, KeyUsageFlags::kCRLSign,
+                                       KeyUsageFlags::kEncipherOnly, KeyUsageFlags::kEncipherOnly),
+                 err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
-        ASN1_ENCODE_BIT_STRING(static_cast<uint16_t>(keyUsageBits));
+    ASN1_ENCODE_BIT_STRING(static_cast<uint16_t>(keyUsageBits));
 
-        certData.mKeyUsageFlags = keyUsageFlags;
-    }
+    certData.mKeyUsageFlags = keyUsageFlags;
 
 exit:
     return err;

--- a/src/credentials/tests/CHIPCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPCert_test_vectors.cpp
@@ -46,7 +46,7 @@ extern const uint8_t gTestCerts[] = {
 
 extern const size_t gNumTestCerts = sizeof(gTestCerts) / sizeof(gTestCerts[0]);
 
-CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
+CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
                        uint32_t & certDataLen)
 {
     CHIP_ERROR err;
@@ -103,8 +103,8 @@ const char * GetTestCertName(uint8_t certType)
     return nullptr;
 }
 
-CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,
-                        BitFlags<CertDecodeFlags> decodeFlags)
+CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags,
+                        BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     ChipCertificateData * cert;

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -28,7 +28,6 @@
 
 #include <asn1/ASN1OID.h>
 #include <core/CHIPConfig.h>
-#include <support/BitFlags.h>
 #include <support/CodeUtils.h>
 
 namespace chip {
@@ -59,11 +58,11 @@ enum class TestCertLoadFlags : uint8_t
     kSetAppDefinedCertType = 0x20,
 };
 
-extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
+extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
                               uint32_t & certDataLen);
 extern const char * GetTestCertName(uint8_t certType);
-extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,
-                               BitFlags<CertDecodeFlags> decodeFlags);
+extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags,
+                               BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
 
 extern const uint8_t gTestCerts[];
 extern const size_t gNumTestCerts;

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -48,59 +48,59 @@ enum
                                 // (in either CHIP or DER form), or to decode the certificates.
 };
 
-static const BitFlags<CertValidateFlags> sIgnoreNotBeforeFlag(CertValidateFlags::kIgnoreNotBefore);
-static const BitFlags<CertValidateFlags> sIgnoreNotAfterFlag(CertValidateFlags::kIgnoreNotAfter);
+static const BitFlags<uint8_t, CertValidateFlags> sIgnoreNotBeforeFlag(CertValidateFlags::kIgnoreNotBefore);
+static const BitFlags<uint8_t, CertValidateFlags> sIgnoreNotAfterFlag(CertValidateFlags::kIgnoreNotAfter);
 
-static const BitFlags<CertDecodeFlags> sNullDecodeFlag;
-static const BitFlags<CertDecodeFlags> sGenTBSHashFlag(CertDecodeFlags::kGenerateTBSHash);
-static const BitFlags<CertDecodeFlags> sTrustAnchorFlag(CertDecodeFlags::kIsTrustAnchor);
+static const BitFlags<uint8_t, CertDecodeFlags> sNullDecodeFlag;
+static const BitFlags<uint8_t, CertDecodeFlags> sGenTBSHashFlag(CertDecodeFlags::kGenerateTBSHash);
+static const BitFlags<uint8_t, CertDecodeFlags> sTrustAnchorFlag(CertDecodeFlags::kIsTrustAnchor);
 
-static const BitFlags<TestCertLoadFlags> sNullLoadFlag;
-static const BitFlags<TestCertLoadFlags> sDerFormFlag(TestCertLoadFlags::kDERForm);
-static const BitFlags<TestCertLoadFlags> sSupIsCAFlag(TestCertLoadFlags::kSuppressIsCA);
-static const BitFlags<TestCertLoadFlags> sSupKeyUsageFlag(TestCertLoadFlags::kSuppressKeyUsage);
-static const BitFlags<TestCertLoadFlags> sSupKeyCertSignFlag(TestCertLoadFlags::kSuppressKeyCertSign);
-static const BitFlags<TestCertLoadFlags> sPathLenZeroFlag(TestCertLoadFlags::kSetPathLenConstZero);
-static const BitFlags<TestCertLoadFlags> sAppDefCertTypeFlag(TestCertLoadFlags::kSetAppDefinedCertType);
+static const BitFlags<uint8_t, TestCertLoadFlags> sNullLoadFlag;
+static const BitFlags<uint8_t, TestCertLoadFlags> sDerFormFlag(TestCertLoadFlags::kDERForm);
+static const BitFlags<uint8_t, TestCertLoadFlags> sSupIsCAFlag(TestCertLoadFlags::kSuppressIsCA);
+static const BitFlags<uint8_t, TestCertLoadFlags> sSupKeyUsageFlag(TestCertLoadFlags::kSuppressKeyUsage);
+static const BitFlags<uint8_t, TestCertLoadFlags> sSupKeyCertSignFlag(TestCertLoadFlags::kSuppressKeyCertSign);
+static const BitFlags<uint8_t, TestCertLoadFlags> sPathLenZeroFlag(TestCertLoadFlags::kSetPathLenConstZero);
+static const BitFlags<uint8_t, TestCertLoadFlags> sAppDefCertTypeFlag(TestCertLoadFlags::kSetAppDefinedCertType);
 
-static const BitFlags<KeyPurposeFlags> sNullKPFlag;
-static const BitFlags<KeyPurposeFlags> sSA(KeyPurposeFlags::kServerAuth);
-static const BitFlags<KeyPurposeFlags> sCA(KeyPurposeFlags::kClientAuth);
-static const BitFlags<KeyPurposeFlags> sCS(KeyPurposeFlags::kCodeSigning);
-static const BitFlags<KeyPurposeFlags> sEP(KeyPurposeFlags::kEmailProtection);
-static const BitFlags<KeyPurposeFlags> sTS(KeyPurposeFlags::kTimeStamping);
-static const BitFlags<KeyPurposeFlags> sOS(KeyPurposeFlags::kOCSPSigning);
-static const BitFlags<KeyPurposeFlags> sSAandCA(sSA, sCA);
-static const BitFlags<KeyPurposeFlags> sSAandCS(sSA, sCS);
-static const BitFlags<KeyPurposeFlags> sSAandEP(sSA, sEP);
-static const BitFlags<KeyPurposeFlags> sSAandTS(sSA, sTS);
+static const BitFlags<uint8_t, KeyPurposeFlags> sNullKPFlag;
+static const BitFlags<uint8_t, KeyPurposeFlags> sSA(KeyPurposeFlags::kServerAuth);
+static const BitFlags<uint8_t, KeyPurposeFlags> sCA(KeyPurposeFlags::kClientAuth);
+static const BitFlags<uint8_t, KeyPurposeFlags> sCS(KeyPurposeFlags::kCodeSigning);
+static const BitFlags<uint8_t, KeyPurposeFlags> sEP(KeyPurposeFlags::kEmailProtection);
+static const BitFlags<uint8_t, KeyPurposeFlags> sTS(KeyPurposeFlags::kTimeStamping);
+static const BitFlags<uint8_t, KeyPurposeFlags> sOS(KeyPurposeFlags::kOCSPSigning);
+static const BitFlags<uint8_t, KeyPurposeFlags> sSAandCA(sSA.Raw() | sCA.Raw());
+static const BitFlags<uint8_t, KeyPurposeFlags> sSAandCS(sSA.Raw() | sCS.Raw());
+static const BitFlags<uint8_t, KeyPurposeFlags> sSAandEP(sSA.Raw() | sEP.Raw());
+static const BitFlags<uint8_t, KeyPurposeFlags> sSAandTS(sSA.Raw() | sTS.Raw());
 
-static const BitFlags<KeyUsageFlags> sNullKUFlag;
-static const BitFlags<KeyUsageFlags> sDS(KeyUsageFlags::kDigitalSignature);
-static const BitFlags<KeyUsageFlags> sNR(KeyUsageFlags::kNonRepudiation);
-static const BitFlags<KeyUsageFlags> sKE(KeyUsageFlags::kKeyEncipherment);
-static const BitFlags<KeyUsageFlags> sDE(KeyUsageFlags::kDataEncipherment);
-static const BitFlags<KeyUsageFlags> sKA(KeyUsageFlags::kKeyAgreement);
-static const BitFlags<KeyUsageFlags> sKC(KeyUsageFlags::kKeyCertSign);
-static const BitFlags<KeyUsageFlags> sCR(KeyUsageFlags::kCRLSign);
-static const BitFlags<KeyUsageFlags> sEO(KeyUsageFlags::kEncipherOnly);
-static const BitFlags<KeyUsageFlags> sDO(KeyUsageFlags::kDecipherOnly);
-static const BitFlags<KeyUsageFlags> sDSandNR(sDS, sNR);
-static const BitFlags<KeyUsageFlags> sDSandKE(sDS, sKE);
-static const BitFlags<KeyUsageFlags> sDSandDE(sDS, sDE);
-static const BitFlags<KeyUsageFlags> sDSandKA(sDS, sKA);
-static const BitFlags<KeyUsageFlags> sDSandKC(sDS, sKC);
-static const BitFlags<KeyUsageFlags> sDSandCR(sDS, sCR);
-static const BitFlags<KeyUsageFlags> sDSandEO(sDS, sEO);
-static const BitFlags<KeyUsageFlags> sDSandDO(sDS, sDO);
-static const BitFlags<KeyUsageFlags> sKCandDS(sKC, sDS);
-static const BitFlags<KeyUsageFlags> sKCandNR(sKC, sNR);
-static const BitFlags<KeyUsageFlags> sKCandKE(sKC, sKE);
-static const BitFlags<KeyUsageFlags> sKCandDE(sKC, sDE);
-static const BitFlags<KeyUsageFlags> sKCandKA(sKC, sKA);
-static const BitFlags<KeyUsageFlags> sKCandCR(sKC, sCR);
-static const BitFlags<KeyUsageFlags> sKCandEO(sKC, sEO);
-static const BitFlags<KeyUsageFlags> sKCandDO(sKC, sDO);
+static const BitFlags<uint16_t, KeyUsageFlags> sNullKUFlag;
+static const BitFlags<uint16_t, KeyUsageFlags> sDS(KeyUsageFlags::kDigitalSignature);
+static const BitFlags<uint16_t, KeyUsageFlags> sNR(KeyUsageFlags::kNonRepudiation);
+static const BitFlags<uint16_t, KeyUsageFlags> sKE(KeyUsageFlags::kKeyEncipherment);
+static const BitFlags<uint16_t, KeyUsageFlags> sDE(KeyUsageFlags::kDataEncipherment);
+static const BitFlags<uint16_t, KeyUsageFlags> sKA(KeyUsageFlags::kKeyAgreement);
+static const BitFlags<uint16_t, KeyUsageFlags> sKC(KeyUsageFlags::kKeyCertSign);
+static const BitFlags<uint16_t, KeyUsageFlags> sCR(KeyUsageFlags::kCRLSign);
+static const BitFlags<uint16_t, KeyUsageFlags> sEO(KeyUsageFlags::kEncipherOnly);
+static const BitFlags<uint16_t, KeyUsageFlags> sDO(KeyUsageFlags::kDecipherOnly);
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandNR(sDS.Raw() | sNR.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandKE(sDS.Raw() | sKE.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandDE(sDS.Raw() | sDE.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandKA(sDS.Raw() | sKA.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandKC(sDS.Raw() | sKC.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandCR(sDS.Raw() | sCR.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandEO(sDS.Raw() | sEO.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sDSandDO(sDS.Raw() | sDO.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandDS(sKC.Raw() | sDS.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandNR(sKC.Raw() | sNR.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandKE(sKC.Raw() | sKE.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandDE(sKC.Raw() | sDE.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandKA(sKC.Raw() | sKA.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandCR(sKC.Raw() | sCR.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandEO(sKC.Raw() | sEO.Raw());
+static const BitFlags<uint16_t, KeyUsageFlags> sKCandDO(sKC.Raw() | sDO.Raw());
 
 static CHIP_ERROR LoadStandardCerts(ChipCertificateSet & certSet)
 {
@@ -207,8 +207,8 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
         struct
         {
             uint8_t Type;
-            BitFlags<CertDecodeFlags> DecodeFlags;
-            BitFlags<TestCertLoadFlags> LoadFlags;
+            BitFlags<uint8_t, CertDecodeFlags> DecodeFlags;
+            BitFlags<uint8_t, TestCertLoadFlags> LoadFlags;
         } InputCerts[kMaxCertsPerTestCase];
     };
 
@@ -475,8 +475,8 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
     struct UsageTestCase
     {
         uint8_t mCertIndex;
-        BitFlags<KeyUsageFlags> mRequiredKeyUsages;
-        BitFlags<KeyPurposeFlags> mRequiredKeyPurposes;
+        BitFlags<uint16_t, KeyUsageFlags> mRequiredKeyUsages;
+        BitFlags<uint8_t, KeyPurposeFlags> mRequiredKeyPurposes;
         CHIP_ERROR mExpectedResult;
     };
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019-2020 Google LLC.
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
@@ -24,8 +24,6 @@
  */
 
 #pragma once
-
-#include <support/BitFlags.h>
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 #include <support/LifetimePersistedCounter.h>
@@ -127,16 +125,16 @@ public:
     void _LogDeviceConfig();
 
 protected:
-    enum class Flags : uint8_t
+    enum
     {
-        kIsServiceProvisioned                    = 0x01,
-        kIsMemberOfFabric                        = 0x02,
-        kIsPairedToAccount                       = 0x04,
-        kOperationalDeviceCredentialsProvisioned = 0x08,
-        kUseManufacturerCredentialsAsOperational = 0x10,
+        kFlag_IsServiceProvisioned                    = 0x01,
+        kFlag_IsMemberOfFabric                        = 0x02,
+        kFlag_IsPairedToAccount                       = 0x04,
+        kFlag_OperationalDeviceCredentialsProvisioned = 0x08,
+        kFlag_UseManufacturerCredentialsAsOperational = 0x10,
     };
 
-    BitFlags<Flags> mFlags;
+    uint8_t mFlags;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     chip::LifetimePersistedCounter mLifetimePersistedCounter;
 #endif

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.cpp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ void GenericConnectivityManagerImpl_Thread<ImplClass>::_OnPlatformEvent(const Ch
 template <class ImplClass>
 ConnectivityManager::ThreadMode GenericConnectivityManagerImpl_Thread<ImplClass>::_GetThreadMode()
 {
-    if (mFlags.Has(Flags::kIsApplicationControlled))
+    if (GetFlag(mFlags, kFlag_IsApplicationControlled))
     {
         return ConnectivityManager::kThreadMode_ApplicationControlled;
     }
@@ -75,11 +75,11 @@ CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadMode(Conn
 
     if (val == ConnectivityManager::kThreadMode_ApplicationControlled)
     {
-        mFlags.Set(Flags::kIsApplicationControlled);
+        SetFlag(mFlags, kFlag_IsApplicationControlled);
     }
     else
     {
-        mFlags.Clear(Flags::kIsApplicationControlled);
+        ClearFlag(mFlags, kFlag_IsApplicationControlled);
 
         err = ThreadStackMgrImpl().SetThreadEnabled(val == ConnectivityManager::kThreadMode_Enabled);
         SuccessOrExit(err);
@@ -92,15 +92,15 @@ exit:
 template <class ImplClass>
 void GenericConnectivityManagerImpl_Thread<ImplClass>::UpdateServiceConnectivity()
 {
-    constexpr bool haveServiceConnectivity = false;
+    bool haveServiceConnectivity = false;
 
     // If service connectivity via Thread has changed, post an event signaling the change.
-    if (mFlags.Has(Flags::kHaveServiceConnectivity) != haveServiceConnectivity)
+    if (GetFlag(mFlags, kFlag_HaveServiceConnectivity) != haveServiceConnectivity)
     {
         ChipLogProgress(DeviceLayer, "ConnectivityManager: Service connectivity via Thread %s",
                         (haveServiceConnectivity) ? "ESTABLISHED" : "LOST");
 
-        mFlags.Set(Flags::kHaveServiceConnectivity, haveServiceConnectivity);
+        SetFlag(mFlags, kFlag_HaveServiceConnectivity, haveServiceConnectivity);
 
         {
             ChipDeviceEvent event;

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,9 +25,6 @@
 #pragma once
 
 #include <platform/ThreadStackManager.h>
-#include <support/BitFlags.h>
-
-#include <cstdint>
 
 namespace chip {
 namespace DeviceLayer {
@@ -76,13 +73,13 @@ protected:
 private:
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint8_t
+    enum Flags
     {
-        kHaveServiceConnectivity = 0x01,
-        kIsApplicationControlled = 0x02
+        kFlag_HaveServiceConnectivity = 0x01,
+        kFlag_IsApplicationControlled = 0x02
     };
 
-    BitFlags<Flags> mFlags;
+    uint8_t mFlags;
 
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
@@ -90,7 +87,7 @@ private:
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_Init()
 {
-    mFlags.ClearAll();
+    mFlags = 0;
 }
 
 template <class ImplClass>
@@ -102,7 +99,7 @@ inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_IsThreadEnabled()
 template <class ImplClass>
 inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_IsThreadApplicationControlled()
 {
-    return mFlags.Has(Flags::kIsApplicationControlled);
+    return GetFlag(mFlags, kFlag_IsApplicationControlled);
 }
 
 template <class ImplClass>
@@ -153,7 +150,7 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadPo
 template <class ImplClass>
 inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_HaveServiceConnectivityViaThread()
 {
-    return mFlags.Has(Flags::kHaveServiceConnectivity);
+    return GetFlag(mFlags, kFlag_HaveServiceConnectivity);
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,11 +82,11 @@ public:
     static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
 
 protected:
-    enum class ConnectivityFlags : uint16_t
+    enum Flags
     {
-        kHaveIPv4InternetConnectivity = 0x0001,
-        kHaveIPv6InternetConnectivity = 0x0002,
-        kAwaitingConnectivity         = 0x0010,
+        kFlag_HaveIPv4InternetConnectivity = 0x0001,
+        kFlag_HaveIPv6InternetConnectivity = 0x0002,
+        kFlag_AwaitingConnectivity         = 0x0010,
     };
 
 private:

--- a/src/lib/support/BitFlags.h
+++ b/src/lib/support/BitFlags.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,6 @@
 
 #include <stdint.h>
 
-#include <type_traits>
 #include <utility>
 
 namespace chip {
@@ -35,217 +34,115 @@ namespace chip {
 /**
  * Stores bit flags in a type safe manner.
  *
- * @tparam FlagsEnum is an `enum` or (preferably) `enum class` type.
  * @tparam StorageType is the underlying storage type (like uint16_t, uint32_t etc.)
- *         and defaults to the underlying storage type of `FlagsEnum`.
+ * @tparam FlagsEnum is the typesafe flags setting
  */
-template <typename FlagsEnum, typename StorageType = typename std::underlying_type_t<FlagsEnum>>
+template <typename StorageType, typename FlagsEnum>
 class BitFlags
 {
 public:
     static_assert(sizeof(StorageType) >= sizeof(FlagsEnum), "All flags should fit in the storage type");
-    using IntegerType = StorageType;
 
-    BitFlags() : mValue(0) {}
-    BitFlags(const BitFlags & other) = default;
+    BitFlags() {}
+    BitFlags(const BitFlags &) = default;
     BitFlags & operator=(const BitFlags &) = default;
 
-    explicit BitFlags(FlagsEnum value) : mValue(static_cast<IntegerType>(value)) {}
-    explicit BitFlags(IntegerType value) : mValue(value) {}
+    explicit BitFlags(FlagsEnum v) { Set(v); }
 
-    template <typename... Args>
-    BitFlags(FlagsEnum flag, Args &&... args) : mValue(Or(flag, std::forward<Args>(args)...))
-    {}
+    explicit BitFlags(StorageType value) { SetRaw(value); }
 
-    template <typename... Args>
-    BitFlags(const BitFlags<FlagsEnum> & flags, Args &&... args) : mValue(Or(flags, std::forward<Args>(args)...))
-    {}
+    BitFlags & Set(FlagsEnum v)
+    {
+        mValue = static_cast<StorageType>(mValue | static_cast<StorageType>(v));
+        return *this;
+    }
 
-    template <typename... Args>
-    BitFlags(IntegerType value, Args &&... args) : mValue(value | Or(std::forward<Args>(args)...))
-    {}
+    BitFlags & Clear(FlagsEnum v)
+    {
+        mValue &= static_cast<StorageType>(~static_cast<StorageType>(v));
+        return *this;
+    }
 
-    /**
-     * Set flag(s).
-     *
-     * @param other     Flag(s) to set. Any flags not set in @a other are unaffected.
-     */
+    BitFlags & Set(FlagsEnum v, bool isSet) { return isSet ? Set(v) : Clear(v); }
+
+    bool Has(FlagsEnum v) const { return (mValue & static_cast<StorageType>(v)) != 0; }
+
+    bool Has(StorageType other) const { return (mValue & other) == other; }
+
     BitFlags & Set(const BitFlags & other)
     {
         mValue |= other.mValue;
         return *this;
     }
 
-    /**
-     * Set flag(s).
-     *
-     * @param flag      Typed flag(s) to set. Any flags not in @a v are unaffected.
-     */
-    BitFlags & Set(FlagsEnum flag)
-    {
-        mValue |= static_cast<IntegerType>(flag);
-        return *this;
-    }
-
-    /**
-     * Set or clear flag(s).
-     *
-     * @param flag      Typed flag(s) to set or clear. Any flags not in @a flag are unaffected.
-     * @param isSet     If true, set the flag; if false, clear it.
-     */
-    BitFlags & Set(FlagsEnum flag, bool isSet) { return isSet ? Set(flag) : Clear(flag); }
-
-    /**
-     * Clear flag(s).
-     *
-     * @param other     Typed flag(s) to clear. Any flags not in @a other are unaffected.
-     */
-    BitFlags & Clear(const BitFlags & other)
-    {
-        mValue &= ~other.mValue;
-        return *this;
-    }
-
-    /**
-     * Clear flag(s).
-     *
-     * @param flag  Typed flag(s) to clear. Any flags not in @a flag are unaffected.
-     */
-    BitFlags & Clear(FlagsEnum flag)
-    {
-        mValue &= static_cast<IntegerType>(~static_cast<IntegerType>(flag));
-        return *this;
-    }
-
-    /**
-     * Clear all flags.
-     */
-    BitFlags & ClearAll()
-    {
-        mValue = 0;
-        return *this;
-    }
-
-    /**
-     * Check whether flag(s) are set.
-     *
-     * @param flag      Flag(s) to test.
-     * @returns         True if any flag in @a flag is set, otherwise false.
-     */
-    bool Has(FlagsEnum flag) const { return (mValue & static_cast<IntegerType>(flag)) != 0; }
-
-    /**
-     * Check that no flags outside the arguments are set.
-     *
-     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
-     * @returns         True if no flag is set other than those passed.
-     *                  False if any flag is set other than those passed.
-     *
-     * @note            Flags passed need not be set; this test only requires that no *other* flags be set.
-     */
-    template <typename... Args>
-    bool HasOnly(Args &&... args) const
-    {
-        return (mValue & Or(std::forward<Args>(args)...)) == mValue;
-    }
-
-    /**
-     * Check that all given flags are set.
-     *
-     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
-     * @returns         True if all given flags are set.
-     *                  False if any given flag is not set.
-     */
-    template <typename... Args>
-    bool HasAll(Args &&... args) const
-    {
-        const IntegerType all = Or(std::forward<Args>(args)...);
-        return (mValue & all) == all;
-    }
-
-    /**
-     * Check that at least one of the given flags is set.
-     *
-     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
-     * @returns         True if all given flags are set.
-     *                  False if any given flag is not set.
-     */
-    template <typename... Args>
-    bool HasAny(Args &&... args) const
-    {
-        return (mValue & Or(std::forward<Args>(args)...)) != 0;
-    }
-
-    /**
-     * Check that at least one flag is set.
-     *
-     * @returns         True if any flag is set, false otherwise.
-     */
-    bool HasAny() const { return mValue != 0; }
-
-    /**
-     * Find the logical intersection of flags.
-     *
-     * @param lhs       Some flags.
-     * @param rhs       Some flags.
-     * @returns         Flags set in both @a lhs and @a rhs.
-     *
-     * @note: A multi-argument `BitFlags` constructor serves the function of `operator|`.
-     */
-    friend BitFlags<FlagsEnum> operator&(BitFlags<FlagsEnum> lhs, const BitFlags<FlagsEnum> & rhs)
-    {
-        return BitFlags<FlagsEnum>(lhs.mValue & rhs.mValue);
-    }
-
-    /**
-     * Get the flags as the type FlagsEnum.
-     *
-     * @note            This allows easily storing flags as a base FlagsEnum in a POD type,
-     *                  and enables equality comparisons.
-     */
-    operator FlagsEnum() const { return static_cast<FlagsEnum>(mValue); }
-
-    /**
-     * Set and/or clear all flags with a value of the underlying storage type.
-     *
-     * @param value     New storage value.
-     */
-    BitFlags & SetRaw(IntegerType value)
+    StorageType Raw() const { return mValue; }
+    BitFlags & SetRaw(StorageType value)
     {
         mValue = value;
         return *this;
     }
 
-    /**
-     * Get the flags as the underlying integer type.
-     *
-     * @note            This is intended to be used only to store flags into a raw binary record.
-     */
-    IntegerType Raw() const { return mValue; }
-
-    /**
-     * Get the address of the flags as a pointer to the underlying integer type.
-     *
-     * @note            This is intended to be used only to read flags from a raw binary record.
-     */
-    StorageType * RawStorage() { return &mValue; }
+    /** Check that no flags outside the arguments are set.*/
+    template <typename... Args>
+    bool HasOnly(Args &&... args) const
+    {
+        return IsZeroAfterClearing(mValue, std::forward<Args>(args)...);
+    }
 
 private:
-    // Find the union of BitFlags and/or FlagsEnum values.
-    template <typename... Args>
-    static constexpr IntegerType Or(FlagsEnum flag, Args &&... args)
-    {
-        return static_cast<IntegerType>(flag) | Or(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    static constexpr IntegerType Or(const BitFlags<FlagsEnum> & flags, Args &&... args)
-    {
-        return flags.mValue | Or(std::forward<Args>(args)...);
-    }
-    static constexpr IntegerType Or(FlagsEnum value) { return static_cast<IntegerType>(value); }
-    static constexpr IntegerType Or(const BitFlags<FlagsEnum> & flags) { return flags.Raw(); }
-
     StorageType mValue = 0;
+
+    template <typename... Args>
+    static bool IsZeroAfterClearing(StorageType value, FlagsEnum flagToClear, Args &&... args)
+    {
+        value &= static_cast<StorageType>(~static_cast<StorageType>(flagToClear));
+        return IsZeroAfterClearing(value, std::forward<Args>(args)...);
+    }
+
+    static bool IsZeroAfterClearing(StorageType value) { return value == 0; }
 };
+
+/**
+ * @deprecated Use typesafe BitFlags class instead.
+ */
+template <typename FlagsT, typename FlagT>
+inline bool GetFlag(const FlagsT & inFlags, const FlagT inFlag)
+{
+    return (inFlags & static_cast<FlagsT>(inFlag)) != 0;
+}
+
+/**
+ * @deprecated Use typesafe BitFlags class instead.
+ */
+template <typename FlagsT, typename FlagT>
+inline void ClearFlag(FlagsT & inFlags, const FlagT inFlag)
+{
+    inFlags &= static_cast<FlagsT>(~static_cast<FlagsT>(inFlag));
+}
+
+/**
+ * @deprecated Use typesafe BitFlags class instead.
+ */
+template <typename FlagsT, typename FlagT>
+inline void SetFlag(FlagsT & inFlags, const FlagT inFlag)
+{
+    inFlags = static_cast<FlagsT>(inFlags | static_cast<FlagsT>(inFlag));
+}
+
+/**
+ * @deprecated Use typesafe BitFlags class instead.
+ */
+template <typename FlagsT, typename FlagT>
+inline void SetFlag(FlagsT & inFlags, const FlagT inFlag, const bool inValue)
+{
+    if (inValue)
+    {
+        SetFlag(inFlags, inFlag);
+    }
+    else
+    {
+        ClearFlag(inFlags, inFlag);
+    }
+}
 
 } // namespace chip

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -38,7 +38,7 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
 
 } // namespace
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags)
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags)
 {
     if ((src_bytes == nullptr) || (dest_hex == nullptr))
     {
@@ -52,14 +52,14 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_he
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    bool nul_terminate          = flags.Has(HexFlags::kNullTerminate);
+    bool nul_terminate          = (static_cast<int>(flags) & static_cast<int>(HexFlags::kNullTerminate)) != 0;
     size_t expected_output_size = (src_size * 2u) + (nul_terminate ? 1u : 0u);
     if (dest_size_max < expected_output_size)
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    bool uppercase = flags.Has(HexFlags::kUppercase);
+    bool uppercase = (static_cast<int>(flags) & static_cast<int>(HexFlags::kUppercase)) != 0;
     char * cursor  = dest_hex;
     for (size_t byte_idx = 0; byte_idx < src_size; ++byte_idx)
     {

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -18,15 +18,13 @@
 #pragma once
 
 #include <core/CHIPError.h>
-#include <support/BitFlags.h>
-
 #include <stdint.h>
 #include <stdlib.h>
 
 namespace chip {
 namespace Encoding {
 
-enum class HexFlags : int
+enum HexFlags : int
 {
     kNone = 0u,
     // Use uppercase A-F if set otherwise, lowercase a-f
@@ -70,7 +68,7 @@ enum class HexFlags : int
  * @return CHIP_NO_ERROR on success
  */
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags);
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags);
 
 // Alias for Uppercase option, no null-termination
 inline CHIP_ERROR BytesToUppercaseHexBuffer(const uint8_t * src_bytes, size_t src_size, char * dest_hex_buf, size_t dest_size_max)

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ private:
     // actions with a delegate pattern.
     uint8_t mChallenge[kMsgCounterChallengeSize]; // Challenge number to identify the sychronization request cryptographically.
 
-    BitFlags<ExFlagValues> mFlags; // Internal state flags
+    BitFlags<uint16_t, ExFlagValues> mFlags; // Internal state flags
 
     /**
      *  Search for an existing exchange that the message applies to.

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ enum class MessageFlagValues : uint32_t
     kViaEphemeralUDPPort = 0x00040000,
 };
 
-using MessageFlags = BitFlags<MessageFlagValues>;
+using MessageFlags = BitFlags<uint32_t, MessageFlagValues>;
 
 enum class SendMessageFlags : uint16_t
 {
@@ -76,7 +76,7 @@ enum class SendMessageFlags : uint16_t
     kNoAutoRequestAck = 0x0400,
 };
 
-using SendFlags = BitFlags<SendMessageFlags>;
+using SendFlags = BitFlags<uint16_t, SendMessageFlags>;
 
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -181,7 +181,7 @@ CHIP_ERROR ReliableMessageContext::HandleRcvdAck(uint32_t AckMsgId)
     return err;
 }
 
-CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> MsgFlags)
+CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> MsgFlags)
 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -260,7 +260,7 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     if (mExchange != nullptr)
     {
         err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
-                                     BitFlags<SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
+                                     BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }
     else
     {

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -203,12 +203,12 @@ private:
         kFlagMsgRcvdFromPeer = 0x0080,
     };
 
-    BitFlags<Flags> mFlags; // Internal state flags
+    BitFlags<uint16_t, Flags> mFlags; // Internal state flags
 
     void Retain();
     void Release();
     CHIP_ERROR HandleRcvdAck(uint32_t AckMsgId);
-    CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> Flags);
+    CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> Flags);
 
 private:
     friend class ReliableMessageMgr;

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -171,7 +171,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
                 CHIP_DEVICE_CONFIG_BLE_APP_TASK_PRIORITY,                         /* Priority at which the task is created. */
                 NULL);                                                            /* Variable to hold the task's data structure. */
 
-    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mFlags = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
 exit:
@@ -315,9 +315,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -331,9 +331,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -366,7 +366,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         strcpy(mDeviceName, deviceName);
-        mFlags.Set(Flags::kDeviceNameSet);
+        SetFlag(mFlags, kFlag_DeviceNameSet, true);
         ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);
         static_assert(kMaxDeviceNameLength <= UINT16_MAX, "deviceName length might not fit in a uint8_t");
         ret = sl_bt_gatt_server_write_attribute_value(gattdb_device_name, 0, strlen(deviceName), (uint8_t *) deviceName);
@@ -539,14 +539,14 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(mFlags.Has(Flags::kEFRBLEStackInitialized), /* */);
+    VerifyOrExit(GetFlag(mFlags, kFlag_EFRBLEStackInitialized), /* */);
 
     // Start advertising if needed...
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kAdvertisingEnabled))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_AdvertisingEnabled))
     {
         // Start/re-start advertising if not already started, or if there is a pending change
         // to the advertising configuration.
-        if (!mFlags.HasAny(Flags::kAdvertising, Flags::kRestartAdvertising))
+        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_RestartAdvertising))
         {
             err = StartAdvertising();
             SuccessOrExit(err);
@@ -554,7 +554,7 @@ void BLEManagerImpl::DriveBLEState(void)
     }
 
     // Otherwise, stop advertising if it is enabled.
-    else if (mFlags.Has(Flags::kAdvertising))
+    else if (GetFlag(mFlags, kFlag_Advertising))
     {
         err = StopAdvertising();
         SuccessOrExit(err);
@@ -587,7 +587,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
     SuccessOrExit(err);
 
-    if (!mFlags.Has(Flags::kDeviceNameSet))
+    if (!GetFlag(mFlags, kFlag_DeviceNameSet))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04" PRIX32, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, (uint32_t) 0);
 
@@ -685,10 +685,10 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     err = ConfigureAdvertisingData();
     SuccessOrExit(err);
 
-    mFlags.Clear(Flags::kRestartAdvertising);
+    ClearFlag(mFlags, kFlag_RestartAdvertising);
 
     interval_min = interval_max =
-        ((numConnectionss == 0 && !ConfigurationMgr().IsPairedToAccount()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
+        ((numConnectionss == 0 && !ConfigurationMgr().IsPairedToAccount()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
         ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 
@@ -700,7 +700,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     if (SL_STATUS_OK == ret)
     {
-        mFlags.Set(Flags::kAdvertising);
+        SetFlag(mFlags, kFlag_Advertising, true);
     }
 
     err = MapBLEError(ret);
@@ -714,9 +714,10 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
     sl_status_t ret;
 
-    if (mFlags.Has(Flags::kAdvertising))
+    if (GetFlag(mFlags, kFlag_Advertising))
     {
-        mFlags.Clear(Flags::kAdvertising).Clear(Flags::kRestartAdvertising);
+        ClearFlag(mFlags, kFlag_Advertising);
+        ClearFlag(mFlags, kFlag_RestartAdvertising);
 
         ret = sl_bt_advertiser_stop(advertising_set_handle);
         sl_bt_advertiser_delete_set(advertising_set_handle);
@@ -753,7 +754,7 @@ void BLEManagerImpl::UpdateMtu(volatile sl_bt_msg_t * evt)
 
 void BLEManagerImpl::HandleBootEvent(void)
 {
-    mFlags.Set(Flags::kEFRBLEStackInitialized);
+    SetFlag(mFlags, kFlag_EFRBLEStackInitialized, true);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 }
 
@@ -767,7 +768,7 @@ void BLEManagerImpl::HandleConnectEvent(volatile sl_bt_msg_t * evt)
 
     AddConnection(connHandle, bondingHandle);
 
-    // mFlags.Set(Flags::kRestartAdvertising);
+    // SetFlag(mFlags, kFlag_RestartAdvertising, true);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 }
 
@@ -807,7 +808,7 @@ void BLEManagerImpl::HandleConnectionCloseEvent(volatile sl_bt_msg_t * evt)
 
         // Arrange to re-enable connectable advertising in case it was disabled due to the
         // maximum connection limit being reached.
-        mFlags.Set(Flags::kRestartAdvertising);
+        SetFlag(mFlags, kFlag_RestartAdvertising, true);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,14 +90,14 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
 
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint16_t
+    enum
     {
-        kAdvertisingEnabled     = 0x0001,
-        kFastAdvertisingEnabled = 0x0002,
-        kAdvertising            = 0x0004,
-        kRestartAdvertising     = 0x0008,
-        kEFRBLEStackInitialized = 0x0010,
-        kDeviceNameSet          = 0x0020,
+        kFlag_AdvertisingEnabled     = 0x0001,
+        kFlag_FastAdvertisingEnabled = 0x0002,
+        kFlag_Advertising            = 0x0004,
+        kFlag_RestartAdvertising     = 0x0008,
+        kFlag_EFRBLEStackInitialized = 0x0010,
+        kFlag_DeviceNameSet          = 0x0020,
     };
 
     enum
@@ -121,7 +121,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     CHIPoBLEConState mBleConnections[kMaxConnections];
     uint8_t mIndConfId[kMaxConnections];
     CHIPoBLEServiceMode mServiceMode;
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     // The advertising set handle allocated from Bluetooth stack.
     uint8_t advertising_set_handle = 0xff;
@@ -182,12 +182,12 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 } // namespace Internal

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -117,20 +117,20 @@ class BLEManagerImpl final : public BLEManager,
 
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint16_t
+    enum
     {
-        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kESPBLELayerInitialized   = 0x0002, /**< The ESP BLE layer has been initialized. */
-        kAppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the ESP BLE layer. */
-        kAttrsRegistered          = 0x0008, /**< The CHIPoBLE GATT attributes have been registered with the ESP BLE layer. */
-        kGATTServiceStarted       = 0x0010, /**< The CHIPoBLE GATT service has been started. */
-        kAdvertisingConfigured    = 0x0020, /**< CHIPoBLE advertising has been configured in the ESP BLE layer. */
-        kAdvertising              = 0x0040, /**< The system is currently CHIPoBLE advertising. */
-        kControlOpInProgress      = 0x0080, /**< An async control operation has been issued to the ESP BLE layer. */
-        kAdvertisingEnabled       = 0x0100, /**< The application has enabled CHIPoBLE advertising. */
-        kFastAdvertisingEnabled   = 0x0200, /**< The application has enabled fast advertising. */
-        kUseCustomDeviceName      = 0x0400, /**< The application has configured a custom BLE device name. */
-        kAdvertisingRefreshNeeded = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
+        kFlag_AsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_ESPBLELayerInitialized   = 0x0002, /**< The ESP BLE layer has been initialized. */
+        kFlag_AppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the ESP BLE layer. */
+        kFlag_AttrsRegistered          = 0x0008, /**< The CHIPoBLE GATT attributes have been registered with the ESP BLE layer. */
+        kFlag_GATTServiceStarted       = 0x0010, /**< The CHIPoBLE GATT service has been started. */
+        kFlag_AdvertisingConfigured    = 0x0020, /**< CHIPoBLE advertising has been configured in the ESP BLE layer. */
+        kFlag_Advertising              = 0x0040, /**< The system is currently CHIPoBLE advertising. */
+        kFlag_ControlOpInProgress      = 0x0080, /**< An async control operation has been issued to the ESP BLE layer. */
+        kFlag_AdvertisingEnabled       = 0x0100, /**< The application has enabled CHIPoBLE advertising. */
+        kFlag_FastAdvertisingEnabled   = 0x0200, /**< The application has enabled fast advertising. */
+        kFlag_UseCustomDeviceName      = 0x0400, /**< The application has configured a custom BLE device name. */
+        kFlag_AdvertisingRefreshNeeded = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
     };
 
     enum
@@ -183,7 +183,7 @@ class BLEManagerImpl final : public BLEManager,
     uint16_t mRXCharAttrHandle;
     uint16_t mTXCharAttrHandle;
     uint16_t mTXCharCCCDAttrHandle;
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
 
     void DriveBLEState(void);
@@ -266,17 +266,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return mFlags.Has(Flags::kAdvertising);
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -401,7 +401,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     mWiFiAPState                    = kWiFiAPState_NotActive;
     mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
     mWiFiAPIdleTimeoutMS            = CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT;
-    mFlags.SetRaw(0);
+    mFlags                          = 0;
 
     // TODO Initialize the Chip Addressing and Routing Module.
 
@@ -902,10 +902,10 @@ void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void 
 
 void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
 {
-    bool haveIPv4Conn      = false;
-    bool haveIPv6Conn      = false;
-    const bool hadIPv4Conn = mFlags.Has(ConnectivityFlags::kHaveIPv4InternetConnectivity);
-    const bool hadIPv6Conn = mFlags.Has(ConnectivityFlags::kHaveIPv6InternetConnectivity);
+    bool haveIPv4Conn = false;
+    bool haveIPv6Conn = false;
+    bool hadIPv4Conn  = GetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity);
+    bool hadIPv6Conn  = GetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity);
     IPAddress addr;
 
     // If the WiFi station is currently in the connected state...
@@ -962,8 +962,8 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
     if (haveIPv4Conn != hadIPv4Conn || haveIPv6Conn != hadIPv6Conn)
     {
         // Update the current state.
-        mFlags.Set(ConnectivityFlags::kHaveIPv4InternetConnectivity, haveIPv4Conn)
-            .Set(ConnectivityFlags::kHaveIPv6InternetConnectivity, haveIPv6Conn);
+        SetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity, haveIPv4Conn);
+        SetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity, haveIPv6Conn);
 
         // Alert other components of the state change.
         ChipDeviceEvent event;

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -28,7 +28,6 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
 #endif
 #include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
-#include <support/BitFlags.h>
 
 #include "esp_event.h"
 
@@ -68,7 +67,6 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
     friend class ConnectivityManager;
 
 private:
-    using Flags = GenericConnectivityManagerImpl_WiFi::ConnectivityFlags;
     // ===== Members that implement the ConnectivityManager abstract interface.
 
     WiFiStationMode _GetWiFiStationMode(void);
@@ -116,7 +114,7 @@ private:
     WiFiAPState mWiFiAPState;
     uint32_t mWiFiStationReconnectIntervalMS;
     uint32_t mWiFiAPIdleTimeoutMS;
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
 
     void DriveStationState(void);
     void OnStationConnected(void);
@@ -174,12 +172,12 @@ inline uint32_t ConnectivityManagerImpl::_GetWiFiAPIdleTimeoutMS(void)
 
 inline bool ConnectivityManagerImpl::_HaveIPv4InternetConnectivity(void)
 {
-    return mFlags.Has(Flags::kHaveIPv4InternetConnectivity);
+    return ::chip::GetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity);
 }
 
 inline bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity(void)
 {
-    return mFlags.Has(Flags::kHaveIPv6InternetConnectivity);
+    return ::chip::GetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity);
 }
 
 inline bool ConnectivityManagerImpl::_CanStartWiFiScan()

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -140,7 +140,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mRXCharAttrHandle     = 0;
     mTXCharAttrHandle     = 0;
     mTXCharCCCDAttrHandle = 0;
-    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mFlags                = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
     memset(mDeviceName, 0, sizeof(mDeviceName));
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
@@ -172,9 +172,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -188,9 +188,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -221,12 +221,12 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         strcpy(mDeviceName, deviceName);
-        mFlags.Set(Flags::kUseCustomDeviceName);
+        SetFlag(mFlags, kFlag_UseCustomDeviceName);
     }
     else
     {
         mDeviceName[0] = 0;
-        mFlags.Clear(Flags::kUseCustomDeviceName);
+        ClearFlag(mFlags, kFlag_UseCustomDeviceName);
     }
     return CHIP_NO_ERROR;
 }
@@ -271,15 +271,15 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            mFlags.Clear(Flags::kAdvertisingEnabled);
+            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
         ChipLogProgress(DeviceLayer, "Updating advertising data");
-        mFlags.Clear(Flags::kAdvertisingConfigured);
-        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
 
         DriveBLEState();
 
@@ -317,8 +317,8 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     ReleaseConnectionState(conId);
 
     // Force a refresh of the advertising state.
-    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
-    mFlags.Clear(Flags::kAdvertisingConfigured);
+    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+    ClearFlag(mFlags, kFlag_AdvertisingConfigured);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
     return (err == CHIP_NO_ERROR);
@@ -390,33 +390,33 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the Chip task is running.
-    if (!mFlags.Has(Flags::kAsyncInitCompleted))
+    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
     {
-        mFlags.Set(Flags::kAsyncInitCompleted);
+        SetFlag(mFlags, kFlag_AsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            mFlags.Clear(Flags::kAdvertisingEnabled);
+            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
     }
 
     // If there's already a control operation in progress, wait until it completes.
-    VerifyOrExit(!mFlags.Has(Flags::kControlOpInProgress), /* */);
+    VerifyOrExit(!GetFlag(mFlags, kFlag_ControlOpInProgress), /* */);
 
     // Initializes the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kESPBLELayerInitialized))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_ESPBLELayerInitialized))
     {
         err = InitESPBleLayer();
         SuccessOrExit(err);
     }
 
     // Register the CHIPoBLE application with the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
     {
         err = esp_ble_gatts_app_register(CHIPoBLEAppId);
         if (err != CHIP_NO_ERROR)
@@ -425,13 +425,13 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        mFlags.Set(Flags::kControlOpInProgress);
+        SetFlag(mFlags, kFlag_ControlOpInProgress);
 
         ExitNow();
     }
 
     // Register the CHIPoBLE GATT attributes with the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAttrsRegistered))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AttrsRegistered))
     {
         err = esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0);
         if (err != CHIP_NO_ERROR)
@@ -440,13 +440,13 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        mFlags.Set(Flags::kControlOpInProgress);
+        SetFlag(mFlags, kFlag_ControlOpInProgress);
 
         ExitNow();
     }
 
     // Start the CHIPoBLE GATT service if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kGATTServiceStarted))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_GATTServiceStarted))
     {
         err = esp_ble_gatts_start_service(mServiceAttrHandle);
         if (err != CHIP_NO_ERROR)
@@ -455,14 +455,14 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        mFlags.Set(Flags::kControlOpInProgress);
+        SetFlag(mFlags, kFlag_ControlOpInProgress);
 
         ExitNow();
     }
 
     // If the application has enabled CHIPoBLE and BLE advertising...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled &&
-        mFlags.Has(Flags::kAdvertisingEnabled)
+        GetFlag(mFlags, kFlag_AdvertisingEnabled)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
         // and no connections are active...
         && (_NumConnections() == 0)
@@ -471,12 +471,12 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         // Start/re-start advertising if not already advertising, or if the advertising state of the
         // ESP BLE layer needs to be refreshed.
-        if (!mFlags.HasAny(Flags::kAdvertising, Flags::kAdvertisingRefreshNeeded))
+        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
         {
             // Configure advertising data if it hasn't been done yet.  This is an asynchronous step which
             // must complete before advertising can be started.  When that happens, this method will
             // be called again, and execution will proceed to the code below.
-            if (!mFlags.Has(Flags::kAdvertisingConfigured))
+            if (!GetFlag(mFlags, kFlag_AdvertisingConfigured))
             {
                 err = ConfigureAdvertisingData();
                 ExitNow();
@@ -491,7 +491,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Otherwise stop advertising if needed...
     else
     {
-        if (mFlags.Has(Flags::kAdvertising))
+        if (GetFlag(mFlags, kFlag_Advertising))
         {
             err = esp_ble_gap_stop_advertising();
             if (err != CHIP_NO_ERROR)
@@ -500,14 +500,14 @@ void BLEManagerImpl::DriveBLEState(void)
                 ExitNow();
             }
 
-            mFlags.Set(Flags::kControlOpInProgress);
+            SetFlag(mFlags, kFlag_ControlOpInProgress);
 
             ExitNow();
         }
     }
 
     // Stop the CHIPoBLE GATT service if needed.
-    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kGATTServiceStarted))
+    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_GATTServiceStarted))
     {
         // TODO: what to do about existing connections??
 
@@ -518,7 +518,7 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        mFlags.Set(Flags::kControlOpInProgress);
+        SetFlag(mFlags, kFlag_ControlOpInProgress);
 
         ExitNow();
     }
@@ -535,7 +535,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(!mFlags.Has(Flags::kESPBLELayerInitialized), /* */);
+    VerifyOrExit(!GetFlag(mFlags, kFlag_ESPBLELayerInitialized), /* */);
 
     // If the ESP Bluetooth controller has not been initialized...
     if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE)
@@ -615,7 +615,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     }
     SuccessOrExit(err);
 
-    mFlags.Set(Flags::kESPBLELayerInitialized);
+    SetFlag(mFlags, kFlag_ESPBLELayerInitialized);
 
 exit:
     return err;
@@ -632,7 +632,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     uint16_t discriminator;
     SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
-    if (!mFlags.Has(Flags::kUseCustomDeviceName))
+    if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
@@ -675,7 +675,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ExitNow();
     }
 
-    mFlags.Set(Flags::kControlOpInProgress);
+    SetFlag(mFlags, kFlag_ControlOpInProgress);
 
 exit:
     return err;
@@ -708,7 +708,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     // Advertise in fast mode if not fully provisioned and there are no CHIPoBLE connections, or
     // if the application has expressly requested fast advertising.
     advertParams.adv_int_min = advertParams.adv_int_max =
-        ((numCons == 0 && !ConfigurationMgr().IsFullyProvisioned()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
+        ((numCons == 0 && !ConfigurationMgr().IsFullyProvisioned()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
         ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 
@@ -722,7 +722,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         ExitNow();
     }
 
-    mFlags.Set(Flags::kControlOpInProgress);
+    SetFlag(mFlags, kFlag_ControlOpInProgress);
 
 exit:
     return err;
@@ -734,7 +734,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
     bool controlOpComplete = false;
 
     // Ignore GATT control events that do not pertain to the CHIPoBLE application, except for ESP_GATTS_REG_EVT.
-    if (event != ESP_GATTS_REG_EVT && (!mFlags.Has(Flags::kAppRegistered) || gatts_if != mAppIf))
+    if (event != ESP_GATTS_REG_EVT && (!GetFlag(mFlags, kFlag_AppRegistered) || gatts_if != mAppIf))
     {
         ExitNow();
     }
@@ -754,7 +754,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
             // Save the 'interface type' assigned to the CHIPoBLE application by the ESP BLE layer.
             mAppIf = gatts_if;
 
-            mFlags.Set(Flags::kAppRegistered);
+            SetFlag(mFlags, kFlag_AppRegistered);
             controlOpComplete = true;
         }
 
@@ -774,7 +774,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
         mTXCharAttrHandle     = param->add_attr_tab.handles[kAttrIndex_TXCharValue];
         mTXCharCCCDAttrHandle = param->add_attr_tab.handles[kAttrIndex_TXCharCCCDValue];
 
-        mFlags.Set(Flags::kAttrsRegistered);
+        SetFlag(mFlags, kFlag_AttrsRegistered);
         controlOpComplete = true;
 
         break;
@@ -789,7 +789,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE GATT service started");
 
-        mFlags.Set(Flags::kGATTServiceStarted);
+        SetFlag(mFlags, kFlag_GATTServiceStarted);
         controlOpComplete = true;
 
         break;
@@ -804,7 +804,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE GATT service stopped");
 
-        mFlags.Clear(Flags::kGATTServiceStarted);
+        ClearFlag(mFlags, kFlag_GATTServiceStarted);
         controlOpComplete = true;
 
         break;
@@ -826,7 +826,7 @@ exit:
     }
     if (controlOpComplete)
     {
-        mFlags.Clear(Flags::kControlOpInProgress);
+        ClearFlag(mFlags, kFlag_ControlOpInProgress);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }
@@ -835,7 +835,7 @@ void BLEManagerImpl::HandleGATTCommEvent(esp_gatts_cb_event_t event, esp_gatt_if
 {
     // Ignore the event if the CHIPoBLE service hasn't been started, or if the event is for a different
     // BLE application.
-    if (!sInstance.mFlags.Has(Flags::kGATTServiceStarted) || gatts_if != sInstance.mAppIf)
+    if (!GetFlag(sInstance.mFlags, kFlag_GATTServiceStarted) || gatts_if != sInstance.mAppIf)
     {
         return;
     }
@@ -850,8 +850,8 @@ void BLEManagerImpl::HandleGATTCommEvent(esp_gatts_cb_event_t event, esp_gatt_if
 
         // Receiving a connection stops the advertising processes.  So force a refresh of the advertising
         // state.
-        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
-        mFlags.Clear(Flags::kAdvertisingConfigured);
+        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
         break;
@@ -1110,8 +1110,8 @@ void BLEManagerImpl::HandleDisconnect(esp_ble_gatts_cb_param_t * param)
         PlatformMgr().PostEvent(&event);
 
         // Force a refresh of the advertising state.
-        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
-        mFlags.Clear(Flags::kAdvertisingConfigured);
+        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }
@@ -1212,8 +1212,8 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        sInstance.mFlags.Set(Flags::kAdvertisingConfigured);
-        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
+        SetFlag(sInstance.mFlags, kFlag_AdvertisingConfigured);
+        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
 
         break;
 
@@ -1225,15 +1225,15 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
-        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
+        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
+        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
 
         // Transition to the Advertising state...
-        if (!sInstance.mFlags.Has(Flags::kAdvertising))
+        if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
         {
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising started");
 
-            sInstance.mFlags.Set(Flags::kAdvertising);
+            SetFlag(sInstance.mFlags, kFlag_Advertising);
 
             // Post a CHIPoBLEAdvertisingChange(Started) event.
             {
@@ -1254,13 +1254,13 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
-        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
+        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
+        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
 
         // Transition to the not Advertising state...
-        if (sInstance.mFlags.Has(Flags::kAdvertising))
+        if (GetFlag(sInstance.mFlags, kFlag_Advertising))
         {
-            sInstance.mFlags.Clear(Flags::kAdvertising);
+            ClearFlag(sInstance.mFlags, kFlag_Advertising);
 
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 

--- a/src/platform/K32W/BLEManagerImpl.cpp
+++ b/src/platform/K32W/BLEManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -119,6 +119,7 @@ EventGroupHandle_t bleAppTaskLoopEvent;
 
 /* keep the device ID of the connected peer */
 uint8_t device_id;
+uint16_t mFlags;
 
 const uint8_t ShortUUID_CHIPoBLEService[]  = { 0xAF, 0xFE };
 const ChipBleUUID ChipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
@@ -139,7 +140,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(!mFlags.Has(Flags::kK32WBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(!GetFlag(mFlags, kFlag_K32WBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
 
     // Initialize the Chip BleLayer.
     err = BleLayer::Init(this, this, &SystemLayer);
@@ -193,8 +194,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     GattServer_RegisterHandlesForWriteNotifications(1, attChipRxHandle);
 
-    mFlags.Set(Flags::kK32WBLEStackInitialized);
-    mFlags.Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
+    SetFlag(mFlags, kFlag_K32WBLEStackInitialized, true);
+    SetFlag(mFlags, kFlag_AdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
 exit:
@@ -217,12 +218,12 @@ uint16_t BLEManagerImpl::_NumConnections(void)
 
 bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 bool BLEManagerImpl::RemoveConnection(uint8_t connectionHandle)
@@ -307,9 +308,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -323,9 +324,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
+    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
     {
-        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -357,13 +358,643 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
         }
         memset(mDeviceName, 0, kMaxDeviceNameLength);
         strcpy(mDeviceName, deviceName);
-        mFlags.Set(Flags::kDeviceNameSet);
+        SetFlag(mFlags, kFlag_DeviceNameSet, true);
         ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);
     }
     else
     {
         mDeviceName[0] = 0;
-        mFlags.Set(Flags::kRestartAdvertising);
+        SetFlag(mFlags, kFlag_DeviceNameSet, false);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
+{
+    switch (event->Type)
+    {
+    case DeviceEventType::kCHIPoBLESubscribe:
+        ChipDeviceEvent connEstEvent;
+
+        HandleSubscribeReceived(event->CHIPoBLESubscribe.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
+        connEstEvent.Type = DeviceEventType::kCHIPoBLEConnectionEstablished;
+        PlatformMgr().PostEvent(&connEstEvent);
+        break;
+
+    case DeviceEventType::kCHIPoBLEUnsubscribe:
+        HandleUnsubscribeReceived(event->CHIPoBLEUnsubscribe.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
+        break;
+
+    case DeviceEventType::kCHIPoBLEWriteReceived:
+        HandleWriteReceived(event->CHIPoBLEWriteReceived.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_RX,
+                            PacketBufferHandle::Adopt(event->CHIPoBLEWriteReceived.Data));
+        break;
+
+    case DeviceEventType::kCHIPoBLEConnectionError:
+        HandleConnectionError(event->CHIPoBLEConnectionError.ConId, event->CHIPoBLEConnectionError.Reason);
+        break;
+
+    case DeviceEventType::kCHIPoBLEIndicateConfirm:
+        HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &ChipUUID_CHIPoBLEChar_TX);
+        break;
+
+#if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+    case DeviceEventType::kServiceProvisioningChange:
+        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kServiceProvisioningChange");
+
+        ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+        PlatformMgr().ScheduleWork(DriveBLEState, 0);
+        break;
+#endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+
+    default:
+        break;
+    }
+}
+
+bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+{
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SubscribeCharacteristic() not supported");
+    return false;
+}
+
+bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId)
+{
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::UnsubscribeCharacteristic() not supported");
+    return false;
+}
+
+bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
+{
+    ChipLogProgress(DeviceLayer, "Closing BLE GATT connection (con %u)", conId);
+
+    if (Gap_Disconnect(conId) != gBleSuccess_c)
+    {
+        ChipLogProgress(DeviceLayer, "Gap_Disconnect() failed.");
+        return false;
+    }
+
+    return true;
+}
+
+uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
+{
+    uint16_t tempMtu = 0;
+    (void) Gatt_GetMtu(conId, &tempMtu);
+
+    return tempMtu;
+}
+
+bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId,
+                                      PacketBufferHandle pBuf)
+{
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SendWriteRequest() not supported");
+    return false;
+}
+
+bool BLEManagerImpl::SendReadRequest(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId,
+                                     PacketBufferHandle pBuf)
+{
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SendReadRequest() not supported");
+    return false;
+}
+
+bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQUEST_CONTEXT requestContext,
+                                      const ChipBleUUID * svcId, const ChipBleUUID * charId)
+{
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SendReadResponse() not supported");
+    return false;
+}
+
+void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
+{
+    // Nothing to do
+}
+
+bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUUID * svcId, const ChipBleUUID * charId,
+                                    PacketBufferHandle data)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint16_t cId   = (UUIDsMatch(&ChipUUID_CHIPoBLEChar_TX, charId) ? value_chipoble_tx : 0);
+    ChipDeviceEvent event;
+
+    if (cId != 0)
+    {
+        if (blekw_send_event(conId, cId, data->Start(), data->DataLength()) != BLE_OK)
+        {
+            err = CHIP_ERROR_SENDING_BLOCKED;
+        }
+        else
+        {
+            event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
+            event.CHIPoBLEIndicateConfirm.ConId = conId;
+            PlatformMgr().PostEvent(&event);
+        }
+
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %s", ErrorStr(err));
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+BLEManagerImpl::ble_err_t BLEManagerImpl::blekw_send_event(int8_t connection_handle, uint16_t handle, uint8_t * data, uint32_t len)
+{
+    osaEventFlags_t event_mask;
+
+#if CHIP_DEVICE_CHIP0BLE_DEBUG
+    ChipLogProgress(DeviceLayer, "Trying to send event.");
+#endif
+
+    if (connection_handle < 0 || handle <= 0)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - Bad Handle");
+        return BLE_E_FAIL;
+    }
+
+    if (len > 0 && data == NULL)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - Invalid Data");
+        return BLE_E_FAIL;
+    }
+
+    /************* Send the indication *************/
+    if (OSA_EventClear(event_msg, CHIP_BLE_KW_EVNT_INDICATION_CONFIRMED | CHIP_BLE_KW_EVNT_INDICATION_FAILED) != osaStatus_Success)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - Can't clear OSA Events");
+        return BLE_E_FAIL;
+    }
+
+    if (GattServer_SendInstantValueIndication(connection_handle, handle, len, data) != gBleSuccess_c)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - Can't sent indication");
+        return BLE_E_FAIL;
+    }
+
+    if (OSA_EventWait(event_msg, CHIP_BLE_KW_EVNT_INDICATION_CONFIRMED | CHIP_BLE_KW_EVNT_INDICATION_FAILED, FALSE,
+                      CHIP_BLE_KW_EVNT_TIMEOUT, &event_mask) != osaStatus_Success)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - OSA Event failed");
+        return BLE_E_FAIL;
+    }
+
+    if (event_mask & CHIP_BLE_KW_EVNT_INDICATION_FAILED)
+    {
+        ChipLogProgress(DeviceLayer, "BLE Event - Sent Failed");
+        return BLE_E_FAIL;
+    }
+
+#if CHIP_DEVICE_CHIP0BLE_DEBUG
+    ChipLogProgress(DeviceLayer, "BLE Event - Sent :-) ");
+#endif
+
+    return BLE_OK;
+}
+/*******************************************************************************
+ * Private functions
+ *******************************************************************************/
+CHIP_ERROR BLEManagerImpl::blekw_controller_init(void)
+{
+    mControllerTaskEvent = OSA_EventCreate(TRUE);
+
+    if (!mControllerTaskEvent)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    Controller_TaskEventInit(mControllerTaskEvent, gUseRtos_c);
+
+    /* Task creation */
+    if (pdPASS !=
+        xTaskCreate(Controller_TaskHandler, "controllerTask", CONTROLLER_TASK_STACK_SIZE, (void *) 0, CONTROLLER_TASK_PRIORITY,
+                    NULL))
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    /* Setup Interrupt priorities of Interrupt handlers that are used
+     * in application to meet requirements of FreeRTOS */
+
+    // BLE_DP_IRQHandler
+    NVIC_SetPriority(BLE_DP_IRQn, configMAX_PRIORITIES - 1);
+    // BLE_DP0_IRQHandler
+    NVIC_SetPriority(BLE_DP0_IRQn, configMAX_PRIORITIES - 1);
+    // BLE_DP1_IRQHandler
+    NVIC_SetPriority(BLE_DP1_IRQn, configMAX_PRIORITIES - 1);
+    // BLE_DP2_IRQHandler
+    NVIC_SetPriority(BLE_DP2_IRQn, configMAX_PRIORITIES - 1);
+    // BLE_LL_ALL_IRQHandler
+    NVIC_SetPriority(BLE_LL_ALL_IRQn, configMAX_PRIORITIES - 1);
+
+    /* Check for available memory storage */
+    if (!Ble_CheckMemoryStorage())
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    /* BLE Controller Init */
+    if (osaStatus_Success != Controller_Init(Ble_HciRecv))
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void BLEManagerImpl::Host_Task(osaTaskParam_t argument)
+{
+    Host_TaskHandler((void *) NULL);
+}
+
+CHIP_ERROR BLEManagerImpl::blekw_host_init(void)
+{
+    /* Initialization of task related */
+    gHost_TaskEvent = OSA_EventCreate(TRUE);
+    if (!gHost_TaskEvent)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    /* Initialization of task message queue */
+    MSG_InitQueue(&gApp2Host_TaskQueue);
+    MSG_InitQueue(&gHci2Host_TaskQueue);
+
+    /* Task creation */
+    if (pdPASS != xTaskCreate(Host_Task, "hostTask", HOST_TASK_STACK_SIZE, (void *) 0, HOST_TASK_PRIORITY, NULL))
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+BLEManagerImpl::ble_err_t BLEManagerImpl::blekw_start_advertising(gapAdvertisingParameters_t * adv_params,
+                                                                  gapAdvertisingData_t * adv, gapScanResponseData_t * scnrsp)
+{
+    osaEventFlags_t event_mask;
+
+    /************* Set the advertising parameters *************/
+    OSA_EventClear(event_msg, (CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED | CHIP_BLE_KW_EVNT_ADV_PAR_SETUP_COMPLETE));
+
+    /* Set the advertising parameters */
+    if (Gap_SetAdvertisingParameters(adv_params) != gBleSuccess_c)
+    {
+        vTaskDelay(1);
+
+        /* Retry, just to make sure before giving up and sending an error. */
+        if (Gap_SetAdvertisingParameters(adv_params) != gBleSuccess_c)
+        {
+            return BLE_E_SET_ADV_PARAMS;
+        }
+    }
+
+    if (OSA_EventWait(event_msg, (CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED | CHIP_BLE_KW_EVNT_ADV_PAR_SETUP_COMPLETE), FALSE,
+                      CHIP_BLE_KW_EVNT_TIMEOUT, &event_mask) != osaStatus_Success)
+    {
+        return BLE_E_ADV_PARAMS_FAILED;
+    }
+
+    if (event_mask & CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED)
+    {
+        return BLE_E_ADV_PARAMS_FAILED;
+    }
+
+    /************* Set the advertising data *************/
+    OSA_EventClear(event_msg, (CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED | CHIP_BLE_KW_EVNT_ADV_DAT_SETUP_COMPLETE));
+
+    /* Set the advertising data */
+    if (Gap_SetAdvertisingData(adv, scnrsp) != gBleSuccess_c)
+    {
+        return BLE_E_SET_ADV_DATA;
+    }
+
+    if (OSA_EventWait(event_msg, (CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED | CHIP_BLE_KW_EVNT_ADV_DAT_SETUP_COMPLETE), FALSE,
+                      CHIP_BLE_KW_EVNT_TIMEOUT, &event_mask) != osaStatus_Success)
+    {
+        return BLE_E_ADV_SETUP_FAILED;
+    }
+
+    if (event_mask & CHIP_BLE_KW_EVNT_ADV_SETUP_FAILED)
+    {
+        return BLE_E_ADV_SETUP_FAILED;
+    }
+
+    /************* Start the advertising *************/
+    OSA_EventClear(event_msg, (CHIP_BLE_KW_EVNT_ADV_CHANGED | CHIP_BLE_KW_EVNT_ADV_FAILED));
+
+    /* Start the advertising */
+    if (Gap_StartAdvertising(blekw_gap_advertising_cb, blekw_gap_connection_cb) != gBleSuccess_c)
+    {
+        return BLE_E_START_ADV;
+    }
+
+    if (OSA_EventWait(event_msg, (CHIP_BLE_KW_EVNT_ADV_CHANGED | CHIP_BLE_KW_EVNT_ADV_FAILED), FALSE, CHIP_BLE_KW_EVNT_TIMEOUT,
+                      &event_mask) != osaStatus_Success)
+    {
+        return BLE_E_START_ADV_FAILED;
+    }
+
+    if (event_mask & CHIP_BLE_KW_EVNT_ADV_FAILED)
+    {
+        return BLE_E_START_ADV_FAILED;
+    }
+
+#if cPWR_UsePowerDownMode
+    PWR_AllowDeviceToSleep();
+#endif
+
+    return BLE_OK;
+}
+
+BLEManagerImpl::ble_err_t BLEManagerImpl::blekw_stop_advertising(void)
+{
+    osaEventFlags_t event_mask;
+    bleResult_t res;
+
+    OSA_EventClear(event_msg, (CHIP_BLE_KW_EVNT_ADV_CHANGED | CHIP_BLE_KW_EVNT_ADV_FAILED));
+
+    /* Stop the advertising data */
+    res = Gap_StopAdvertising();
+    if (res != gBleSuccess_c)
+    {
+        ChipLogProgress(DeviceLayer, "Failed to stop advertising %d", res);
+        return BLE_E_STOP;
+    }
+
+    if (OSA_EventWait(event_msg, (CHIP_BLE_KW_EVNT_ADV_CHANGED | CHIP_BLE_KW_EVNT_ADV_FAILED), FALSE, CHIP_BLE_KW_EVNT_TIMEOUT,
+                      &event_mask) != osaStatus_Success)
+    {
+        ChipLogProgress(DeviceLayer, "Stop advertising event timeout.");
+        return BLE_E_ADV_CHANGED;
+    }
+
+    if (event_mask & CHIP_BLE_KW_EVNT_ADV_FAILED)
+    {
+        ChipLogProgress(DeviceLayer, "Stop advertising flat out failed.");
+        return BLE_E_ADV_FAILED;
+    }
+
+    return BLE_OK;
+}
+
+CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
+{
+    ble_err_t err;
+    CHIP_ERROR chipErr;
+    uint16_t discriminator;
+    gapAdvertisingData_t adv                              = { 0 };
+    gapAdStructure_t adv_data[BLEKW_ADV_MAX_NO]           = { 0 };
+    gapAdStructure_t scan_rsp_data[BLEKW_SCAN_RSP_MAX_NO] = { 0 };
+    uint8_t advPayload[BLEKW_MAX_ADV_DATA_LEN]            = { 0 };
+    gapScanResponseData_t scanRsp                         = { 0 };
+    gapAdvertisingParameters_t adv_params                 = { 0 };
+    uint16_t advInterval                                  = 0;
+    uint8_t chipAdvDataFlags                              = (gLeGeneralDiscoverableMode_c | gBrEdrNotSupported_c);
+    uint8_t chipOverBleService[2];
+    ChipBLEDeviceIdentificationInfo mDeviceIdInfo = { 0 };
+    uint8_t mDeviceIdInfoLength                   = 0;
+
+    chipErr = ConfigurationMgr().GetSetupDiscriminator(discriminator);
+    if (chipErr != CHIP_NO_ERROR)
+    {
+        return chipErr;
+    }
+
+    if (!GetFlag(mFlags, kFlag_DeviceNameSet))
+    {
+        memset(mDeviceName, 0, kMaxDeviceNameLength);
+        snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
+    }
+
+    /**************** Prepare advertising data *******************************************/
+    adv.cNumAdStructures = BLEKW_ADV_MAX_NO;
+
+    chipErr = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
+    SuccessOrExit(chipErr);
+    mDeviceIdInfoLength = sizeof(mDeviceIdInfo);
+
+    if ((mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1) > BLEKW_MAX_ADV_DATA_LEN)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    adv_data[0].length = 0x02;
+    adv_data[0].adType = gAdFlags_c;
+    adv_data[0].aData  = (uint8_t *) (&chipAdvDataFlags);
+
+    adv_data[1].length = static_cast<uint8_t>(mDeviceIdInfoLength + CHIP_ADV_SHORT_UUID_LEN + 1);
+    adv_data[1].adType = gAdServiceData16bit_c;
+    memcpy(advPayload, ShortUUID_CHIPoBLEService, CHIP_ADV_SHORT_UUID_LEN);
+    memcpy(&advPayload[CHIP_ADV_SHORT_UUID_LEN], (void *) &mDeviceIdInfo, mDeviceIdInfoLength);
+    adv_data[1].aData = advPayload;
+
+    adv.aAdStructures = adv_data;
+    /**************** Prepare scan response data *******************************************/
+    scanRsp.cNumAdStructures = BLEKW_SCAN_RSP_MAX_NO;
+
+    scan_rsp_data[0].length = static_cast<uint8_t>(strlen(mDeviceName) + 1);
+    scan_rsp_data[0].adType = gAdCompleteLocalName_c;
+    scan_rsp_data[0].aData  = (uint8_t *) mDeviceName;
+
+    scan_rsp_data[1].length = sizeof(chipOverBleService) + 1;
+    scan_rsp_data[1].adType = gAdComplete16bitServiceList_c;
+    chipOverBleService[0]   = ShortUUID_CHIPoBLEService[0];
+    chipOverBleService[1]   = ShortUUID_CHIPoBLEService[1];
+    scan_rsp_data[1].aData  = (uint8_t *) chipOverBleService;
+
+    scanRsp.aAdStructures = scan_rsp_data;
+
+    /**************** Prepare advertising parameters *************************************/
+    advInterval =
+        ((NumConnections() == 0 && !ConfigurationMgr().IsPairedToAccount()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
+        ? (CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL * 3)
+        : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
+
+    adv_params.advertisingType = gAdvConnectableUndirected_c;
+    adv_params.ownAddressType  = gBleAddrTypePublic_c;
+    adv_params.peerAddressType = gBleAddrTypePublic_c;
+    memset(adv_params.peerAddress, 0, gcBleDeviceAddressSize_c);
+    adv_params.channelMap   = (gapAdvertisingChannelMapFlags_t)(gAdvChanMapFlag37_c | gAdvChanMapFlag38_c | gAdvChanMapFlag39_c);
+    adv_params.filterPolicy = gProcessAll_c;
+    adv_params.minInterval = adv_params.maxInterval = advInterval;
+
+    err = blekw_start_advertising(&adv_params, &adv, &scanRsp);
+    if (err == BLE_OK)
+    {
+        ChipLogProgress(DeviceLayer, "Started Advertising.");
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Advertising error!");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+exit:
+    return chipErr;
+}
+
+CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
+{
+    SetFlag(mFlags, kFlag_Advertising, true);
+    ClearFlag(mFlags, kFlag_RestartAdvertising);
+
+    return ConfigureAdvertisingData();
+}
+
+CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
+{
+    ble_err_t err;
+
+    if (GetFlag(mFlags, kFlag_Advertising))
+    {
+        ClearFlag(mFlags, kFlag_Advertising);
+        ClearFlag(mFlags, kFlag_RestartAdvertising);
+
+        err = blekw_stop_advertising();
+        if (err != BLE_OK)
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void BLEManagerImpl::DriveBLEState(void)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Check if BLE stack is initialized
+    VerifyOrExit(GetFlag(mFlags, kFlag_K32WBLEStackInitialized), /* */);
+
+#if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+    if (ConfigurationMgr().IsFullyProvisioned())
+    {
+        ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+        ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
+    }
+#endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
+
+    // Start advertising if needed...
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_AdvertisingEnabled))
+    {
+        // Start/re-start advertising if not already started, or if there is a pending change
+        // to the advertising configuration.
+        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_RestartAdvertising))
+        {
+            err = StartAdvertising();
+            SuccessOrExit(err);
+        }
+    }
+    // Otherwise, stop advertising if it is enabled.
+    else if (GetFlag(mFlags, kFlag_Advertising))
+    {
+        err = StopAdvertising();
+        SuccessOrExit(err);
+        ChipLogProgress(DeviceLayer, "Stopped Advertising");
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
+    }
+}
+
+void BLEManagerImpl::DriveBLEState(intptr_t arg)
+{
+    sInstance.DriveBLEState();
+}
+
+/*******************************************************************************
+ * BLE App Task Processing
+ *******************************************************************************/
+void BLEManagerImpl::bleAppTask(void * p_arg)
+{
+    while (1)
+    {
+        xEventGroupWaitBits(bleAppTaskLoopEvent, LOOP_EV_BLE, true, false, portMAX_DELAY);
+
+        PlatformMgr().LockChipStack();
+
+        if (MSG_Pending(&blekw_msg_list))
+        {
+            /* There is message from the BLE tasks to solve */
+            blekw_msg_t * msg = (blekw_msg_t *) MSG_DeQueue(&blekw_msg_list);
+
+            assert(msg != NULL);
+
+            if (msg->type == BLE_KW_MSG_ERROR)
+            {
+                ChipLogProgress(DeviceLayer, "BLE Fatal Error: %d.\n", msg->data.u8);
+            }
+            else if (msg->type == BLE_KW_MSG_CONNECTED)
+            {
+                sInstance.HandleConnectEvent(msg);
+            }
+            else if (msg->type == BLE_KW_MSG_DISCONNECTED)
+            {
+                sInstance.HandleConnectionCloseEvent(msg);
+            }
+            else if (msg->type == BLE_KW_MSG_MTU_CHANGED)
+            {
+                blekw_start_connection_timeout();
+                ChipLogProgress(DeviceLayer, "BLE MTU size has been changed to %d.", msg->data.u16);
+            }
+            else if (msg->type == BLE_KW_MSG_ATT_WRITTEN || msg->type == BLE_KW_MSG_ATT_LONG_WRITTEN ||
+                     msg->type == BLE_KW_MSG_ATT_CCCD_WRITTEN)
+            {
+                sInstance.HandleWriteEvent(msg);
+            }
+            else if (msg->type == BLE_KW_MSG_FORCE_DISCONNECT)
+            {
+                ChipLogProgress(DeviceLayer, "BLE connection timeout: Forcing disconnection.");
+
+                /* Set the advertising parameters */
+                if (Gap_Disconnect(device_id) != gBleSuccess_c)
+                {
+                    ChipLogProgress(DeviceLayer, "Gap_Disconnect() failed.");
+                }
+            }
+
+            /* Freed the message from the queue */
+            MSG_Free(msg);
+        }
+        PlatformMgr().UnlockChipStack();
+    }
+}
+
+void BLEManagerImpl::HandleConnectEvent(blekw_msg_t * msg)
+{
+    uint8_t device_id_loc = msg->data.u8;
+    ChipLogProgress(DeviceLayer, "BLE is connected with device: %d.\n", device_id_loc);
+
+    device_id = device_id_loc;
+    blekw_start_connection_timeout();
+    sInstance.AddConnection(device_id_loc);
+    SetFlag(mFlags, kFlag_RestartAdvertising, true);
+    PlatformMgr().ScheduleWork(DriveBLEState, 0);
+}
+
+void BLEManagerImpl::HandleConnectionCloseEvent(blekw_msg_t * msg)
+{
+    uint8_t device_id_loc = msg->data.u8;
+    ChipLogProgress(DeviceLayer, "BLE is disconnected with device: %d.\n", device_id_loc);
+
+    if (sInstance.RemoveConnection(device_id_loc))
+    {
+        ChipDeviceEvent event;
+        event.Type                           = DeviceEventType::kCHIPoBLEConnectionError;
+        event.CHIPoBLEConnectionError.ConId  = device_id_loc;
+        event.CHIPoBLEConnectionError.Reason = BLE_ERROR_REMOTE_DEVICE_DISCONNECTED;
+
+        PlatformMgr().PostEvent(&event);
+        SetFlag(mFlags, kFlag_RestartAdvertising, true);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }

--- a/src/platform/K32W/BLEManagerImpl.h
+++ b/src/platform/K32W/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -107,16 +107,15 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint8_t
+    enum
     {
-        kAdvertisingEnabled      = 0x0001,
-        kFastAdvertisingEnabled  = 0x0002,
-        kAdvertising             = 0x0004,
-        kRestartAdvertising      = 0x0008,
-        kK32WBLEStackInitialized = 0x0010,
-        kDeviceNameSet           = 0x0020,
+        kFlag_AdvertisingEnabled      = 0x0001,
+        kFlag_FastAdvertisingEnabled  = 0x0002,
+        kFlag_Advertising             = 0x0004,
+        kFlag_RestartAdvertising      = 0x0008,
+        kFlag_K32WBLEStackInitialized = 0x0010,
+        kFlag_DeviceNameSet           = 0x0020,
     };
-    BitFlags<BLEManagerImpl::Flags> mFlags;
 
     enum
     {

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -163,18 +163,18 @@ private:
     static BLEManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
-    enum class Flags : uint16_t
+    enum
     {
-        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kBluezBLELayerInitialized = 0x0002, /**< The Bluez layer has been initialized. */
-        kAppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the Bluez layer. */
-        kAdvertisingConfigured    = 0x0008, /**< CHIPoBLE advertising has been configured in the Bluez layer. */
-        kAdvertising              = 0x0010, /**< The system is currently CHIPoBLE advertising. */
-        kControlOpInProgress      = 0x0020, /**< An async control operation has been issued to the ESP BLE layer. */
-        kAdvertisingEnabled       = 0x0040, /**< The application has enabled CHIPoBLE advertising. */
-        kFastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
-        kUseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
-        kAdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
+        kFlag_AsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_BluezBLELayerInitialized = 0x0002, /**< The Bluez layer has been initialized. */
+        kFlag_AppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the Bluez layer. */
+        kFlag_AdvertisingConfigured    = 0x0008, /**< CHIPoBLE advertising has been configured in the Bluez layer. */
+        kFlag_Advertising              = 0x0010, /**< The system is currently CHIPoBLE advertising. */
+        kFlag_ControlOpInProgress      = 0x0020, /**< An async control operation has been issued to the ESP BLE layer. */
+        kFlag_AdvertisingEnabled       = 0x0040, /**< The application has enabled CHIPoBLE advertising. */
+        kFlag_FastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
+        kFlag_UseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
+        kFlag_AdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
     };
 
     enum
@@ -196,7 +196,7 @@ private:
     CHIPoBLEServiceMode mServiceMode;
     BLEAdvConfig mBLEAdvConfig;
     BLEScanConfig mBLEScanConfig;
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     bool mIsCentral            = false;
     BluezEndpoint * mpEndpoint = nullptr;
@@ -237,17 +237,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode()
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled()
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled()
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising()
 {
-    return mFlags.Has(Flags::kAdvertising);
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -256,18 +256,17 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 
-BitFlags<Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>::ConnectivityFlags>
-    ConnectivityManagerImpl::mConnectivityFlag;
+uint16_t ConnectivityManagerImpl::mConnectivityFlag;
 struct GDBusWpaSupplicant ConnectivityManagerImpl::mWpaSupplicant;
 
 bool ConnectivityManagerImpl::_HaveIPv4InternetConnectivity()
 {
-    return mConnectivityFlag.Has(ConnectivityFlags::kHaveIPv4InternetConnectivity);
+    return ((mConnectivityFlag & kFlag_HaveIPv4InternetConnectivity) != 0);
 }
 
 bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity()
 {
-    return mConnectivityFlag.Has(ConnectivityFlags::kHaveIPv6InternetConnectivity);
+    return ((mConnectivityFlag & kFlag_HaveIPv6InternetConnectivity) != 0);
 }
 
 ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
@@ -328,8 +327,8 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
     state = wpa_fi_w1_wpa_supplicant1_interface_get_state(mWpaSupplicant.iface);
     if (g_strcmp0(state, "completed") == 0)
     {
-        mConnectivityFlag.Set(ConnectivityFlags::kHaveIPv4InternetConnectivity)
-            .Set(ConnectivityFlags::kHaveIPv6InternetConnectivity);
+        SetFlag(mConnectivityFlag, kFlag_HaveIPv4InternetConnectivity, true);
+        SetFlag(mConnectivityFlag, kFlag_HaveIPv6InternetConnectivity, true);
         ret = true;
     }
 
@@ -621,7 +620,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
 
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
-    mConnectivityFlag.ClearAll();
+    mConnectivityFlag            = 0;
     mWpaSupplicant.state         = GDBusWpaSupplicant::INIT;
     mWpaSupplicant.scanState     = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
     mWpaSupplicant.proxy         = nullptr;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +148,7 @@ private:
     static void _OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
 
-    static BitFlags<ConnectivityFlags> mConnectivityFlag;
+    static uint16_t mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
 #endif
 

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1192,7 +1192,7 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1];
     size_t serialNumberSize  = 0;
     uint16_t lifetimeCounter = 0;
-    BitFlags<AdditionalDataFields> additionalDataFields;
+    BitFlags<uint8_t, AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber), serialNumberSize);

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -93,19 +93,19 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint8_t
+    enum
     {
-        kAsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kAdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
-        kFastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
-        kAdvertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
-        kAdvertisingRefreshNeeded =
+        kFlag_AsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_AdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
+        kFlag_FastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
+        kFlag_Advertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
+        kFlag_AdvertisingRefreshNeeded =
             0x0010, /**< The advertising state/configuration has changed, but the SoftDevice has yet to be updated. */
     };
 
     struct ServiceData;
 
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
     uint16_t mGAPConns;
     CHIPoBLEServiceMode mServiceMode;
     bool mSubscribedConns[CONFIG_BT_MAX_CONN];
@@ -182,17 +182,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return mFlags.Has(Flags::kAdvertising);
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,7 +113,7 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
     /* Register BLE Stack assert handler */
     RegisterAssertCback(AssertHandler);
 
-    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mFlags = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
 
     mServiceMode             = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     OnChipBleConnectReceived = HandleIncomingBleConnection;
@@ -137,13 +137,13 @@ CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(BLEManager::CHIPoBLEServiceMo
 
 bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 /* Post event to app processing loop to begin CHIP advertising */
 CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 {
-    mFlags.Set(Flags::kAdvertisingEnabled, val);
+    SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
 
     /* Send event to process state change request */
     return DriveBLEState();
@@ -151,16 +151,16 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
 bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 {
     CHIP_ERROR ret = CHIP_NO_ERROR;
 
-    if (!mFlags.Has(Flags::kFastAdvertisingEnabled))
+    if (!GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
     {
-        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
+        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
 
         /* Send event to process state change request */
         ret = DriveBLEState();
@@ -170,7 +170,7 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
 bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return mFlags.Has(Flags::kAdvertising);
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
@@ -197,7 +197,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     {
         strncpy(mDeviceName, deviceName, strlen(deviceName));
 
-        mFlags.Set(Flags::kBLEStackGATTNameUpdate);
+        SetFlag(mFlags, kFlag_BLEStackGATTNameUpdate, true);
 
         ret = DriveBLEState();
     }
@@ -409,7 +409,7 @@ void BLEManagerImpl::AdvInit(void)
     ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
 
     // Verify device name was not already set
-    if (!sInstance.mFlags.Has(Flags::kBLEStackGATTNameSet))
+    if (!GetFlag(sInstance.mFlags, kFlag_BLEStackGATTNameSet))
     {
         /* Default device name is CHIP-<DISCRIMINATOR> */
         deviceDiscriminator = mDeviceIdInfo.GetDeviceDiscriminator();
@@ -758,13 +758,13 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
             /* Advertising flag set, either advertising or fast adv is enabled: Do nothing  */
             /* Advertising flag not set, neither advertising nor fast adv is enabled: do nothing */
             /* Advertising flag not set, either advertising or fast adv is enabled: Turn on */
-            if (!sInstance.mFlags.Has(Flags::kAdvertising))
+            if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
             {
                 BLEMGR_LOG("BLEMGR: BLE Process Application Message: Not advertising");
 
-                if (sInstance.mFlags.Has(Flags::kAdvertisingEnabled))
+                if (GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled))
                 {
-                    sInstance.mFlags.Clear(Flags::kFastAdvertisingEnabled);
+                    ClearFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled);
 
                     BLEMGR_LOG("BLEMGR: BLE Process Application Message: Slow Advertising Enabled");
 // Send notification to thread manager that CHIPoBLE advertising is starting
@@ -780,11 +780,11 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                     // Start advertisement timer
                     Util_startClock(&sInstance.clkAdvTimeout);
 
-                    sInstance.mFlags.Set(Flags::kAdvertising);
+                    SetFlag(sInstance.mFlags, kFlag_Advertising, true);
                 }
-                else if (sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
+                else if (GetFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled))
                 {
-                    sInstance.mFlags.Clear(Flags::kAdvertisingEnabled);
+                    ClearFlag(sInstance.mFlags, kFlag_AdvertisingEnabled);
 
                     BLEMGR_LOG("BLEMGR: BLE Process Application Message: Fast Advertising Enabled");
 
@@ -795,27 +795,28 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                     // Enable legacy advertising for set #1
                     status = (bStatus_t) GapAdv_enable(sInstance.advHandleLegacy, GAP_ADV_ENABLE_OPTIONS_USE_MAX, 0);
                     assert(status == SUCCESS);
-                    sInstance.mFlags.Set(Flags::kAdvertising);
+                    SetFlag(sInstance.mFlags, kFlag_Advertising, true);
                 }
             }
             /* Advertising flag set, neither advertising nor fast adv is enabled: Turn off*/
-            else if (!sInstance.mFlags.Has(Flags::kAdvertisingEnabled) && !sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
+            else if (!GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled) &&
+                     !GetFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled))
             {
                 BLEMGR_LOG("BLEMGR: BLE Process Application Message: Advertising disables");
 
                 // Stop advertising
                 GapAdv_disable(sInstance.advHandleLegacy);
-                sInstance.mFlags.Clear(Flags::kAdvertising);
+                ClearFlag(sInstance.mFlags, kFlag_Advertising);
 
                 Util_stopClock(&sInstance.clkAdvTimeout);
             }
         }
 
-        if (sInstance.mFlags.Has(Flags::kBLEStackGATTNameUpdate))
+        if (GetFlag(sInstance.mFlags, kFlag_BLEStackGATTNameUpdate))
         {
-            sInstance.mFlags.Clear(Flags::kBLEStackGATTNameUpdate);
+            ClearFlag(sInstance.mFlags, kFlag_BLEStackGATTNameUpdate);
             // Indicate that Device name has been set externally
-            mFlags.Set(Flags::kBLEStackGATTNameSet);
+            SetFlag(mFlags, kFlag_BLEStackGATTNameSet, true);
 
             // Set the Device Name characteristic in the GAP GATT Service
             GGS_SetParameter(GGS_DEVICE_NAME_ATT, GAP_DEVICE_NAME_LEN, sInstance.mDeviceName);
@@ -1025,7 +1026,7 @@ void BLEManagerImpl::ProcessGapMessage(gapEventHdr_t * pMsg)
 
             AdvInit();
 
-            sInstance.mFlags.Set(Flags::kBLEStackInitialized);
+            SetFlag(sInstance.mFlags, kFlag_BLEStackInitialized, true);
 
             /* Trigger post-initialization state update */
             DriveBLEState();
@@ -1059,13 +1060,13 @@ void BLEManagerImpl::ProcessGapMessage(gapEventHdr_t * pMsg)
         if (numActive < MAX_NUM_BLE_CONNS)
         {
             // Start advertising since there is room for more connections. Advertisements stop automatically following connection.
-            sInstance.mFlags.Clear(Flags::kAdvertising);
+            ClearFlag(sInstance.mFlags, kFlag_Advertising);
         }
         else
         {
             // Stop advertising since there is no room for more connections
             BLEMGR_LOG("BLEMGR: BLE event GAP_LINK_ESTABLISHED_EVENT: MAX connections");
-            sInstance.mFlags.Clear(Flags::kFastAdvertisingEnabled).Clear(Flags::kAdvertisingEnabled.Clear(Flags::kAdvertising);
+            ClearFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled | kFlag_AdvertisingEnabled | kFlag_Advertising);
         }
 
         /* Stop advertisement timeout timer */
@@ -1685,11 +1686,11 @@ void BLEManagerImpl::AdvTimeoutHandler(uintptr_t arg)
 {
     BLEMGR_LOG("BLEMGR: AdvTimeoutHandler");
 
-    if (sInstance.mFlags.Has(Flags::kAdvertisingEnabled))
+    if (GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled))
     {
         BLEMGR_LOG("BLEMGR: AdvTimeoutHandler ble adv 15 minute timeout");
 
-        sInstance.mFlags.Clear(Flags::kAdvertisingEnabled);
+        SetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled, false);
 
         /* Send event to process state change request */
         DriveBLEState();

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -87,14 +87,15 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum class Flags : uint16_t
+    enum
     {
-        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kAdvertisingEnabled       = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
-        kFastAdvertisingEnabled   = 0x0004, /**< The application has enabled fast advertising. */
-        kAdvertising              = 0x0008, /**< The system is currently CHIPoBLE advertising. */
-        kAdvertisingRefreshNeeded = 0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
-        kDeviceNameSet            = 0x0020,
+        kFlag_AsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_AdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
+        kFlag_FastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
+        kFlag_Advertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
+        kFlag_AdvertisingRefreshNeeded =
+            0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
+        kFlag_DeviceNameSet = 0x0020,
     };
 
     enum
@@ -105,7 +106,7 @@ private:
     };
 
     CHIPoBLEServiceMode mServiceMode;
-    BitFlags<Flags> mFlags;
+    uint16_t mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     uint16_t mNumGAPCons;
     uint16_t mSubscribedConIds[kMaxConnections];
@@ -172,17 +173,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return mFlags.Has(Flags::kFastAdvertisingEnabled);
+    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return mFlags.Has(Flags::kAdvertising);
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -45,39 +45,39 @@ enum class MessageType : uint8_t
     BlockAckEOF   = 0x14,
 };
 
-enum class StatusCode : uint16_t
+enum StatusCode : uint16_t
 {
-    kNone                       = 0x0000,
-    kOverflow                   = 0x0011,
-    kLengthTooLarge             = 0x0012,
-    kLengthTooShort             = 0x0013,
-    kLengthMismatch             = 0x0014,
-    kLengthRequired             = 0x0015,
-    kBadMessageContents         = 0x0016,
-    kBadBlockCounter            = 0x0017,
-    kTransferFailedUnknownError = 0x001F,
-    kServerBadState             = 0x0020,
-    kFailureToSend              = 0x0021,
-    kTransferMethodNotSupported = 0x0050,
-    kFileDesignatorUnknown      = 0x0051,
-    kStartOffsetNotSupported    = 0x0052,
-    kVersionNotSupported        = 0x0053,
-    kUnknown                    = 0x005F,
+    kStatus_None                       = 0x0000,
+    kStatus_Overflow                   = 0x0011,
+    kStatus_LengthTooLarge             = 0x0012,
+    kStatus_LengthTooShort             = 0x0013,
+    kStatus_LengthMismatch             = 0x0014,
+    kStatus_LengthRequired             = 0x0015,
+    kStatus_BadMessageContents         = 0x0016,
+    kStatus_BadBlockCounter            = 0x0017,
+    kStatus_TransferFailedUnknownError = 0x001F,
+    kStatus_ServerBadState             = 0x0020,
+    kStatus_FailureToSend              = 0x0021,
+    kStatus_TransferMethodNotSupported = 0x0050,
+    kStatus_FileDesignatorUnknown      = 0x0051,
+    kStatus_StartOffsetNotSupported    = 0x0052,
+    kStatus_VersionNotSupported        = 0x0053,
+    kStatus_Unknown                    = 0x005F,
 };
 
-enum class TransferControlFlags : uint8_t
+enum TransferControlFlags : uint8_t
 {
     // first 4 bits reserved for version
-    kSenderDrive   = (1U << 4),
-    kReceiverDrive = (1U << 5),
-    kAsync         = (1U << 6),
+    kControl_SenderDrive   = (1U << 4),
+    kControl_ReceiverDrive = (1U << 5),
+    kControl_Async         = (1U << 6),
 };
 
-enum class RangeControlFlags : uint8_t
+enum RangeControlFlags : uint8_t
 {
-    kDefLen      = (1U),
-    kStartOffset = (1U << 1),
-    kWiderange   = (1U << 4),
+    kRange_DefLen      = (1U),
+    kRange_StartOffset = (1U << 1),
+    kRange_Widerange   = (1U << 4),
 };
 
 /**
@@ -136,7 +136,7 @@ struct TransferInit : public BdxMessage
     bool operator==(const TransferInit &) const;
 
     // Proposed Transfer Control (required)
-    BitFlags<TransferControlFlags> TransferCtlOptions;
+    BitFlags<uint8_t, TransferControlFlags> TransferCtlOptions;
     uint8_t Version = 0; ///< The highest version supported by the sender
 
     // All required
@@ -175,7 +175,7 @@ struct SendAccept : public BdxMessage
     bool operator==(const SendAccept &) const;
 
     // Transfer Control (required, only one should be set)
-    BitFlags<TransferControlFlags> TransferCtlFlags;
+    BitFlags<uint8_t, TransferControlFlags> TransferCtlFlags;
 
     uint8_t Version       = 0; ///< The agreed upon version for the transfer (required)
     uint16_t MaxBlockSize = 0; ///< Chosen max block size to use in transfer (required)
@@ -206,7 +206,7 @@ struct ReceiveAccept : public BdxMessage
     bool operator==(const ReceiveAccept &) const;
 
     // Transfer Control (required, only one should be set)
-    BitFlags<TransferControlFlags> TransferCtlFlags;
+    BitFlags<uint8_t, TransferControlFlags> TransferCtlFlags;
 
     // All required
     uint8_t Version       = 0; ///< The agreed upon version for the transfer

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -15,16 +15,16 @@
 namespace chip {
 namespace bdx {
 
-enum class TransferRole : uint8_t
+enum TransferRole : uint8_t
 {
-    kReceiver = 0,
-    kSender   = 1,
+    kRole_Receiver = 0,
+    kRole_Sender   = 1,
 };
 
 class DLL_EXPORT TransferSession
 {
 public:
-    enum class OutputEventType : uint16_t
+    enum OutputEventType : uint16_t
     {
         kNone = 0,
         kMsgToSend,
@@ -41,7 +41,7 @@ public:
 
     struct TransferInitData
     {
-        TransferControlFlags TransferCtlFlags;
+        uint8_t TransferCtlFlagsRaw = 0;
 
         uint16_t MaxBlockSize = 0;
         uint64_t StartOffset  = 0;
@@ -70,7 +70,7 @@ public:
 
     struct StatusReportData
     {
-        StatusCode statusCode;
+        uint16_t StatusCode;
     };
 
     struct BlockData
@@ -99,8 +99,8 @@ public:
             StatusReportData statusData;
         };
 
-        OutputEvent() : EventType(OutputEventType::kNone) { statusData = { StatusCode::kNone }; }
-        OutputEvent(OutputEventType type) : EventType(type) { statusData = { StatusCode::kNone }; }
+        OutputEvent() : EventType(kNone) { statusData = { kStatus_None }; }
+        OutputEvent(OutputEventType type) : EventType(type) { statusData = { kStatus_None }; }
 
         static OutputEvent TransferInitEvent(TransferInitData data, System::PacketBufferHandle msg);
         static OutputEvent TransferAcceptEvent(TransferAcceptData data);
@@ -160,7 +160,7 @@ public:
      * @return CHIP_ERROR Result of initialization. May also indicate if the TransferSession object is unable to handle this
      *                    request.
      */
-    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
+    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<uint8_t, TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
                                uint32_t timeoutMs);
 
     /**
@@ -252,7 +252,7 @@ public:
     TransferSession();
 
 private:
-    enum class TransferState : uint8_t
+    enum TransferState : uint8_t
     {
         kUnitialized,
         kAwaitingInitMsg,
@@ -282,23 +282,23 @@ private:
      *   Used when handling a TransferInit message. Determines if there are any compatible Transfer control modes between the two
      *   transfer peers.
      */
-    void ResolveTransferControlOptions(const BitFlags<TransferControlFlags> & proposed);
+    void ResolveTransferControlOptions(const BitFlags<uint8_t, TransferControlFlags> & proposed);
 
     /**
      * @brief
      *   Used when handling an Accept message. Verifies that the chosen control mode is compatible with the orignal supported modes.
      */
-    CHIP_ERROR VerifyProposedMode(const BitFlags<TransferControlFlags> & proposed);
+    CHIP_ERROR VerifyProposedMode(const BitFlags<uint8_t, TransferControlFlags> & proposed);
 
     void PrepareStatusReport(StatusCode code);
     bool IsTransferLengthDefinite();
 
-    OutputEventType mPendingOutput = OutputEventType::kNone;
-    TransferState mState           = TransferState::kUnitialized;
+    OutputEventType mPendingOutput = kNone;
+    TransferState mState           = kUnitialized;
     TransferRole mRole;
 
     // Indicate supported options pre- transfer accept
-    BitFlags<TransferControlFlags> mSuppportedXferOpts;
+    BitFlags<uint8_t, TransferControlFlags> mSuppportedXferOpts;
     uint16_t mMaxSupportedBlockSize = 0;
 
     // Used to govern transfer once it has been accepted

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -43,7 +43,8 @@ void TestTransferInitMessage(nlTestSuite * inSuite, void * inContext)
 {
     TransferInit testMsg;
 
-    testMsg.TransferCtlOptions.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
+    testMsg.TransferCtlOptions.SetRaw(0);
+    testMsg.TransferCtlOptions.Set(kControl_ReceiverDrive, true);
     testMsg.Version = 1;
 
     // Make sure MaxLength is greater than UINT32_MAX to test widerange being set
@@ -68,7 +69,8 @@ void TestSendAcceptMessage(nlTestSuite * inSuite, void * inContext)
     SendAccept testMsg;
 
     testMsg.Version = 1;
-    testMsg.TransferCtlFlags.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
+    testMsg.TransferCtlFlags.SetRaw(0);
+    testMsg.TransferCtlFlags.Set(kControl_ReceiverDrive, true);
     testMsg.MaxBlockSize = 256;
 
     uint8_t fakeData[5]    = { 7, 6, 5, 4, 3 };
@@ -83,7 +85,8 @@ void TestReceiveAcceptMessage(nlTestSuite * inSuite, void * inContext)
     ReceiveAccept testMsg;
 
     testMsg.Version = 1;
-    testMsg.TransferCtlFlags.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
+    testMsg.TransferCtlFlags.SetRaw(0);
+    testMsg.TransferCtlFlags.Set(kControl_ReceiverDrive, true);
 
     // Make sure Length is greater than UINT32_MAX to test widerange being set
     testMsg.Length = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -115,9 +115,9 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     CHIP_ERROR err      = CHIP_NO_ERROR;
     uint16_t headerSize = 0;
     PayloadHeader payloadHeader;
-    uint16_t generalCode = 0;
-    uint32_t protocolId  = 0;
-    BitFlags<StatusCode> protocolCode;
+    uint16_t generalCode  = 0;
+    uint32_t protocolId   = 0;
+    uint16_t protocolCode = 0;
 
     if (msg.IsNull())
     {
@@ -136,7 +136,7 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     }
 
     Encoding::LittleEndian::Reader reader(msg->Start(), msg->DataLength());
-    err = reader.Skip(headerSize).Read16(&generalCode).Read32(&protocolId).Read16(protocolCode.RawStorage()).StatusCode();
+    err = reader.Skip(headerSize).Read16(&generalCode).Read32(&protocolId).Read16(&protocolCode).StatusCode();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, generalCode == static_cast<uint16_t>(Protocols::Common::StatusCode::Failure));
     NL_TEST_ASSERT(inSuite, protocolId == Protocols::kProtocol_BDX);
@@ -147,19 +147,19 @@ void VerifyNoMoreOutput(nlTestSuite * inSuite, void * inContext, TransferSession
 {
     TransferSession::OutputEvent event;
     transferSession.PollOutput(event, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, event.EventType == TransferSession::OutputEventType::kNone);
+    NL_TEST_ASSERT(inSuite, event.EventType == TransferSession::kNone);
 }
 
 // Helper method for initializing two TransferSession objects, generating a TransferInit message, and passing it to a responding
 // TransferSession.
 void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, TransferSession::OutputEvent & outEvent, uint32_t timeoutMs,
                                TransferSession & initiator, TransferRole initiatorRole, TransferSession::TransferInitData initData,
-                               TransferSession & responder, BitFlags<TransferControlFlags> & responderControlOpts,
+                               TransferSession & responder, BitFlags<uint8_t, TransferControlFlags> & responderControlOpts,
                                uint16_t responderMaxBlock)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
-    TransferRole responderRole  = (initiatorRole == TransferRole::kSender) ? TransferRole::kReceiver : TransferRole::kSender;
-    MessageType expectedInitMsg = (initiatorRole == TransferRole::kSender) ? MessageType::SendInit : MessageType::ReceiveInit;
+    TransferRole responderRole  = (initiatorRole == kRole_Sender) ? kRole_Receiver : kRole_Sender;
+    MessageType expectedInitMsg = (initiatorRole == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
 
     // Initializer responder to wait for transfer
     err = responder.WaitForTransfer(responderRole, responderControlOpts, responderMaxBlock, timeoutMs);
@@ -170,7 +170,7 @@ void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, Transfer
     err = initiator.StartTransfer(initiatorRole, initData, timeoutMs);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiator.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedInitMsg);
     VerifyNoMoreOutput(inSuite, inContext, initiator);
 
@@ -179,15 +179,14 @@ void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, Transfer
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     responder.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, responder);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInitReceived);
-    NL_TEST_ASSERT(inSuite, outEvent.transferInitData.TransferCtlFlags == initData.TransferCtlFlags);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInitReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.transferInitData.TransferCtlFlagsRaw == initData.TransferCtlFlagsRaw);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.MaxBlockSize == initData.MaxBlockSize);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.StartOffset == initData.StartOffset);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.Length == initData.Length);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.FileDesignator != nullptr);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.FileDesLength == initData.FileDesLength);
-    if (outEvent.EventType == TransferSession::OutputEventType::kInitReceived &&
-        outEvent.transferInitData.FileDesignator != nullptr)
+    if (outEvent.EventType == TransferSession::kInitReceived && outEvent.transferInitData.FileDesignator != nullptr)
     {
         NL_TEST_ASSERT(
             inSuite,
@@ -224,7 +223,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // If the node sending the Accept message is also the one that will send Blocks, then this should be a ReceiveAccept message.
-    MessageType expectedMsg = (acceptSenderRole == TransferRole::kSender) ? MessageType::ReceiveAccept : MessageType::SendAccept;
+    MessageType expectedMsg = (acceptSenderRole == kRole_Sender) ? MessageType::ReceiveAccept : MessageType::SendAccept;
 
     err = acceptSender.AcceptTransfer(acceptData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -232,7 +231,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     // Verify Sender emits ReceiveAccept message for sending
     acceptSender.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, acceptSender);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedMsg);
 
     // Pass Accept message to acceptReceiver
@@ -244,7 +243,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     // Transfer at this point.
     acceptReceiver.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, acceptReceiver);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kAcceptReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kAcceptReceived);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.ControlMode == acceptData.ControlMode);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.MaxBlockSize == acceptData.MaxBlockSize);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.StartOffset == acceptData.StartOffset);
@@ -278,7 +277,7 @@ void SendAndVerifyQuery(nlTestSuite * inSuite, void * inContext, TransferSession
     CHIP_ERROR err = querySender.PrepareBlockQuery();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     querySender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, MessageType::BlockQuery);
     VerifyNoMoreOutput(inSuite, inContext, querySender);
 
@@ -286,7 +285,7 @@ void SendAndVerifyQuery(nlTestSuite * inSuite, void * inContext, TransferSession
     err = queryReceiver.HandleMessageReceived(std::move(outEvent.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     queryReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kQueryReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kQueryReceived);
     VerifyNoMoreOutput(inSuite, inContext, queryReceiver);
 }
 
@@ -321,7 +320,7 @@ void SendAndVerifyArbitraryBlock(nlTestSuite * inSuite, void * inContext, Transf
     err = sender.PrepareBlock(blockData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     sender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expected);
     VerifyNoMoreOutput(inSuite, inContext, sender);
 
@@ -329,9 +328,9 @@ void SendAndVerifyArbitraryBlock(nlTestSuite * inSuite, void * inContext, Transf
     err = receiver.HandleMessageReceived(std::move(outEvent.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     receiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kBlockReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kBlockReceived);
     NL_TEST_ASSERT(inSuite, outEvent.blockdata.Data != nullptr);
-    if (outEvent.EventType == TransferSession::OutputEventType::kBlockReceived && outEvent.blockdata.Data != nullptr)
+    if (outEvent.EventType == TransferSession::kBlockReceived && outEvent.blockdata.Data != nullptr)
     {
         NL_TEST_ASSERT(inSuite, !memcmp(fakeBlockData, outEvent.blockdata.Data, outEvent.blockdata.Length));
     }
@@ -343,14 +342,14 @@ void SendAndVerifyBlockAck(nlTestSuite * inSuite, void * inContext, TransferSess
                            TransferSession::OutputEvent & outEvent, bool expectEOF)
 {
     TransferSession::OutputEventType expectedEventType =
-        expectEOF ? TransferSession::OutputEventType::kAckEOFReceived : TransferSession::OutputEventType::kAckReceived;
+        expectEOF ? TransferSession::kAckEOFReceived : TransferSession::kAckReceived;
     MessageType expectedMsgType = expectEOF ? MessageType::BlockAckEOF : MessageType::BlockAck;
 
     // Verify PrepareBlockAck() outputs message to send
     CHIP_ERROR err = ackSender.PrepareBlockAck();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     ackSender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedMsgType);
     VerifyNoMoreOutput(inSuite, inContext, ackSender);
 
@@ -380,21 +379,21 @@ void TestInitiatingReceiverReceiverDrive(nlTestSuite * inSuite, void * inContext
     uint32_t timeoutMs            = 1000 * 24;
 
     // Chosen specifically for this test
-    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
+    TransferControlFlags driveMode = kControl_ReceiverDrive;
 
     // ReceiveInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlags = driveMode;
-    initOptions.MaxBlockSize     = proposedBlockSize;
-    char testFileDes[9]          = { "test.txt" };
-    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.TransferCtlFlagsRaw = driveMode;
+    initOptions.MaxBlockSize        = proposedBlockSize;
+    char testFileDes[9]             = { "test.txt" };
+    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
 
     // Initialize respondingSender and pass ReceiveInit message
-    BitFlags<TransferControlFlags> senderOpts;
+    BitFlags<uint8_t, TransferControlFlags> senderOpts;
     senderOpts.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
                               respondingSender, senderOpts, proposedBlockSize);
 
     // Test metadata for Accept message
@@ -414,7 +413,7 @@ void TestInitiatingReceiverReceiverDrive(nlTestSuite * inSuite, void * inContext
     acceptData.Metadata       = tlvBuf;
     acceptData.MetadataLength = metadataSize;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, TransferRole::kSender, acceptData, initiatingReceiver,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, kRole_Sender, acceptData, initiatingReceiver,
                            initOptions);
 
     // Verify that MaxBlockSize was chosen correctly
@@ -474,14 +473,14 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
     TransferSession initiatingSender;
     TransferSession respondingReceiver;
 
-    TransferControlFlags driveMode = TransferControlFlags::kSenderDrive;
+    TransferControlFlags driveMode = kControl_SenderDrive;
 
     // Chosen arbitrarily for this test
     uint16_t transferBlockSize = 10;
     uint32_t timeoutMs         = 1000 * 24;
 
     // Initialize respondingReceiver
-    BitFlags<TransferControlFlags> receiverOpts;
+    BitFlags<uint8_t, TransferControlFlags> receiverOpts;
     receiverOpts.Set(driveMode);
 
     // Test metadata for TransferInit message
@@ -494,15 +493,15 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
 
     // Initialize struct with TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlags = driveMode;
-    initOptions.MaxBlockSize     = transferBlockSize;
-    char testFileDes[9]          = { "test.txt" };
-    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata         = tlvBuf;
-    initOptions.MetadataLength   = metadataSize;
+    initOptions.TransferCtlFlagsRaw = driveMode;
+    initOptions.MaxBlockSize        = transferBlockSize;
+    char testFileDes[9]             = { "test.txt" };
+    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata            = tlvBuf;
+    initOptions.MetadataLength      = metadataSize;
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingSender, TransferRole::kSender, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingSender, kRole_Sender, initOptions,
                               respondingReceiver, receiverOpts, transferBlockSize);
 
     // Verify parsed TLV metadata matches the original
@@ -520,7 +519,7 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
     acceptData.Metadata       = nullptr;
     acceptData.MetadataLength = 0;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingReceiver, TransferRole::kReceiver, acceptData, initiatingSender,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingReceiver, kRole_Receiver, acceptData, initiatingSender,
                            initOptions);
 
     // Test multiple Block -> BlockAck -> Block
@@ -543,28 +542,28 @@ void TestBadAcceptMessageFields(nlTestSuite * inSuite, void * inContext)
     TransferSession respondingSender;
 
     uint16_t maxBlockSize          = 64;
-    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
+    TransferControlFlags driveMode = kControl_ReceiverDrive;
     uint64_t commonLength          = 0;
     uint64_t commonOffset          = 0;
     uint32_t timeoutMs             = 1000 * 24;
 
     // Initialize struct with TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlags = driveMode;
-    initOptions.MaxBlockSize     = maxBlockSize;
-    initOptions.StartOffset      = commonOffset;
-    initOptions.Length           = commonLength;
-    char testFileDes[9]          = { "test.txt" }; // arbitrary file designator
-    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata         = nullptr;
-    initOptions.MetadataLength   = 0;
+    initOptions.TransferCtlFlagsRaw = driveMode;
+    initOptions.MaxBlockSize        = maxBlockSize;
+    initOptions.StartOffset         = commonOffset;
+    initOptions.Length              = commonLength;
+    char testFileDes[9]             = { "test.txt" }; // arbitrary file designator
+    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata            = nullptr;
+    initOptions.MetadataLength      = 0;
 
     // Responder parameters
-    BitFlags<TransferControlFlags> responderControl;
+    BitFlags<uint8_t, TransferControlFlags> responderControl;
     responderControl.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
                               respondingSender, responderControl, maxBlockSize);
 
     // Verify AcceptTransfer() returns error for choosing larger max block size
@@ -578,8 +577,7 @@ void TestBadAcceptMessageFields(nlTestSuite * inSuite, void * inContext)
 
     // Verify AcceptTransfer() returns error for choosing unsupported transfer control mode
     TransferSession::TransferAcceptData acceptData2;
-    acceptData2.ControlMode = (driveMode == TransferControlFlags::kReceiverDrive) ? TransferControlFlags::kSenderDrive
-                                                                                  : TransferControlFlags::kReceiverDrive;
+    acceptData2.ControlMode  = (driveMode == kControl_ReceiverDrive) ? kControl_SenderDrive : kControl_ReceiverDrive;
     acceptData2.MaxBlockSize = maxBlockSize;
     acceptData2.StartOffset  = commonOffset;
     acceptData2.Length       = commonLength;
@@ -600,17 +598,17 @@ void TestTimeout(nlTestSuite * inSuite, void * inContext)
 
     // Initialize struct with arbitrary TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlags = TransferControlFlags::kReceiverDrive;
-    initOptions.MaxBlockSize     = 64;
-    initOptions.StartOffset      = 0;
-    initOptions.Length           = 0;
-    char testFileDes[9]          = { "test.txt" }; // arbitrary file designator
-    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata         = nullptr;
-    initOptions.MetadataLength   = 0;
+    initOptions.TransferCtlFlagsRaw = kControl_ReceiverDrive;
+    initOptions.MaxBlockSize        = 64;
+    initOptions.StartOffset         = 0;
+    initOptions.Length              = 0;
+    char testFileDes[9]             = { "test.txt" }; // arbitrary file designator
+    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata            = nullptr;
+    initOptions.MetadataLength      = 0;
 
-    TransferRole role = TransferRole::kReceiver;
+    TransferRole role = kRole_Receiver;
 
     // Verify initiator outputs respective Init message (depending on role) after StartTransfer()
     err = initiator.StartTransfer(role, initOptions, timeoutMs);
@@ -618,13 +616,13 @@ void TestTimeout(nlTestSuite * inSuite, void * inContext)
 
     // First PollOutput() should output the TransferInit message
     initiator.PollOutput(outEvent, startTimeMs);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
-    MessageType expectedInitMsg = (role == TransferRole::kSender) ? MessageType::SendInit : MessageType::ReceiveInit;
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    MessageType expectedInitMsg = (role == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedInitMsg);
 
     // Second PollOutput() with no call to HandleMessageReceived() should result in a timeout.
     initiator.PollOutput(outEvent, endTimeMs);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kTransferTimeout);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kTransferTimeout);
 }
 
 // Test that sending the same block twice (with same block counter) results in a StatusReport message with BadBlockCounter. Also
@@ -647,21 +645,21 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     uint32_t timeoutMs      = 1000 * 24;
 
     // Chosen specifically for this test
-    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
+    TransferControlFlags driveMode = kControl_ReceiverDrive;
 
     // ReceiveInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlags = driveMode;
-    initOptions.MaxBlockSize     = blockSize;
-    char testFileDes[9]          = { "test.txt" };
-    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.TransferCtlFlagsRaw = driveMode;
+    initOptions.MaxBlockSize        = blockSize;
+    char testFileDes[9]             = { "test.txt" };
+    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
 
     // Initialize respondingSender and pass ReceiveInit message
-    BitFlags<TransferControlFlags> senderOpts;
+    BitFlags<uint8_t, TransferControlFlags> senderOpts;
     senderOpts.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
                               respondingSender, senderOpts, blockSize);
 
     // Compose ReceiveAccept parameters struct and give to respondingSender
@@ -673,7 +671,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     acceptData.Metadata       = nullptr;
     acceptData.MetadataLength = 0;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, TransferRole::kSender, acceptData, initiatingReceiver,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, kRole_Sender, acceptData, initiatingReceiver,
                            initOptions);
 
     SendAndVerifyQuery(inSuite, inContext, respondingSender, initiatingReceiver, outEvent);
@@ -687,7 +685,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = respondingSender.PrepareBlock(blockData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     respondingSender.PollOutput(eventWithBlock, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, eventWithBlock.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, eventWithBlock.EventType == TransferSession::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, eventWithBlock.MsgData, MessageType::Block);
     VerifyNoMoreOutput(inSuite, inContext, respondingSender);
     System::PacketBufferHandle blockCopy =
@@ -697,7 +695,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = initiatingReceiver.HandleMessageReceived(std::move(eventWithBlock.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kBlockReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kBlockReceived);
     NL_TEST_ASSERT(inSuite, outEvent.blockdata.Data != nullptr);
     VerifyNoMoreOutput(inSuite, inContext, initiatingReceiver);
 
@@ -707,30 +705,30 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = initiatingReceiver.HandleMessageReceived(std::move(blockCopy), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
     System::PacketBufferHandle statusReportMsg = outEvent.MsgData.Retain();
-    VerifyStatusReport(inSuite, inContext, std::move(outEvent.MsgData), StatusCode::kBadBlockCounter);
+    VerifyStatusReport(inSuite, inContext, std::move(outEvent.MsgData), kStatus_BadBlockCounter);
 
     // All subsequent PollOutput() calls should return kInternalError
     for (int i = 0; i < 5; ++i)
     {
         initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInternalError);
-        NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
+        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInternalError);
+        NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
     }
 
     err = respondingSender.HandleMessageReceived(std::move(statusReportMsg), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     respondingSender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kStatusReceived);
-    NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kStatusReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
 
     // All subsequent PollOutput() calls should return kInternalError
     for (int i = 0; i < 5; ++i)
     {
         respondingSender.PollOutput(outEvent, kNoAdvanceTime);
-        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInternalError);
-        NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
+        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInternalError);
+        NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
     }
 }
 

--- a/src/setup_payload/AdditionalDataPayloadGenerator.cpp
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.cpp
@@ -44,7 +44,7 @@ using namespace chip::Encoding::LittleEndian;
 CHIP_ERROR
 AdditionalDataPayloadGenerator::generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * serialNumberBuffer,
                                                               size_t serialNumberBufferSize, PacketBufferHandle & bufferHandle,
-                                                              BitFlags<AdditionalDataFields> additionalDataFields)
+                                                              BitFlags<uint8_t, AdditionalDataFields> additionalDataFields)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferTLVWriter writer;

--- a/src/setup_payload/AdditionalDataPayloadGenerator.h
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.h
@@ -71,7 +71,7 @@ public:
      */
     CHIP_ERROR generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * serialNumberBuffer,
                                              size_t serialNumberBufferSize, chip::System::PacketBufferHandle & bufferHandle,
-                                             BitFlags<AdditionalDataFields> additionalDataFields);
+                                             BitFlags<uint8_t, AdditionalDataFields> additionalDataFields);
     // Generate Device Rotating ID
     /**
      * Generate additional data payload (i.e. TLV encoded).

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -319,9 +319,9 @@ CHIP_ERROR PacketHeader::EncodeBeforeData(const System::PacketBufferHandle & buf
 
 CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const
 {
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    uint8_t * p          = data;
-    const uint8_t header = mExchangeFlags.Raw();
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t * p    = data;
+    uint8_t header = mExchangeFlags.Raw();
 
     VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -95,9 +95,9 @@ enum class FlagValues : uint16_t
 
 };
 
-using Flags         = BitFlags<FlagValues>;
-using ExFlags       = BitFlags<ExFlagValues>;
-using InternalFlags = BitFlags<InternalFlagValues>;
+using Flags         = BitFlags<uint16_t, FlagValues>;
+using ExFlags       = BitFlags<uint8_t, ExFlagValues>;
+using InternalFlags = BitFlags<uint8_t, InternalFlagValues>;
 
 // Header is a 16-bit value of the form
 //  |  4 bit  | 4 bit |8 bit Security Flags|


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#5232

This breaks Flags::kRestartAdvertising in EFR32, likely due to incorrect update to src/platform/EFR32/BLEManagerImpl.cpp around line 539.

There also seem to be some issues with updates to  src/platform/K32W/BLEManagerImpl.h