### PR TITLE
Followup #1 for #5244. Always add 'chip.ble' modules even if ble is n…

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -168,7 +168,7 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
-#ifdef CONFIG_NETWORK_BLE
+#if CONFIG_NETWORK_LAYER_BLE
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
 #endif
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -168,7 +168,7 @@ int main(int argc, char * argv[])
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(nullptr); // Use default device name (CHIP-XXXX)
 
-#ifdef CONFIG_NETWORK_BLE
+#if CONFIG_NETWORK_LAYER_BLE
     chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(LinuxDeviceOptions::GetInstance().mBleDevice, false);
 #endif
 

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -100,6 +100,12 @@ pw_python_action("python") {
         "chip/ChipStack.py",
         "chip/ChipUtility.py",
         "chip/__init__.py",
+        "chip/ble/__init__.py",
+        "chip/ble/commissioning/__init__.py",
+        "chip/ble/get_adapters.py",
+        "chip/ble/library_handle.py",
+        "chip/ble/scan_devices.py",
+        "chip/ble/types.py",
         "chip/configuration/__init__.py",
         "chip/exceptions/__init__.py",
         "chip/internal/__init__.py",
@@ -122,22 +128,6 @@ pw_python_action("python") {
       sources = [ "//LICENSE" ]
     },
   ]
-
-  if (chip_enable_ble) {
-    _py_manifest_files += [
-      {
-        src_dir = "."
-        sources = [
-          "chip/ble/__init__.py",
-          "chip/ble/commissioning/__init__.py",
-          "chip/ble/get_adapters.py",
-          "chip/ble/library_handle.py",
-          "chip/ble/scan_devices.py",
-          "chip/ble/types.py",
-        ]
-      },
-    ]
-  }
 
   _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
 

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -126,6 +126,8 @@ try:
     #
     packages=[
             'chip',
+            'chip.ble',
+            'chip.ble.commissioning',
             'chip.configuration',
             'chip.exceptions',
             'chip.internal',
@@ -133,10 +135,6 @@ try:
             'chip.native',
             'chip.tlv',
     ]
-
-    if os.path.isdir(os.path.join(tmpDir, 'chip', 'ble')):
-      packages += ['chip.ble']
-      packages += ['chip.ble.commissioning']
 
     # Invoke the setuptools 'bdist_wheel' command to generate a wheel containing
     # the CHIP python packages, shared libraries and scripts.


### PR DESCRIPTION
…atively disabled


 #### Problem
Based on https://github.com/project-chip/connectedhomeip/pull/5244#discussion_r592067190, this PR keeps adding `chip.ble` and `chip.ble.commisioning` as python modules even if `ble` has been disabled inside the CHIP stack.

I have also added some changes to the `#ifdef` since I mistype it. Sorry about that.