### PR TITLE
Switch pigweed repo to point to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	branch = master
 [submodule "pigweed"]
 	path = third_party/pigweed/repo
-	url = https://pigweed.googlesource.com/pigweed/pigweed
+	url = https://github.com/google/pigweed.git
 	branch = master
 [submodule "openthread"]
 	path = third_party/openthread/repo


### PR DESCRIPTION
 #### Problem
Existing pigweed repo is firewalled in some countries. 

 #### Summary of Changes
 A pigweed mirror was created in github and will be auto-synced with the main repo. Use the github repository for pigweed.