### PR TITLE
Expand use of type-safe `BitFlags` and `enum class`.

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -152,18 +152,10 @@ chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
     return mCommandDataWriter;
 }
 
-CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
-                               chip::CommandId aCommandId, uint8_t aFlags)
+CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpointId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
+                               chip::CommandId aCommandId, BitFlags<CommandPathFlags> aFlags)
 {
-    CommandParams commandParams;
-
-    memset(&commandParams, 0, sizeof(CommandParams));
-
-    commandParams.EndpointId = aEndpintId;
-    commandParams.GroupId    = aGroupId;
-    commandParams.ClusterId  = aClusterId;
-    commandParams.CommandId  = aCommandId;
-    commandParams.Flags      = aFlags;
+    CommandParams commandParams(aEndpointId, aGroupId, aClusterId, aCommandId, aFlags);
 
     return AddCommand(commandParams);
 }
@@ -191,12 +183,12 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
         CommandDataElement::Builder commandDataElement =
             mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
         CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
-        if (aCommandParams.Flags & kCommandPathFlag_EndpointIdValid)
+        if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
         {
             commandPath.EndpointId(aCommandParams.EndpointId);
         }
 
-        if (aCommandParams.Flags & kCommandPathFlag_GroupIdValid)
+        if (aCommandParams.Flags.Has(CommandPathFlags::kGroupIdValid))
         {
             commandPath.GroupId(aCommandParams.GroupId);
         }

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
+#include <support/BitFlags.h>
 #include <support/CodeUtils.h>
 #include <support/DLLUtil.h>
 #include <support/logging/CHIPLogging.h>
@@ -59,24 +60,30 @@ public:
         Sending,           //< The invoke command message  has sent out the invoke command
     };
 
+    enum class CommandPathFlags : uint8_t
+    {
+        kEndpointIdValid = 0x01, /**< Set when the EndpointId field is valid */
+        kGroupIdValid    = 0x02, /**< Set when the GroupId field is valid */
+    };
+
     /**
      * Encapsulates arguments to be passed into SendCommand().
      *
      */
     struct CommandParams
     {
+        CommandParams(chip::EndpointId endpointId, chip::GroupId groupId, chip::ClusterId clusterId, chip::CommandId commandId,
+                      const BitFlags<CommandPathFlags> & flags) :
+            EndpointId(endpointId),
+            GroupId(groupId), ClusterId(clusterId), CommandId(commandId), Flags(flags)
+        {}
+
         chip::EndpointId EndpointId;
         chip::GroupId GroupId;
         chip::ClusterId ClusterId;
         chip::CommandId CommandId;
-        uint8_t Flags;
+        BitFlags<CommandPathFlags> Flags;
     };
-
-    enum CommandPathFlags
-    {
-        kCommandPathFlag_EndpointIdValid = 0x0001, /**< Set when the EndpointId field is valid */
-        kCommandPathFlag_GroupIdValid    = 0x0002, /**< Set when the GroupId field is valid */
-    } CommandPathFlags;
 
     /**
      *  Initialize the Command object. Within the lifetime
@@ -110,7 +117,7 @@ public:
 
     chip::TLV::TLVWriter & CreateCommandDataElementTLVWriter();
     CHIP_ERROR AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
-                          chip::CommandId aCommandId, uint8_t Flags);
+                          chip::CommandId aCommandId, BitFlags<CommandPathFlags> Flags);
     CHIP_ERROR AddCommand(CommandParams & aCommandParams);
     CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
                              const chip::ClusterId aClusterId);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ CHIP_ERROR SendCommandRequest(void)
                                                         kTestGroupId,    // GroupId
                                                         kTestClusterId,  // ClusterId
                                                         kTestCommandId,  // CommandId
-                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
 
     // Add command data here
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
                                                         kTestGroupId,    // GroupId
                                                         kTestClusterId,  // ClusterId
                                                         kTestCommandId,  // CommandId
-                                                        (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
 
     // Add command data here
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -73,7 +73,7 @@ bool IMEmberAfSendDefaultResponseWithCallback(EmberAfStatus status)
                                                              0, // GroupId
                                                              imCompatibilityEmberApsFrame.clusterId,
                                                              imCompatibilityEmberAfCluster.commandId,
-                                                             (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                                             (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
 
     chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
     chip::TLV::TLVWriter writer  = currentCommandObject->CreateCommandDataElementTLVWriter();

--- a/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
@@ -26,7 +26,7 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
 (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, k{{asCamelCased name false}}CommandId,
-                                         (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                         (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer  = ZCLcommand->CreateCommandDataElementTLVWriter();

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -272,7 +272,7 @@ exit:
 void BLEEndPoint::HandleSubscribeComplete()
 {
     ChipLogProgress(Ble, "subscribe complete, ep = %p", this);
-    SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, false);
+    mConnStateFlags.Clear(ConnectionStateFlag::kGattOperationInFlight);
 
     BLE_ERROR err = DriveSending();
 
@@ -295,7 +295,7 @@ bool BLEEndPoint::IsConnected(uint8_t state) const
 
 bool BLEEndPoint::IsUnsubscribePending() const
 {
-    return (GetFlag(mTimerStateFlags, kTimerState_UnsubscribeTimerRunning));
+    return mTimerStateFlags.Has(TimerStateFlag::kUnsubscribeTimerRunning);
 }
 
 void BLEEndPoint::Abort()
@@ -392,7 +392,7 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
     }
     else // Otherwise, try to signal close to remote device before end point releases BLE connection and frees itself.
     {
-        if (mRole == kBleRole_Central && GetFlag(mConnStateFlags, kConnState_DidBeginSubscribe))
+        if (mRole == kBleRole_Central && mConnStateFlags.Has(ConnectionStateFlag::kDidBeginSubscribe))
         {
             // Cancel send and receive-ack timers, if running.
             StopAckReceivedTimer();
@@ -420,10 +420,10 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
                 }
 
                 // Mark unsubscribe GATT operation in progress.
-                SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
+                mConnStateFlags.Set(ConnectionStateFlag::kGattOperationInFlight);
             }
         }
-        else // mRole == kBleRole_Peripheral, OR GetFlag(mTimerStateFlags, kConnState_DidBeginSubscribe) == false...
+        else // mRole == kBleRole_Peripheral, OR mTimerStateFlags.Has(ConnectionStateFlag::kDidBeginSubscribe) == false...
         {
             Free();
         }
@@ -456,7 +456,7 @@ void BLEEndPoint::ReleaseBleConnection()
 {
     if (mConnObj != BLE_CONNECTION_UNINITIALIZED)
     {
-        if (GetFlag(mConnStateFlags, kConnState_AutoClose))
+        if (mConnStateFlags.Has(ConnectionStateFlag::kAutoClose))
         {
             ChipLogProgress(Ble, "Auto-closing end point's BLE connection.");
             mBle->mPlatformDelegate->CloseConnection(mConnObj);
@@ -562,11 +562,10 @@ BLE_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj, 
     mRefCount = 1;
 
     // BLEEndPoint data members:
-    mConnObj         = connObj;
-    mRole            = role;
-    mConnStateFlags  = 0;
-    mTimerStateFlags = 0;
-    SetFlag(mConnStateFlags, kConnState_AutoClose, autoClose);
+    mConnObj = connObj;
+    mRole    = role;
+    mTimerStateFlags.ClearAll();
+    mConnStateFlags.ClearAll().Set(ConnectionStateFlag::kAutoClose, autoClose);
     mLocalReceiveWindowSize  = 0;
     mRemoteReceiveWindowSize = 0;
     mReceiveWindowMaxSize    = 0;
@@ -686,7 +685,7 @@ exit:
 bool BLEEndPoint::PrepareNextFragment(PacketBufferHandle && data, bool & sentAck)
 {
     // If we have a pending fragment acknowledgement to send, piggyback it on the fragment we're about to transmit.
-    if (GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning))
+    if (mTimerStateFlags.Has(TimerStateFlag::kSendAckTimerRunning))
     {
         // Reset local receive window counter.
         mLocalReceiveWindowSize = mReceiveWindowMaxSize;
@@ -818,10 +817,10 @@ BLE_ERROR BLEEndPoint::HandleHandshakeConfirmationReceived()
                      err = BLE_ERROR_GATT_SUBSCRIBE_FAILED);
 
         // We just sent a GATT subscribe request, so make sure to attempt unsubscribe on close.
-        SetFlag(mConnStateFlags, kConnState_DidBeginSubscribe, true);
+        mConnStateFlags.Set(ConnectionStateFlag::kDidBeginSubscribe);
 
         // Mark GATT operation in progress for subscribe request.
-        SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
+        mConnStateFlags.Set(ConnectionStateFlag::kGattOperationInFlight);
     }
     else // (mRole == kBleRole_Peripheral), verified on Init
     {
@@ -882,12 +881,12 @@ BLE_ERROR BLEEndPoint::HandleFragmentConfirmationReceived()
     // TODO Packet buffer high water mark optimization: if ack pending, but fragmenter state == complete, free fragmenter's
     // tx buf before sending ack.
 
-    if (GetFlag(mConnStateFlags, kConnState_StandAloneAckInFlight))
+    if (mConnStateFlags.Has(ConnectionStateFlag::kStandAloneAckInFlight))
     {
         // If confirmation was received for stand-alone ack, free its tx buffer.
         mAckToSend = nullptr;
 
-        SetFlag(mConnStateFlags, kConnState_StandAloneAckInFlight, false);
+        mConnStateFlags.Clear(ConnectionStateFlag::kStandAloneAckInFlight);
     }
 
     // If local receive window size has shrunk to or below immediate ack threshold, AND a message fragment is not
@@ -922,12 +921,12 @@ BLE_ERROR BLEEndPoint::HandleGattSendConfirmationReceived()
     ChipLogDebugBleEndPoint(Ble, "entered HandleGattSendConfirmationReceived");
 
     // Mark outstanding GATT operation as finished.
-    SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, false);
+    mConnStateFlags.Clear(ConnectionStateFlag::kGattOperationInFlight);
 
     // If confirmation was for outbound portion of BTP connect handshake...
-    if (!GetFlag(mConnStateFlags, kConnState_CapabilitiesConfReceived))
+    if (!mConnStateFlags.Has(ConnectionStateFlag::kCapabilitiesConfReceived))
     {
-        SetFlag(mConnStateFlags, kConnState_CapabilitiesConfReceived, true);
+        mConnStateFlags.Set(ConnectionStateFlag::kCapabilitiesConfReceived);
 
         return HandleHandshakeConfirmationReceived();
     }
@@ -970,7 +969,7 @@ BLE_ERROR BLEEndPoint::DoSendStandAloneAck()
     mLocalReceiveWindowSize = mReceiveWindowMaxSize;
     ChipLogDebugBleEndPoint(Ble, "reset local rx window on stand-alone ack tx, size = %u", mLocalReceiveWindowSize);
 
-    SetFlag(mConnStateFlags, kConnState_StandAloneAckInFlight, true);
+    mConnStateFlags.Set(ConnectionStateFlag::kStandAloneAckInFlight);
 
     // Start ack received timer, if it's not already running.
     err = StartAckReceivedTimer();
@@ -989,12 +988,12 @@ BLE_ERROR BLEEndPoint::DriveSending()
     // If receiver's window is almost closed and we don't have an ack to send, OR we do have an ack to send but
     // receiver's window is completely empty, OR another GATT operation is in flight, awaiting confirmation...
     if ((mRemoteReceiveWindowSize <= BTP_WINDOW_NO_ACK_SEND_THRESHOLD &&
-         !GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning) && mAckToSend.IsNull()) ||
-        (mRemoteReceiveWindowSize == 0) || (GetFlag(mConnStateFlags, kConnState_GattOperationInFlight)))
+         !mTimerStateFlags.Has(TimerStateFlag::kSendAckTimerRunning) && mAckToSend.IsNull()) ||
+        (mRemoteReceiveWindowSize == 0) || (mConnStateFlags.Has(ConnectionStateFlag::kGattOperationInFlight)))
     {
 #ifdef CHIP_BLE_END_POINT_DEBUG_LOGGING_ENABLED
         if (mRemoteReceiveWindowSize <= BTP_WINDOW_NO_ACK_SEND_THRESHOLD &&
-            !GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning) && mAckToSend == NULL)
+            !mTimerStateFlags.Has(TimerStateFlag::kSendAckTimerRunning) && mAckToSend == NULL)
         {
             ChipLogDebugBleEndPoint(Ble, "NO SEND: receive window almost closed, and no ack to send");
         }
@@ -1004,7 +1003,7 @@ BLE_ERROR BLEEndPoint::DriveSending()
             ChipLogDebugBleEndPoint(Ble, "NO SEND: remote receive window closed");
         }
 
-        if (GetFlag(mConnStateFlags, kConnState_GattOperationInFlight))
+        if (mConnStateFlags.Has(ConnectionStateFlag::kGattOperationInFlight))
         {
             ChipLogDebugBleEndPoint(Ble, "NO SEND: Gatt op in flight");
         }
@@ -1273,13 +1272,13 @@ BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
         }
 
         // If we're receiving the first inbound packet of a BLE transport connection handshake...
-        if (!GetFlag(mConnStateFlags, kConnState_CapabilitiesMsgReceived))
+        if (!mConnStateFlags.Has(ConnectionStateFlag::kCapabilitiesMsgReceived))
         {
             if (mRole == kBleRole_Central) // If we're a central receiving a capabilities response indication...
             {
                 // Ensure end point's in the right state before continuing.
                 VerifyOrExit(mState == kState_Connecting, err = BLE_ERROR_INCORRECT_STATE);
-                SetFlag(mConnStateFlags, kConnState_CapabilitiesMsgReceived, true);
+                mConnStateFlags.Set(ConnectionStateFlag::kCapabilitiesMsgReceived);
 
                 err = HandleCapabilitiesResponseReceived(std::move(data));
                 SuccessOrExit(err);
@@ -1288,7 +1287,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
             {
                 // Ensure end point's in the right state before continuing.
                 VerifyOrExit(mState == kState_Ready, err = BLE_ERROR_INCORRECT_STATE);
-                SetFlag(mConnStateFlags, kConnState_CapabilitiesMsgReceived, true);
+                mConnStateFlags.Set(ConnectionStateFlag::kCapabilitiesMsgReceived);
 
                 err = HandleCapabilitiesRequestReceived(std::move(data));
 
@@ -1391,7 +1390,7 @@ BLE_ERROR BLEEndPoint::Receive(PacketBufferHandle data)
     if (mBtpEngine.HasUnackedData())
     {
         if (mLocalReceiveWindowSize <= BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD &&
-            !GetFlag(mConnStateFlags, kConnState_GattOperationInFlight))
+            !mConnStateFlags.Has(ConnectionStateFlag::kGattOperationInFlight))
         {
             ChipLogDebugBleEndPoint(Ble, "sending immediate ack");
             err = DriveStandAloneAck();
@@ -1446,14 +1445,14 @@ exit:
 
 bool BLEEndPoint::SendWrite(PacketBufferHandle && buf)
 {
-    SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
+    mConnStateFlags.Set(ConnectionStateFlag::kGattOperationInFlight);
 
     return mBle->mPlatformDelegate->SendWriteRequest(mConnObj, &CHIP_BLE_SVC_ID, &mBle->CHIP_BLE_CHAR_1_ID, std::move(buf));
 }
 
 bool BLEEndPoint::SendIndication(PacketBufferHandle && buf)
 {
-    SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
+    mConnStateFlags.Set(ConnectionStateFlag::kGattOperationInFlight);
 
     return mBle->mPlatformDelegate->SendIndication(mConnObj, &CHIP_BLE_SVC_ID, &mBle->CHIP_BLE_CHAR_2_ID, std::move(buf));
 }
@@ -1465,7 +1464,7 @@ BLE_ERROR BLEEndPoint::StartConnectTimer()
 
     timerErr = mBle->mSystemLayer->StartTimer(BLE_CONNECT_TIMEOUT_MS, HandleConnectTimeout, this);
     VerifyOrExit(timerErr == CHIP_SYSTEM_NO_ERROR, err = BLE_ERROR_START_TIMER_FAILED);
-    SetFlag(mTimerStateFlags, kTimerState_ConnectTimerRunning, true);
+    mTimerStateFlags.Set(TimerStateFlag::kConnectTimerRunning);
 
 exit:
     return err;
@@ -1478,7 +1477,7 @@ BLE_ERROR BLEEndPoint::StartReceiveConnectionTimer()
 
     timerErr = mBle->mSystemLayer->StartTimer(BLE_CONNECT_TIMEOUT_MS, HandleReceiveConnectionTimeout, this);
     VerifyOrExit(timerErr == CHIP_SYSTEM_NO_ERROR, err = BLE_ERROR_START_TIMER_FAILED);
-    SetFlag(mTimerStateFlags, kTimerState_ReceiveConnectionTimerRunning, true);
+    mTimerStateFlags.Set(TimerStateFlag::kReceiveConnectionTimerRunning);
 
 exit:
     return err;
@@ -1489,12 +1488,12 @@ BLE_ERROR BLEEndPoint::StartAckReceivedTimer()
     BLE_ERROR err = BLE_NO_ERROR;
     chip::System::Error timerErr;
 
-    if (!GetFlag(mTimerStateFlags, kTimerState_AckReceivedTimerRunning))
+    if (!mTimerStateFlags.Has(TimerStateFlag::kAckReceivedTimerRunning))
     {
         timerErr = mBle->mSystemLayer->StartTimer(BTP_ACK_RECEIVED_TIMEOUT_MS, HandleAckReceivedTimeout, this);
         VerifyOrExit(timerErr == CHIP_SYSTEM_NO_ERROR, err = BLE_ERROR_START_TIMER_FAILED);
 
-        SetFlag(mTimerStateFlags, kTimerState_AckReceivedTimerRunning, true);
+        mTimerStateFlags.Set(TimerStateFlag::kAckReceivedTimerRunning);
     }
 
 exit:
@@ -1505,7 +1504,7 @@ BLE_ERROR BLEEndPoint::RestartAckReceivedTimer()
 {
     BLE_ERROR err = BLE_NO_ERROR;
 
-    VerifyOrExit(GetFlag(mTimerStateFlags, kTimerState_AckReceivedTimerRunning), err = BLE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mTimerStateFlags.Has(TimerStateFlag::kAckReceivedTimerRunning), err = BLE_ERROR_INCORRECT_STATE);
 
     StopAckReceivedTimer();
 
@@ -1523,13 +1522,13 @@ BLE_ERROR BLEEndPoint::StartSendAckTimer()
 
     ChipLogDebugBleEndPoint(Ble, "entered StartSendAckTimer");
 
-    if (!GetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning))
+    if (!mTimerStateFlags.Has(TimerStateFlag::kSendAckTimerRunning))
     {
         ChipLogDebugBleEndPoint(Ble, "starting new SendAckTimer");
         timerErr = mBle->mSystemLayer->StartTimer(BTP_ACK_SEND_TIMEOUT_MS, HandleSendAckTimeout, this);
         VerifyOrExit(timerErr == CHIP_SYSTEM_NO_ERROR, err = BLE_ERROR_START_TIMER_FAILED);
 
-        SetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning, true);
+        mTimerStateFlags.Set(TimerStateFlag::kSendAckTimerRunning);
     }
 
 exit:
@@ -1543,7 +1542,7 @@ BLE_ERROR BLEEndPoint::StartUnsubscribeTimer()
 
     timerErr = mBle->mSystemLayer->StartTimer(BLE_UNSUBSCRIBE_TIMEOUT_MS, HandleUnsubscribeTimeout, this);
     VerifyOrExit(timerErr == CHIP_SYSTEM_NO_ERROR, err = BLE_ERROR_START_TIMER_FAILED);
-    SetFlag(mTimerStateFlags, kTimerState_UnsubscribeTimerRunning, true);
+    mTimerStateFlags.Set(TimerStateFlag::kUnsubscribeTimerRunning);
 
 exit:
     return err;
@@ -1553,35 +1552,35 @@ void BLEEndPoint::StopConnectTimer()
 {
     // Cancel any existing connect timer.
     mBle->mSystemLayer->CancelTimer(HandleConnectTimeout, this);
-    SetFlag(mTimerStateFlags, kTimerState_ConnectTimerRunning, false);
+    mTimerStateFlags.Clear(TimerStateFlag::kConnectTimerRunning);
 }
 
 void BLEEndPoint::StopReceiveConnectionTimer()
 {
     // Cancel any existing receive connection timer.
     mBle->mSystemLayer->CancelTimer(HandleReceiveConnectionTimeout, this);
-    SetFlag(mTimerStateFlags, kTimerState_ReceiveConnectionTimerRunning, false);
+    mTimerStateFlags.Clear(TimerStateFlag::kReceiveConnectionTimerRunning);
 }
 
 void BLEEndPoint::StopAckReceivedTimer()
 {
     // Cancel any existing ack-received timer.
     mBle->mSystemLayer->CancelTimer(HandleAckReceivedTimeout, this);
-    SetFlag(mTimerStateFlags, kTimerState_AckReceivedTimerRunning, false);
+    mTimerStateFlags.Clear(TimerStateFlag::kAckReceivedTimerRunning);
 }
 
 void BLEEndPoint::StopSendAckTimer()
 {
     // Cancel any existing send-ack timer.
     mBle->mSystemLayer->CancelTimer(HandleSendAckTimeout, this);
-    SetFlag(mTimerStateFlags, kTimerState_SendAckTimerRunning, false);
+    mTimerStateFlags.Clear(TimerStateFlag::kSendAckTimerRunning);
 }
 
 void BLEEndPoint::StopUnsubscribeTimer()
 {
     // Cancel any existing unsubscribe timer.
     mBle->mSystemLayer->CancelTimer(HandleUnsubscribeTimeout, this);
-    SetFlag(mTimerStateFlags, kTimerState_UnsubscribeTimerRunning, false);
+    mTimerStateFlags.Clear(TimerStateFlag::kUnsubscribeTimerRunning);
 }
 
 void BLEEndPoint::HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState, chip::System::Error err)
@@ -1589,10 +1588,10 @@ void BLEEndPoint::HandleConnectTimeout(chip::System::Layer * systemLayer, void *
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
     // Check for event-based timer race condition.
-    if (GetFlag(ep->mTimerStateFlags, kTimerState_ConnectTimerRunning))
+    if (ep->mTimerStateFlags.Has(TimerStateFlag::kConnectTimerRunning))
     {
         ChipLogError(Ble, "connect handshake timed out, closing ep %p", ep);
-        SetFlag(ep->mTimerStateFlags, kTimerState_ConnectTimerRunning, false);
+        ep->mTimerStateFlags.Clear(TimerStateFlag::kConnectTimerRunning);
         ep->DoClose(kBleCloseFlag_AbortTransmission, BLE_ERROR_CONNECT_TIMED_OUT);
     }
 }
@@ -1602,10 +1601,10 @@ void BLEEndPoint::HandleReceiveConnectionTimeout(chip::System::Layer * systemLay
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
     // Check for event-based timer race condition.
-    if (GetFlag(ep->mTimerStateFlags, kTimerState_ReceiveConnectionTimerRunning))
+    if (ep->mTimerStateFlags.Has(TimerStateFlag::kReceiveConnectionTimerRunning))
     {
         ChipLogError(Ble, "receive handshake timed out, closing ep %p", ep);
-        SetFlag(ep->mTimerStateFlags, kTimerState_ReceiveConnectionTimerRunning, false);
+        ep->mTimerStateFlags.Clear(TimerStateFlag::kReceiveConnectionTimerRunning);
         ep->DoClose(kBleCloseFlag_SuppressCallback | kBleCloseFlag_AbortTransmission, BLE_ERROR_RECEIVE_TIMED_OUT);
     }
 }
@@ -1615,11 +1614,11 @@ void BLEEndPoint::HandleAckReceivedTimeout(chip::System::Layer * systemLayer, vo
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
     // Check for event-based timer race condition.
-    if (GetFlag(ep->mTimerStateFlags, kTimerState_AckReceivedTimerRunning))
+    if (ep->mTimerStateFlags.Has(TimerStateFlag::kAckReceivedTimerRunning))
     {
         ChipLogError(Ble, "ack recv timeout, closing ep %p", ep);
         ep->mBtpEngine.LogStateDebug();
-        SetFlag(ep->mTimerStateFlags, kTimerState_AckReceivedTimerRunning, false);
+        ep->mTimerStateFlags.Clear(TimerStateFlag::kAckReceivedTimerRunning);
         ep->DoClose(kBleCloseFlag_AbortTransmission, BLE_ERROR_FRAGMENT_ACK_TIMED_OUT);
     }
 }
@@ -1629,12 +1628,12 @@ void BLEEndPoint::HandleSendAckTimeout(chip::System::Layer * systemLayer, void *
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
     // Check for event-based timer race condition.
-    if (GetFlag(ep->mTimerStateFlags, kTimerState_SendAckTimerRunning))
+    if (ep->mTimerStateFlags.Has(TimerStateFlag::kSendAckTimerRunning))
     {
-        SetFlag(ep->mTimerStateFlags, kTimerState_SendAckTimerRunning, false);
+        ep->mTimerStateFlags.Clear(TimerStateFlag::kSendAckTimerRunning);
 
         // If previous stand-alone ack isn't still in flight...
-        if (!GetFlag(ep->mConnStateFlags, kConnState_StandAloneAckInFlight))
+        if (!ep->mConnStateFlags.Has(ConnectionStateFlag::kStandAloneAckInFlight))
         {
             BLE_ERROR sendErr = ep->DriveStandAloneAck();
 
@@ -1651,10 +1650,10 @@ void BLEEndPoint::HandleUnsubscribeTimeout(chip::System::Layer * systemLayer, vo
     BLEEndPoint * ep = static_cast<BLEEndPoint *>(appState);
 
     // Check for event-based timer race condition.
-    if (GetFlag(ep->mTimerStateFlags, kTimerState_UnsubscribeTimerRunning))
+    if (ep->mTimerStateFlags.Has(TimerStateFlag::kUnsubscribeTimerRunning))
     {
         ChipLogError(Ble, "unsubscribe timed out, ble ep %p", ep);
-        SetFlag(ep->mTimerStateFlags, kTimerState_UnsubscribeTimerRunning, false);
+        ep->mTimerStateFlags.Clear(TimerStateFlag::kUnsubscribeTimerRunning);
         ep->HandleUnsubscribeComplete();
     }
 }

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2014-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,26 +107,26 @@ public:
 
 private:
     // Private data members:
-    enum ConnectionStateFlags
+    enum class ConnectionStateFlag : uint8_t
     {
-        kConnState_AutoClose                = 0x01, // End point should close underlying BLE conn on BTP close.
-        kConnState_CapabilitiesConfReceived = 0x02, // GATT confirmation received for sent capabilities req/resp.
-        kConnState_CapabilitiesMsgReceived  = 0x04, // Capabilities request or response message received.
-        kConnState_DidBeginSubscribe        = 0x08, // GATT subscribe request sent; must unsubscribe on close.
-        kConnState_StandAloneAckInFlight    = 0x10, // Stand-alone ack in flight, awaiting GATT confirmation.
-        kConnState_GattOperationInFlight    = 0x20  // GATT write, indication, subscribe, or unsubscribe in flight,
-                                                    // awaiting GATT confirmation.
+        kAutoClose                = 0x01, // End point should close underlying BLE conn on BTP close.
+        kCapabilitiesConfReceived = 0x02, // GATT confirmation received for sent capabilities req/resp.
+        kCapabilitiesMsgReceived  = 0x04, // Capabilities request or response message received.
+        kDidBeginSubscribe        = 0x08, // GATT subscribe request sent; must unsubscribe on close.
+        kStandAloneAckInFlight    = 0x10, // Stand-alone ack in flight, awaiting GATT confirmation.
+        kGattOperationInFlight    = 0x20  // GATT write, indication, subscribe, or unsubscribe in flight,
+                                          // awaiting GATT confirmation.
     };
 
-    enum TimerStateFlags
+    enum class TimerStateFlag : uint8_t
     {
-        kTimerState_ConnectTimerRunning           = 0x01, // BTP connect completion timer running.
-        kTimerState_ReceiveConnectionTimerRunning = 0x02, // BTP receive connection completion timer running.
-        kTimerState_AckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
-        kTimerState_SendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
-        kTimerState_UnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
+        kConnectTimerRunning           = 0x01, // BTP connect completion timer running.
+        kReceiveConnectionTimerRunning = 0x02, // BTP receive connection completion timer running.
+        kAckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
+        kSendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
+        kUnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
 #if CHIP_ENABLE_CHIPOBLE_TEST
-        kTimerState_UnderTestTimerRunnung = 0x80 // running throughput Tx test
+        kUnderTestTimerRunnung = 0x80 // running throughput Tx test
 #endif
     };
 
@@ -147,8 +147,8 @@ private:
 
     BtpEngine mBtpEngine;
     BleRole mRole;
-    uint8_t mConnStateFlags;
-    uint8_t mTimerStateFlags;
+    BitFlags<ConnectionStateFlag> mConnStateFlags;
+    BitFlags<TimerStateFlag> mTimerStateFlags;
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -55,10 +55,10 @@ static inline void IncSeqNum(SequenceNumber_t & a_seq_num)
     a_seq_num = static_cast<SequenceNumber_t>(0xff & ((a_seq_num) + 1));
 }
 
-static inline bool DidReceiveData(uint8_t rx_flags)
+static inline bool DidReceiveData(BitFlags<BtpEngine::HeaderFlags> rx_flags)
 {
-    return (GetFlag(rx_flags, BtpEngine::kHeaderFlag_StartMessage) || GetFlag(rx_flags, BtpEngine::kHeaderFlag_ContinueMessage) ||
-            GetFlag(rx_flags, BtpEngine::kHeaderFlag_EndMessage));
+    return rx_flags.HasAny(BtpEngine::HeaderFlags::kStartMessage, BtpEngine::HeaderFlags::kContinueMessage,
+                           BtpEngine::HeaderFlags::kEndMessage);
 }
 
 static void PrintBufDebug(const System::PacketBufferHandle & buf)
@@ -213,7 +213,7 @@ BLE_ERROR BtpEngine::EncodeStandAloneAck(const PacketBufferHandle & data)
     characteristic = data->Start();
 
     // Since there's no preexisting message payload, we can write BTP header without adjusting data start pointer.
-    characteristic[0] = kHeaderFlag_FragmentAck;
+    characteristic[0] = static_cast<uint8_t>(HeaderFlags::kFragmentAck);
 
     // Acknowledge most recently received sequence number.
     characteristic[1] = GetAndRecordRxAckSeqNum();
@@ -245,8 +245,8 @@ exit:
 BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle data, SequenceNumber_t & receivedAck,
                                                   bool & didReceiveAck)
 {
-    BLE_ERROR err    = BLE_NO_ERROR;
-    uint8_t rx_flags = 0;
+    BLE_ERROR err = BLE_NO_ERROR;
+    BitFlags<HeaderFlags> rx_flags;
     // BLE data uses little-endian byte order.
     Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
 
@@ -255,15 +255,15 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
     mRxCharCount++;
 
     // Get header flags, always in first byte.
-    VerifyOrExit(reader.Read8(&rx_flags).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
+    VerifyOrExit(reader.Read8(rx_flags.RawStorage()).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
 #if CHIP_ENABLE_CHIPOBLE_TEST
-    if (GetFlag(rx_flags, kHeaderFlag_CommandMessage))
+    if (rx_flags.Has(HeaderFlags::kCommandMessage))
         SetRxPacketType(kType_Control);
     else
         SetRxPacketType(kType_Data);
 #endif
 
-    didReceiveAck = GetFlag(rx_flags, kHeaderFlag_FragmentAck);
+    didReceiveAck = rx_flags.Has(HeaderFlags::kFragmentAck);
 
     // Get ack number, if any.
     if (didReceiveAck)
@@ -309,7 +309,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
         Encoding::LittleEndian::Reader startReader(data->Start(), data->DataLength());
 
         // Verify StartMessage header flag set.
-        VerifyOrExit(rx_flags & kHeaderFlag_StartMessage, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
+        VerifyOrExit(rx_flags.Has(HeaderFlags::kStartMessage), err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         VerifyOrExit(startReader.Read16(&mRxLength).StatusCode() == CHIP_NO_ERROR, err = BLE_ERROR_MESSAGE_INCOMPLETE);
 
@@ -328,10 +328,10 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
     else if (mRxState == kState_InProgress)
     {
         // Verify StartMessage header flag NOT set, since we're in the middle of receiving a message.
-        VerifyOrExit((rx_flags & kHeaderFlag_StartMessage) == 0, err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
+        VerifyOrExit(!rx_flags.Has(HeaderFlags::kStartMessage), err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         // Verify ContinueMessage or EndMessage header flag set.
-        VerifyOrExit((rx_flags & kHeaderFlag_ContinueMessage) || (rx_flags & kHeaderFlag_EndMessage),
+        VerifyOrExit(rx_flags.HasAny(HeaderFlags::kContinueMessage, HeaderFlags::kEndMessage),
                      err = BLE_ERROR_INVALID_BTP_HEADER_FLAGS);
 
         // Add received fragment to reassembled message buffer.
@@ -348,7 +348,7 @@ BLE_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle dat
         ExitNow();
     }
 
-    if (rx_flags & kHeaderFlag_EndMessage)
+    if (rx_flags.Has(HeaderFlags::kEndMessage))
     {
         // Trim remainder, if any, of the received packet buffer based on sender-specified length of reassembled message.
         int padding = mRxBuf->DataLength() - mRxLength;
@@ -372,7 +372,7 @@ exit:
         mRxState = kState_Error;
 
         // Dump protocol engine state, plus header flags and received data length.
-        ChipLogError(Ble, "HandleCharacteristicReceived failed, err = %d, rx_flags = %u", err, rx_flags);
+        ChipLogError(Ble, "HandleCharacteristicReceived failed, err = %d, rx_flags = %u", err, rx_flags.Raw());
         if (didReceiveAck)
         {
             ChipLogError(Ble, "With rx'd ack = %u", receivedAck);
@@ -457,17 +457,16 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         characteristic -= header_size;
         mTxBuf->SetStart(characteristic);
         uint8_t cursor = 1; // first position past header flags byte
-
-        characteristic[0] = kHeaderFlag_StartMessage;
+        BitFlags<HeaderFlags> headerFlags(HeaderFlags::kStartMessage);
 
 #if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
-            SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
+            headerFlags.Set(HeaderFlags::kCommandMessage);
 #endif
 
         if (send_ack)
         {
-            SetFlag(characteristic[0], kHeaderFlag_FragmentAck, true);
+            headerFlags.Set(HeaderFlags::kFragmentAck);
             characteristic[cursor++] = GetAndRecordRxAckSeqNum();
             ChipLogDebugBtpEngine(Ble, "===> encoded piggybacked ack, ack_num = %u", characteristic[cursor - 1]);
         }
@@ -480,7 +479,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         {
             mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
-            SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
+            headerFlags.Set(HeaderFlags::kEndMessage);
             mTxState = kState_Complete;
             mTxPacketCount++;
         }
@@ -490,6 +489,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
             mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
+        characteristic[0] = headerFlags.Raw();
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send first fragment:");
         PrintBufDebug(data);
     }
@@ -510,16 +510,16 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         mTxBuf->SetStart(characteristic);
         uint8_t cursor = 1; // first position past header flags byte
 
-        characteristic[0] = kHeaderFlag_ContinueMessage;
+        BitFlags<HeaderFlags> headerFlags(HeaderFlags::kContinueMessage);
 
 #if CHIP_ENABLE_CHIPOBLE_TEST
         if (TxPacketType() == kType_Control)
-            SetFlag(characteristic[0], kHeaderFlag_CommandMessage, true);
+            headerFlags.Set(HeaderFlags::kCommandMessage);
 #endif
 
         if (send_ack)
         {
-            SetFlag(characteristic[0], kHeaderFlag_FragmentAck, true);
+            headerFlags.Set(HeaderFlags::kFragmentAck);
             characteristic[cursor++] = GetAndRecordRxAckSeqNum();
             ChipLogDebugBtpEngine(Ble, "===> encoded piggybacked ack, ack_num = %u", characteristic[cursor - 1]);
         }
@@ -530,7 +530,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         {
             mTxBuf->SetDataLength(static_cast<uint16_t>(mTxLength + cursor));
             mTxLength = 0;
-            SetFlag(characteristic[0], kHeaderFlag_EndMessage, true);
+            headerFlags.Set(HeaderFlags::kEndMessage);
             mTxState = kState_Complete;
             mTxPacketCount++;
         }
@@ -540,6 +540,7 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
             mTxLength = static_cast<uint16_t>((mTxLength + cursor) - mTxFragmentSize);
         }
 
+        characteristic[0] = headerFlags.Raw();
         ChipLogDebugBtpEngine(Ble, ">>> CHIPoBle preparing to send additional fragment:");
         PrintBufDebug(mTxBuf);
     }

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -87,16 +87,17 @@ public:
         kState_Error      = 3
     } State_t; // [READ-ONLY] Current state
 
-    enum
+    // Masks for BTP fragment header flag bits.
+    enum class HeaderFlags : uint8_t
     {
-        kHeaderFlag_StartMessage    = 0x01,
-        kHeaderFlag_ContinueMessage = 0x02,
-        kHeaderFlag_EndMessage      = 0x04,
-        kHeaderFlag_FragmentAck     = 0x08,
+        kStartMessage    = 0x01,
+        kContinueMessage = 0x02,
+        kEndMessage      = 0x04,
+        kFragmentAck     = 0x08,
 #if CHIP_ENABLE_CHIPOBLE_TEST
-        kHeaderFlag_CommandMessage = 0x10,
+        kCommandMessage = 0x10,
 #endif
-    }; // Masks for BTP fragment header flag bits.
+    };
 
     static const uint16_t sDefaultFragmentSize;
     static const uint16_t sMaxFragmentSize;
@@ -129,7 +130,10 @@ public:
     inline SequenceNumber_t SetRxPacketSeq(SequenceNumber_t seq) { return (mRxPacketSeq = seq); }
     inline SequenceNumber_t TxPacketSeq() { return mTxPacketSeq; }
     inline SequenceNumber_t RxPacketSeq() { return mRxPacketSeq; }
-    inline bool IsCommandPacket(const PacketBufferHandle & p) { return GetFlag(*(p->Start()), kHeaderFlag_CommandMessage); }
+    inline bool IsCommandPacket(const PacketBufferHandle & p)
+    {
+        return BitFlags<HeaderFlags>(*(p->Start())).Has(HeaderFlags::kCommandMessage);
+    }
     inline void PushPacketTag(const PacketBufferHandle & p, PacketType_t type)
     {
         p->SetStart(p->Start() - sizeof(type));

--- a/src/controller/CHIPClusters.cpp
+++ b/src/controller/CHIPClusters.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -148,7 +148,7 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -227,7 +227,7 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -257,7 +257,7 @@ CHIP_ERROR BasicCluster::ResetToFactoryDefaults(Callback::Cancelable * onSuccess
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kResetToFactoryDefaultsCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -319,7 +319,7 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -360,7 +360,7 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -416,7 +416,7 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -458,7 +458,7 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -502,7 +502,7 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -542,7 +542,7 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -583,7 +583,7 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -626,7 +626,7 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -667,7 +667,7 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -710,7 +710,7 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -753,7 +753,7 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -794,7 +794,7 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -838,7 +838,7 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -886,7 +886,7 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -929,7 +929,7 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -971,7 +971,7 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1610,7 +1610,7 @@ CHIP_ERROR ContentLaunchCluster::LaunchContent(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchContentCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1640,7 +1640,7 @@ CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallb
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchURLCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1687,7 +1687,7 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1717,7 +1717,7 @@ CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1748,7 +1748,7 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1781,7 +1781,7 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1814,7 +1814,7 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1847,7 +1847,7 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1883,7 +1883,7 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1919,7 +1919,7 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1952,7 +1952,7 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -1985,7 +1985,7 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2018,7 +2018,7 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2051,7 +2051,7 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2084,7 +2084,7 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2120,7 +2120,7 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2155,7 +2155,7 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2189,7 +2189,7 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2229,7 +2229,7 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2269,7 +2269,7 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2309,7 +2309,7 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2345,7 +2345,7 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2391,7 +2391,7 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2431,7 +2431,7 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2464,7 +2464,7 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2556,7 +2556,7 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2594,7 +2594,7 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2626,7 +2626,7 @@ CHIP_ERROR GeneralCommissioningCluster::SetFabric(Callback::Cancelable * onSucce
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2707,7 +2707,7 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2742,7 +2742,7 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2778,7 +2778,7 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2813,7 +2813,7 @@ CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2844,7 +2844,7 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2877,7 +2877,7 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -2996,7 +2996,7 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3028,7 +3028,7 @@ CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3091,7 +3091,7 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3131,7 +3131,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3172,7 +3172,7 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3208,7 +3208,7 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3244,7 +3244,7 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3286,7 +3286,7 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3324,7 +3324,7 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3358,7 +3358,7 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3475,7 +3475,7 @@ CHIP_ERROR MediaPlaybackCluster::FastForwardRequest(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kFastForwardRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3505,7 +3505,7 @@ CHIP_ERROR MediaPlaybackCluster::NextRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kNextRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3535,7 +3535,7 @@ CHIP_ERROR MediaPlaybackCluster::PauseRequest(Callback::Cancelable * onSuccessCa
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPauseRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3565,7 +3565,7 @@ CHIP_ERROR MediaPlaybackCluster::PlayRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPlayRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3595,7 +3595,7 @@ CHIP_ERROR MediaPlaybackCluster::PreviousRequest(Callback::Cancelable * onSucces
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kPreviousRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3625,7 +3625,7 @@ CHIP_ERROR MediaPlaybackCluster::RewindRequest(Callback::Cancelable * onSuccessC
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRewindRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3656,7 +3656,7 @@ CHIP_ERROR MediaPlaybackCluster::SkipBackwardRequest(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipBackwardRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3687,7 +3687,7 @@ CHIP_ERROR MediaPlaybackCluster::SkipForwardRequest(Callback::Cancelable * onSuc
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipForwardRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3718,7 +3718,7 @@ CHIP_ERROR MediaPlaybackCluster::StartOverRequest(Callback::Cancelable * onSucce
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStartOverRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3748,7 +3748,7 @@ CHIP_ERROR MediaPlaybackCluster::StopRequest(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopRequestCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3805,7 +3805,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3844,7 +3844,7 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3885,7 +3885,7 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3924,7 +3924,7 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3963,7 +3963,7 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -3998,7 +3998,7 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4037,7 +4037,7 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4077,7 +4077,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4116,7 +4116,7 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4172,7 +4172,7 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4202,7 +4202,7 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4232,7 +4232,7 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4301,7 +4301,7 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4347,7 +4347,7 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4380,7 +4380,7 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4418,7 +4418,7 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4451,7 +4451,7 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4486,7 +4486,7 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();
@@ -4521,7 +4521,7 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
     (void) onFailureCallback;
 
     app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
-                                              (chip::app::Command::kCommandPathFlag_EndpointIdValid) };
+                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand             = mDevice->GetCommandSender();
 
     TLV::TLVWriter writer = ZCLcommand->CreateCommandDataElementTLVWriter();

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -143,8 +143,7 @@ void ChipCertificateSet::Clear()
     mCertCount = 0;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipCertLen,
-                                        BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     TLVReader reader;
@@ -161,7 +160,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     ASN1Writer writer; // ASN1Writer is used to encode TBS portion of the certificate for the purpose of signature
@@ -192,8 +191,7 @@ CHIP_ERROR ChipCertificateSet::LoadCert(TLVReader & reader, BitFlags<uint8_t, Ce
 
         // Verify the cert has both the Subject Key Id and Authority Key Id extensions present.
         // Only certs with both these extensions are supported for the purposes of certificate validation.
-        VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_SubjectKeyId) &&
-                         cert->mCertFlags.Has(CertFlags::kExtPresent_AuthKeyId),
+        VerifyOrExit(cert->mCertFlags.HasAll(CertFlags::kExtPresent_SubjectKeyId, CertFlags::kExtPresent_AuthKeyId),
                      err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
         // Verify the cert was signed with ECDSA-SHA256. This is the only signature algorithm currently supported.
@@ -248,8 +246,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen,
-                                         BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     TLVReader reader;
@@ -275,7 +272,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
+CHIP_ERROR ChipCertificateSet::LoadCerts(TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     uint8_t initialCertCount = mCertCount;
@@ -463,7 +460,7 @@ exit:
 }
 
 CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, ValidationContext & context,
-                                            BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth)
+                                            BitFlags<CertValidateFlags> validateFlags, uint8_t depth)
 {
     CHIP_ERROR err               = CHIP_NO_ERROR;
     ChipCertificateData * caCert = nullptr;
@@ -499,19 +496,19 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
     {
         // If a set of desired key usages has been specified, verify that the key usage extension exists
         // in the certificate and that the corresponding usages are supported.
-        if (context.mRequiredKeyUsages.Raw() != 0)
+        if (context.mRequiredKeyUsages.HasAny())
         {
             VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_KeyUsage) &&
-                             cert->mKeyUsageFlags.Has(context.mRequiredKeyUsages.Raw()),
+                             cert->mKeyUsageFlags.HasAll(context.mRequiredKeyUsages),
                          err = CHIP_ERROR_CERT_USAGE_NOT_ALLOWED);
         }
 
         // If a set of desired key purposes has been specified, verify that the extended key usage extension
         // exists in the certificate and that the corresponding purposes are supported.
-        if (context.mRequiredKeyPurposes.Raw() != 0)
+        if (context.mRequiredKeyPurposes.HasAny())
         {
             VerifyOrExit(cert->mCertFlags.Has(CertFlags::kExtPresent_ExtendedKeyUsage) &&
-                             cert->mKeyPurposeFlags.Has(context.mRequiredKeyPurposes.Raw()),
+                             cert->mKeyPurposeFlags.HasAll(context.mRequiredKeyPurposes),
                          err = CHIP_ERROR_CERT_USAGE_NOT_ALLOWED);
         }
 
@@ -577,8 +574,8 @@ exit:
 }
 
 CHIP_ERROR ChipCertificateSet::FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId,
-                                             ValidationContext & context, BitFlags<uint8_t, CertValidateFlags> validateFlags,
-                                             uint8_t depth, ChipCertificateData *& cert)
+                                             ValidationContext & context, BitFlags<CertValidateFlags> validateFlags, uint8_t depth,
+                                             ChipCertificateData *& cert)
 {
     CHIP_ERROR err;
 
@@ -646,9 +643,9 @@ void ChipCertificateData::Clear()
     mPubKeyCurveOID = 0;
     mPubKeyAlgoOID  = 0;
     mSigAlgoOID     = 0;
-    mCertFlags.SetRaw(0);
-    mKeyUsageFlags.SetRaw(0);
-    mKeyPurposeFlags.SetRaw(0);
+    mCertFlags.ClearAll();
+    mKeyUsageFlags.ClearAll();
+    mKeyPurposeFlags.ClearAll();
     mPathLenConstraint = 0;
     mCertType          = kCertType_NotSpecified;
     mSignature.R       = nullptr;
@@ -663,9 +660,9 @@ void ValidationContext::Reset()
     mEffectiveTime = 0;
     mTrustAnchor   = nullptr;
     mSigningCert   = nullptr;
-    mRequiredKeyUsages.SetRaw(0);
-    mRequiredKeyPurposes.SetRaw(0);
-    mValidateFlags.SetRaw(0);
+    mRequiredKeyUsages.ClearAll();
+    mRequiredKeyPurposes.ClearAll();
+    mValidateFlags.ClearAll();
     mRequiredCertType = kCertType_NotSpecified;
 }
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -241,22 +241,22 @@ struct ChipCertificateData
 
     void Clear();
 
-    ChipDN mSubjectDN;                                   /**< Certificate Subject DN. */
-    ChipDN mIssuerDN;                                    /**< Certificate Issuer DN. */
-    CertificateKeyId mSubjectKeyId;                      /**< Certificate Subject public key identifier. */
-    CertificateKeyId mAuthKeyId;                         /**< Certificate Authority public key identifier. */
-    uint32_t mNotBeforeTime;                             /**< Certificate validity: Not Before field. */
-    uint32_t mNotAfterTime;                              /**< Certificate validity: Not After field. */
-    const uint8_t * mPublicKey;                          /**< Pointer to the certificate public key. */
-    uint8_t mPublicKeyLen;                               /**< Certificate public key length. */
-    uint16_t mPubKeyCurveOID;                            /**< Public key Elliptic Curve CHIP OID. */
-    uint16_t mPubKeyAlgoOID;                             /**< Public key algorithm CHIP OID. */
-    uint16_t mSigAlgoOID;                                /**< Certificate signature algorithm CHIP OID. */
-    BitFlags<uint16_t, CertFlags> mCertFlags;            /**< Certificate data flags. */
-    BitFlags<uint16_t, KeyUsageFlags> mKeyUsageFlags;    /**< Certificate key usage extensions flags. */
-    BitFlags<uint8_t, KeyPurposeFlags> mKeyPurposeFlags; /**< Certificate extended key usage extensions flags. */
-    uint8_t mPathLenConstraint;                          /**< Basic constraint: path length. */
-    uint8_t mCertType;                                   /**< Certificate type. */
+    ChipDN mSubjectDN;                          /**< Certificate Subject DN. */
+    ChipDN mIssuerDN;                           /**< Certificate Issuer DN. */
+    CertificateKeyId mSubjectKeyId;             /**< Certificate Subject public key identifier. */
+    CertificateKeyId mAuthKeyId;                /**< Certificate Authority public key identifier. */
+    uint32_t mNotBeforeTime;                    /**< Certificate validity: Not Before field. */
+    uint32_t mNotAfterTime;                     /**< Certificate validity: Not After field. */
+    const uint8_t * mPublicKey;                 /**< Pointer to the certificate public key. */
+    uint8_t mPublicKeyLen;                      /**< Certificate public key length. */
+    uint16_t mPubKeyCurveOID;                   /**< Public key Elliptic Curve CHIP OID. */
+    uint16_t mPubKeyAlgoOID;                    /**< Public key algorithm CHIP OID. */
+    uint16_t mSigAlgoOID;                       /**< Certificate signature algorithm CHIP OID. */
+    BitFlags<CertFlags> mCertFlags;             /**< Certificate data flags. */
+    BitFlags<KeyUsageFlags> mKeyUsageFlags;     /**< Certificate key usage extensions flags. */
+    BitFlags<KeyPurposeFlags> mKeyPurposeFlags; /**< Certificate extended key usage extensions flags. */
+    uint8_t mPathLenConstraint;                 /**< Basic constraint: path length. */
+    uint8_t mCertType;                          /**< Certificate type. */
     struct
     {
         const uint8_t * R; /**< Pointer to the R element of the signature, encoded as ASN.1 DER Integer. */
@@ -275,16 +275,16 @@ struct ChipCertificateData
  */
 struct ValidationContext
 {
-    uint32_t mEffectiveTime;                                 /**< Current CHIP Epoch UTC time. */
-    const ChipCertificateData * mTrustAnchor;                /**< Pointer to the Trust Anchor Certificate data structure. */
-    const ChipCertificateData * mSigningCert;                /**< Pointer to the Signing Certificate data structure. */
-    BitFlags<uint16_t, KeyUsageFlags> mRequiredKeyUsages;    /**< Key usage extensions that should be present in the
-                                                                validated certificate. */
-    BitFlags<uint8_t, KeyPurposeFlags> mRequiredKeyPurposes; /**< Extended Key usage extensions that should be present
-                                                                in the validated certificate. */
-    BitFlags<uint8_t, CertValidateFlags> mValidateFlags;     /**< Certificate validation flags, specifying how a certificate
-                                                                should be validated. */
-    uint8_t mRequiredCertType;                               /**< Required certificate type. */
+    uint32_t mEffectiveTime;                        /**< Current CHIP Epoch UTC time. */
+    const ChipCertificateData * mTrustAnchor;       /**< Pointer to the Trust Anchor Certificate data structure. */
+    const ChipCertificateData * mSigningCert;       /**< Pointer to the Signing Certificate data structure. */
+    BitFlags<KeyUsageFlags> mRequiredKeyUsages;     /**< Key usage extensions that should be present in the
+                                                       validated certificate. */
+    BitFlags<KeyPurposeFlags> mRequiredKeyPurposes; /**< Extended Key usage extensions that should be present
+                                                       in the validated certificate. */
+    BitFlags<CertValidateFlags> mValidateFlags;     /**< Certificate validation flags, specifying how a certificate
+                                                       should be validated. */
+    uint8_t mRequiredCertType;                      /**< Required certificate type. */
 
     void Reset();
 };
@@ -350,7 +350,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCert(const uint8_t * chipCert, uint32_t chipCertLen, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificate into set.
@@ -363,7 +363,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCert(chip::TLV::TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCert(chip::TLV::TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificates into set.
@@ -377,7 +377,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCerts(const uint8_t * chipCerts, uint32_t chipCertsLen, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Load CHIP certificates into set.
@@ -391,7 +391,7 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR LoadCerts(chip::TLV::TLVReader & reader, BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
+    CHIP_ERROR LoadCerts(chip::TLV::TLVReader & reader, BitFlags<CertDecodeFlags> decodeFlags);
 
     /**
      * @brief Add trusted anchor key to the certificate set.
@@ -505,7 +505,7 @@ private:
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR FindValidCert(const ChipDN & subjectDN, const CertificateKeyId & subjectKeyId, ValidationContext & context,
-                             BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth, ChipCertificateData *& cert);
+                             BitFlags<CertValidateFlags> validateFlags, uint8_t depth, ChipCertificateData *& cert);
 
     /**
      * @brief Validate CHIP certificate.
@@ -518,7 +518,7 @@ private:
      * @return Returns a CHIP_ERROR on validation or other error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR ValidateCert(const ChipCertificateData * cert, ValidationContext & context,
-                            BitFlags<uint8_t, CertValidateFlags> validateFlags, uint8_t depth);
+                            BitFlags<CertValidateFlags> validateFlags, uint8_t depth);
 };
 
 /**

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -363,8 +363,7 @@ static CHIP_ERROR ConvertExtension(ASN1Reader & reader, TLVWriter & writer)
                 VerifyOrExit(keyUsageBits <= UINT16_MAX, err = ASN1_ERROR_INVALID_ENCODING);
 
                 // Check that only supported flags are set.
-                BitFlags<uint16_t, KeyUsageFlags> keyUsageFlags;
-                keyUsageFlags.SetRaw(static_cast<uint16_t>(keyUsageBits));
+                BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
                 VerifyOrExit(keyUsageFlags.HasOnly(
                                  KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation, KeyUsageFlags::kKeyEncipherment,
                                  KeyUsageFlags::kDataEncipherment, KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign,

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -382,7 +382,6 @@ static CHIP_ERROR DecodeConvertKeyUsageExtension(TLVReader & reader, ASN1Writer 
 {
     CHIP_ERROR err;
     uint64_t keyUsageBits;
-    BitFlags<uint16_t, KeyUsageFlags> keyUsageFlags;
 
     certData.mCertFlags.Set(CertFlags::kExtPresent_KeyUsage);
 
@@ -395,16 +394,18 @@ static CHIP_ERROR DecodeConvertKeyUsageExtension(TLVReader & reader, ASN1Writer 
 
     VerifyOrExit(keyUsageBits <= UINT16_MAX, err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
-    keyUsageFlags.SetRaw(static_cast<uint16_t>(keyUsageBits));
-    VerifyOrExit(keyUsageFlags.HasOnly(KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation,
-                                       KeyUsageFlags::kKeyEncipherment, KeyUsageFlags::kDataEncipherment,
-                                       KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign, KeyUsageFlags::kCRLSign,
-                                       KeyUsageFlags::kEncipherOnly, KeyUsageFlags::kEncipherOnly),
-                 err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
+    {
+        BitFlags<KeyUsageFlags> keyUsageFlags(static_cast<uint16_t>(keyUsageBits));
+        VerifyOrExit(keyUsageFlags.HasOnly(KeyUsageFlags::kDigitalSignature, KeyUsageFlags::kNonRepudiation,
+                                           KeyUsageFlags::kKeyEncipherment, KeyUsageFlags::kDataEncipherment,
+                                           KeyUsageFlags::kKeyAgreement, KeyUsageFlags::kKeyCertSign, KeyUsageFlags::kCRLSign,
+                                           KeyUsageFlags::kEncipherOnly, KeyUsageFlags::kEncipherOnly),
+                     err = CHIP_ERROR_UNSUPPORTED_CERT_FORMAT);
 
-    ASN1_ENCODE_BIT_STRING(static_cast<uint16_t>(keyUsageBits));
+        ASN1_ENCODE_BIT_STRING(static_cast<uint16_t>(keyUsageBits));
 
-    certData.mKeyUsageFlags = keyUsageFlags;
+        certData.mKeyUsageFlags = keyUsageFlags;
+    }
 
 exit:
     return err;

--- a/src/credentials/tests/CHIPCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPCert_test_vectors.cpp
@@ -46,7 +46,7 @@ extern const uint8_t gTestCerts[] = {
 
 extern const size_t gNumTestCerts = sizeof(gTestCerts) / sizeof(gTestCerts[0]);
 
-CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
+CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
                        uint32_t & certDataLen)
 {
     CHIP_ERROR err;
@@ -103,8 +103,8 @@ const char * GetTestCertName(uint8_t certType)
     return nullptr;
 }
 
-CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags,
-                        BitFlags<uint8_t, CertDecodeFlags> decodeFlags)
+CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,
+                        BitFlags<CertDecodeFlags> decodeFlags)
 {
     CHIP_ERROR err;
     ChipCertificateData * cert;

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -28,6 +28,7 @@
 
 #include <asn1/ASN1OID.h>
 #include <core/CHIPConfig.h>
+#include <support/BitFlags.h>
 #include <support/CodeUtils.h>
 
 namespace chip {
@@ -58,11 +59,11 @@ enum class TestCertLoadFlags : uint8_t
     kSetAppDefinedCertType = 0x20,
 };
 
-extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
+extern CHIP_ERROR GetTestCert(uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags, const uint8_t *& certData,
                               uint32_t & certDataLen);
 extern const char * GetTestCertName(uint8_t certType);
-extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<uint8_t, TestCertLoadFlags> certLoadFlags,
-                               BitFlags<uint8_t, CertDecodeFlags> decodeFlags);
+extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, uint8_t certType, BitFlags<TestCertLoadFlags> certLoadFlags,
+                               BitFlags<CertDecodeFlags> decodeFlags);
 
 extern const uint8_t gTestCerts[];
 extern const size_t gNumTestCerts;

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -48,59 +48,59 @@ enum
                                 // (in either CHIP or DER form), or to decode the certificates.
 };
 
-static const BitFlags<uint8_t, CertValidateFlags> sIgnoreNotBeforeFlag(CertValidateFlags::kIgnoreNotBefore);
-static const BitFlags<uint8_t, CertValidateFlags> sIgnoreNotAfterFlag(CertValidateFlags::kIgnoreNotAfter);
+static const BitFlags<CertValidateFlags> sIgnoreNotBeforeFlag(CertValidateFlags::kIgnoreNotBefore);
+static const BitFlags<CertValidateFlags> sIgnoreNotAfterFlag(CertValidateFlags::kIgnoreNotAfter);
 
-static const BitFlags<uint8_t, CertDecodeFlags> sNullDecodeFlag;
-static const BitFlags<uint8_t, CertDecodeFlags> sGenTBSHashFlag(CertDecodeFlags::kGenerateTBSHash);
-static const BitFlags<uint8_t, CertDecodeFlags> sTrustAnchorFlag(CertDecodeFlags::kIsTrustAnchor);
+static const BitFlags<CertDecodeFlags> sNullDecodeFlag;
+static const BitFlags<CertDecodeFlags> sGenTBSHashFlag(CertDecodeFlags::kGenerateTBSHash);
+static const BitFlags<CertDecodeFlags> sTrustAnchorFlag(CertDecodeFlags::kIsTrustAnchor);
 
-static const BitFlags<uint8_t, TestCertLoadFlags> sNullLoadFlag;
-static const BitFlags<uint8_t, TestCertLoadFlags> sDerFormFlag(TestCertLoadFlags::kDERForm);
-static const BitFlags<uint8_t, TestCertLoadFlags> sSupIsCAFlag(TestCertLoadFlags::kSuppressIsCA);
-static const BitFlags<uint8_t, TestCertLoadFlags> sSupKeyUsageFlag(TestCertLoadFlags::kSuppressKeyUsage);
-static const BitFlags<uint8_t, TestCertLoadFlags> sSupKeyCertSignFlag(TestCertLoadFlags::kSuppressKeyCertSign);
-static const BitFlags<uint8_t, TestCertLoadFlags> sPathLenZeroFlag(TestCertLoadFlags::kSetPathLenConstZero);
-static const BitFlags<uint8_t, TestCertLoadFlags> sAppDefCertTypeFlag(TestCertLoadFlags::kSetAppDefinedCertType);
+static const BitFlags<TestCertLoadFlags> sNullLoadFlag;
+static const BitFlags<TestCertLoadFlags> sDerFormFlag(TestCertLoadFlags::kDERForm);
+static const BitFlags<TestCertLoadFlags> sSupIsCAFlag(TestCertLoadFlags::kSuppressIsCA);
+static const BitFlags<TestCertLoadFlags> sSupKeyUsageFlag(TestCertLoadFlags::kSuppressKeyUsage);
+static const BitFlags<TestCertLoadFlags> sSupKeyCertSignFlag(TestCertLoadFlags::kSuppressKeyCertSign);
+static const BitFlags<TestCertLoadFlags> sPathLenZeroFlag(TestCertLoadFlags::kSetPathLenConstZero);
+static const BitFlags<TestCertLoadFlags> sAppDefCertTypeFlag(TestCertLoadFlags::kSetAppDefinedCertType);
 
-static const BitFlags<uint8_t, KeyPurposeFlags> sNullKPFlag;
-static const BitFlags<uint8_t, KeyPurposeFlags> sSA(KeyPurposeFlags::kServerAuth);
-static const BitFlags<uint8_t, KeyPurposeFlags> sCA(KeyPurposeFlags::kClientAuth);
-static const BitFlags<uint8_t, KeyPurposeFlags> sCS(KeyPurposeFlags::kCodeSigning);
-static const BitFlags<uint8_t, KeyPurposeFlags> sEP(KeyPurposeFlags::kEmailProtection);
-static const BitFlags<uint8_t, KeyPurposeFlags> sTS(KeyPurposeFlags::kTimeStamping);
-static const BitFlags<uint8_t, KeyPurposeFlags> sOS(KeyPurposeFlags::kOCSPSigning);
-static const BitFlags<uint8_t, KeyPurposeFlags> sSAandCA(sSA.Raw() | sCA.Raw());
-static const BitFlags<uint8_t, KeyPurposeFlags> sSAandCS(sSA.Raw() | sCS.Raw());
-static const BitFlags<uint8_t, KeyPurposeFlags> sSAandEP(sSA.Raw() | sEP.Raw());
-static const BitFlags<uint8_t, KeyPurposeFlags> sSAandTS(sSA.Raw() | sTS.Raw());
+static const BitFlags<KeyPurposeFlags> sNullKPFlag;
+static const BitFlags<KeyPurposeFlags> sSA(KeyPurposeFlags::kServerAuth);
+static const BitFlags<KeyPurposeFlags> sCA(KeyPurposeFlags::kClientAuth);
+static const BitFlags<KeyPurposeFlags> sCS(KeyPurposeFlags::kCodeSigning);
+static const BitFlags<KeyPurposeFlags> sEP(KeyPurposeFlags::kEmailProtection);
+static const BitFlags<KeyPurposeFlags> sTS(KeyPurposeFlags::kTimeStamping);
+static const BitFlags<KeyPurposeFlags> sOS(KeyPurposeFlags::kOCSPSigning);
+static const BitFlags<KeyPurposeFlags> sSAandCA(sSA, sCA);
+static const BitFlags<KeyPurposeFlags> sSAandCS(sSA, sCS);
+static const BitFlags<KeyPurposeFlags> sSAandEP(sSA, sEP);
+static const BitFlags<KeyPurposeFlags> sSAandTS(sSA, sTS);
 
-static const BitFlags<uint16_t, KeyUsageFlags> sNullKUFlag;
-static const BitFlags<uint16_t, KeyUsageFlags> sDS(KeyUsageFlags::kDigitalSignature);
-static const BitFlags<uint16_t, KeyUsageFlags> sNR(KeyUsageFlags::kNonRepudiation);
-static const BitFlags<uint16_t, KeyUsageFlags> sKE(KeyUsageFlags::kKeyEncipherment);
-static const BitFlags<uint16_t, KeyUsageFlags> sDE(KeyUsageFlags::kDataEncipherment);
-static const BitFlags<uint16_t, KeyUsageFlags> sKA(KeyUsageFlags::kKeyAgreement);
-static const BitFlags<uint16_t, KeyUsageFlags> sKC(KeyUsageFlags::kKeyCertSign);
-static const BitFlags<uint16_t, KeyUsageFlags> sCR(KeyUsageFlags::kCRLSign);
-static const BitFlags<uint16_t, KeyUsageFlags> sEO(KeyUsageFlags::kEncipherOnly);
-static const BitFlags<uint16_t, KeyUsageFlags> sDO(KeyUsageFlags::kDecipherOnly);
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandNR(sDS.Raw() | sNR.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandKE(sDS.Raw() | sKE.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandDE(sDS.Raw() | sDE.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandKA(sDS.Raw() | sKA.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandKC(sDS.Raw() | sKC.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandCR(sDS.Raw() | sCR.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandEO(sDS.Raw() | sEO.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sDSandDO(sDS.Raw() | sDO.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandDS(sKC.Raw() | sDS.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandNR(sKC.Raw() | sNR.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandKE(sKC.Raw() | sKE.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandDE(sKC.Raw() | sDE.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandKA(sKC.Raw() | sKA.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandCR(sKC.Raw() | sCR.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandEO(sKC.Raw() | sEO.Raw());
-static const BitFlags<uint16_t, KeyUsageFlags> sKCandDO(sKC.Raw() | sDO.Raw());
+static const BitFlags<KeyUsageFlags> sNullKUFlag;
+static const BitFlags<KeyUsageFlags> sDS(KeyUsageFlags::kDigitalSignature);
+static const BitFlags<KeyUsageFlags> sNR(KeyUsageFlags::kNonRepudiation);
+static const BitFlags<KeyUsageFlags> sKE(KeyUsageFlags::kKeyEncipherment);
+static const BitFlags<KeyUsageFlags> sDE(KeyUsageFlags::kDataEncipherment);
+static const BitFlags<KeyUsageFlags> sKA(KeyUsageFlags::kKeyAgreement);
+static const BitFlags<KeyUsageFlags> sKC(KeyUsageFlags::kKeyCertSign);
+static const BitFlags<KeyUsageFlags> sCR(KeyUsageFlags::kCRLSign);
+static const BitFlags<KeyUsageFlags> sEO(KeyUsageFlags::kEncipherOnly);
+static const BitFlags<KeyUsageFlags> sDO(KeyUsageFlags::kDecipherOnly);
+static const BitFlags<KeyUsageFlags> sDSandNR(sDS, sNR);
+static const BitFlags<KeyUsageFlags> sDSandKE(sDS, sKE);
+static const BitFlags<KeyUsageFlags> sDSandDE(sDS, sDE);
+static const BitFlags<KeyUsageFlags> sDSandKA(sDS, sKA);
+static const BitFlags<KeyUsageFlags> sDSandKC(sDS, sKC);
+static const BitFlags<KeyUsageFlags> sDSandCR(sDS, sCR);
+static const BitFlags<KeyUsageFlags> sDSandEO(sDS, sEO);
+static const BitFlags<KeyUsageFlags> sDSandDO(sDS, sDO);
+static const BitFlags<KeyUsageFlags> sKCandDS(sKC, sDS);
+static const BitFlags<KeyUsageFlags> sKCandNR(sKC, sNR);
+static const BitFlags<KeyUsageFlags> sKCandKE(sKC, sKE);
+static const BitFlags<KeyUsageFlags> sKCandDE(sKC, sDE);
+static const BitFlags<KeyUsageFlags> sKCandKA(sKC, sKA);
+static const BitFlags<KeyUsageFlags> sKCandCR(sKC, sCR);
+static const BitFlags<KeyUsageFlags> sKCandEO(sKC, sEO);
+static const BitFlags<KeyUsageFlags> sKCandDO(sKC, sDO);
 
 static CHIP_ERROR LoadStandardCerts(ChipCertificateSet & certSet)
 {
@@ -207,8 +207,8 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
         struct
         {
             uint8_t Type;
-            BitFlags<uint8_t, CertDecodeFlags> DecodeFlags;
-            BitFlags<uint8_t, TestCertLoadFlags> LoadFlags;
+            BitFlags<CertDecodeFlags> DecodeFlags;
+            BitFlags<TestCertLoadFlags> LoadFlags;
         } InputCerts[kMaxCertsPerTestCase];
     };
 
@@ -475,8 +475,8 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
     struct UsageTestCase
     {
         uint8_t mCertIndex;
-        BitFlags<uint16_t, KeyUsageFlags> mRequiredKeyUsages;
-        BitFlags<uint8_t, KeyPurposeFlags> mRequiredKeyPurposes;
+        BitFlags<KeyUsageFlags> mRequiredKeyUsages;
+        BitFlags<KeyPurposeFlags> mRequiredKeyPurposes;
         CHIP_ERROR mExpectedResult;
     };
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019-2020 Google LLC.
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
@@ -50,15 +50,14 @@ namespace Internal {
 template <class ImplClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_Init()
 {
-    mFlags = 0;
-
     // Cache flags indicating whether the device is currently service provisioned, is a member of a fabric,
     // is paired to an account, and/or provisioned with operational credentials.
-    SetFlag(mFlags, kFlag_IsServiceProvisioned, Impl()->ConfigValueExists(ImplClass::kConfigKey_ServiceConfig));
-    SetFlag(mFlags, kFlag_IsMemberOfFabric, Impl()->ConfigValueExists(ImplClass::kConfigKey_FabricId));
-    SetFlag(mFlags, kFlag_IsPairedToAccount, Impl()->ConfigValueExists(ImplClass::kConfigKey_PairedAccountId));
-    SetFlag(mFlags, kFlag_OperationalDeviceCredentialsProvisioned,
-            Impl()->ConfigValueExists(ImplClass::kConfigKey_OperationalDeviceCert));
+    mFlags.ClearAll()
+        .Set(Flags::kIsServiceProvisioned, Impl()->ConfigValueExists(ImplClass::kConfigKey_ServiceConfig))
+        .Set(Flags::kIsMemberOfFabric, Impl()->ConfigValueExists(ImplClass::kConfigKey_FabricId))
+        .Set(Flags::kIsPairedToAccount, Impl()->ConfigValueExists(ImplClass::kConfigKey_PairedAccountId))
+        .Set(Flags::kOperationalDeviceCredentialsProvisioned,
+             Impl()->ConfigValueExists(ImplClass::kConfigKey_OperationalDeviceCert));
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     mLifetimePersistedCounter.Init(CHIP_CONFIG_LIFETIIME_PERSISTED_COUNTER_KEY);
@@ -524,7 +523,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ClearOperationalDeviceCr
     Impl()->ClearConfigValue(ImplClass::kConfigKey_OperationalDeviceICACerts);
     Impl()->ClearConfigValue(ImplClass::kConfigKey_OperationalDevicePrivateKey);
 
-    ClearFlag(mFlags, kFlag_OperationalDeviceCredentialsProvisioned);
+    mFlags.Clear(Flags::kOperationalDeviceCredentialsProvisioned);
 
     return CHIP_NO_ERROR;
 }
@@ -532,19 +531,19 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ClearOperationalDeviceCr
 template <class ImplClass>
 bool GenericConfigurationManagerImpl<ImplClass>::_OperationalDeviceCredentialsProvisioned()
 {
-    return ::chip::GetFlag(mFlags, kFlag_OperationalDeviceCredentialsProvisioned);
+    return mFlags.Has(Flags::kOperationalDeviceCredentialsProvisioned);
 }
 
 template <class ImplClass>
 bool GenericConfigurationManagerImpl<ImplClass>::UseManufacturerCredentialsAsOperational()
 {
-    return ::chip::GetFlag(mFlags, kFlag_UseManufacturerCredentialsAsOperational);
+    return mFlags.Has(Flags::kUseManufacturerCredentialsAsOperational);
 }
 
 template <class ImplClass>
 void GenericConfigurationManagerImpl<ImplClass>::_UseManufacturerCredentialsAsOperational(bool val)
 {
-    SetFlag(mFlags, kFlag_UseManufacturerCredentialsAsOperational, val);
+    mFlags.Set(Flags::kUseManufacturerCredentialsAsOperational, val);
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
@@ -627,11 +626,11 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreFabricId(uint64_t f
     {
         err = Impl()->WriteConfigValue(ImplClass::kConfigKey_FabricId, fabricId);
         SuccessOrExit(err);
-        SetFlag(mFlags, kFlag_IsMemberOfFabric);
+        mFlags.Set(Flags::kIsMemberOfFabric);
     }
     else
     {
-        ClearFlag(mFlags, kFlag_IsMemberOfFabric);
+        mFlags.Clear(Flags::kIsMemberOfFabric);
         err = Impl()->ClearConfigValue(ImplClass::kConfigKey_FabricId);
         SuccessOrExit(err);
     }
@@ -689,7 +688,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePairedAccountId(con
     err = Impl()->WriteConfigValueStr(ImplClass::kConfigKey_PairedAccountId, accountId, accountIdLen);
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
+    mFlags.Set(Flags::kIsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
 
 exit:
     return err;
@@ -712,8 +711,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_StoreServiceProvisioning
     err = _StorePairedAccountId(accountId, accountIdLen);
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_IsServiceProvisioned);
-    SetFlag(mFlags, kFlag_IsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
+    mFlags.Set(Flags::kIsServiceProvisioned);
+    mFlags.Set(Flags::kIsPairedToAccount, (accountId != nullptr && accountIdLen != 0));
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -721,8 +720,8 @@ exit:
         Impl()->ClearConfigValue(ImplClass::kConfigKey_ServiceId);
         Impl()->ClearConfigValue(ImplClass::kConfigKey_ServiceConfig);
         Impl()->ClearConfigValue(ImplClass::kConfigKey_PairedAccountId);
-        ClearFlag(mFlags, kFlag_IsServiceProvisioned);
-        ClearFlag(mFlags, kFlag_IsPairedToAccount);
+        mFlags.Clear(Flags::kIsServiceProvisioned);
+        mFlags.Clear(Flags::kIsPairedToAccount);
     }
     return err;
 }
@@ -757,8 +756,8 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::_ClearServiceProvisioning
         PlatformMgr().PostEvent(&event);
     }
 
-    ClearFlag(mFlags, kFlag_IsServiceProvisioned);
-    ClearFlag(mFlags, kFlag_IsPairedToAccount);
+    mFlags.Clear(Flags::kIsServiceProvisioned);
+    mFlags.Clear(Flags::kIsPairedToAccount);
 
     return CHIP_NO_ERROR;
 }
@@ -851,19 +850,19 @@ exit:
 template <class ImplClass>
 bool GenericConfigurationManagerImpl<ImplClass>::_IsServiceProvisioned()
 {
-    return ::chip::GetFlag(mFlags, kFlag_IsServiceProvisioned);
+    return mFlags.Has(Flags::kIsServiceProvisioned);
 }
 
 template <class ImplClass>
 bool GenericConfigurationManagerImpl<ImplClass>::_IsMemberOfFabric()
 {
-    return ::chip::GetFlag(mFlags, kFlag_IsMemberOfFabric);
+    return mFlags.Has(Flags::kIsMemberOfFabric);
 }
 
 template <class ImplClass>
 bool GenericConfigurationManagerImpl<ImplClass>::_IsPairedToAccount()
 {
-    return ::chip::GetFlag(mFlags, kFlag_IsPairedToAccount);
+    return mFlags.Has(Flags::kIsPairedToAccount);
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019-2020 Google LLC.
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
@@ -24,6 +24,8 @@
  */
 
 #pragma once
+
+#include <support/BitFlags.h>
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
 #include <support/LifetimePersistedCounter.h>
@@ -125,16 +127,16 @@ public:
     void _LogDeviceConfig();
 
 protected:
-    enum
+    enum class Flags : uint8_t
     {
-        kFlag_IsServiceProvisioned                    = 0x01,
-        kFlag_IsMemberOfFabric                        = 0x02,
-        kFlag_IsPairedToAccount                       = 0x04,
-        kFlag_OperationalDeviceCredentialsProvisioned = 0x08,
-        kFlag_UseManufacturerCredentialsAsOperational = 0x10,
+        kIsServiceProvisioned                    = 0x01,
+        kIsMemberOfFabric                        = 0x02,
+        kIsPairedToAccount                       = 0x04,
+        kOperationalDeviceCredentialsProvisioned = 0x08,
+        kUseManufacturerCredentialsAsOperational = 0x10,
     };
 
-    uint8_t mFlags;
+    BitFlags<Flags> mFlags;
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     chip::LifetimePersistedCounter mLifetimePersistedCounter;
 #endif

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.cpp
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ void GenericConnectivityManagerImpl_Thread<ImplClass>::_OnPlatformEvent(const Ch
 template <class ImplClass>
 ConnectivityManager::ThreadMode GenericConnectivityManagerImpl_Thread<ImplClass>::_GetThreadMode()
 {
-    if (GetFlag(mFlags, kFlag_IsApplicationControlled))
+    if (mFlags.Has(Flags::kIsApplicationControlled))
     {
         return ConnectivityManager::kThreadMode_ApplicationControlled;
     }
@@ -75,11 +75,11 @@ CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadMode(Conn
 
     if (val == ConnectivityManager::kThreadMode_ApplicationControlled)
     {
-        SetFlag(mFlags, kFlag_IsApplicationControlled);
+        mFlags.Set(Flags::kIsApplicationControlled);
     }
     else
     {
-        ClearFlag(mFlags, kFlag_IsApplicationControlled);
+        mFlags.Clear(Flags::kIsApplicationControlled);
 
         err = ThreadStackMgrImpl().SetThreadEnabled(val == ConnectivityManager::kThreadMode_Enabled);
         SuccessOrExit(err);
@@ -92,15 +92,15 @@ exit:
 template <class ImplClass>
 void GenericConnectivityManagerImpl_Thread<ImplClass>::UpdateServiceConnectivity()
 {
-    bool haveServiceConnectivity = false;
+    constexpr bool haveServiceConnectivity = false;
 
     // If service connectivity via Thread has changed, post an event signaling the change.
-    if (GetFlag(mFlags, kFlag_HaveServiceConnectivity) != haveServiceConnectivity)
+    if (mFlags.Has(Flags::kHaveServiceConnectivity) != haveServiceConnectivity)
     {
         ChipLogProgress(DeviceLayer, "ConnectivityManager: Service connectivity via Thread %s",
                         (haveServiceConnectivity) ? "ESTABLISHED" : "LOST");
 
-        SetFlag(mFlags, kFlag_HaveServiceConnectivity, haveServiceConnectivity);
+        mFlags.Set(Flags::kHaveServiceConnectivity, haveServiceConnectivity);
 
         {
             ChipDeviceEvent event;

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,9 @@
 #pragma once
 
 #include <platform/ThreadStackManager.h>
+#include <support/BitFlags.h>
+
+#include <cstdint>
 
 namespace chip {
 namespace DeviceLayer {
@@ -73,13 +76,13 @@ protected:
 private:
     // ===== Private members reserved for use by this class only.
 
-    enum Flags
+    enum class Flags : uint8_t
     {
-        kFlag_HaveServiceConnectivity = 0x01,
-        kFlag_IsApplicationControlled = 0x02
+        kHaveServiceConnectivity = 0x01,
+        kIsApplicationControlled = 0x02
     };
 
-    uint8_t mFlags;
+    BitFlags<Flags> mFlags;
 
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 };
@@ -87,7 +90,7 @@ private:
 template <class ImplClass>
 inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_Init()
 {
-    mFlags = 0;
+    mFlags.ClearAll();
 }
 
 template <class ImplClass>
@@ -99,7 +102,7 @@ inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_IsThreadEnabled()
 template <class ImplClass>
 inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_IsThreadApplicationControlled()
 {
-    return GetFlag(mFlags, kFlag_IsApplicationControlled);
+    return mFlags.Has(Flags::kIsApplicationControlled);
 }
 
 template <class ImplClass>
@@ -150,7 +153,7 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadPo
 template <class ImplClass>
 inline bool GenericConnectivityManagerImpl_Thread<ImplClass>::_HaveServiceConnectivityViaThread()
 {
-    return GetFlag(mFlags, kFlag_HaveServiceConnectivity);
+    return mFlags.Has(Flags::kHaveServiceConnectivity);
 }
 
 } // namespace Internal

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,11 +82,11 @@ public:
     static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
 
 protected:
-    enum Flags
+    enum class ConnectivityFlags : uint16_t
     {
-        kFlag_HaveIPv4InternetConnectivity = 0x0001,
-        kFlag_HaveIPv6InternetConnectivity = 0x0002,
-        kFlag_AwaitingConnectivity         = 0x0010,
+        kHaveIPv4InternetConnectivity = 0x0001,
+        kHaveIPv6InternetConnectivity = 0x0002,
+        kAwaitingConnectivity         = 0x0010,
     };
 
 private:

--- a/src/lib/support/BitFlags.h
+++ b/src/lib/support/BitFlags.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 
+#include <type_traits>
 #include <utility>
 
 namespace chip {
@@ -34,115 +35,217 @@ namespace chip {
 /**
  * Stores bit flags in a type safe manner.
  *
+ * @tparam FlagsEnum is an `enum` or (preferably) `enum class` type.
  * @tparam StorageType is the underlying storage type (like uint16_t, uint32_t etc.)
- * @tparam FlagsEnum is the typesafe flags setting
+ *         and defaults to the underlying storage type of `FlagsEnum`.
  */
-template <typename StorageType, typename FlagsEnum>
+template <typename FlagsEnum, typename StorageType = typename std::underlying_type_t<FlagsEnum>>
 class BitFlags
 {
 public:
     static_assert(sizeof(StorageType) >= sizeof(FlagsEnum), "All flags should fit in the storage type");
+    using IntegerType = StorageType;
 
-    BitFlags() {}
-    BitFlags(const BitFlags &) = default;
+    BitFlags() : mValue(0) {}
+    BitFlags(const BitFlags & other) = default;
     BitFlags & operator=(const BitFlags &) = default;
 
-    explicit BitFlags(FlagsEnum v) { Set(v); }
+    explicit BitFlags(FlagsEnum value) : mValue(static_cast<IntegerType>(value)) {}
+    explicit BitFlags(IntegerType value) : mValue(value) {}
 
-    explicit BitFlags(StorageType value) { SetRaw(value); }
+    template <typename... Args>
+    BitFlags(FlagsEnum flag, Args &&... args) : mValue(Or(flag, std::forward<Args>(args)...))
+    {}
 
-    BitFlags & Set(FlagsEnum v)
-    {
-        mValue = static_cast<StorageType>(mValue | static_cast<StorageType>(v));
-        return *this;
-    }
+    template <typename... Args>
+    BitFlags(const BitFlags<FlagsEnum> & flags, Args &&... args) : mValue(Or(flags, std::forward<Args>(args)...))
+    {}
 
-    BitFlags & Clear(FlagsEnum v)
-    {
-        mValue &= static_cast<StorageType>(~static_cast<StorageType>(v));
-        return *this;
-    }
+    template <typename... Args>
+    BitFlags(IntegerType value, Args &&... args) : mValue(value | Or(std::forward<Args>(args)...))
+    {}
 
-    BitFlags & Set(FlagsEnum v, bool isSet) { return isSet ? Set(v) : Clear(v); }
-
-    bool Has(FlagsEnum v) const { return (mValue & static_cast<StorageType>(v)) != 0; }
-
-    bool Has(StorageType other) const { return (mValue & other) == other; }
-
+    /**
+     * Set flag(s).
+     *
+     * @param other     Flag(s) to set. Any flags not set in @a other are unaffected.
+     */
     BitFlags & Set(const BitFlags & other)
     {
         mValue |= other.mValue;
         return *this;
     }
 
-    StorageType Raw() const { return mValue; }
-    BitFlags & SetRaw(StorageType value)
+    /**
+     * Set flag(s).
+     *
+     * @param flag      Typed flag(s) to set. Any flags not in @a v are unaffected.
+     */
+    BitFlags & Set(FlagsEnum flag)
+    {
+        mValue |= static_cast<IntegerType>(flag);
+        return *this;
+    }
+
+    /**
+     * Set or clear flag(s).
+     *
+     * @param flag      Typed flag(s) to set or clear. Any flags not in @a flag are unaffected.
+     * @param isSet     If true, set the flag; if false, clear it.
+     */
+    BitFlags & Set(FlagsEnum flag, bool isSet) { return isSet ? Set(flag) : Clear(flag); }
+
+    /**
+     * Clear flag(s).
+     *
+     * @param other     Typed flag(s) to clear. Any flags not in @a other are unaffected.
+     */
+    BitFlags & Clear(const BitFlags & other)
+    {
+        mValue &= ~other.mValue;
+        return *this;
+    }
+
+    /**
+     * Clear flag(s).
+     *
+     * @param flag  Typed flag(s) to clear. Any flags not in @a flag are unaffected.
+     */
+    BitFlags & Clear(FlagsEnum flag)
+    {
+        mValue &= static_cast<IntegerType>(~static_cast<IntegerType>(flag));
+        return *this;
+    }
+
+    /**
+     * Clear all flags.
+     */
+    BitFlags & ClearAll()
+    {
+        mValue = 0;
+        return *this;
+    }
+
+    /**
+     * Check whether flag(s) are set.
+     *
+     * @param flag      Flag(s) to test.
+     * @returns         True if any flag in @a flag is set, otherwise false.
+     */
+    bool Has(FlagsEnum flag) const { return (mValue & static_cast<IntegerType>(flag)) != 0; }
+
+    /**
+     * Check that no flags outside the arguments are set.
+     *
+     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
+     * @returns         True if no flag is set other than those passed.
+     *                  False if any flag is set other than those passed.
+     *
+     * @note            Flags passed need not be set; this test only requires that no *other* flags be set.
+     */
+    template <typename... Args>
+    bool HasOnly(Args &&... args) const
+    {
+        return (mValue & Or(std::forward<Args>(args)...)) == mValue;
+    }
+
+    /**
+     * Check that all given flags are set.
+     *
+     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
+     * @returns         True if all given flags are set.
+     *                  False if any given flag is not set.
+     */
+    template <typename... Args>
+    bool HasAll(Args &&... args) const
+    {
+        const IntegerType all = Or(std::forward<Args>(args)...);
+        return (mValue & all) == all;
+    }
+
+    /**
+     * Check that at least one of the given flags is set.
+     *
+     * @param args      Flags to test. Arguments can be BitFlags<FlagsEnum>, BitFlags<FlagsEnum>, or FlagsEnum.
+     * @returns         True if all given flags are set.
+     *                  False if any given flag is not set.
+     */
+    template <typename... Args>
+    bool HasAny(Args &&... args) const
+    {
+        return (mValue & Or(std::forward<Args>(args)...)) != 0;
+    }
+
+    /**
+     * Check that at least one flag is set.
+     *
+     * @returns         True if any flag is set, false otherwise.
+     */
+    bool HasAny() const { return mValue != 0; }
+
+    /**
+     * Find the logical intersection of flags.
+     *
+     * @param lhs       Some flags.
+     * @param rhs       Some flags.
+     * @returns         Flags set in both @a lhs and @a rhs.
+     *
+     * @note: A multi-argument `BitFlags` constructor serves the function of `operator|`.
+     */
+    friend BitFlags<FlagsEnum> operator&(BitFlags<FlagsEnum> lhs, const BitFlags<FlagsEnum> & rhs)
+    {
+        return BitFlags<FlagsEnum>(lhs.mValue & rhs.mValue);
+    }
+
+    /**
+     * Get the flags as the type FlagsEnum.
+     *
+     * @note            This allows easily storing flags as a base FlagsEnum in a POD type,
+     *                  and enables equality comparisons.
+     */
+    operator FlagsEnum() const { return static_cast<FlagsEnum>(mValue); }
+
+    /**
+     * Set and/or clear all flags with a value of the underlying storage type.
+     *
+     * @param value     New storage value.
+     */
+    BitFlags & SetRaw(IntegerType value)
     {
         mValue = value;
         return *this;
     }
 
-    /** Check that no flags outside the arguments are set.*/
-    template <typename... Args>
-    bool HasOnly(Args &&... args) const
-    {
-        return IsZeroAfterClearing(mValue, std::forward<Args>(args)...);
-    }
+    /**
+     * Get the flags as the underlying integer type.
+     *
+     * @note            This is intended to be used only to store flags into a raw binary record.
+     */
+    IntegerType Raw() const { return mValue; }
+
+    /**
+     * Get the address of the flags as a pointer to the underlying integer type.
+     *
+     * @note            This is intended to be used only to read flags from a raw binary record.
+     */
+    StorageType * RawStorage() { return &mValue; }
 
 private:
-    StorageType mValue = 0;
-
+    // Find the union of BitFlags and/or FlagsEnum values.
     template <typename... Args>
-    static bool IsZeroAfterClearing(StorageType value, FlagsEnum flagToClear, Args &&... args)
+    static constexpr IntegerType Or(FlagsEnum flag, Args &&... args)
     {
-        value &= static_cast<StorageType>(~static_cast<StorageType>(flagToClear));
-        return IsZeroAfterClearing(value, std::forward<Args>(args)...);
+        return static_cast<IntegerType>(flag) | Or(std::forward<Args>(args)...);
     }
+    template <typename... Args>
+    static constexpr IntegerType Or(const BitFlags<FlagsEnum> & flags, Args &&... args)
+    {
+        return flags.mValue | Or(std::forward<Args>(args)...);
+    }
+    static constexpr IntegerType Or(FlagsEnum value) { return static_cast<IntegerType>(value); }
+    static constexpr IntegerType Or(const BitFlags<FlagsEnum> & flags) { return flags.Raw(); }
 
-    static bool IsZeroAfterClearing(StorageType value) { return value == 0; }
+    StorageType mValue = 0;
 };
-
-/**
- * @deprecated Use typesafe BitFlags class instead.
- */
-template <typename FlagsT, typename FlagT>
-inline bool GetFlag(const FlagsT & inFlags, const FlagT inFlag)
-{
-    return (inFlags & static_cast<FlagsT>(inFlag)) != 0;
-}
-
-/**
- * @deprecated Use typesafe BitFlags class instead.
- */
-template <typename FlagsT, typename FlagT>
-inline void ClearFlag(FlagsT & inFlags, const FlagT inFlag)
-{
-    inFlags &= static_cast<FlagsT>(~static_cast<FlagsT>(inFlag));
-}
-
-/**
- * @deprecated Use typesafe BitFlags class instead.
- */
-template <typename FlagsT, typename FlagT>
-inline void SetFlag(FlagsT & inFlags, const FlagT inFlag)
-{
-    inFlags = static_cast<FlagsT>(inFlags | static_cast<FlagsT>(inFlag));
-}
-
-/**
- * @deprecated Use typesafe BitFlags class instead.
- */
-template <typename FlagsT, typename FlagT>
-inline void SetFlag(FlagsT & inFlags, const FlagT inFlag, const bool inValue)
-{
-    if (inValue)
-    {
-        SetFlag(inFlags, inFlag);
-    }
-    else
-    {
-        ClearFlag(inFlags, inFlag);
-    }
-}
 
 } // namespace chip

--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -38,7 +38,7 @@ char NibbleToHex(uint8_t nibble, bool uppercase)
 
 } // namespace
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags)
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags)
 {
     if ((src_bytes == nullptr) || (dest_hex == nullptr))
     {
@@ -52,14 +52,14 @@ CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_he
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    bool nul_terminate          = (static_cast<int>(flags) & static_cast<int>(HexFlags::kNullTerminate)) != 0;
+    bool nul_terminate          = flags.Has(HexFlags::kNullTerminate);
     size_t expected_output_size = (src_size * 2u) + (nul_terminate ? 1u : 0u);
     if (dest_size_max < expected_output_size)
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    bool uppercase = (static_cast<int>(flags) & static_cast<int>(HexFlags::kUppercase)) != 0;
+    bool uppercase = flags.Has(HexFlags::kUppercase);
     char * cursor  = dest_hex;
     for (size_t byte_idx = 0; byte_idx < src_size; ++byte_idx)
     {

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -18,13 +18,15 @@
 #pragma once
 
 #include <core/CHIPError.h>
+#include <support/BitFlags.h>
+
 #include <stdint.h>
 #include <stdlib.h>
 
 namespace chip {
 namespace Encoding {
 
-enum HexFlags : int
+enum class HexFlags : int
 {
     kNone = 0u,
     // Use uppercase A-F if set otherwise, lowercase a-f
@@ -68,7 +70,7 @@ enum HexFlags : int
  * @return CHIP_NO_ERROR on success
  */
 
-CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, HexFlags flags);
+CHIP_ERROR BytesToHex(const uint8_t * src_bytes, size_t src_size, char * dest_hex, size_t dest_size_max, BitFlags<HexFlags> flags);
 
 // Alias for Uppercase option, no null-termination
 inline CHIP_ERROR BytesToUppercaseHexBuffer(const uint8_t * src_bytes, size_t src_size, char * dest_hex_buf, size_t dest_size_max)

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -205,7 +205,7 @@ private:
     // actions with a delegate pattern.
     uint8_t mChallenge[kMsgCounterChallengeSize]; // Challenge number to identify the sychronization request cryptographically.
 
-    BitFlags<uint16_t, ExFlagValues> mFlags; // Internal state flags
+    BitFlags<ExFlagValues> mFlags; // Internal state flags
 
     /**
      *  Search for an existing exchange that the message applies to.

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +55,7 @@ enum class MessageFlagValues : uint32_t
     kViaEphemeralUDPPort = 0x00040000,
 };
 
-using MessageFlags = BitFlags<uint32_t, MessageFlagValues>;
+using MessageFlags = BitFlags<MessageFlagValues>;
 
 enum class SendMessageFlags : uint16_t
 {
@@ -76,7 +76,7 @@ enum class SendMessageFlags : uint16_t
     kNoAutoRequestAck = 0x0400,
 };
 
-using SendFlags = BitFlags<uint16_t, SendMessageFlags>;
+using SendFlags = BitFlags<SendMessageFlags>;
 
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -181,7 +181,7 @@ CHIP_ERROR ReliableMessageContext::HandleRcvdAck(uint32_t AckMsgId)
     return err;
 }
 
-CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> MsgFlags)
+CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> MsgFlags)
 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -260,7 +260,7 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     if (mExchange != nullptr)
     {
         err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
-                                     BitFlags<uint16_t, SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
+                                     BitFlags<SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }
     else
     {

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -203,12 +203,12 @@ private:
         kFlagMsgRcvdFromPeer = 0x0080,
     };
 
-    BitFlags<uint16_t, Flags> mFlags; // Internal state flags
+    BitFlags<Flags> mFlags; // Internal state flags
 
     void Retain();
     void Release();
     CHIP_ERROR HandleRcvdAck(uint32_t AckMsgId);
-    CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<uint32_t, MessageFlagValues> Flags);
+    CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> Flags);
 
 private:
     friend class ReliableMessageMgr;

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,14 +90,14 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
 
     // ===== Private members reserved for use by this class only.
 
-    enum
+    enum class Flags : uint16_t
     {
-        kFlag_AdvertisingEnabled     = 0x0001,
-        kFlag_FastAdvertisingEnabled = 0x0002,
-        kFlag_Advertising            = 0x0004,
-        kFlag_RestartAdvertising     = 0x0008,
-        kFlag_EFRBLEStackInitialized = 0x0010,
-        kFlag_DeviceNameSet          = 0x0020,
+        kAdvertisingEnabled     = 0x0001,
+        kFastAdvertisingEnabled = 0x0002,
+        kAdvertising            = 0x0004,
+        kRestartAdvertising     = 0x0008,
+        kEFRBLEStackInitialized = 0x0010,
+        kDeviceNameSet          = 0x0020,
     };
 
     enum
@@ -121,7 +121,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     CHIPoBLEConState mBleConnections[kMaxConnections];
     uint8_t mIndConfId[kMaxConnections];
     CHIPoBLEServiceMode mServiceMode;
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     // The advertising set handle allocated from Bluetooth stack.
     uint8_t advertising_set_handle = 0xff;
@@ -182,12 +182,12 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 } // namespace Internal

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -117,20 +117,20 @@ class BLEManagerImpl final : public BLEManager,
 
     // ===== Private members reserved for use by this class only.
 
-    enum
+    enum class Flags : uint16_t
     {
-        kFlag_AsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kFlag_ESPBLELayerInitialized   = 0x0002, /**< The ESP BLE layer has been initialized. */
-        kFlag_AppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the ESP BLE layer. */
-        kFlag_AttrsRegistered          = 0x0008, /**< The CHIPoBLE GATT attributes have been registered with the ESP BLE layer. */
-        kFlag_GATTServiceStarted       = 0x0010, /**< The CHIPoBLE GATT service has been started. */
-        kFlag_AdvertisingConfigured    = 0x0020, /**< CHIPoBLE advertising has been configured in the ESP BLE layer. */
-        kFlag_Advertising              = 0x0040, /**< The system is currently CHIPoBLE advertising. */
-        kFlag_ControlOpInProgress      = 0x0080, /**< An async control operation has been issued to the ESP BLE layer. */
-        kFlag_AdvertisingEnabled       = 0x0100, /**< The application has enabled CHIPoBLE advertising. */
-        kFlag_FastAdvertisingEnabled   = 0x0200, /**< The application has enabled fast advertising. */
-        kFlag_UseCustomDeviceName      = 0x0400, /**< The application has configured a custom BLE device name. */
-        kFlag_AdvertisingRefreshNeeded = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
+        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kESPBLELayerInitialized   = 0x0002, /**< The ESP BLE layer has been initialized. */
+        kAppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the ESP BLE layer. */
+        kAttrsRegistered          = 0x0008, /**< The CHIPoBLE GATT attributes have been registered with the ESP BLE layer. */
+        kGATTServiceStarted       = 0x0010, /**< The CHIPoBLE GATT service has been started. */
+        kAdvertisingConfigured    = 0x0020, /**< CHIPoBLE advertising has been configured in the ESP BLE layer. */
+        kAdvertising              = 0x0040, /**< The system is currently CHIPoBLE advertising. */
+        kControlOpInProgress      = 0x0080, /**< An async control operation has been issued to the ESP BLE layer. */
+        kAdvertisingEnabled       = 0x0100, /**< The application has enabled CHIPoBLE advertising. */
+        kFastAdvertisingEnabled   = 0x0200, /**< The application has enabled fast advertising. */
+        kUseCustomDeviceName      = 0x0400, /**< The application has configured a custom BLE device name. */
+        kAdvertisingRefreshNeeded = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
     };
 
     enum
@@ -183,7 +183,7 @@ class BLEManagerImpl final : public BLEManager,
     uint16_t mRXCharAttrHandle;
     uint16_t mTXCharAttrHandle;
     uint16_t mTXCharCCCDAttrHandle;
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
 
     void DriveBLEState(void);
@@ -266,17 +266,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return GetFlag(mFlags, kFlag_Advertising);
+    return mFlags.Has(Flags::kAdvertising);
 }
 
 } // namespace Internal

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -401,7 +401,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     mWiFiAPState                    = kWiFiAPState_NotActive;
     mWiFiStationReconnectIntervalMS = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
     mWiFiAPIdleTimeoutMS            = CHIP_DEVICE_CONFIG_WIFI_AP_IDLE_TIMEOUT;
-    mFlags                          = 0;
+    mFlags.SetRaw(0);
 
     // TODO Initialize the Chip Addressing and Routing Module.
 
@@ -902,10 +902,10 @@ void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void 
 
 void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
 {
-    bool haveIPv4Conn = false;
-    bool haveIPv6Conn = false;
-    bool hadIPv4Conn  = GetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity);
-    bool hadIPv6Conn  = GetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity);
+    bool haveIPv4Conn      = false;
+    bool haveIPv6Conn      = false;
+    const bool hadIPv4Conn = mFlags.Has(ConnectivityFlags::kHaveIPv4InternetConnectivity);
+    const bool hadIPv6Conn = mFlags.Has(ConnectivityFlags::kHaveIPv6InternetConnectivity);
     IPAddress addr;
 
     // If the WiFi station is currently in the connected state...
@@ -962,8 +962,8 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
     if (haveIPv4Conn != hadIPv4Conn || haveIPv6Conn != hadIPv6Conn)
     {
         // Update the current state.
-        SetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity, haveIPv4Conn);
-        SetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity, haveIPv6Conn);
+        mFlags.Set(ConnectivityFlags::kHaveIPv4InternetConnectivity, haveIPv4Conn)
+            .Set(ConnectivityFlags::kHaveIPv6InternetConnectivity, haveIPv6Conn);
 
         // Alert other components of the state change.
         ChipDeviceEvent event;

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -28,6 +28,7 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoBLE.h>
 #endif
 #include <platform/internal/GenericConnectivityManagerImpl_NoThread.h>
+#include <support/BitFlags.h>
 
 #include "esp_event.h"
 
@@ -67,6 +68,7 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
     friend class ConnectivityManager;
 
 private:
+    using Flags = GenericConnectivityManagerImpl_WiFi::ConnectivityFlags;
     // ===== Members that implement the ConnectivityManager abstract interface.
 
     WiFiStationMode _GetWiFiStationMode(void);
@@ -114,7 +116,7 @@ private:
     WiFiAPState mWiFiAPState;
     uint32_t mWiFiStationReconnectIntervalMS;
     uint32_t mWiFiAPIdleTimeoutMS;
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
 
     void DriveStationState(void);
     void OnStationConnected(void);
@@ -172,12 +174,12 @@ inline uint32_t ConnectivityManagerImpl::_GetWiFiAPIdleTimeoutMS(void)
 
 inline bool ConnectivityManagerImpl::_HaveIPv4InternetConnectivity(void)
 {
-    return ::chip::GetFlag(mFlags, kFlag_HaveIPv4InternetConnectivity);
+    return mFlags.Has(Flags::kHaveIPv4InternetConnectivity);
 }
 
 inline bool ConnectivityManagerImpl::_HaveIPv6InternetConnectivity(void)
 {
-    return ::chip::GetFlag(mFlags, kFlag_HaveIPv6InternetConnectivity);
+    return mFlags.Has(Flags::kHaveIPv6InternetConnectivity);
 }
 
 inline bool ConnectivityManagerImpl::_CanStartWiFiScan()

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -140,7 +140,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mRXCharAttrHandle     = 0;
     mTXCharAttrHandle     = 0;
     mTXCharCCCDAttrHandle = 0;
-    mFlags                = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     memset(mDeviceName, 0, sizeof(mDeviceName));
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
@@ -172,9 +172,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -188,9 +188,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -221,12 +221,12 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         strcpy(mDeviceName, deviceName);
-        SetFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Set(Flags::kUseCustomDeviceName);
     }
     else
     {
         mDeviceName[0] = 0;
-        ClearFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Clear(Flags::kUseCustomDeviceName);
     }
     return CHIP_NO_ERROR;
 }
@@ -271,15 +271,15 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
         ChipLogProgress(DeviceLayer, "Updating advertising data");
-        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Clear(Flags::kAdvertisingConfigured);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
 
         DriveBLEState();
 
@@ -317,8 +317,8 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     ReleaseConnectionState(conId);
 
     // Force a refresh of the advertising state.
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-    ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+    mFlags.Clear(Flags::kAdvertisingConfigured);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
     return (err == CHIP_NO_ERROR);
@@ -390,33 +390,33 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the Chip task is running.
-    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
+    if (!mFlags.Has(Flags::kAsyncInitCompleted))
     {
-        SetFlag(mFlags, kFlag_AsyncInitCompleted);
+        mFlags.Set(Flags::kAsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
     }
 
     // If there's already a control operation in progress, wait until it completes.
-    VerifyOrExit(!GetFlag(mFlags, kFlag_ControlOpInProgress), /* */);
+    VerifyOrExit(!mFlags.Has(Flags::kControlOpInProgress), /* */);
 
     // Initializes the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_ESPBLELayerInitialized))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kESPBLELayerInitialized))
     {
         err = InitESPBleLayer();
         SuccessOrExit(err);
     }
 
     // Register the CHIPoBLE application with the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
         err = esp_ble_gatts_app_register(CHIPoBLEAppId);
         if (err != CHIP_NO_ERROR)
@@ -425,13 +425,13 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        SetFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Set(Flags::kControlOpInProgress);
 
         ExitNow();
     }
 
     // Register the CHIPoBLE GATT attributes with the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AttrsRegistered))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAttrsRegistered))
     {
         err = esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0);
         if (err != CHIP_NO_ERROR)
@@ -440,13 +440,13 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        SetFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Set(Flags::kControlOpInProgress);
 
         ExitNow();
     }
 
     // Start the CHIPoBLE GATT service if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_GATTServiceStarted))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kGATTServiceStarted))
     {
         err = esp_ble_gatts_start_service(mServiceAttrHandle);
         if (err != CHIP_NO_ERROR)
@@ -455,14 +455,14 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        SetFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Set(Flags::kControlOpInProgress);
 
         ExitNow();
     }
 
     // If the application has enabled CHIPoBLE and BLE advertising...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled &&
-        GetFlag(mFlags, kFlag_AdvertisingEnabled)
+        mFlags.Has(Flags::kAdvertisingEnabled)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
         // and no connections are active...
         && (_NumConnections() == 0)
@@ -471,12 +471,12 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         // Start/re-start advertising if not already advertising, or if the advertising state of the
         // ESP BLE layer needs to be refreshed.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             // Configure advertising data if it hasn't been done yet.  This is an asynchronous step which
             // must complete before advertising can be started.  When that happens, this method will
             // be called again, and execution will proceed to the code below.
-            if (!GetFlag(mFlags, kFlag_AdvertisingConfigured))
+            if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
                 err = ConfigureAdvertisingData();
                 ExitNow();
@@ -491,7 +491,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Otherwise stop advertising if needed...
     else
     {
-        if (GetFlag(mFlags, kFlag_Advertising))
+        if (mFlags.Has(Flags::kAdvertising))
         {
             err = esp_ble_gap_stop_advertising();
             if (err != CHIP_NO_ERROR)
@@ -500,14 +500,14 @@ void BLEManagerImpl::DriveBLEState(void)
                 ExitNow();
             }
 
-            SetFlag(mFlags, kFlag_ControlOpInProgress);
+            mFlags.Set(Flags::kControlOpInProgress);
 
             ExitNow();
         }
     }
 
     // Stop the CHIPoBLE GATT service if needed.
-    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_GATTServiceStarted))
+    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kGATTServiceStarted))
     {
         // TODO: what to do about existing connections??
 
@@ -518,7 +518,7 @@ void BLEManagerImpl::DriveBLEState(void)
             ExitNow();
         }
 
-        SetFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Set(Flags::kControlOpInProgress);
 
         ExitNow();
     }
@@ -535,7 +535,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(!GetFlag(mFlags, kFlag_ESPBLELayerInitialized), /* */);
+    VerifyOrExit(!mFlags.Has(Flags::kESPBLELayerInitialized), /* */);
 
     // If the ESP Bluetooth controller has not been initialized...
     if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE)
@@ -615,7 +615,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     }
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_ESPBLELayerInitialized);
+    mFlags.Set(Flags::kESPBLELayerInitialized);
 
 exit:
     return err;
@@ -632,7 +632,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     uint16_t discriminator;
     SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
-    if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
+    if (!mFlags.Has(Flags::kUseCustomDeviceName))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
@@ -675,7 +675,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ExitNow();
     }
 
-    SetFlag(mFlags, kFlag_ControlOpInProgress);
+    mFlags.Set(Flags::kControlOpInProgress);
 
 exit:
     return err;
@@ -708,7 +708,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     // Advertise in fast mode if not fully provisioned and there are no CHIPoBLE connections, or
     // if the application has expressly requested fast advertising.
     advertParams.adv_int_min = advertParams.adv_int_max =
-        ((numCons == 0 && !ConfigurationMgr().IsFullyProvisioned()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
+        ((numCons == 0 && !ConfigurationMgr().IsFullyProvisioned()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
         ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 
@@ -722,7 +722,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         ExitNow();
     }
 
-    SetFlag(mFlags, kFlag_ControlOpInProgress);
+    mFlags.Set(Flags::kControlOpInProgress);
 
 exit:
     return err;
@@ -734,7 +734,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
     bool controlOpComplete = false;
 
     // Ignore GATT control events that do not pertain to the CHIPoBLE application, except for ESP_GATTS_REG_EVT.
-    if (event != ESP_GATTS_REG_EVT && (!GetFlag(mFlags, kFlag_AppRegistered) || gatts_if != mAppIf))
+    if (event != ESP_GATTS_REG_EVT && (!mFlags.Has(Flags::kAppRegistered) || gatts_if != mAppIf))
     {
         ExitNow();
     }
@@ -754,7 +754,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
             // Save the 'interface type' assigned to the CHIPoBLE application by the ESP BLE layer.
             mAppIf = gatts_if;
 
-            SetFlag(mFlags, kFlag_AppRegistered);
+            mFlags.Set(Flags::kAppRegistered);
             controlOpComplete = true;
         }
 
@@ -774,7 +774,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
         mTXCharAttrHandle     = param->add_attr_tab.handles[kAttrIndex_TXCharValue];
         mTXCharCCCDAttrHandle = param->add_attr_tab.handles[kAttrIndex_TXCharCCCDValue];
 
-        SetFlag(mFlags, kFlag_AttrsRegistered);
+        mFlags.Set(Flags::kAttrsRegistered);
         controlOpComplete = true;
 
         break;
@@ -789,7 +789,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE GATT service started");
 
-        SetFlag(mFlags, kFlag_GATTServiceStarted);
+        mFlags.Set(Flags::kGATTServiceStarted);
         controlOpComplete = true;
 
         break;
@@ -804,7 +804,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE GATT service stopped");
 
-        ClearFlag(mFlags, kFlag_GATTServiceStarted);
+        mFlags.Clear(Flags::kGATTServiceStarted);
         controlOpComplete = true;
 
         break;
@@ -826,7 +826,7 @@ exit:
     }
     if (controlOpComplete)
     {
-        ClearFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Clear(Flags::kControlOpInProgress);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }
@@ -835,7 +835,7 @@ void BLEManagerImpl::HandleGATTCommEvent(esp_gatts_cb_event_t event, esp_gatt_if
 {
     // Ignore the event if the CHIPoBLE service hasn't been started, or if the event is for a different
     // BLE application.
-    if (!GetFlag(sInstance.mFlags, kFlag_GATTServiceStarted) || gatts_if != sInstance.mAppIf)
+    if (!sInstance.mFlags.Has(Flags::kGATTServiceStarted) || gatts_if != sInstance.mAppIf)
     {
         return;
     }
@@ -850,8 +850,8 @@ void BLEManagerImpl::HandleGATTCommEvent(esp_gatts_cb_event_t event, esp_gatt_if
 
         // Receiving a connection stops the advertising processes.  So force a refresh of the advertising
         // state.
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+        mFlags.Clear(Flags::kAdvertisingConfigured);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
         break;
@@ -1110,8 +1110,8 @@ void BLEManagerImpl::HandleDisconnect(esp_ble_gatts_cb_param_t * param)
         PlatformMgr().PostEvent(&event);
 
         // Force a refresh of the advertising state.
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+        mFlags.Clear(Flags::kAdvertisingConfigured);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }
@@ -1212,8 +1212,8 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        SetFlag(sInstance.mFlags, kFlag_AdvertisingConfigured);
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
+        sInstance.mFlags.Set(Flags::kAdvertisingConfigured);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
 
         break;
 
@@ -1225,15 +1225,15 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
+        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
         // Transition to the Advertising state...
-        if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (!sInstance.mFlags.Has(Flags::kAdvertising))
         {
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising started");
 
-            SetFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Set(Flags::kAdvertising);
 
             // Post a CHIPoBLEAdvertisingChange(Started) event.
             {
@@ -1254,13 +1254,13 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
             ExitNow(err = ESP_ERR_INVALID_RESPONSE);
         }
 
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
+        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
         // Transition to the not Advertising state...
-        if (GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (sInstance.mFlags.Has(Flags::kAdvertising))
         {
-            ClearFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Clear(Flags::kAdvertising);
 
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -129,8 +129,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     mRXCharAttrHandle     = 0;
     mTXCharCCCDAttrHandle = 0;
-    mFlags                = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
-    mNumGAPCons           = 0;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mNumGAPCons = 0;
     memset(mCons, 0, sizeof(mCons));
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     memset(mDeviceName, 0, sizeof(mDeviceName));
@@ -164,9 +164,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -180,9 +180,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -212,12 +212,12 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         strcpy(mDeviceName, deviceName);
-        SetFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Set(Flags::kUseCustomDeviceName);
     }
     else
     {
         mDeviceName[0] = 0;
-        ClearFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Clear(Flags::kUseCustomDeviceName);
     }
 
 exit:
@@ -265,15 +265,15 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
         ChipLogProgress(DeviceLayer, "Updating advertising data");
-        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Clear(Flags::kAdvertisingConfigured);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
 
         DriveBLEState();
         break;
@@ -309,8 +309,8 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     }
 
     // Force a refresh of the advertising state.
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-    ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+    mFlags.Clear(Flags::kAdvertisingConfigured);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
     return (err == CHIP_NO_ERROR);
@@ -384,23 +384,23 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the Chip task is running.
-    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
+    if (!mFlags.Has(Flags::kAsyncInitCompleted))
     {
-        SetFlag(mFlags, kFlag_AsyncInitCompleted);
+        mFlags.Set(Flags::kAsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
     }
 
     // Initializes the ESP BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_ESPBLELayerInitialized))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kESPBLELayerInitialized))
     {
         err = InitESPBleLayer();
         SuccessOrExit(err);
@@ -413,7 +413,7 @@ void BLEManagerImpl::DriveBLEState(void)
 
     // If the application has enabled CHIPoBLE and BLE advertising...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled &&
-        GetFlag(mFlags, kFlag_AdvertisingEnabled)
+        mFlags.Has(Flags::kAdvertisingEnabled)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
         // and no connections are active...
         && (_NumConnections() == 0)
@@ -422,12 +422,12 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         // Start/re-start advertising if not already advertising, or if the advertising state of the
         // ESP BLE layer needs to be refreshed.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             // Configure advertising data if it hasn't been done yet.  This is an asynchronous step which
             // must complete before advertising can be started.  When that happens, this method will
             // be called again, and execution will proceed to the code below.
-            if (!GetFlag(mFlags, kFlag_AdvertisingConfigured))
+            if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
                 err = ConfigureAdvertisingData();
                 if (err != CHIP_NO_ERROR)
@@ -446,13 +446,13 @@ void BLEManagerImpl::DriveBLEState(void)
                 ExitNow();
             }
 
-            ClearFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+            mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
             // Transition to the Advertising state...
-            if (!GetFlag(mFlags, kFlag_Advertising))
+            if (!mFlags.Has(Flags::kAdvertising))
             {
                 ChipLogProgress(DeviceLayer, "CHIPoBLE advertising started");
 
-                SetFlag(mFlags, kFlag_Advertising);
+                mFlags.Set(Flags::kAdvertising);
 
                 // Post a CHIPoBLEAdvertisingChange(Started) event.
                 {
@@ -468,7 +468,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Otherwise stop advertising if needed...
     else
     {
-        if (GetFlag(mFlags, kFlag_Advertising))
+        if (mFlags.Has(Flags::kAdvertising))
         {
             ret = ble_gap_adv_stop();
             if (ret != 0)
@@ -478,12 +478,12 @@ void BLEManagerImpl::DriveBLEState(void)
                 ExitNow();
             }
 
-            // ClearFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+            // mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
             // Transition to the not Advertising state...
-            if (GetFlag(mFlags, kFlag_Advertising))
+            if (mFlags.Has(Flags::kAdvertising))
             {
-                ClearFlag(mFlags, kFlag_Advertising);
+                mFlags.Clear(Flags::kAdvertising);
 
                 ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 
@@ -506,7 +506,7 @@ void BLEManagerImpl::DriveBLEState(void)
     }
 
     // Stop the CHIPoBLE GATT service if needed.
-    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_GATTServiceStarted))
+    if (mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kGATTServiceStarted))
     {
         // TODO: Not supported
     }
@@ -528,8 +528,8 @@ void BLEManagerImpl::bleprph_on_sync(void)
 {
     int rc;
 
-    SetFlag(sInstance.mFlags, kFlag_ESPBLELayerInitialized);
-    SetFlag(sInstance.mFlags, kFlag_GATTServiceStarted);
+    sInstance.mFlags.Set(Flags::kESPBLELayerInitialized);
+    sInstance.mFlags.Set(Flags::kGATTServiceStarted);
     ESP_LOGI(TAG, "BLE host-controller synced");
 
     uint8_t own_addr_type = BLE_OWN_ADDR_PUBLIC;
@@ -554,7 +554,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(!GetFlag(mFlags, kFlag_ESPBLELayerInitialized), /* */);
+    VerifyOrExit(!mFlags.Has(Flags::kESPBLELayerInitialized), /* */);
 
     for (int i = 0; i < kMaxConnections; i++)
     {
@@ -609,7 +609,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     uint16_t discriminator;
     SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
 
-    if (!GetFlag(mFlags, kFlag_UseCustomDeviceName))
+    if (!mFlags.Has(Flags::kUseCustomDeviceName))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
@@ -809,8 +809,8 @@ CHIP_ERROR BLEManagerImpl::HandleGAPConnect(struct ble_gap_event * gapEvent)
     VerifyOrExit(err != CHIP_ERROR_NO_MEMORY, err = CHIP_NO_ERROR);
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-    ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+    mFlags.Clear(Flags::kAdvertisingConfigured);
 
 exit:
     return err;
@@ -847,8 +847,8 @@ CHIP_ERROR BLEManagerImpl::HandleGAPDisconnect(struct ble_gap_event * gapEvent)
 
     // Force a reconfiguration of advertising in case we switched to non-connectable mode when
     // the BLE connection was established.
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
-    ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
+    mFlags.Clear(Flags::kAdvertisingConfigured);
 
     return CHIP_NO_ERROR;
 }
@@ -1025,7 +1025,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-    ClearFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+    mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
     // Advertise connectable if we haven't reached the maximum number of connections.
     size_t numCons       = _NumConnections();

--- a/src/platform/K32W/BLEManagerImpl.cpp
+++ b/src/platform/K32W/BLEManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -119,7 +119,6 @@ EventGroupHandle_t bleAppTaskLoopEvent;
 
 /* keep the device ID of the connected peer */
 uint8_t device_id;
-uint16_t mFlags;
 
 const uint8_t ShortUUID_CHIPoBLEService[]  = { 0xAF, 0xFE };
 const ChipBleUUID ChipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
@@ -140,7 +139,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(!GetFlag(mFlags, kFlag_K32WBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(!mFlags.Has(Flags::kK32WBLEStackInitialized), err = CHIP_ERROR_INCORRECT_STATE);
 
     // Initialize the Chip BleLayer.
     err = BleLayer::Init(this, this, &SystemLayer);
@@ -194,8 +193,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     GattServer_RegisterHandlesForWriteNotifications(1, attChipRxHandle);
 
-    SetFlag(mFlags, kFlag_K32WBLEStackInitialized, true);
-    SetFlag(mFlags, kFlag_AdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
+    mFlags.Set(Flags::kK32WBLEStackInitialized);
+    mFlags.Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? true : false);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
 exit:
@@ -218,12 +217,12 @@ uint16_t BLEManagerImpl::_NumConnections(void)
 
 bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 bool BLEManagerImpl::RemoveConnection(uint8_t connectionHandle)
@@ -308,9 +307,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -324,9 +323,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -358,13 +357,13 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
         }
         memset(mDeviceName, 0, kMaxDeviceNameLength);
         strcpy(mDeviceName, deviceName);
-        SetFlag(mFlags, kFlag_DeviceNameSet, true);
+        mFlags.Set(Flags::kDeviceNameSet);
         ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);
     }
     else
     {
         mDeviceName[0] = 0;
-        SetFlag(mFlags, kFlag_DeviceNameSet, false);
+        mFlags.Clear(Flags::kDeviceNameSet);
     }
 
     return CHIP_NO_ERROR;
@@ -403,7 +402,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kServiceProvisioningChange:
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kServiceProvisioningChange");
 
-        ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+        mFlags.Clear(Flags::kAdvertisingEnabled);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
         break;
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
@@ -764,7 +763,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         return chipErr;
     }
 
-    if (!GetFlag(mFlags, kFlag_DeviceNameSet))
+    if (!mFlags.Has(Flags::kDeviceNameSet))
     {
         memset(mDeviceName, 0, kMaxDeviceNameLength);
         snprintf(mDeviceName, kMaxDeviceNameLength, "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
@@ -809,8 +808,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     scanRsp.aAdStructures = scan_rsp_data;
 
     /**************** Prepare advertising parameters *************************************/
-    advInterval =
-        ((NumConnections() == 0 && !ConfigurationMgr().IsPairedToAccount()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
+    advInterval = ((NumConnections() == 0 && !ConfigurationMgr().IsPairedToAccount()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
         ? (CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL * 3)
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 
@@ -839,8 +837,8 @@ exit:
 
 CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 {
-    SetFlag(mFlags, kFlag_Advertising, true);
-    ClearFlag(mFlags, kFlag_RestartAdvertising);
+    mFlags.Set(Flags::kAdvertising);
+    mFlags.Clear(Flags::kRestartAdvertising);
 
     return ConfigureAdvertisingData();
 }
@@ -849,10 +847,10 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
 {
     ble_err_t err;
 
-    if (GetFlag(mFlags, kFlag_Advertising))
+    if (mFlags.Has(Flags::kAdvertising))
     {
-        ClearFlag(mFlags, kFlag_Advertising);
-        ClearFlag(mFlags, kFlag_RestartAdvertising);
+        mFlags.Clear(Flags::kAdvertising);
+        mFlags.Clear(Flags::kRestartAdvertising);
 
         err = blekw_stop_advertising();
         if (err != BLE_OK)
@@ -869,29 +867,29 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Check if BLE stack is initialized
-    VerifyOrExit(GetFlag(mFlags, kFlag_K32WBLEStackInitialized), /* */);
+    VerifyOrExit(mFlags.Has(Flags::kK32WBLEStackInitialized), /* */);
 
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
     if (ConfigurationMgr().IsFullyProvisioned())
     {
-        ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+        mFlags.Clear(Flags::kAdvertisingEnabled);
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
     }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
     // Start advertising if needed...
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_AdvertisingEnabled))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kAdvertisingEnabled))
     {
         // Start/re-start advertising if not already started, or if there is a pending change
         // to the advertising configuration.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_RestartAdvertising))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kRestartAdvertising))
         {
             err = StartAdvertising();
             SuccessOrExit(err);
         }
     }
     // Otherwise, stop advertising if it is enabled.
-    else if (GetFlag(mFlags, kFlag_Advertising))
+    else if (mFlags.Has(Flags::kAdvertising))
     {
         err = StopAdvertising();
         SuccessOrExit(err);
@@ -977,7 +975,7 @@ void BLEManagerImpl::HandleConnectEvent(blekw_msg_t * msg)
     device_id = device_id_loc;
     blekw_start_connection_timeout();
     sInstance.AddConnection(device_id_loc);
-    SetFlag(mFlags, kFlag_RestartAdvertising, true);
+    mFlags.Set(Flags::kRestartAdvertising);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 }
 
@@ -994,7 +992,7 @@ void BLEManagerImpl::HandleConnectionCloseEvent(blekw_msg_t * msg)
         event.CHIPoBLEConnectionError.Reason = BLE_ERROR_REMOTE_DEVICE_DISCONNECTED;
 
         PlatformMgr().PostEvent(&event);
-        SetFlag(mFlags, kFlag_RestartAdvertising, true);
+        mFlags.Set(Flags::kRestartAdvertising);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 }

--- a/src/platform/K32W/BLEManagerImpl.h
+++ b/src/platform/K32W/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2020 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -107,15 +107,16 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum
+    enum class Flags : uint8_t
     {
-        kFlag_AdvertisingEnabled      = 0x0001,
-        kFlag_FastAdvertisingEnabled  = 0x0002,
-        kFlag_Advertising             = 0x0004,
-        kFlag_RestartAdvertising      = 0x0008,
-        kFlag_K32WBLEStackInitialized = 0x0010,
-        kFlag_DeviceNameSet           = 0x0020,
+        kAdvertisingEnabled      = 0x0001,
+        kFastAdvertisingEnabled  = 0x0002,
+        kAdvertising             = 0x0004,
+        kRestartAdvertising      = 0x0008,
+        kK32WBLEStackInitialized = 0x0010,
+        kDeviceNameSet           = 0x0020,
     };
+    BitFlags<BLEManagerImpl::Flags> mFlags;
 
     enum
     {

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -69,8 +69,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
     SuccessOrExit(err);
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
-    mFlags       = (CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART && !mIsCentral) ? kFlag_AdvertisingEnabled : 0;
-    mAppState    = nullptr;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART && !mIsCentral);
+    mAppState = nullptr;
 
     memset(mDeviceName, 0, sizeof(mDeviceName));
 
@@ -103,9 +103,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
     }
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
@@ -119,9 +119,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -150,7 +150,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     {
         VerifyOrExit(strlen(deviceName) < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
         strcpy(mDeviceName, deviceName);
-        SetFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Set(Flags::kUseCustomDeviceName);
     }
     else
     {
@@ -158,7 +158,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
         SuccessOrExit(err = ConfigurationMgr().GetSetupDiscriminator(discriminator));
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04u", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, discriminator);
         mDeviceName[kMaxDeviceNameLength] = 0;
-        ClearFlag(mFlags, kFlag_UseCustomDeviceName);
+        mFlags.Clear(Flags::kUseCustomDeviceName);
     }
 
 exit:
@@ -240,13 +240,13 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising configuration to be refreshed to reflect new provisioning state.
-        ClearFlag(mFlags, kFlag_AdvertisingConfigured);
+        mFlags.Clear(Flags::kAdvertisingConfigured);
 
         DriveBLEState();
         break;
@@ -284,38 +284,35 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
         break;
     case DeviceEventType::kPlatformLinuxBLEPeripheralAdvConfiguredComplete:
         VerifyOrExit(apEvent->Platform.BLEPeripheralAdvConfiguredComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
-        SetFlag(sInstance.mFlags, kFlag_AdvertisingConfigured);
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
+        sInstance.mFlags.Set(Flags::kAdvertisingConfigured).Clear(Flags::kControlOpInProgress);
         controlOpComplete = true;
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising config complete");
         break;
     case DeviceEventType::kPlatformLinuxBLEPeripheralAdvStartComplete:
         VerifyOrExit(apEvent->Platform.BLEPeripheralAdvStartComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress).Clear(Flags::kAdvertisingRefreshNeeded);
 
-        if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (!sInstance.mFlags.Has(Flags::kAdvertising))
         {
-            SetFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Set(Flags::kAdvertising);
         }
 
         break;
     case DeviceEventType::kPlatformLinuxBLEPeripheralAdvStopComplete:
         VerifyOrExit(apEvent->Platform.BLEPeripheralAdvStopComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
 
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress).Clear(Flags::kAdvertisingRefreshNeeded);
 
         // Transition to the not Advertising state...
-        if (GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (sInstance.mFlags.Has(Flags::kAdvertising))
         {
-            ClearFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Clear(Flags::kAdvertising);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
         }
         break;
     case DeviceEventType::kPlatformLinuxBLEPeripheralRegisterAppComplete:
         VerifyOrExit(apEvent->Platform.BLEPeripheralRegisterAppComplete.mIsSuccess, err = CHIP_ERROR_INCORRECT_STATE);
-        SetFlag(mFlags, kFlag_AppRegistered);
+        mFlags.Set(Flags::kAppRegistered);
         controlOpComplete = true;
         break;
     default:
@@ -327,12 +324,12 @@ exit:
     {
         ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
-        ClearFlag(sInstance.mFlags, kFlag_ControlOpInProgress);
+        sInstance.mFlags.Clear(Flags::kControlOpInProgress);
     }
 
     if (controlOpComplete)
     {
-        ClearFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Clear(Flags::kControlOpInProgress);
         DriveBLEState();
     }
 }
@@ -542,16 +539,16 @@ void BLEManagerImpl::DriveBLEState()
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the Chip task is running.
-    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
+    if (!mFlags.Has(Flags::kAsyncInitCompleted))
     {
-        SetFlag(mFlags, kFlag_AsyncInitCompleted);
+        mFlags.Set(Flags::kAsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
@@ -559,35 +556,35 @@ void BLEManagerImpl::DriveBLEState()
     }
 
     // If there's already a control operation in progress, wait until it completes.
-    VerifyOrExit(!GetFlag(mFlags, kFlag_ControlOpInProgress), /* */);
+    VerifyOrExit(!mFlags.Has(Flags::kControlOpInProgress), /* */);
 
     // Initializes the Bluez BLE layer if needed.
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_BluezBLELayerInitialized))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kBluezBLELayerInitialized))
     {
         err = InitBluezBleLayer(mIsCentral, nullptr, mBLEAdvConfig, mpEndpoint);
         SuccessOrExit(err);
-        SetFlag(mFlags, kFlag_BluezBLELayerInitialized);
+        mFlags.Set(Flags::kBluezBLELayerInitialized);
     }
 
     // Register the CHIPoBLE application with the Bluez BLE layer if needed.
-    if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !GetFlag(mFlags, kFlag_AppRegistered))
+    if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
         err = BluezGattsAppRegister(mpEndpoint);
-        SetFlag(mFlags, kFlag_ControlOpInProgress);
+        mFlags.Set(Flags::kControlOpInProgress);
         ExitNow();
     }
 
     // If the application has enabled CHIPoBLE and BLE advertising...
-    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && GetFlag(mFlags, kFlag_AdvertisingEnabled))
+    if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && mFlags.Has(Flags::kAdvertisingEnabled))
     {
         // Start/re-start advertising if not already advertising, or if the advertising state of the
         // Bluez BLE layer needs to be refreshed.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             // Configure advertising data if it hasn't been done yet.  This is an asynchronous step which
             // must complete before advertising can be started.  When that happens, this method will
             // be called again, and execution will proceed to the code below.
-            if (!GetFlag(mFlags, kFlag_AdvertisingConfigured))
+            if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
                 err = BluezAdvertisementSetup(mpEndpoint);
                 ExitNow();
@@ -597,7 +594,7 @@ void BLEManagerImpl::DriveBLEState()
             err = StartBLEAdvertising();
             SuccessOrExit(err);
 
-            SetFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Set(Flags::kAdvertising);
             ExitNow();
         }
     }
@@ -605,11 +602,11 @@ void BLEManagerImpl::DriveBLEState()
     // Otherwise stop advertising if needed...
     else
     {
-        if (GetFlag(mFlags, kFlag_Advertising))
+        if (mFlags.Has(Flags::kAdvertising))
         {
             err = StopBLEAdvertising();
             SuccessOrExit(err);
-            SetFlag(mFlags, kFlag_ControlOpInProgress);
+            mFlags.Set(Flags::kControlOpInProgress);
 
             ExitNow();
         }

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -163,18 +163,18 @@ private:
     static BLEManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
-    enum
+    enum class Flags : uint16_t
     {
-        kFlag_AsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kFlag_BluezBLELayerInitialized = 0x0002, /**< The Bluez layer has been initialized. */
-        kFlag_AppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the Bluez layer. */
-        kFlag_AdvertisingConfigured    = 0x0008, /**< CHIPoBLE advertising has been configured in the Bluez layer. */
-        kFlag_Advertising              = 0x0010, /**< The system is currently CHIPoBLE advertising. */
-        kFlag_ControlOpInProgress      = 0x0020, /**< An async control operation has been issued to the ESP BLE layer. */
-        kFlag_AdvertisingEnabled       = 0x0040, /**< The application has enabled CHIPoBLE advertising. */
-        kFlag_FastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
-        kFlag_UseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
-        kFlag_AdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
+        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kBluezBLELayerInitialized = 0x0002, /**< The Bluez layer has been initialized. */
+        kAppRegistered            = 0x0004, /**< The CHIPoBLE application has been registered with the Bluez layer. */
+        kAdvertisingConfigured    = 0x0008, /**< CHIPoBLE advertising has been configured in the Bluez layer. */
+        kAdvertising              = 0x0010, /**< The system is currently CHIPoBLE advertising. */
+        kControlOpInProgress      = 0x0020, /**< An async control operation has been issued to the ESP BLE layer. */
+        kAdvertisingEnabled       = 0x0040, /**< The application has enabled CHIPoBLE advertising. */
+        kFastAdvertisingEnabled   = 0x0080, /**< The application has enabled fast advertising. */
+        kUseCustomDeviceName      = 0x0100, /**< The application has configured a custom BLE device name. */
+        kAdvertisingRefreshNeeded = 0x0200, /**< The advertising configuration/state in BLE layer needs to be updated. */
     };
 
     enum
@@ -196,7 +196,7 @@ private:
     CHIPoBLEServiceMode mServiceMode;
     BLEAdvConfig mBLEAdvConfig;
     BLEScanConfig mBLEScanConfig;
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     bool mIsCentral            = false;
     BluezEndpoint * mpEndpoint = nullptr;
@@ -237,17 +237,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode()
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled()
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled()
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising()
 {
-    return GetFlag(mFlags, kFlag_Advertising);
+    return mFlags.Has(Flags::kAdvertising);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -148,7 +148,7 @@ private:
     static void _OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
     static void _OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
 
-    static uint16_t mConnectivityFlag;
+    static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
 #endif
 

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1192,7 +1192,7 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
     char serialNumber[ConfigurationManager::kMaxSerialNumberLength + 1];
     size_t serialNumberSize  = 0;
     uint16_t lifetimeCounter = 0;
-    BitFlags<uint8_t, AdditionalDataFields> additionalDataFields;
+    BitFlags<AdditionalDataFields> additionalDataFields;
 
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
     err = ConfigurationMgr().GetSerialNumber(serialNumber, sizeof(serialNumber), serialNumberSize);

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -92,8 +92,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
-    mFlags       = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
-    mGAPConns    = 0;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mGAPConns = 0;
 
     memset(mSubscribedConns, 0, sizeof(mSubscribedConns));
 
@@ -128,16 +128,16 @@ void BLEManagerImpl::DriveBLEState()
     ChipLogDetail(DeviceLayer, "In DriveBLEState");
 
     // Perform any initialization actions that must occur after the CHIP task is running.
-    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
+    if (!mFlags.Has(Flags::kAsyncInitCompleted))
     {
-        SetFlag(mFlags, kFlag_AsyncInitCompleted);
+        mFlags.Set(Flags::kAsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
@@ -145,7 +145,7 @@ void BLEManagerImpl::DriveBLEState()
 
     // If the application has enabled CHIPoBLE and BLE advertising...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled &&
-        GetFlag(mFlags, kFlag_AdvertisingEnabled)
+        mFlags.Has(Flags::kAdvertisingEnabled)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
         // and no connections are active...
         && (NumConnections() == 0)
@@ -154,7 +154,7 @@ void BLEManagerImpl::DriveBLEState()
     {
         // Start/re-start advertising if not already advertising, or if the
         // advertising state needs to be refreshed.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             err = StartAdvertising();
             SuccessOrExit(err);
@@ -204,7 +204,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     // If necessary, inform the ThreadStackManager that CHIPoBLE advertising is about to start.
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    if (!GetFlag(mFlags, kFlag_Advertising))
+    if (!mFlags.Has(Flags::kAdvertising))
     {
         ThreadStackMgr().OnCHIPoBLEAdvertisingStart();
     }
@@ -225,11 +225,11 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     VerifyOrExit(err == CHIP_NO_ERROR, err = MapErrorZephyr(err));
 
     // Transition to the Advertising state...
-    if (!GetFlag(mFlags, kFlag_Advertising))
+    if (!mFlags.Has(Flags::kAdvertising))
     {
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising started");
 
-        SetFlag(mFlags, kFlag_Advertising);
+        mFlags.Set(Flags::kAdvertising);
 
         // Post a CHIPoBLEAdvertisingChange(Started) event.
         {
@@ -255,9 +255,9 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
     VerifyOrExit(err == CHIP_NO_ERROR, err = MapErrorZephyr(err));
 
     // Transition to the not Advertising state...
-    if (GetFlag(mFlags, kFlag_Advertising))
+    if (mFlags.Has(Flags::kAdvertising))
     {
-        ClearFlag(mFlags, kFlag_Advertising);
+        mFlags.Clear(Flags::kAdvertising);
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 
@@ -305,11 +305,11 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
         ChipLogDetail(DeviceLayer, "SetAdvertisingEnabled(%s)", val ? "true" : "false");
 
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -323,11 +323,11 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
         ChipLogDetail(DeviceLayer, "SetFastAdvertisingEnabled(%s)", val ? "true" : "false");
 
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -372,7 +372,7 @@ CHIP_ERROR BLEManagerImpl::HandleGAPConnect(const ChipDeviceEvent * event)
 
     ChipLogProgress(DeviceLayer, "Current number of connections: %" PRIu16 "/%" PRIu16, NumConnections(), CONFIG_BT_MAX_CONN);
 
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
     bt_conn_unref(connEvent->BtConn);
@@ -418,7 +418,7 @@ exit:
 
     // Force a reconfiguration of advertising in case we switched to non-connectable mode when
     // the BLE connection was established.
-    SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
     return CHIP_NO_ERROR;
@@ -530,13 +530,13 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising state to be refreshed to reflect new provisioning state.
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
 
         DriveBLEState();
 
@@ -674,7 +674,7 @@ bool BLEManagerImpl::UnsetSubscribed(bt_conn * conn)
 
 uint32_t BLEManagerImpl::GetAdvertisingInterval()
 {
-    return (NumConnections() == 0 && !ConfigurationMgr().IsFullyProvisioned()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled)
+    return (NumConnections() == 0 && !ConfigurationMgr().IsFullyProvisioned()) || mFlags.Has(Flags::kFastAdvertisingEnabled)
         ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 }

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -93,19 +93,19 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum
+    enum class Flags : uint8_t
     {
-        kFlag_AsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kFlag_AdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
-        kFlag_FastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
-        kFlag_Advertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
-        kFlag_AdvertisingRefreshNeeded =
+        kAsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kAdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
+        kFastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
+        kAdvertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
+        kAdvertisingRefreshNeeded =
             0x0010, /**< The advertising state/configuration has changed, but the SoftDevice has yet to be updated. */
     };
 
     struct ServiceData;
 
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     uint16_t mGAPConns;
     CHIPoBLEServiceMode mServiceMode;
     bool mSubscribedConns[CONFIG_BT_MAX_CONN];
@@ -182,17 +182,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return GetFlag(mFlags, kFlag_Advertising);
+    return mFlags.Has(Flags::kAdvertising);
 }
 
 } // namespace Internal

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -113,7 +113,7 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
     /* Register BLE Stack assert handler */
     RegisterAssertCback(AssertHandler);
 
-    mFlags = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
 
     mServiceMode             = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     OnChipBleConnectReceived = HandleIncomingBleConnection;
@@ -137,13 +137,13 @@ CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(BLEManager::CHIPoBLEServiceMo
 
 bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 /* Post event to app processing loop to begin CHIP advertising */
 CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 {
-    SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+    mFlags.Set(Flags::kAdvertisingEnabled, val);
 
     /* Send event to process state change request */
     return DriveBLEState();
@@ -151,16 +151,16 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
 bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 {
     CHIP_ERROR ret = CHIP_NO_ERROR;
 
-    if (!GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
+    if (!mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
 
         /* Send event to process state change request */
         ret = DriveBLEState();
@@ -170,7 +170,7 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
 bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return GetFlag(mFlags, kFlag_Advertising);
+    return mFlags.Has(Flags::kAdvertising);
 }
 
 CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
@@ -197,7 +197,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     {
         strncpy(mDeviceName, deviceName, strlen(deviceName));
 
-        SetFlag(mFlags, kFlag_BLEStackGATTNameUpdate, true);
+        mFlags.Set(Flags::kBLEStackGATTNameUpdate);
 
         ret = DriveBLEState();
     }
@@ -409,7 +409,7 @@ void BLEManagerImpl::AdvInit(void)
     ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
 
     // Verify device name was not already set
-    if (!GetFlag(sInstance.mFlags, kFlag_BLEStackGATTNameSet))
+    if (!sInstance.mFlags.Has(Flags::kBLEStackGATTNameSet))
     {
         /* Default device name is CHIP-<DISCRIMINATOR> */
         deviceDiscriminator = mDeviceIdInfo.GetDeviceDiscriminator();
@@ -758,13 +758,13 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
             /* Advertising flag set, either advertising or fast adv is enabled: Do nothing  */
             /* Advertising flag not set, neither advertising nor fast adv is enabled: do nothing */
             /* Advertising flag not set, either advertising or fast adv is enabled: Turn on */
-            if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
+            if (!sInstance.mFlags.Has(Flags::kAdvertising))
             {
                 BLEMGR_LOG("BLEMGR: BLE Process Application Message: Not advertising");
 
-                if (GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled))
+                if (sInstance.mFlags.Has(Flags::kAdvertisingEnabled))
                 {
-                    ClearFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled);
+                    sInstance.mFlags.Clear(Flags::kFastAdvertisingEnabled);
 
                     BLEMGR_LOG("BLEMGR: BLE Process Application Message: Slow Advertising Enabled");
 // Send notification to thread manager that CHIPoBLE advertising is starting
@@ -780,11 +780,11 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                     // Start advertisement timer
                     Util_startClock(&sInstance.clkAdvTimeout);
 
-                    SetFlag(sInstance.mFlags, kFlag_Advertising, true);
+                    sInstance.mFlags.Set(Flags::kAdvertising);
                 }
-                else if (GetFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled))
+                else if (sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
                 {
-                    ClearFlag(sInstance.mFlags, kFlag_AdvertisingEnabled);
+                    sInstance.mFlags.Clear(Flags::kAdvertisingEnabled);
 
                     BLEMGR_LOG("BLEMGR: BLE Process Application Message: Fast Advertising Enabled");
 
@@ -795,28 +795,27 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                     // Enable legacy advertising for set #1
                     status = (bStatus_t) GapAdv_enable(sInstance.advHandleLegacy, GAP_ADV_ENABLE_OPTIONS_USE_MAX, 0);
                     assert(status == SUCCESS);
-                    SetFlag(sInstance.mFlags, kFlag_Advertising, true);
+                    sInstance.mFlags.Set(Flags::kAdvertising);
                 }
             }
             /* Advertising flag set, neither advertising nor fast adv is enabled: Turn off*/
-            else if (!GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled) &&
-                     !GetFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled))
+            else if (!sInstance.mFlags.Has(Flags::kAdvertisingEnabled) && !sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
             {
                 BLEMGR_LOG("BLEMGR: BLE Process Application Message: Advertising disables");
 
                 // Stop advertising
                 GapAdv_disable(sInstance.advHandleLegacy);
-                ClearFlag(sInstance.mFlags, kFlag_Advertising);
+                sInstance.mFlags.Clear(Flags::kAdvertising);
 
                 Util_stopClock(&sInstance.clkAdvTimeout);
             }
         }
 
-        if (GetFlag(sInstance.mFlags, kFlag_BLEStackGATTNameUpdate))
+        if (sInstance.mFlags.Has(Flags::kBLEStackGATTNameUpdate))
         {
-            ClearFlag(sInstance.mFlags, kFlag_BLEStackGATTNameUpdate);
+            sInstance.mFlags.Clear(Flags::kBLEStackGATTNameUpdate);
             // Indicate that Device name has been set externally
-            SetFlag(mFlags, kFlag_BLEStackGATTNameSet, true);
+            mFlags.Set(Flags::kBLEStackGATTNameSet);
 
             // Set the Device Name characteristic in the GAP GATT Service
             GGS_SetParameter(GGS_DEVICE_NAME_ATT, GAP_DEVICE_NAME_LEN, sInstance.mDeviceName);
@@ -1026,7 +1025,7 @@ void BLEManagerImpl::ProcessGapMessage(gapEventHdr_t * pMsg)
 
             AdvInit();
 
-            SetFlag(sInstance.mFlags, kFlag_BLEStackInitialized, true);
+            sInstance.mFlags.Set(Flags::kBLEStackInitialized);
 
             /* Trigger post-initialization state update */
             DriveBLEState();
@@ -1060,13 +1059,13 @@ void BLEManagerImpl::ProcessGapMessage(gapEventHdr_t * pMsg)
         if (numActive < MAX_NUM_BLE_CONNS)
         {
             // Start advertising since there is room for more connections. Advertisements stop automatically following connection.
-            ClearFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Clear(Flags::kAdvertising);
         }
         else
         {
             // Stop advertising since there is no room for more connections
             BLEMGR_LOG("BLEMGR: BLE event GAP_LINK_ESTABLISHED_EVENT: MAX connections");
-            ClearFlag(sInstance.mFlags, kFlag_FastAdvertisingEnabled | kFlag_AdvertisingEnabled | kFlag_Advertising);
+            sInstance.mFlags.Clear(Flags::kFastAdvertisingEnabled).Clear(Flags::kAdvertisingEnabled.Clear(Flags::kAdvertising);
         }
 
         /* Stop advertisement timeout timer */
@@ -1686,11 +1685,11 @@ void BLEManagerImpl::AdvTimeoutHandler(uintptr_t arg)
 {
     BLEMGR_LOG("BLEMGR: AdvTimeoutHandler");
 
-    if (GetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled))
+    if (sInstance.mFlags.Has(Flags::kAdvertisingEnabled))
     {
         BLEMGR_LOG("BLEMGR: AdvTimeoutHandler ble adv 15 minute timeout");
 
-        SetFlag(sInstance.mFlags, kFlag_AdvertisingEnabled, false);
+        sInstance.mFlags.Clear(Flags::kAdvertisingEnabled);
 
         /* Send event to process state change request */
         DriveBLEState();

--- a/src/platform/qpg6100/BLEManagerImpl.cpp
+++ b/src/platform/qpg6100/BLEManagerImpl.cpp
@@ -68,8 +68,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
     CHIP_ERROR err;
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
-    mFlags       = CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART ? kFlag_AdvertisingEnabled : 0;
-    mNumGAPCons  = 0;
+    mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
+    mNumGAPCons = 0;
     for (int i = 0; i < kMaxConnections; i++)
     {
         mSubscribedConIds[i] = BLE_CONNECTION_UNINITIALIZED;
@@ -115,9 +115,9 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode != ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_AdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_AdvertisingEnabled, val);
+        mFlags.Set(Flags::kAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -131,9 +131,9 @@ CHIP_ERROR BLEManagerImpl::_SetFastAdvertisingEnabled(bool val)
 
     VerifyOrExit(mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported, err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    if (GetFlag(mFlags, kFlag_FastAdvertisingEnabled) != val)
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled) != val)
     {
-        SetFlag(mFlags, kFlag_FastAdvertisingEnabled, val);
+        mFlags.Set(Flags::kFastAdvertisingEnabled, val);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
 
@@ -209,13 +209,13 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
 
         // Force the advertising state to be refreshed to reflect new provisioning state.
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
 
         DriveBLEState();
 
@@ -353,16 +353,16 @@ void BLEManagerImpl::DriveBLEState(void)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the CHIP task is running.
-    if (!GetFlag(mFlags, kFlag_AsyncInitCompleted))
+    if (!mFlags.Has(Flags::kAsyncInitCompleted))
     {
-        SetFlag(mFlags, kFlag_AsyncInitCompleted);
+        mFlags.Set(Flags::kAsyncInitCompleted);
 
         // If CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED is enabled,
         // disable CHIPoBLE advertising if the device is fully provisioned.
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
         if (ConfigurationMgr().IsFullyProvisioned())
         {
-            ClearFlag(mFlags, kFlag_AdvertisingEnabled);
+            mFlags.Clear(Flags::kAdvertisingEnabled);
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising disabled because device is fully provisioned");
         }
 #endif // CHIP_DEVICE_CONFIG_CHIPOBLE_DISABLE_ADVERTISING_WHEN_PROVISIONED
@@ -370,7 +370,7 @@ void BLEManagerImpl::DriveBLEState(void)
 
     // If the application has enabled CHIPoBLE and BLE advertising...
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled &&
-        GetFlag(mFlags, kFlag_AdvertisingEnabled)
+        mFlags.Has(Flags::kAdvertisingEnabled)
 #if CHIP_DEVICE_CONFIG_CHIPOBLE_SINGLE_CONNECTION
         // and no connections are active...
         && (mNumGAPCons == 0)
@@ -379,7 +379,7 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         // Start/re-start BLE advertising if not already advertising, or if the
         // advertising state of the underlying stack needs to be refreshed.
-        if (!GetFlag(mFlags, kFlag_Advertising) || GetFlag(mFlags, kFlag_AdvertisingRefreshNeeded))
+        if (!mFlags.Has(Flags::kAdvertising) || mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             err = StartAdvertising();
             SuccessOrExit(err);
@@ -415,7 +415,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
     SuccessOrExit(err);
 
-    if (!GetFlag(mFlags, kFlag_DeviceNameSet))
+    if (!mFlags.Has(Flags::kDeviceNameSet))
     {
         snprintf(mDeviceName, sizeof(mDeviceName), "%s%04" PRIX32, CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, (uint32_t) 0);
 
@@ -474,9 +474,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     err = ConfigureAdvertisingData();
     SuccessOrExit(err);
 
-    SetFlag(mFlags, kFlag_Advertising, true);
+    mFlags.Set(Flags::kAdvertising);
 
-    interval = ((mNumGAPCons == 0 && !ConfigurationMgr().IsPairedToAccount()) || GetFlag(mFlags, kFlag_FastAdvertisingEnabled))
+    interval = ((mNumGAPCons == 0 && !ConfigurationMgr().IsPairedToAccount()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
         ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
         : CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL;
 
@@ -498,9 +498,9 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
     SuccessOrExit(err);
 
     // Transition to the not Advertising state...
-    if (GetFlag(mFlags, kFlag_Advertising))
+    if (mFlags.Has(Flags::kAdvertising))
     {
-        ClearFlag(mFlags, kFlag_Advertising);
+        mFlags.Clear(Flags::kAdvertising);
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 
@@ -648,14 +648,14 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
             ExitNow();
         }
 
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
         // Transition to the Advertising state...
-        if (!GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (!sInstance.mFlags.Has(Flags::kAdvertising))
         {
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising started");
 
-            SetFlag(sInstance.mFlags, kFlag_Advertising, true);
+            sInstance.mFlags.Set(Flags::kAdvertising);
 
             // Post a CHIPoBLEAdvertisingChange(Started) event.
             {
@@ -674,12 +674,12 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
             ExitNow();
         }
 
-        ClearFlag(sInstance.mFlags, kFlag_AdvertisingRefreshNeeded);
+        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
         // Transition to the not Advertising state...
-        if (GetFlag(sInstance.mFlags, kFlag_Advertising))
+        if (sInstance.mFlags.Has(Flags::kAdvertising))
         {
-            ClearFlag(sInstance.mFlags, kFlag_Advertising);
+            sInstance.mFlags.Clear(Flags::kAdvertising);
 
             ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 
@@ -706,7 +706,7 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
 
         // Receiving a connection stops the advertising processes.  So force a refresh of the advertising
         // state.
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
         break;
     }
@@ -742,7 +742,7 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
             PlatformMgr().PostEvent(&event);
         }
 
-        SetFlag(mFlags, kFlag_AdvertisingRefreshNeeded);
+        mFlags.Set(Flags::kAdvertisingRefreshNeeded);
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
         break;
     }

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -87,15 +87,14 @@ private:
 
     // ===== Private members reserved for use by this class only.
 
-    enum
+    enum class Flags : uint16_t
     {
-        kFlag_AsyncInitCompleted     = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
-        kFlag_AdvertisingEnabled     = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
-        kFlag_FastAdvertisingEnabled = 0x0004, /**< The application has enabled fast advertising. */
-        kFlag_Advertising            = 0x0008, /**< The system is currently CHIPoBLE advertising. */
-        kFlag_AdvertisingRefreshNeeded =
-            0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
-        kFlag_DeviceNameSet = 0x0020,
+        kAsyncInitCompleted       = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kAdvertisingEnabled       = 0x0002, /**< The application has enabled CHIPoBLE advertising. */
+        kFastAdvertisingEnabled   = 0x0004, /**< The application has enabled fast advertising. */
+        kAdvertising              = 0x0008, /**< The system is currently CHIPoBLE advertising. */
+        kAdvertisingRefreshNeeded = 0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
+        kDeviceNameSet            = 0x0020,
     };
 
     enum
@@ -106,7 +105,7 @@ private:
     };
 
     CHIPoBLEServiceMode mServiceMode;
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
     uint16_t mNumGAPCons;
     uint16_t mSubscribedConIds[kMaxConnections];
@@ -173,17 +172,17 @@ inline BLEManager::CHIPoBLEServiceMode BLEManagerImpl::_GetCHIPoBLEServiceMode(v
 
 inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_AdvertisingEnabled);
+    return mFlags.Has(Flags::kAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
-    return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+    return mFlags.Has(Flags::kFastAdvertisingEnabled);
 }
 
 inline bool BLEManagerImpl::_IsAdvertising(void)
 {
-    return GetFlag(mFlags, kFlag_Advertising);
+    return mFlags.Has(Flags::kAdvertising);
 }
 
 } // namespace Internal

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -45,39 +45,39 @@ enum class MessageType : uint8_t
     BlockAckEOF   = 0x14,
 };
 
-enum StatusCode : uint16_t
+enum class StatusCode : uint16_t
 {
-    kStatus_None                       = 0x0000,
-    kStatus_Overflow                   = 0x0011,
-    kStatus_LengthTooLarge             = 0x0012,
-    kStatus_LengthTooShort             = 0x0013,
-    kStatus_LengthMismatch             = 0x0014,
-    kStatus_LengthRequired             = 0x0015,
-    kStatus_BadMessageContents         = 0x0016,
-    kStatus_BadBlockCounter            = 0x0017,
-    kStatus_TransferFailedUnknownError = 0x001F,
-    kStatus_ServerBadState             = 0x0020,
-    kStatus_FailureToSend              = 0x0021,
-    kStatus_TransferMethodNotSupported = 0x0050,
-    kStatus_FileDesignatorUnknown      = 0x0051,
-    kStatus_StartOffsetNotSupported    = 0x0052,
-    kStatus_VersionNotSupported        = 0x0053,
-    kStatus_Unknown                    = 0x005F,
+    kNone                       = 0x0000,
+    kOverflow                   = 0x0011,
+    kLengthTooLarge             = 0x0012,
+    kLengthTooShort             = 0x0013,
+    kLengthMismatch             = 0x0014,
+    kLengthRequired             = 0x0015,
+    kBadMessageContents         = 0x0016,
+    kBadBlockCounter            = 0x0017,
+    kTransferFailedUnknownError = 0x001F,
+    kServerBadState             = 0x0020,
+    kFailureToSend              = 0x0021,
+    kTransferMethodNotSupported = 0x0050,
+    kFileDesignatorUnknown      = 0x0051,
+    kStartOffsetNotSupported    = 0x0052,
+    kVersionNotSupported        = 0x0053,
+    kUnknown                    = 0x005F,
 };
 
-enum TransferControlFlags : uint8_t
+enum class TransferControlFlags : uint8_t
 {
     // first 4 bits reserved for version
-    kControl_SenderDrive   = (1U << 4),
-    kControl_ReceiverDrive = (1U << 5),
-    kControl_Async         = (1U << 6),
+    kSenderDrive   = (1U << 4),
+    kReceiverDrive = (1U << 5),
+    kAsync         = (1U << 6),
 };
 
-enum RangeControlFlags : uint8_t
+enum class RangeControlFlags : uint8_t
 {
-    kRange_DefLen      = (1U),
-    kRange_StartOffset = (1U << 1),
-    kRange_Widerange   = (1U << 4),
+    kDefLen      = (1U),
+    kStartOffset = (1U << 1),
+    kWiderange   = (1U << 4),
 };
 
 /**
@@ -136,7 +136,7 @@ struct TransferInit : public BdxMessage
     bool operator==(const TransferInit &) const;
 
     // Proposed Transfer Control (required)
-    BitFlags<uint8_t, TransferControlFlags> TransferCtlOptions;
+    BitFlags<TransferControlFlags> TransferCtlOptions;
     uint8_t Version = 0; ///< The highest version supported by the sender
 
     // All required
@@ -175,7 +175,7 @@ struct SendAccept : public BdxMessage
     bool operator==(const SendAccept &) const;
 
     // Transfer Control (required, only one should be set)
-    BitFlags<uint8_t, TransferControlFlags> TransferCtlFlags;
+    BitFlags<TransferControlFlags> TransferCtlFlags;
 
     uint8_t Version       = 0; ///< The agreed upon version for the transfer (required)
     uint16_t MaxBlockSize = 0; ///< Chosen max block size to use in transfer (required)
@@ -206,7 +206,7 @@ struct ReceiveAccept : public BdxMessage
     bool operator==(const ReceiveAccept &) const;
 
     // Transfer Control (required, only one should be set)
-    BitFlags<uint8_t, TransferControlFlags> TransferCtlFlags;
+    BitFlags<TransferControlFlags> TransferCtlFlags;
 
     // All required
     uint8_t Version       = 0; ///< The agreed upon version for the transfer

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -15,16 +15,16 @@
 namespace chip {
 namespace bdx {
 
-enum TransferRole : uint8_t
+enum class TransferRole : uint8_t
 {
-    kRole_Receiver = 0,
-    kRole_Sender   = 1,
+    kReceiver = 0,
+    kSender   = 1,
 };
 
 class DLL_EXPORT TransferSession
 {
 public:
-    enum OutputEventType : uint16_t
+    enum class OutputEventType : uint16_t
     {
         kNone = 0,
         kMsgToSend,
@@ -41,7 +41,7 @@ public:
 
     struct TransferInitData
     {
-        uint8_t TransferCtlFlagsRaw = 0;
+        TransferControlFlags TransferCtlFlags;
 
         uint16_t MaxBlockSize = 0;
         uint64_t StartOffset  = 0;
@@ -70,7 +70,7 @@ public:
 
     struct StatusReportData
     {
-        uint16_t StatusCode;
+        StatusCode statusCode;
     };
 
     struct BlockData
@@ -99,8 +99,8 @@ public:
             StatusReportData statusData;
         };
 
-        OutputEvent() : EventType(kNone) { statusData = { kStatus_None }; }
-        OutputEvent(OutputEventType type) : EventType(type) { statusData = { kStatus_None }; }
+        OutputEvent() : EventType(OutputEventType::kNone) { statusData = { StatusCode::kNone }; }
+        OutputEvent(OutputEventType type) : EventType(type) { statusData = { StatusCode::kNone }; }
 
         static OutputEvent TransferInitEvent(TransferInitData data, System::PacketBufferHandle msg);
         static OutputEvent TransferAcceptEvent(TransferAcceptData data);
@@ -160,7 +160,7 @@ public:
      * @return CHIP_ERROR Result of initialization. May also indicate if the TransferSession object is unable to handle this
      *                    request.
      */
-    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<uint8_t, TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
+    CHIP_ERROR WaitForTransfer(TransferRole role, BitFlags<TransferControlFlags> xferControlOpts, uint16_t maxBlockSize,
                                uint32_t timeoutMs);
 
     /**
@@ -252,7 +252,7 @@ public:
     TransferSession();
 
 private:
-    enum TransferState : uint8_t
+    enum class TransferState : uint8_t
     {
         kUnitialized,
         kAwaitingInitMsg,
@@ -282,23 +282,23 @@ private:
      *   Used when handling a TransferInit message. Determines if there are any compatible Transfer control modes between the two
      *   transfer peers.
      */
-    void ResolveTransferControlOptions(const BitFlags<uint8_t, TransferControlFlags> & proposed);
+    void ResolveTransferControlOptions(const BitFlags<TransferControlFlags> & proposed);
 
     /**
      * @brief
      *   Used when handling an Accept message. Verifies that the chosen control mode is compatible with the orignal supported modes.
      */
-    CHIP_ERROR VerifyProposedMode(const BitFlags<uint8_t, TransferControlFlags> & proposed);
+    CHIP_ERROR VerifyProposedMode(const BitFlags<TransferControlFlags> & proposed);
 
     void PrepareStatusReport(StatusCode code);
     bool IsTransferLengthDefinite();
 
-    OutputEventType mPendingOutput = kNone;
-    TransferState mState           = kUnitialized;
+    OutputEventType mPendingOutput = OutputEventType::kNone;
+    TransferState mState           = TransferState::kUnitialized;
     TransferRole mRole;
 
     // Indicate supported options pre- transfer accept
-    BitFlags<uint8_t, TransferControlFlags> mSuppportedXferOpts;
+    BitFlags<TransferControlFlags> mSuppportedXferOpts;
     uint16_t mMaxSupportedBlockSize = 0;
 
     // Used to govern transfer once it has been accepted

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -43,8 +43,7 @@ void TestTransferInitMessage(nlTestSuite * inSuite, void * inContext)
 {
     TransferInit testMsg;
 
-    testMsg.TransferCtlOptions.SetRaw(0);
-    testMsg.TransferCtlOptions.Set(kControl_ReceiverDrive, true);
+    testMsg.TransferCtlOptions.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
     testMsg.Version = 1;
 
     // Make sure MaxLength is greater than UINT32_MAX to test widerange being set
@@ -69,8 +68,7 @@ void TestSendAcceptMessage(nlTestSuite * inSuite, void * inContext)
     SendAccept testMsg;
 
     testMsg.Version = 1;
-    testMsg.TransferCtlFlags.SetRaw(0);
-    testMsg.TransferCtlFlags.Set(kControl_ReceiverDrive, true);
+    testMsg.TransferCtlFlags.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
     testMsg.MaxBlockSize = 256;
 
     uint8_t fakeData[5]    = { 7, 6, 5, 4, 3 };
@@ -85,8 +83,7 @@ void TestReceiveAcceptMessage(nlTestSuite * inSuite, void * inContext)
     ReceiveAccept testMsg;
 
     testMsg.Version = 1;
-    testMsg.TransferCtlFlags.SetRaw(0);
-    testMsg.TransferCtlFlags.Set(kControl_ReceiverDrive, true);
+    testMsg.TransferCtlFlags.ClearAll().Set(TransferControlFlags::kReceiverDrive, true);
 
     // Make sure Length is greater than UINT32_MAX to test widerange being set
     testMsg.Length = static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -115,9 +115,9 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     CHIP_ERROR err      = CHIP_NO_ERROR;
     uint16_t headerSize = 0;
     PayloadHeader payloadHeader;
-    uint16_t generalCode  = 0;
-    uint32_t protocolId   = 0;
-    uint16_t protocolCode = 0;
+    uint16_t generalCode = 0;
+    uint32_t protocolId  = 0;
+    BitFlags<StatusCode> protocolCode;
 
     if (msg.IsNull())
     {
@@ -136,7 +136,7 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     }
 
     Encoding::LittleEndian::Reader reader(msg->Start(), msg->DataLength());
-    err = reader.Skip(headerSize).Read16(&generalCode).Read32(&protocolId).Read16(&protocolCode).StatusCode();
+    err = reader.Skip(headerSize).Read16(&generalCode).Read32(&protocolId).Read16(protocolCode.RawStorage()).StatusCode();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, generalCode == static_cast<uint16_t>(Protocols::Common::StatusCode::Failure));
     NL_TEST_ASSERT(inSuite, protocolId == Protocols::kProtocol_BDX);
@@ -147,19 +147,19 @@ void VerifyNoMoreOutput(nlTestSuite * inSuite, void * inContext, TransferSession
 {
     TransferSession::OutputEvent event;
     transferSession.PollOutput(event, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, event.EventType == TransferSession::kNone);
+    NL_TEST_ASSERT(inSuite, event.EventType == TransferSession::OutputEventType::kNone);
 }
 
 // Helper method for initializing two TransferSession objects, generating a TransferInit message, and passing it to a responding
 // TransferSession.
 void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, TransferSession::OutputEvent & outEvent, uint32_t timeoutMs,
                                TransferSession & initiator, TransferRole initiatorRole, TransferSession::TransferInitData initData,
-                               TransferSession & responder, BitFlags<uint8_t, TransferControlFlags> & responderControlOpts,
+                               TransferSession & responder, BitFlags<TransferControlFlags> & responderControlOpts,
                                uint16_t responderMaxBlock)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
-    TransferRole responderRole  = (initiatorRole == kRole_Sender) ? kRole_Receiver : kRole_Sender;
-    MessageType expectedInitMsg = (initiatorRole == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
+    TransferRole responderRole  = (initiatorRole == TransferRole::kSender) ? TransferRole::kReceiver : TransferRole::kSender;
+    MessageType expectedInitMsg = (initiatorRole == TransferRole::kSender) ? MessageType::SendInit : MessageType::ReceiveInit;
 
     // Initializer responder to wait for transfer
     err = responder.WaitForTransfer(responderRole, responderControlOpts, responderMaxBlock, timeoutMs);
@@ -170,7 +170,7 @@ void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, Transfer
     err = initiator.StartTransfer(initiatorRole, initData, timeoutMs);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiator.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedInitMsg);
     VerifyNoMoreOutput(inSuite, inContext, initiator);
 
@@ -179,14 +179,15 @@ void SendAndVerifyTransferInit(nlTestSuite * inSuite, void * inContext, Transfer
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     responder.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, responder);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInitReceived);
-    NL_TEST_ASSERT(inSuite, outEvent.transferInitData.TransferCtlFlagsRaw == initData.TransferCtlFlagsRaw);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInitReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.transferInitData.TransferCtlFlags == initData.TransferCtlFlags);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.MaxBlockSize == initData.MaxBlockSize);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.StartOffset == initData.StartOffset);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.Length == initData.Length);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.FileDesignator != nullptr);
     NL_TEST_ASSERT(inSuite, outEvent.transferInitData.FileDesLength == initData.FileDesLength);
-    if (outEvent.EventType == TransferSession::kInitReceived && outEvent.transferInitData.FileDesignator != nullptr)
+    if (outEvent.EventType == TransferSession::OutputEventType::kInitReceived &&
+        outEvent.transferInitData.FileDesignator != nullptr)
     {
         NL_TEST_ASSERT(
             inSuite,
@@ -223,7 +224,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // If the node sending the Accept message is also the one that will send Blocks, then this should be a ReceiveAccept message.
-    MessageType expectedMsg = (acceptSenderRole == kRole_Sender) ? MessageType::ReceiveAccept : MessageType::SendAccept;
+    MessageType expectedMsg = (acceptSenderRole == TransferRole::kSender) ? MessageType::ReceiveAccept : MessageType::SendAccept;
 
     err = acceptSender.AcceptTransfer(acceptData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
@@ -231,7 +232,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     // Verify Sender emits ReceiveAccept message for sending
     acceptSender.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, acceptSender);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedMsg);
 
     // Pass Accept message to acceptReceiver
@@ -243,7 +244,7 @@ void SendAndVerifyAcceptMsg(nlTestSuite * inSuite, void * inContext, TransferSes
     // Transfer at this point.
     acceptReceiver.PollOutput(outEvent, kNoAdvanceTime);
     VerifyNoMoreOutput(inSuite, inContext, acceptReceiver);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kAcceptReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kAcceptReceived);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.ControlMode == acceptData.ControlMode);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.MaxBlockSize == acceptData.MaxBlockSize);
     NL_TEST_ASSERT(inSuite, outEvent.transferAcceptData.StartOffset == acceptData.StartOffset);
@@ -277,7 +278,7 @@ void SendAndVerifyQuery(nlTestSuite * inSuite, void * inContext, TransferSession
     CHIP_ERROR err = querySender.PrepareBlockQuery();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     querySender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, MessageType::BlockQuery);
     VerifyNoMoreOutput(inSuite, inContext, querySender);
 
@@ -285,7 +286,7 @@ void SendAndVerifyQuery(nlTestSuite * inSuite, void * inContext, TransferSession
     err = queryReceiver.HandleMessageReceived(std::move(outEvent.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     queryReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kQueryReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kQueryReceived);
     VerifyNoMoreOutput(inSuite, inContext, queryReceiver);
 }
 
@@ -320,7 +321,7 @@ void SendAndVerifyArbitraryBlock(nlTestSuite * inSuite, void * inContext, Transf
     err = sender.PrepareBlock(blockData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     sender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expected);
     VerifyNoMoreOutput(inSuite, inContext, sender);
 
@@ -328,9 +329,9 @@ void SendAndVerifyArbitraryBlock(nlTestSuite * inSuite, void * inContext, Transf
     err = receiver.HandleMessageReceived(std::move(outEvent.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     receiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kBlockReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kBlockReceived);
     NL_TEST_ASSERT(inSuite, outEvent.blockdata.Data != nullptr);
-    if (outEvent.EventType == TransferSession::kBlockReceived && outEvent.blockdata.Data != nullptr)
+    if (outEvent.EventType == TransferSession::OutputEventType::kBlockReceived && outEvent.blockdata.Data != nullptr)
     {
         NL_TEST_ASSERT(inSuite, !memcmp(fakeBlockData, outEvent.blockdata.Data, outEvent.blockdata.Length));
     }
@@ -342,14 +343,14 @@ void SendAndVerifyBlockAck(nlTestSuite * inSuite, void * inContext, TransferSess
                            TransferSession::OutputEvent & outEvent, bool expectEOF)
 {
     TransferSession::OutputEventType expectedEventType =
-        expectEOF ? TransferSession::kAckEOFReceived : TransferSession::kAckReceived;
+        expectEOF ? TransferSession::OutputEventType::kAckEOFReceived : TransferSession::OutputEventType::kAckReceived;
     MessageType expectedMsgType = expectEOF ? MessageType::BlockAckEOF : MessageType::BlockAck;
 
     // Verify PrepareBlockAck() outputs message to send
     CHIP_ERROR err = ackSender.PrepareBlockAck();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     ackSender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedMsgType);
     VerifyNoMoreOutput(inSuite, inContext, ackSender);
 
@@ -379,21 +380,21 @@ void TestInitiatingReceiverReceiverDrive(nlTestSuite * inSuite, void * inContext
     uint32_t timeoutMs            = 1000 * 24;
 
     // Chosen specifically for this test
-    TransferControlFlags driveMode = kControl_ReceiverDrive;
+    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
 
     // ReceiveInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlagsRaw = driveMode;
-    initOptions.MaxBlockSize        = proposedBlockSize;
-    char testFileDes[9]             = { "test.txt" };
-    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.TransferCtlFlags = driveMode;
+    initOptions.MaxBlockSize     = proposedBlockSize;
+    char testFileDes[9]          = { "test.txt" };
+    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
 
     // Initialize respondingSender and pass ReceiveInit message
-    BitFlags<uint8_t, TransferControlFlags> senderOpts;
+    BitFlags<TransferControlFlags> senderOpts;
     senderOpts.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
                               respondingSender, senderOpts, proposedBlockSize);
 
     // Test metadata for Accept message
@@ -413,7 +414,7 @@ void TestInitiatingReceiverReceiverDrive(nlTestSuite * inSuite, void * inContext
     acceptData.Metadata       = tlvBuf;
     acceptData.MetadataLength = metadataSize;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, kRole_Sender, acceptData, initiatingReceiver,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, TransferRole::kSender, acceptData, initiatingReceiver,
                            initOptions);
 
     // Verify that MaxBlockSize was chosen correctly
@@ -473,14 +474,14 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
     TransferSession initiatingSender;
     TransferSession respondingReceiver;
 
-    TransferControlFlags driveMode = kControl_SenderDrive;
+    TransferControlFlags driveMode = TransferControlFlags::kSenderDrive;
 
     // Chosen arbitrarily for this test
     uint16_t transferBlockSize = 10;
     uint32_t timeoutMs         = 1000 * 24;
 
     // Initialize respondingReceiver
-    BitFlags<uint8_t, TransferControlFlags> receiverOpts;
+    BitFlags<TransferControlFlags> receiverOpts;
     receiverOpts.Set(driveMode);
 
     // Test metadata for TransferInit message
@@ -493,15 +494,15 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
 
     // Initialize struct with TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlagsRaw = driveMode;
-    initOptions.MaxBlockSize        = transferBlockSize;
-    char testFileDes[9]             = { "test.txt" };
-    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata            = tlvBuf;
-    initOptions.MetadataLength      = metadataSize;
+    initOptions.TransferCtlFlags = driveMode;
+    initOptions.MaxBlockSize     = transferBlockSize;
+    char testFileDes[9]          = { "test.txt" };
+    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata         = tlvBuf;
+    initOptions.MetadataLength   = metadataSize;
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingSender, kRole_Sender, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingSender, TransferRole::kSender, initOptions,
                               respondingReceiver, receiverOpts, transferBlockSize);
 
     // Verify parsed TLV metadata matches the original
@@ -519,7 +520,7 @@ void TestInitiatingSenderSenderDrive(nlTestSuite * inSuite, void * inContext)
     acceptData.Metadata       = nullptr;
     acceptData.MetadataLength = 0;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingReceiver, kRole_Receiver, acceptData, initiatingSender,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingReceiver, TransferRole::kReceiver, acceptData, initiatingSender,
                            initOptions);
 
     // Test multiple Block -> BlockAck -> Block
@@ -542,28 +543,28 @@ void TestBadAcceptMessageFields(nlTestSuite * inSuite, void * inContext)
     TransferSession respondingSender;
 
     uint16_t maxBlockSize          = 64;
-    TransferControlFlags driveMode = kControl_ReceiverDrive;
+    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
     uint64_t commonLength          = 0;
     uint64_t commonOffset          = 0;
     uint32_t timeoutMs             = 1000 * 24;
 
     // Initialize struct with TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlagsRaw = driveMode;
-    initOptions.MaxBlockSize        = maxBlockSize;
-    initOptions.StartOffset         = commonOffset;
-    initOptions.Length              = commonLength;
-    char testFileDes[9]             = { "test.txt" }; // arbitrary file designator
-    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata            = nullptr;
-    initOptions.MetadataLength      = 0;
+    initOptions.TransferCtlFlags = driveMode;
+    initOptions.MaxBlockSize     = maxBlockSize;
+    initOptions.StartOffset      = commonOffset;
+    initOptions.Length           = commonLength;
+    char testFileDes[9]          = { "test.txt" }; // arbitrary file designator
+    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata         = nullptr;
+    initOptions.MetadataLength   = 0;
 
     // Responder parameters
-    BitFlags<uint8_t, TransferControlFlags> responderControl;
+    BitFlags<TransferControlFlags> responderControl;
     responderControl.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
                               respondingSender, responderControl, maxBlockSize);
 
     // Verify AcceptTransfer() returns error for choosing larger max block size
@@ -577,7 +578,8 @@ void TestBadAcceptMessageFields(nlTestSuite * inSuite, void * inContext)
 
     // Verify AcceptTransfer() returns error for choosing unsupported transfer control mode
     TransferSession::TransferAcceptData acceptData2;
-    acceptData2.ControlMode  = (driveMode == kControl_ReceiverDrive) ? kControl_SenderDrive : kControl_ReceiverDrive;
+    acceptData2.ControlMode = (driveMode == TransferControlFlags::kReceiverDrive) ? TransferControlFlags::kSenderDrive
+                                                                                  : TransferControlFlags::kReceiverDrive;
     acceptData2.MaxBlockSize = maxBlockSize;
     acceptData2.StartOffset  = commonOffset;
     acceptData2.Length       = commonLength;
@@ -598,17 +600,17 @@ void TestTimeout(nlTestSuite * inSuite, void * inContext)
 
     // Initialize struct with arbitrary TransferInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlagsRaw = kControl_ReceiverDrive;
-    initOptions.MaxBlockSize        = 64;
-    initOptions.StartOffset         = 0;
-    initOptions.Length              = 0;
-    char testFileDes[9]             = { "test.txt" }; // arbitrary file designator
-    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
-    initOptions.Metadata            = nullptr;
-    initOptions.MetadataLength      = 0;
+    initOptions.TransferCtlFlags = TransferControlFlags::kReceiverDrive;
+    initOptions.MaxBlockSize     = 64;
+    initOptions.StartOffset      = 0;
+    initOptions.Length           = 0;
+    char testFileDes[9]          = { "test.txt" }; // arbitrary file designator
+    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.Metadata         = nullptr;
+    initOptions.MetadataLength   = 0;
 
-    TransferRole role = kRole_Receiver;
+    TransferRole role = TransferRole::kReceiver;
 
     // Verify initiator outputs respective Init message (depending on role) after StartTransfer()
     err = initiator.StartTransfer(role, initOptions, timeoutMs);
@@ -616,13 +618,13 @@ void TestTimeout(nlTestSuite * inSuite, void * inContext)
 
     // First PollOutput() should output the TransferInit message
     initiator.PollOutput(outEvent, startTimeMs);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
-    MessageType expectedInitMsg = (role == kRole_Sender) ? MessageType::SendInit : MessageType::ReceiveInit;
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
+    MessageType expectedInitMsg = (role == TransferRole::kSender) ? MessageType::SendInit : MessageType::ReceiveInit;
     VerifyBdxMessageType(inSuite, inContext, outEvent.MsgData, expectedInitMsg);
 
     // Second PollOutput() with no call to HandleMessageReceived() should result in a timeout.
     initiator.PollOutput(outEvent, endTimeMs);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kTransferTimeout);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kTransferTimeout);
 }
 
 // Test that sending the same block twice (with same block counter) results in a StatusReport message with BadBlockCounter. Also
@@ -645,21 +647,21 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     uint32_t timeoutMs      = 1000 * 24;
 
     // Chosen specifically for this test
-    TransferControlFlags driveMode = kControl_ReceiverDrive;
+    TransferControlFlags driveMode = TransferControlFlags::kReceiverDrive;
 
     // ReceiveInit parameters
     TransferSession::TransferInitData initOptions;
-    initOptions.TransferCtlFlagsRaw = driveMode;
-    initOptions.MaxBlockSize        = blockSize;
-    char testFileDes[9]             = { "test.txt" };
-    initOptions.FileDesLength       = static_cast<uint16_t>(strlen(testFileDes));
-    initOptions.FileDesignator      = reinterpret_cast<uint8_t *>(testFileDes);
+    initOptions.TransferCtlFlags = driveMode;
+    initOptions.MaxBlockSize     = blockSize;
+    char testFileDes[9]          = { "test.txt" };
+    initOptions.FileDesLength    = static_cast<uint16_t>(strlen(testFileDes));
+    initOptions.FileDesignator   = reinterpret_cast<uint8_t *>(testFileDes);
 
     // Initialize respondingSender and pass ReceiveInit message
-    BitFlags<uint8_t, TransferControlFlags> senderOpts;
+    BitFlags<TransferControlFlags> senderOpts;
     senderOpts.Set(driveMode);
 
-    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, kRole_Receiver, initOptions,
+    SendAndVerifyTransferInit(inSuite, inContext, outEvent, timeoutMs, initiatingReceiver, TransferRole::kReceiver, initOptions,
                               respondingSender, senderOpts, blockSize);
 
     // Compose ReceiveAccept parameters struct and give to respondingSender
@@ -671,7 +673,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     acceptData.Metadata       = nullptr;
     acceptData.MetadataLength = 0;
 
-    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, kRole_Sender, acceptData, initiatingReceiver,
+    SendAndVerifyAcceptMsg(inSuite, inContext, outEvent, respondingSender, TransferRole::kSender, acceptData, initiatingReceiver,
                            initOptions);
 
     SendAndVerifyQuery(inSuite, inContext, respondingSender, initiatingReceiver, outEvent);
@@ -685,7 +687,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = respondingSender.PrepareBlock(blockData);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     respondingSender.PollOutput(eventWithBlock, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, eventWithBlock.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, eventWithBlock.EventType == TransferSession::OutputEventType::kMsgToSend);
     VerifyBdxMessageType(inSuite, inContext, eventWithBlock.MsgData, MessageType::Block);
     VerifyNoMoreOutput(inSuite, inContext, respondingSender);
     System::PacketBufferHandle blockCopy =
@@ -695,7 +697,7 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = initiatingReceiver.HandleMessageReceived(std::move(eventWithBlock.MsgData), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kBlockReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kBlockReceived);
     NL_TEST_ASSERT(inSuite, outEvent.blockdata.Data != nullptr);
     VerifyNoMoreOutput(inSuite, inContext, initiatingReceiver);
 
@@ -705,30 +707,30 @@ void TestDuplicateBlockError(nlTestSuite * inSuite, void * inContext)
     err = initiatingReceiver.HandleMessageReceived(std::move(blockCopy), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kMsgToSend);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kMsgToSend);
     System::PacketBufferHandle statusReportMsg = outEvent.MsgData.Retain();
-    VerifyStatusReport(inSuite, inContext, std::move(outEvent.MsgData), kStatus_BadBlockCounter);
+    VerifyStatusReport(inSuite, inContext, std::move(outEvent.MsgData), StatusCode::kBadBlockCounter);
 
     // All subsequent PollOutput() calls should return kInternalError
     for (int i = 0; i < 5; ++i)
     {
         initiatingReceiver.PollOutput(outEvent, kNoAdvanceTime);
-        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInternalError);
-        NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
+        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInternalError);
+        NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
     }
 
     err = respondingSender.HandleMessageReceived(std::move(statusReportMsg), kNoAdvanceTime);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     respondingSender.PollOutput(outEvent, kNoAdvanceTime);
-    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kStatusReceived);
-    NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
+    NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kStatusReceived);
+    NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
 
     // All subsequent PollOutput() calls should return kInternalError
     for (int i = 0; i < 5; ++i)
     {
         respondingSender.PollOutput(outEvent, kNoAdvanceTime);
-        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::kInternalError);
-        NL_TEST_ASSERT(inSuite, outEvent.statusData.StatusCode == kStatus_BadBlockCounter);
+        NL_TEST_ASSERT(inSuite, outEvent.EventType == TransferSession::OutputEventType::kInternalError);
+        NL_TEST_ASSERT(inSuite, outEvent.statusData.statusCode == StatusCode::kBadBlockCounter);
     }
 }
 

--- a/src/setup_payload/AdditionalDataPayloadGenerator.cpp
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.cpp
@@ -44,7 +44,7 @@ using namespace chip::Encoding::LittleEndian;
 CHIP_ERROR
 AdditionalDataPayloadGenerator::generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * serialNumberBuffer,
                                                               size_t serialNumberBufferSize, PacketBufferHandle & bufferHandle,
-                                                              BitFlags<uint8_t, AdditionalDataFields> additionalDataFields)
+                                                              BitFlags<AdditionalDataFields> additionalDataFields)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     System::PacketBufferTLVWriter writer;

--- a/src/setup_payload/AdditionalDataPayloadGenerator.h
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.h
@@ -71,7 +71,7 @@ public:
      */
     CHIP_ERROR generateAdditionalDataPayload(uint16_t lifetimeCounter, const char * serialNumberBuffer,
                                              size_t serialNumberBufferSize, chip::System::PacketBufferHandle & bufferHandle,
-                                             BitFlags<uint8_t, AdditionalDataFields> additionalDataFields);
+                                             BitFlags<AdditionalDataFields> additionalDataFields);
     // Generate Device Rotating ID
     /**
      * Generate additional data payload (i.e. TLV encoded).

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -319,9 +319,9 @@ CHIP_ERROR PacketHeader::EncodeBeforeData(const System::PacketBufferHandle & buf
 
 CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encode_size) const
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    uint8_t * p    = data;
-    uint8_t header = mExchangeFlags.Raw();
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    uint8_t * p          = data;
+    const uint8_t header = mExchangeFlags.Raw();
 
     VerifyOrExit(size >= EncodeSizeBytes(), err = CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -95,9 +95,9 @@ enum class FlagValues : uint16_t
 
 };
 
-using Flags         = BitFlags<uint16_t, FlagValues>;
-using ExFlags       = BitFlags<uint8_t, ExFlagValues>;
-using InternalFlags = BitFlags<uint8_t, InternalFlagValues>;
+using Flags         = BitFlags<FlagValues>;
+using ExFlags       = BitFlags<ExFlagValues>;
+using InternalFlags = BitFlags<InternalFlagValues>;
 
 // Header is a 16-bit value of the form
 //  |  4 bit  | 4 bit |8 bit Security Flags|


### PR DESCRIPTION
#### Problem

- `BitFlags.h` has relatively unsafe deprecated functions.
- Some bit flags use `enum` rather than type-safe `enum class`.

#### Summary of Changes

- Removed deprecated `SetFlags()`, `ClearFlags()`, and `GetFlags()`,
  replacing uses with `BitFlags`.

- BitFlags.h changes:
  - Default to use `std::underlying_type` rather than requiring it as a template parameter.
  - Added `BitFlags` operations to reduce uses of type-unsafe `Raw()` and `SetRaw()`:
    - Multi-argument constructors.
    - `operator FlagsEnum()`.
    - `ClearAll()`.
    - `HasAny()` and `HasAll()`, following the pattern of the existing `HasOnly()`.
    - Binary `&`.

- Converted various bit flag types from `enum` to `enum class`:
  - BLEEndPoint::ConnectionStateFlags
  - BLEEndPoint::TimerStateFlags
  - BLEManagerImpl::Flags
  - Command::CommandPathFlags
  - Encoding::HexFlags
  - GenericConfigurationManagerImpl::Flags
  - GenericConnectivityManagerImpl_Thread::Flags
  - GenericConnectivityManagerImpl_WiFi::ConnectivityFlags
  - bdx::RangeControlFlags
  - bdx::StatusCode
  - bdx::TransferControlFlags
  - bdx::TransferRole

Reland of 4b8d5582 (#5232) due to a logic error in `*/BLEManagerImpl.cpp` and a large
accidental deletion in `K32W/BLEManagerImpl.cpp`.

