### PR TITLE
Fix build error on RP4 with Ubuntu 20.10 64-bit server OS

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -43,7 +43,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following:
 
 ```
-sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev unzip
+sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip
 ```
 
 #### How to install prerequisites on macOS


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
As I run "source scripts/activate.sh" command on RP4 with a new installed Ubuntu 20.10 64-bit server OS, got the following errors:
Failed to build dbus-python
Installing collected packages: dbus-python, cryptography, coloredlogs
    Running setup.py install for dbus-python: started
    Running setup.py install for dbus-python: finished with status 'error'
ERROR: Command errored out with exit status 1: /home/ubuntu/connectedhomeip/.environment/pigweed-venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-txl64dhb/dbus-python_f8d2014427a944f792e6b477e32ab192/setup.py'"'"'; __file__='"'"'/tmp/pip-install-txl64dhb/dbus-python_f8d2014427a944f792e6b477e32ab192/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-2oyocrno/install-record.txt --single-version-externally-managed --compile --install-headers /home/ubuntu/connectedhomeip/.environment/pigweed-venv/include/site/python3.8/dbus-python Check the logs for full command output.
['/home/ubuntu/connectedhomeip/.environment/pigweed-venv/bin/python', '-m', 'pip', 'install', '--log', '/home/ubuntu/connectedhomeip/.environment/pigweed-venv/pip-requirements.log', '--requirement=/home/ubuntu/connectedhomeip/scripts/requirements.txt'] {'stderr': -2, 'stdout': <open file '<fdopen>', mode 'w+' at 0xffffa42cb780>}
None
Traceback (most recent call last):
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/env_setup.py", line 596, in <module>
    sys.exit(main())
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/env_setup.py", line 588, in main
    return EnvSetup(**vars(parse())).setup()
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/env_setup.py", line 306, in setup
    result = step()
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/env_setup.py", line 414, in virtualenv
    env=self._env,
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/virtualenv_setup/install.py", line 188, in install
    *requirement_args)
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/virtualenv_setup/install.py", line 180, in pip_install
    return _check_call(cmd)
  File "/home/ubuntu/connectedhomeip/third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/virtualenv_setup/install.py", line 94, in _check_call
    subprocess.check_call(args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/ubuntu/connectedhomeip/.environment/pigweed-venv/bin/python', '-m', 'pip', 'install', '--log', '/home/ubuntu/connectedhomeip/.environment/pigweed-venv/pip-requirements.log', '--requirement=/home/ubuntu/connectedhomeip/scripts/requirements.txt']' returned non-zero exit status 1
Error during bootstrap--see messages above.
ubuntu@ubuntu:~/connectedhomeip$

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Update the building guide to install the missing prerequisites

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
