### PR TITLE
Integrated SRP client API with the existing mDNS API.

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -202,6 +202,10 @@ chip_gn_arg_bool  ("chip_inet_config_enable_dns_resolver"   CONFIG_CHIP_BUILD_TE
 chip_gn_arg_bool  ("chip_build_libshell"                    CONFIG_CHIP_LIB_SHELL)
 chip_gn_arg_bool  ("chip_build_pw_rpc_lib"                  CONFIG_CHIP_PW_RPC)
 
+if (CONFIG_CHIP_ENABLE_DNSSD_SRP)
+    chip_gn_arg_string("chip_mdns" "platform")
+endif()
+
 if (CHIP_PROJECT_CONFIG)
     chip_gn_arg_string("chip_project_config_include"        ${CHIP_PROJECT_CONFIG})
     chip_gn_arg_string("chip_system_project_config_include" ${CHIP_PROJECT_CONFIG})

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -142,7 +142,12 @@ void StartServer()
     }
     else
     {
+// TODO: Thread devices are not able to advertise using mDNS before being provisioned,
+// so configuraton should be added to enable commissioning advertising based on supported
+// Rendezvous methods.
+#if !CHIP_DEVICE_CONFIG_ENABLE_THREAD
         err = app::Mdns::AdvertiseCommisioning();
+#endif
     }
 
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -531,6 +531,11 @@ void InitServer(AppDelegate * delegate)
 #endif
     }
 
+// Starting mDNS server only for Thread devices due to problem reported in issue #5076.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    app::Mdns::StartServer();
+#endif
+
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -24,6 +24,11 @@
 #pragma once
 
 namespace chip {
+
+namespace Mdns {
+struct TextEntry;
+}
+
 namespace DeviceLayer {
 
 class PlatformManagerImpl;
@@ -74,6 +79,7 @@ public:
     CHIP_ERROR GetAndLogThreadTopologyMinimal();
     CHIP_ERROR GetAndLogThreadTopologyFull();
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
     CHIP_ERROR GetExternalIPv6Address(chip::Inet::IPAddress & addr);
 
     CHIP_ERROR JoinerStart();
@@ -82,8 +88,8 @@ public:
     CHIP_ERROR SetThreadEnabled(bool val);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    CHIP_ERROR AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, uint32_t aLeaseInterval,
-                             uint32_t aKeyLeaseInterval);
+    CHIP_ERROR AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
+                             size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR SetupSrpHost(const char * aHostName);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
@@ -227,9 +233,11 @@ inline CHIP_ERROR ThreadStackManager::SetThreadEnabled(bool val)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 inline CHIP_ERROR ThreadStackManager::AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort,
+                                                    chip::Mdns::TextEntry * aTxtEntries, size_t aTxtEntiresSize,
                                                     uint32_t aLeaseInterval = 0, uint32_t aKeyLeaseInterval = 0)
 {
-    return static_cast<ImplClass *>(this)->_AddSrpService(aInstanceName, aName, aPort, aLeaseInterval, aKeyLeaseInterval);
+    return static_cast<ImplClass *>(this)->_AddSrpService(aInstanceName, aName, aPort, aTxtEntries, aTxtEntiresSize, aLeaseInterval,
+                                                          aKeyLeaseInterval);
 }
 
 inline CHIP_ERROR ThreadStackManager::RemoveSrpService(const char * aInstanceName, const char * aName)
@@ -331,6 +339,11 @@ inline CHIP_ERROR ThreadStackManager::GetAndLogThreadTopologyFull()
 inline CHIP_ERROR ThreadStackManager::GetPrimary802154MACAddress(uint8_t * buf)
 {
     return static_cast<ImplClass *>(this)->_GetPrimary802154MACAddress(buf);
+}
+
+inline CHIP_ERROR ThreadStackManager::GetFactoryAssignedEUI64(uint8_t (&buf)[8])
+{
+    return static_cast<ImplClass *>(this)->_GetFactoryAssignedEUI64(buf);
 }
 
 inline CHIP_ERROR ThreadStackManager::GetExternalIPv6Address(chip::Inet::IPAddress & addr)

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -64,6 +64,7 @@ public:
     CHIP_ERROR _GetPrimaryWiFiMACAddress(uint8_t * buf);
     CHIP_ERROR _StorePrimaryWiFiMACAddress(const uint8_t * buf);
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR _GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
     CHIP_ERROR _StorePrimary802154MACAddress(const uint8_t * buf);
     CHIP_ERROR _GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & dayOfMonth);
     CHIP_ERROR _StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen);

--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -15,11 +15,6 @@
 import("//build_overrides/chip.gni")
 import("${chip_root}/src/platform/device.gni")
 
-declare_args() {
-  # Set up what advertiser to use for mDNS advertisement
-  chip_mdns_advertiser = "minimal"
-}
-
 source_set("platform_header") {
   sources = [ "platform/Mdns.h" ]
 }
@@ -33,24 +28,18 @@ static_library("mdns") {
 
   sources = [ "Advertiser.h" ]
 
-  if (chip_enable_mdns) {
-    _chip_mdns_advertiser = chip_mdns_advertiser
-  } else {
-    _chip_mdns_advertiser = "none"
-  }
-
-  if (_chip_mdns_advertiser == "none") {
+  if (chip_mdns == "none") {
     sources += [
       "Advertiser_ImplNone.cpp",
       "Resolver_ImplNone.cpp",
     ]
-  } else if (_chip_mdns_advertiser == "minimal") {
+  } else if (chip_mdns == "minimal") {
     sources += [
       "Advertiser_ImplMinimalMdns.cpp",
       "Resolver_ImplNone.cpp",
     ]
     public_deps += [ "${chip_root}/src/lib/mdns/minimal" ]
-  } else if (_chip_mdns_advertiser == "platform") {
+  } else if (chip_mdns == "platform") {
     sources += [
       "Discovery_ImplPlatform.cpp",
       "Discovery_ImplPlatform.h",

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -35,9 +35,10 @@
 namespace chip {
 namespace Mdns {
 
-static constexpr uint8_t kMdnsNameMaxSize  = 33;
-static constexpr uint8_t kMdnsTypeMaxSize  = 32;
-static constexpr uint16_t kMdnsTextMaxSize = 64;
+static constexpr uint8_t kMdnsNameMaxSize         = 33;
+static constexpr uint8_t kMdnsProtocolTextMaxSize = 8;
+static constexpr uint8_t kMdnsTypeMaxSize         = 32;
+static constexpr uint16_t kMdnsTextMaxSize        = 64;
 
 enum class MdnsServiceProtocol : uint8_t
 {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -30,7 +30,7 @@ if (chip_enable_openthread) {
   }
 }
 
-if (chip_device_platform == "linux" && chip_enable_mdns) {
+if (chip_device_platform == "linux" && chip_mdns != "none") {
   pkg_config("avahi_client_config") {
     packages = [ "avahi-client" ]
   }
@@ -75,7 +75,7 @@ if (chip_device_platform != "none") {
       defines += [ "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_ble}" ]
     }
 
-    if (chip_enable_mdns) {
+    if (chip_mdns != "none") {
       defines += [ "CHIP_DEVICE_CONFIG_ENABLE_MDNS=1" ]
     }
 
@@ -241,7 +241,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "${chip_root}/src:includes",
     ]
 
-    if (chip_enable_mdns) {
+    if (chip_mdns != "none") {
       public_deps += [ "${chip_root}/src/lib/mdns:platform_header" ]
     }
 
@@ -494,7 +494,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "Linux/bluez/Types.h",
       ]
 
-      if (chip_enable_mdns) {
+      if (chip_mdns != "none") {
         sources += [
           "Linux/MdnsImpl.cpp",
           "Linux/MdnsImpl.h",
@@ -593,6 +593,11 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
           "qpg6100/ThreadStackManagerImpl.h",
         ]
       }
+    }
+
+    if (chip_enable_openthread && chip_mdns == "platform" &&
+        chip_device_platform != "linux") {
+      sources += [ "OpenThread/MdnsImpl.cpp" ]
     }
 
     allow_circular_includes_from = [ "${chip_root}/src/lib/support" ]

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -441,6 +441,11 @@ exit:
     return OTBR_TO_CHIP_ERROR(error);
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_GetFactoryAssignedEUI64(uint8_t (&buf)[8])
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_GetExternalIPv6Address(chip::Inet::IPAddress & addr)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -86,6 +86,8 @@ public:
 
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
 
+    CHIP_ERROR _GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
+
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
 
     CHIP_ERROR _JoinerStart();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -80,6 +80,19 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnOpenThreadStateChang
     event.ThreadStateChange.NetDataChanged    = (flags & OT_CHANGED_THREAD_NETDATA) != 0;
     event.ThreadStateChange.ChildNodesChanged = (flags & (OT_CHANGED_THREAD_CHILD_ADDED | OT_CHANGED_THREAD_CHILD_REMOVED)) != 0;
     event.ThreadStateChange.OpenThread.Flags  = flags;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    if (event.ThreadStateChange.AddressChanged)
+    {
+        const otSrpClientHostInfo * hostInfo =
+            otSrpClientGetHostInfo(static_cast<GenericThreadStackManagerImpl_OpenThread *>(context)->Impl()->OTInstance());
+        if (hostInfo && hostInfo->mName)
+        {
+            static_cast<GenericThreadStackManagerImpl_OpenThread *>(context)->Impl()->_SetupSrpHost(hostInfo->mName);
+        }
+    }
+#endif
+
     PlatformMgr().PostEvent(&event);
 }
 
@@ -818,6 +831,15 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPrimary80215
 };
 
 template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetFactoryAssignedEUI64(uint8_t (&buf)[8])
+{
+    otExtAddress extendedAddr;
+    otLinkGetFactoryAssignedIeeeEui64(mOTInst, &extendedAddr);
+    memcpy(buf, extendedAddr.m8, sizeof(extendedAddr.m8));
+    return CHIP_NO_ERROR;
+};
+
+template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6Address(chip::Inet::IPAddress & addr)
 {
     const otNetifAddress * otAddresses = otIp6GetUnicastAddresses(mOTInst);
@@ -875,7 +897,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     // state change occurs.  Note that we reference the OnOpenThreadStateChange method
     // on the concrete implementation class so that that class can override the default
     // method implementation if it chooses to.
-    otErr = otSetStateChangedCallback(otInst, ImplClass::OnOpenThreadStateChange, NULL);
+    otErr = otSetStateChangedCallback(otInst, ImplClass::OnOpenThreadStateChange, this);
     VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
 
     // Enable automatic assignment of Thread advertised addresses.
@@ -1116,7 +1138,8 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnSrpClientStateChange
 
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AddSrpService(const char * aInstanceName, const char * aName,
-                                                                               uint16_t aPort, uint32_t aLeaseInterval,
+                                                                               uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
+                                                                               size_t aTxtEntiresSize, uint32_t aLeaseInterval,
                                                                                uint32_t aKeyLeaseInterval)
 {
     CHIP_ERROR error                         = CHIP_NO_ERROR;
@@ -1157,6 +1180,29 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_AddSrpService(c
     srpService->mService.mName = srpService->mName;
 
     srpService->mService.mPort = aPort;
+
+    // Check if there are some optional text entries to add.
+    if (aTxtEntries && aTxtEntiresSize != 0)
+    {
+        VerifyOrExit(aTxtEntiresSize <= SrpClient::kMaxTxtEntriesNumber, error = CHIP_ERROR_INVALID_LIST_LENGTH);
+
+        srpService->mService.mNumTxtEntries = static_cast<uint8_t>(aTxtEntiresSize);
+
+        for (uint8_t entryId = 0; entryId < aTxtEntiresSize; entryId++)
+        {
+            VerifyOrExit(aTxtEntries[entryId].mDataSize <= SrpClient::kMaxTxtValueSize, error = CHIP_ERROR_BUFFER_TOO_SMALL);
+            VerifyOrExit((strlen(aTxtEntries[entryId].mKey) + 1) <= SrpClient::kMaxTxtKeySize, error = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+            srpService->mTxtEntries[entryId].mValueLength = static_cast<uint8_t>(aTxtEntries[entryId].mDataSize);
+            memcpy(&(srpService->mTxtValueBuffers[entryId][0]), aTxtEntries[entryId].mData, aTxtEntries[entryId].mDataSize);
+            srpService->mTxtEntries[entryId].mValue = &(srpService->mTxtValueBuffers[entryId][0]);
+
+            memcpy(&(srpService->mTxtKeyBuffers[entryId][0]), aTxtEntries[entryId].mKey, strlen(aTxtEntries[entryId].mKey) + 1);
+            srpService->mTxtEntries[entryId].mKey = &(srpService->mTxtKeyBuffers[entryId][0]);
+        }
+
+        srpService->mService.mTxtEntries = srpService->mTxtEntries;
+    }
 
     error = MapOpenThreadError(otSrpClientAddService(mOTInst, &(srpService->mService)));
 
@@ -1214,11 +1260,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
     error = MapOpenThreadError(otSrpClientSetHostName(mOTInst, aHostName));
     SuccessOrExit(error);
 
-    error = ThreadStackMgr().GetExternalIPv6Address(hostAddress);
-    SuccessOrExit(error);
-
-    memcpy(&mSrpClient.mHostAddress.mFields.m32, hostAddress.Addr, sizeof(hostAddress.Addr));
-    error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, &mSrpClient.mHostAddress, 1));
+    // Check if device has any external IPv6 assigned. If not, host will be set without IPv6 addresses
+    // and updated later on.
+    if (ThreadStackMgr().GetExternalIPv6Address(hostAddress) == CHIP_NO_ERROR)
+    {
+        memcpy(&mSrpClient.mHostAddress.mFields.m32, hostAddress.Addr, sizeof(hostAddress.Addr));
+        error = MapOpenThreadError(otSrpClientSetHostAddresses(mOTInst, &mSrpClient.mHostAddress, 1));
+    }
 
 exit:
     Impl()->UnlockThreadStack();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -32,6 +32,8 @@
 #include <openthread/srp_client.h>
 #endif
 
+#include <lib/mdns/platform/Mdns.h>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -87,13 +89,14 @@ protected:
     CHIP_ERROR _GetAndLogThreadTopologyMinimal(void);
     CHIP_ERROR _GetAndLogThreadTopologyFull(void);
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
+    CHIP_ERROR _GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
     void _OnWoBLEAdvertisingStart(void);
     void _OnWoBLEAdvertisingStop(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    CHIP_ERROR _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, uint32_t aLeaseInterval,
-                              uint32_t aKeyLeaseInterval);
+    CHIP_ERROR _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
+                              size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
@@ -122,12 +125,18 @@ private:
         static constexpr uint8_t kMaxInstanceNameSize = 64;
         static constexpr uint8_t kMaxNameSize         = 16;
         static constexpr uint8_t kMaxHostNameSize     = 32;
+        static constexpr uint8_t kMaxTxtEntriesNumber = 4;
+        static constexpr uint8_t kMaxTxtValueSize     = 255;
+        static constexpr uint8_t kMaxTxtKeySize       = 16;
 
         struct Service
         {
             otSrpClientService mService;
             char mInstanceName[kMaxInstanceNameSize];
             char mName[kMaxNameSize];
+            otDnsTxtEntry mTxtEntries[kMaxTxtEntriesNumber];
+            uint8_t mTxtValueBuffers[kMaxTxtEntriesNumber][kMaxTxtValueSize];
+            char mTxtKeyBuffers[kMaxTxtEntriesNumber][kMaxTxtKeySize];
         };
 
         char mHostName[kMaxHostNameSize];

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "lib/mdns/platform/Mdns.h"
+
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace ::chip::DeviceLayer;
+
+namespace chip {
+namespace Mdns {
+
+CHIP_ERROR ChipMdnsInit(MdnsAsyncReturnCallback initCallback, MdnsAsyncReturnCallback errorCallback, void * context)
+{
+    // Intentionally empty
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ChipMdnsSetHostname(const char * hostname)
+{
+    return ThreadStackMgr().SetupSrpHost(hostname);
+}
+
+const char * GetProtocolString(MdnsServiceProtocol protocol)
+{
+    return protocol == MdnsServiceProtocol::kMdnsProtocolUdp ? "_udp" : "_tcp";
+}
+
+CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
+{
+    char serviceType[kMdnsTypeMaxSize + kMdnsProtocolTextMaxSize + 1];
+    snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
+
+    return ThreadStackMgr().AddSrpService(service->mName, serviceType, service->mPort, service->mTextEntries,
+                                          service->mTextEntrySize);
+}
+
+CHIP_ERROR ChipMdnsStopPublish()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, Inet::IPAddressType addressType,
+                          Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ChipMdnsResolve(MdnsService * browseResult, Inet::InterfaceId interface, MdnsResolveCallback callback, void * context)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+} // namespace Mdns
+} // namespace chip

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -46,8 +46,11 @@ declare_args() {
       (chip_device_platform == "linux" || chip_device_platform == "darwin" ||
        chip_device_platform == "cc13x2_26x2")
 
-  chip_enable_mdns =
-      chip_device_platform == "linux" || chip_device_platform == "esp32"
+  if (chip_device_platform == "linux" || chip_device_platform == "esp32") {
+    chip_mdns = "minimal"
+  } else {
+    chip_mdns = "none"
+  }
 }
 
 _chip_device_layer = "none"

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -32,7 +32,7 @@ if (chip_device_platform != "none") {
       test_sources += [ "TestPlatformMgr.cpp" ]
     }
 
-    if (chip_enable_mdns && chip_enable_happy_tests &&
+    if (chip_mdns != "none" && chip_enable_happy_tests &&
         chip_device_platform == "linux") {
       test_sources += [ "TestMdns.cpp" ]
     }


### PR DESCRIPTION
 #### Problem
The SRP and mDNS protocols should have some common layer and API. For now it seems to be reasonable to make SRP client to behave as mDNS implementation for Thread devices, so some integration is necessary in order to reuse existing mDNS code.

 #### Summary of Changes
* Replaced chip_mdns_advertiser and chip_enable_mdns arguments, with one - chip_mdns acting as both of them.
* Added implementation of SetupHostname() method for Thread devices.
* Added MdnsImpl for the OpenThread platform.
* Expanded AddSrpService method by possibility to pass text entries.
* Added ifdef to not call AdvertiseCommissioning for Thread devices, as they are not able to do that in unprovisioned state.
* Added ThreadStackManager method for getting device EUI64.
* Added starting mdns server to the Server.cpp InitServer() method, as it was removed in the https://github.com/project-chip/connectedhomeip/pull/5154 for platforms other than ESP32.

SRP usage for nrfconnect platform remains disabled by CONFIG_CHIP_ENABLE_DNSSD_SRP option, as still we are waiting for the nRF Connect SDK update including also OpenThread version update.
