### PR TITLE
[mdns] Fix Resolver initialization

### DIFF
--- a/src/lib/mdns/Discovery_ImplPlatform.h
+++ b/src/lib/mdns/Discovery_ImplPlatform.h
@@ -30,6 +30,8 @@ namespace Mdns {
 class DiscoveryImplPlatform : public ServiceAdvertiser, public Resolver
 {
 public:
+    CHIP_ERROR Init();
+
     CHIP_ERROR Start(Inet::InetLayer * inetLayer, uint16_t port) override;
 
     /// Advertises the CHIP node as an operational node


### PR DESCRIPTION
 #### Problem
ChipMdnsInit() call has recently been moved to ServiceAdvertiser::Start, hence the function is never called on the mDNS resolver side and any node ID resolution fails.

 #### Summary of Changes
Call the initialization function when necessary. A better place IMHO would be to initialize the Mdns platform code in `PlatformManager::InitChipStack`, it however requires some refactoring since currently, `lib/mdns` depends on the platform code and the platform mdns initialization function takes a callback which is provided by `lib/mdns`...