### PR TITLE
Support chained buffers in PacketBufferHandle::CloneData()

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -614,6 +614,10 @@ PacketBufferHandle PacketBufferHandle::CloneData()
         uint16_t originalDataSize     = original->MaxDataLength();
         uint16_t originalReservedSize = original->ReservedSize();
         PacketBufferHandle clone      = PacketBufferHandle::New(originalDataSize, originalReservedSize);
+        if (clone.IsNull())
+        {
+            return PacketBufferHandle();
+        }
         clone.mBuffer->tot_len = clone.mBuffer->len = original->len;
         memcpy(reinterpret_cast<uint8_t *>(clone.mBuffer) + PacketBuffer::kStructureSize,
                reinterpret_cast<uint8_t *>(original) + PacketBuffer::kStructureSize, originalDataSize + originalReservedSize);

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -611,13 +611,12 @@ PacketBufferHandle PacketBufferHandle::CloneData()
 
     for (PacketBuffer * original = mBuffer; original != nullptr; original = static_cast<PacketBuffer *>(original->next))
     {
-        uint16_t originalDataSize = original->MaxDataLength();
+        uint16_t originalDataSize     = original->MaxDataLength();
         uint16_t originalReservedSize = original->ReservedSize();
-        PacketBufferHandle clone = PacketBufferHandle::New(originalDataSize, originalReservedSize);
+        PacketBufferHandle clone      = PacketBufferHandle::New(originalDataSize, originalReservedSize);
         clone.mBuffer->tot_len = clone.mBuffer->len = original->len;
         memcpy(reinterpret_cast<uint8_t *>(clone.mBuffer) + PacketBuffer::kStructureSize,
-               reinterpret_cast<uint8_t *>(original) + PacketBuffer::kStructureSize,
-               originalDataSize + originalReservedSize);
+               reinterpret_cast<uint8_t *>(original) + PacketBuffer::kStructureSize, originalDataSize + originalReservedSize);
 
         if (cloneHead.IsNull())
         {

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -598,16 +598,11 @@ public:
                                           uint16_t aReservedSize = PacketBuffer::kDefaultHeaderReserve);
 
     /**
-     * Creates a copy of the data in this packet.
+     * Creates a copy of a packet buffer (or chain).
      *
-     * Does NOT support chained buffers.
-     *
-     *  @param[in]  aAdditionalSize Size of additional application data space after the initial contents.
-     *  @param[in]  aReservedSize   Number of octets to reserve for protocol headers.
-     *
-     * @returns empty handle on allocation failure.
+     * @returns empty handle on allocation failure. Otherwise, the returned buffer has the same sizes and contents as the original.
      */
-    PacketBufferHandle CloneData(uint16_t aAdditionalSize = 0, uint16_t aReservedSize = PacketBuffer::kDefaultHeaderReserve);
+    PacketBufferHandle CloneData();
 
     /**
      * Perform an implementation-defined check on the validity of a PacketBufferHandle.

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -68,12 +68,12 @@ using ::chip::System::pbuf;
 #define OF_LWIP_PBUF(x) (reinterpret_cast<PacketBuffer *>(reinterpret_cast<void *>(x)))
 
 namespace {
-    void ScrambleData(uint8_t * start, uint16_t length)
-    {
-        for (uint16_t i = 0; i < length; ++i)
-            ++start[i];
-    }
+void ScrambleData(uint8_t * start, uint16_t length)
+{
+    for (uint16_t i = 0; i < length; ++i)
+        ++start[i];
 }
+} // namespace
 
 /*
  * An instance of this class created for the test suite.
@@ -1723,7 +1723,7 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
     NL_TEST_ASSERT(inSuite, test->mContext == theContext);
 
     uint8_t lPayload[2 * PacketBuffer::kMaxSizeWithoutReserve];
-    for (size_t i = 0; i < sizeof (lPayload); ++i)
+    for (size_t i = 0; i < sizeof(lPayload); ++i)
     {
         lPayload[i] = static_cast<uint8_t>(random());
     }
@@ -1740,11 +1740,11 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
             test->PrepareTestBuffer(&config_1);
             test->PrepareTestBuffer(&config_2);
 
-            const uint8_t *payload_1 = lPayload;
+            const uint8_t * payload_1 = lPayload;
             memcpy(config_1.handle->Start(), payload_1, config_1.handle->MaxDataLength());
             config_1.handle->SetDataLength(config_1.handle->MaxDataLength());
 
-            const uint8_t *payload_2 = lPayload + config_1.handle->MaxDataLength();
+            const uint8_t * payload_2 = lPayload + config_1.handle->MaxDataLength();
             memcpy(config_2.handle->Start(), payload_2, config_2.handle->MaxDataLength());
             config_2.handle->SetDataLength(config_2.handle->MaxDataLength());
 
@@ -1764,7 +1764,7 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
             // Clone buffer chain.
             config_1.handle->AddToEnd(config_2.handle.Retain());
             NL_TEST_ASSERT(inSuite, config_1.handle->HasChainedBuffer());
-            clone_1 = config_1.handle.CloneData();
+            clone_1                         = config_1.handle.CloneData();
             PacketBufferHandle clone_1_next = clone_1->Next();
             NL_TEST_ASSERT(inSuite, !clone_1.IsNull());
             NL_TEST_ASSERT(inSuite, clone_1->HasChainedBuffer());
@@ -1791,7 +1791,6 @@ void PacketBufferTest::CheckHandleCloneData(nlTestSuite * inSuite, void * inCont
         }
     }
 }
-
 
 void PacketBufferTest::CheckPacketBufferWriter(nlTestSuite * inSuite, void * inContext)
 {


### PR DESCRIPTION
#### Problem

It's sometimes useful to clone an entire packet buffer chain (e.g. #5309).

The old behaviour of cloning only the head buffer data, if desired, can be achieved using
 `NewWithData(buffer->Start(), buffer->DataLength(), 0, buffer->ReservedSize())`

#### Summary of Changes

- Support chained buffers in `PacketBufferHandle::CloneData()`.
- Added a unit test.

Fixes #5348 - Support CloneData with chained buffers in PacketBufferHandle
