### PR TITLE
Fix failing to make network commissioning on RP4

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -86,6 +86,38 @@ sudo apt-get install pi-bluetooth
 
 You need to reboot your RPi after install `pi-bluetooth`.
 
+By default, wpa_supplicant is not allowed to update (overwrite) configuration,
+if you want chip app to be able to store the configuration changes permanently,
+we need to make the following changes.
+
+1. Edit the dbus-fi.w1.wpa_supplicant1.service file to use configuration file
+   instead.
+
+```
+sudo nano /etc/systemd/system/dbus-fi.w1.wpa_supplicant1.service
+```
+
+Change the wpa_supplicant start parameters to:
+
+```
+ExecStart=/sbin/wpa_supplicant -u -s -i wlan0 -c /etc/wpa_supplicant/wpa_supplicant.conf
+```
+
+2. Add the wpa-supplicant configuration file
+
+```
+sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
+```
+
+And add the following content to the file:
+
+```
+ctrl_interface=DIR=/run/wpa_supplicant
+update_config=1
+```
+
+Finally, reboot your RPi.
+
 ### Build Preparation
 
 Before running any other build command, the `scripts/activate.sh` environment


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
When reproducing the example setup, the wpa_supplicant failed to save config after connecting to network.

CHIP:DL: wpa_supplicant: added network: SSID: test: /fi/w1/wpa_supplicant1/Interfaces/0/Networks/1
CHIP:DL: wpa_supplicant: connected to network: SSID: test
CHIP:DL: wpa_supplicant: failed to save config: GDBus.Error:fi.w1.wpa_supplicant1.UnknownError: Not allowed to update configuration (update_config=0)

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add instructions in setup document to allow wpa_supplicant update (overwrite) configuration.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5289

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
