### PR TITLE
Fix help info in shell is not correctly shown issue

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -361,14 +361,15 @@ void PrintUsage(streamer_t * stream)
 {
     streamer_printf(stream, "Usage: ping [options] <destination>\n\nOptions:\n");
 
-    streamer_printf(stream,
-                    "  -h              print help information\n"
-                    "  -u              use UDP (default)\n"
-                    "  -t              use TCP\n"
-                    "  -p  <port>      echo server port\n"
-                    "  -i  <interval>  ping interval time in seconds\n"
-                    "  -c  <count>     stop after <count> replies\n"
-                    "  -r  <1|0>       enalbe/disable CRMP\n");
+    // Need to split the help info to prevent overflowing the streamer_printf
+    // buffer (CONSOLE_DEFAULT_MAX_LINE 256)
+    streamer_printf(stream, "  -h              print help information\n");
+    streamer_printf(stream, "  -u              use UDP (default)\n");
+    streamer_printf(stream, "  -t              use TCP\n");
+    streamer_printf(stream, "  -p  <port>      echo server port\n");
+    streamer_printf(stream, "  -i  <interval>  ping interval time in seconds\n");
+    streamer_printf(stream, "  -c  <count>     stop after <count> replies\n");
+    streamer_printf(stream, "  -r  <1|0>       enable or disable CRMP\n");
 }
 
 int cmd_ping(int argc, char ** argv)


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The last part of help info for ping cmd is cut since the printed info exceeded the maximum buffer of streamer_printf.

> ping -h
Usage: ping [options] <destination>

Options:
  -h              print help information
  -u              use UDP (default)
  -t              use TCP
  -p  <port>      echo server port
  -i  <interval>  ping interval time in seconds
  -c  <count>     stop after <count> replies
  -r  <1|0>       enableDone
> 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Split the long printed content into multiple streamer_printf so that no info is cut. 

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
