### PR TITLE
Fix random Segmentation fault issue in CRMP testing. 

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -87,6 +87,8 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, System::Layer * systemLaye
 
 void SecureSessionMgr::Shutdown()
 {
+    CancelExpiryTimer();
+
     mState        = State::kNotReady;
     mLocalNodeId  = kUndefinedNodeId;
     mSystemLayer  = nullptr;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Thread 8 "chip-shell" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffe77fe700 (LWP 102296)]
0x00005555555781c0 in chip::System::Layer::State (this=0x0) at ../../src/system/SystemLayer.h:222
222     return this->mLayerState;

From crash log, it seems there are still pending timer alive after SecureSessionMgr is shut down.

#0  0x00005555555781c0 in chip::System::Layer::State() const (this=0x0) at ../../src/system/SystemLayer.h:222
#1  0x000055555557845c in chip::System::Layer::CancelTimer(void (*)(chip::System::Layer*, void*, int), void*)
    (this=0x0, aOnComplete=0x55555559243e <chip::SecureSessionMgr::ExpiryTimerCallback(chip::System::Layer*, void*, int)>, aAppState=0x5555555f7ba0 <(anonymous namespace)::gSessionManager>) at ../../src/system/SystemLayer.cpp:321
#2  0x00005555555783d1 in chip::System::Layer::StartTimer(unsigned int, void (*)(chip::System::Layer*, void*, int), void*)
    (this=0x0, aMilliseconds=5000, aComplete=0x55555559243e <chip::SecureSessionMgr::ExpiryTimerCallback(chip::System::Layer*, void*, int)>, aAppState=0x5555555f7ba0 <(anonymous namespace)::gSessionManager>)
    at ../../src/system/SystemLayer.cpp:292
#3  0x0000555555591df7 in chip::SecureSessionMgr::ScheduleExpiryTimer() (this=0x5555555f7ba0 <(anonymous namespace)::gSessionManager>) at ../../src/transport/SecureSessionMgr.cpp:307
#4  0x0000555555592469 in chip::SecureSessionMgr::ExpiryTimerCallback(chip::System::Layer*, void*, int) (layer=0x5555555f87c0 <chip::DeviceLayer::SystemLayer>, param=0x5555555f7ba0 <(anonymous namespace)::gSessionManager>, error=0)
    at ../../src/transport/SecureSessionMgr.cpp:420
#5  0x0000555555577ae7 in chip::System::Timer::HandleComplete() (this=0x5555555f8460 <chip::System::Timer::sPool>) at ../../src/system/SystemTimer.cpp:274
#6  0x0000555555578a5e in chip::System::Layer::HandleSelectResult(int, fd_set*, fd_set*, fd_set*)
    (this=0x5555555f87c0 <chip::DeviceLayer::SystemLayer>, aSetSize=13, aReadSet=0x5555555f8970 <chip::DeviceLayer::PlatformManagerImpl::sInstance+16>, aWriteSet=0x5555555f89f0 <chip::DeviceLayer::PlatformManagerImpl::sInstance+144>, aExceptionSet=0x5555555f8a70 <chip::DeviceLayer::PlatformManagerImpl::sInstance+272>) at ../../src/system/SystemLayer.cpp:698
#7  0x0000555555582763 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::SysProcess() (this=0x5555555f8960 <chip::DeviceLayer::PlatformManagerImpl::sInstance>)
    at ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp:186
#8  0x000055555558230e in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::_RunEventLoop() (this=0x5555555f8960 <chip::DeviceLayer::PlatformManagerImpl::sInstance>)
    at ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp:212
#9  0x0000555555581c8a in chip::DeviceLayer::PlatformManager::RunEventLoop() (this=0x5555555f8960 <chip::DeviceLayer::PlatformManagerImpl::sInstance>) at ../../src/include/platform/PlatformManager.h:204
#10 0x00005555555828b9 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::EventLoopTaskMain(void*) (arg=0x5555555f8960 <chip::DeviceLayer::PlatformManagerImpl::sInstance>)
    at ../../src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp:223
#11 0x00007ffff7f9c609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#12 0x00007ffff762e293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Clear any pending timer after SecureSessionMgr is shut down.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
