### PR TITLE
Rename persistent storage APIs to be more unique

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -53,7 +53,7 @@ exit:
     return err;
 }
 
-void PersistentStorage::SetDelegate(PersistentStorageResultDelegate * delegate) {}
+void PersistentStorage::SetStorageDelegate(PersistentStorageResultDelegate * delegate) {}
 
 void PersistentStorage::GetKeyValue(const char * key) {}
 

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -55,9 +55,9 @@ exit:
 
 void PersistentStorage::SetStorageDelegate(PersistentStorageResultDelegate * delegate) {}
 
-void PersistentStorage::GetKeyValue(const char * key) {}
+void PersistentStorage::AsyncGetKeyValue(const char * key) {}
 
-CHIP_ERROR PersistentStorage::GetKeyValue(const char * key, char * value, uint16_t & size)
+CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, char * value, uint16_t & size)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     std::string iniValue;
@@ -79,7 +79,7 @@ exit:
     return err;
 }
 
-void PersistentStorage::SetKeyValue(const char * key, const char * value)
+void PersistentStorage::AsyncSetKeyValue(const char * key, const char * value)
 {
     auto section = mConfig.sections[kDefaultSectionName];
     section[key] = std::string(value);
@@ -88,7 +88,7 @@ void PersistentStorage::SetKeyValue(const char * key, const char * value)
     CommitConfig();
 }
 
-void PersistentStorage::DeleteKeyValue(const char * key)
+void PersistentStorage::AsyncDeleteKeyValue(const char * key)
 {
     auto section = mConfig.sections[kDefaultSectionName];
     section.erase(key);
@@ -126,7 +126,7 @@ uint16_t PersistentStorage::GetListenPort()
 
     char value[6];
     uint16_t size = static_cast<uint16_t>(sizeof(value));
-    err           = GetKeyValue(kPortKey, value, size);
+    err           = SyncGetKeyValue(kPortKey, value, size);
     if (CHIP_NO_ERROR == err)
     {
         uint16_t tmpValue;
@@ -148,7 +148,7 @@ LogCategory PersistentStorage::GetLoggingLevel()
 
     char value[9];
     uint16_t size = static_cast<uint16_t>(sizeof(value));
-    err           = GetKeyValue(kLoggingKey, value, size);
+    err           = SyncGetKeyValue(kLoggingKey, value, size);
     if (CHIP_NO_ERROR == err)
     {
         if (strcasecmp(value, "none") == 0)

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -28,7 +28,7 @@ public:
     CHIP_ERROR Init();
 
     /////////// PersistentStorageDelegate Interface /////////
-    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override;
+    void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
     void GetKeyValue(const char * key) override;
     CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
     void SetKeyValue(const char * key, const char * value) override;

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -29,10 +29,10 @@ public:
 
     /////////// PersistentStorageDelegate Interface /////////
     void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
-    void GetKeyValue(const char * key) override;
-    CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
-    void SetKeyValue(const char * key, const char * value) override;
-    void DeleteKeyValue(const char * key) override;
+    void AsyncGetKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const char * key, char * value, uint16_t & size) override;
+    void AsyncSetKeyValue(const char * key, const char * value) override;
+    void AsyncDeleteKeyValue(const char * key) override;
 
     uint16_t GetListenPort();
     chip::Logging::LogCategory GetLoggingLevel();

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -74,7 +74,7 @@ void RendezvousServer::OnRendezvousComplete()
                    ChipLogError(AppServer, "Failed to store the connection state"));
 
     uint16_t nextKeyId = mRendezvousSession.GetNextKeyId();
-    mStorage->SetKeyValue(kStorablePeerConnectionCountKey, &nextKeyId, sizeof(nextKeyId));
+    mStorage->SyncSetKeyValue(kStorablePeerConnectionCountKey, &nextKeyId, sizeof(nextKeyId));
 }
 
 void RendezvousServer::OnRendezvousStatusUpdate(Status status, CHIP_ERROR err)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -78,29 +78,29 @@ class ServerStorageDelegate : public PersistentStorageDelegate
         chipDie();
     }
 
-    void GetKeyValue(const char * key) override
+    void AsyncGetKeyValue(const char * key) override
     {
         ChipLogError(AppServer, "ServerStorageDelegate does not support async operations");
         chipDie();
     }
 
-    void SetKeyValue(const char * key, const char * value) override
+    void AsyncSetKeyValue(const char * key, const char * value) override
     {
         ChipLogError(AppServer, "ServerStorageDelegate does not support async operations");
         chipDie();
     }
 
-    CHIP_ERROR GetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
         return PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
     }
 
-    CHIP_ERROR SetKeyValue(const char * key, const void * value, uint16_t size) override
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
     {
         return PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
     }
 
-    void DeleteKeyValue(const char * key) override { PersistedStorage::KeyValueStoreMgr().Delete(key); }
+    void AsyncDeleteKeyValue(const char * key) override { PersistedStorage::KeyValueStoreMgr().Delete(key); }
 };
 
 ServerStorageDelegate gServerStorage;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -72,7 +72,7 @@ constexpr bool useTestPairing()
 
 class ServerStorageDelegate : public PersistentStorageDelegate
 {
-    void SetDelegate(PersistentStorageResultDelegate * delegate) override
+    void SetStorageDelegate(PersistentStorageResultDelegate * delegate) override
     {
         ChipLogError(AppServer, "ServerStorageDelegate does not support async operations");
         chipDie();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR DeviceController::Shutdown()
 
     if (mStorageDelegate != nullptr)
     {
-        mStorageDelegate->SetDelegate(nullptr);
+        mStorageDelegate->SetStorageDelegate(nullptr);
         mStorageDelegate = nullptr;
     }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -126,7 +126,7 @@ CHIP_ERROR DeviceController::Init(NodeId localDeviceId, PersistentStorageDelegat
 
     if (mStorageDelegate != nullptr)
     {
-        mStorageDelegate->SetDelegate(this);
+        mStorageDelegate->SetStorageDelegate(this);
     }
 
     mTransportMgr   = chip::Platform::New<DeviceTransportMgr>();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -485,9 +485,9 @@ exit:
     return err;
 }
 
-void DeviceController::OnValue(const char * key, const char * value) {}
+void DeviceController::OnPersistentStorageValue(const char * key, const char * value) {}
 
-void DeviceController::OnStatus(const char * key, Operation op, CHIP_ERROR err) {}
+void DeviceController::OnPersistentStorageStatus(const char * key, Operation op, CHIP_ERROR err) {}
 
 DeviceCommissioner::DeviceCommissioner()
 {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -287,7 +287,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
             VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
 
             PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kPairedDeviceListKeyPrefix, key,
-                              err = mStorageDelegate->GetKeyValue(key, buffer, size));
+                              err = mStorageDelegate->SyncGetKeyValue(key, buffer, size));
             SuccessOrExit(err);
             VerifyOrExit(size <= max_size, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
 
@@ -306,7 +306,7 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
             uint16_t size = sizeof(deviceInfo.inner);
 
             PERSISTENT_KEY_OP(deviceId, kPairedDeviceKeyPrefix, key,
-                              err = mStorageDelegate->GetKeyValue(key, Uint8::to_char(deviceInfo.inner), size));
+                              err = mStorageDelegate->SyncGetKeyValue(key, Uint8::to_char(deviceInfo.inner), size));
             SuccessOrExit(err);
             VerifyOrExit(size <= sizeof(deviceInfo.inner), err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
 
@@ -671,7 +671,7 @@ CHIP_ERROR DeviceCommissioner::UnpairDevice(NodeId remoteDeviceId)
 
     if (mStorageDelegate != nullptr)
     {
-        PERSISTENT_KEY_OP(remoteDeviceId, kPairedDeviceKeyPrefix, key, mStorageDelegate->DeleteKeyValue(key));
+        PERSISTENT_KEY_OP(remoteDeviceId, kPairedDeviceKeyPrefix, key, mStorageDelegate->AsyncDeleteKeyValue(key));
     }
 
     mPairedDevices.Remove(remoteDeviceId);
@@ -733,7 +733,7 @@ void DeviceCommissioner::OnRendezvousComplete()
         SerializedDevice serialized;
         device->Serialize(serialized);
         PERSISTENT_KEY_OP(device->GetDeviceId(), kPairedDeviceKeyPrefix, key,
-                          mStorageDelegate->SetKeyValue(key, Uint8::to_const_char(serialized.inner)));
+                          mStorageDelegate->AsyncSetKeyValue(key, Uint8::to_const_char(serialized.inner)));
     }
 
     RendezvousCleanup(CHIP_NO_ERROR);
@@ -796,7 +796,7 @@ void DeviceCommissioner::PersistDeviceList()
             if (value != nullptr && requiredSize <= size)
             {
                 PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kPairedDeviceListKeyPrefix, key,
-                                  mStorageDelegate->SetKeyValue(key, value));
+                                  mStorageDelegate->AsyncSetKeyValue(key, value));
                 mPairedDevicesUpdated = false;
             }
             chip::Platform::MemoryFree(serialized);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -213,8 +213,8 @@ private:
     void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
 
     //////////// PersistentStorageResultDelegate Implementation ///////////////
-    void OnValue(const char * key, const char * value) override;
-    void OnStatus(const char * key, Operation op, CHIP_ERROR err) override;
+    void OnPersistentStorageValue(const char * key, const char * value) override;
+    void OnPersistentStorageStatus(const char * key, Operation op, CHIP_ERROR err) override;
 
     void ReleaseAllDevices();
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -289,7 +289,7 @@ void AndroidDeviceControllerWrapper::SetStorageDelegate(PersistentStorageResultD
     mStorageResultDelegate = delegate;
 }
 
-void AndroidDeviceControllerWrapper::GetKeyValue(const char * key)
+void AndroidDeviceControllerWrapper::AsyncGetKeyValue(const char * key)
 {
     jstring keyString       = NULL;
     jstring valueString     = NULL;
@@ -321,7 +321,7 @@ exit:
     GetJavaEnv()->DeleteLocalRef(valueString);
 }
 
-CHIP_ERROR AndroidDeviceControllerWrapper::GetKeyValue(const char * key, char * value, uint16_t & size)
+CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, char * value, uint16_t & size)
 {
     jstring keyString       = NULL;
     jstring valueString     = NULL;
@@ -367,7 +367,7 @@ exit:
     return err;
 }
 
-void AndroidDeviceControllerWrapper::SetKeyValue(const char * key, const char * value)
+void AndroidDeviceControllerWrapper::AsyncSetKeyValue(const char * key, const char * value)
 {
     jclass storageCls = GetPersistentStorageClass();
     jmethodID method  = GetJavaEnv()->GetStaticMethodID(storageCls, "setKeyValue", "(Ljava/lang/String;Ljava/lang/String;)V");
@@ -396,7 +396,7 @@ exit:
     GetJavaEnv()->DeleteLocalRef(valueString);
 }
 
-void AndroidDeviceControllerWrapper::DeleteKeyValue(const char * key)
+void AndroidDeviceControllerWrapper::AsyncDeleteKeyValue(const char * key)
 {
     jclass storageCls = GetPersistentStorageClass();
     jmethodID method  = GetJavaEnv()->GetStaticMethodID(storageCls, "deleteKeyValue", "(Ljava/lang/String;)V");

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -291,12 +291,12 @@ void AndroidDeviceControllerWrapper::SetDelegate(PersistentStorageResultDelegate
 
 void AndroidDeviceControllerWrapper::GetKeyValue(const char * key)
 {
-    jstring keyString   = NULL;
-    jstring valueString = NULL;
-    const char * valueChars   = nullptr;
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    jclass storageCls   = GetPersistentStorageClass();
-    jmethodID method    = GetJavaEnv()->GetStaticMethodID(storageCls, "getKeyValue", "(Ljava/lang/String;)Ljava/lang/String;");
+    jstring keyString       = NULL;
+    jstring valueString     = NULL;
+    const char * valueChars = nullptr;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    jclass storageCls       = GetPersistentStorageClass();
+    jmethodID method        = GetJavaEnv()->GetStaticMethodID(storageCls, "getKeyValue", "(Ljava/lang/String;)Ljava/lang/String;");
 
     GetJavaEnv()->ExceptionClear();
 
@@ -308,12 +308,13 @@ void AndroidDeviceControllerWrapper::GetKeyValue(const char * key)
     if (mStorageResultDelegate)
     {
         valueChars = GetJavaEnv()->GetStringUTFChars(valueString, 0);
-        mStorageResultDelegate->OnValue(key, valueChars);
+        mStorageResultDelegate->OnPersistentStorageValue(key, valueChars);
     }
 
 exit:
     GetJavaEnv()->ExceptionClear();
-    if (valueChars != nullptr) {
+    if (valueChars != nullptr)
+    {
         GetJavaEnv()->ReleaseStringUTFChars(valueString, valueChars);
     }
     GetJavaEnv()->DeleteLocalRef(keyString);
@@ -322,12 +323,12 @@ exit:
 
 CHIP_ERROR AndroidDeviceControllerWrapper::GetKeyValue(const char * key, char * value, uint16_t & size)
 {
-    jstring keyString   = NULL;
-    jstring valueString = NULL;
-    const char * valueChars   = nullptr;
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    jclass storageCls   = GetPersistentStorageClass();
-    jmethodID method    = GetJavaEnv()->GetStaticMethodID(storageCls, "getKeyValue", "(Ljava/lang/String;)Ljava/lang/String;");
+    jstring keyString       = NULL;
+    jstring valueString     = NULL;
+    const char * valueChars = nullptr;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    jclass storageCls       = GetPersistentStorageClass();
+    jmethodID method        = GetJavaEnv()->GetStaticMethodID(storageCls, "getKeyValue", "(Ljava/lang/String;)Ljava/lang/String;");
 
     GetJavaEnv()->ExceptionClear();
 
@@ -341,7 +342,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GetKeyValue(const char * key, char * 
         if (value != nullptr)
         {
             valueChars = GetJavaEnv()->GetStringUTFChars(valueString, 0);
-            size = strlcpy(value, GetJavaEnv()->GetStringUTFChars(valueString, 0), size);
+            size       = strlcpy(value, GetJavaEnv()->GetStringUTFChars(valueString, 0), size);
         }
         else
         {
@@ -357,7 +358,8 @@ CHIP_ERROR AndroidDeviceControllerWrapper::GetKeyValue(const char * key, char * 
 
 exit:
     GetJavaEnv()->ExceptionClear();
-    if (valueChars != nullptr) {
+    if (valueChars != nullptr)
+    {
         GetJavaEnv()->ReleaseStringUTFChars(valueString, valueChars);
     }
     GetJavaEnv()->DeleteLocalRef(keyString);
@@ -385,7 +387,7 @@ void AndroidDeviceControllerWrapper::SetKeyValue(const char * key, const char * 
 
     if (mStorageResultDelegate)
     {
-        mStorageResultDelegate->OnStatus(key, PersistentStorageResultDelegate::Operation::kSET, CHIP_NO_ERROR);
+        mStorageResultDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kSET, CHIP_NO_ERROR);
     }
 
 exit:
@@ -411,7 +413,7 @@ void AndroidDeviceControllerWrapper::DeleteKeyValue(const char * key)
 
     if (mStorageResultDelegate)
     {
-        mStorageResultDelegate->OnStatus(key, PersistentStorageResultDelegate::Operation::kDELETE, CHIP_NO_ERROR);
+        mStorageResultDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kDELETE, CHIP_NO_ERROR);
     }
 
 exit:

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -284,7 +284,7 @@ void AndroidDeviceControllerWrapper::OnMessage(chip::System::PacketBufferHandle 
 
 void AndroidDeviceControllerWrapper::OnStatusChange(void) {}
 
-void AndroidDeviceControllerWrapper::SetDelegate(PersistentStorageResultDelegate * delegate)
+void AndroidDeviceControllerWrapper::SetStorageDelegate(PersistentStorageResultDelegate * delegate)
 {
     mStorageResultDelegate = delegate;
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -56,7 +56,7 @@ public:
     void OnStatusChange(void) override;
 
     // PersistentStorageDelegate implementation
-    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override;
+    void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
     void GetKeyValue(const char * key) override;
     CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
     void SetKeyValue(const char * key, const char * value) override;

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -57,10 +57,10 @@ public:
 
     // PersistentStorageDelegate implementation
     void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
-    void GetKeyValue(const char * key) override;
-    CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
-    void SetKeyValue(const char * key, const char * value) override;
-    void DeleteKeyValue(const char * key) override;
+    void AsyncGetKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const char * key, char * value, uint16_t & size) override;
+    void AsyncSetKeyValue(const char * key, const char * value) override;
+    void AsyncDeleteKeyValue(const char * key) override;
 
     jlong ToJNIHandle()
     {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -39,11 +39,11 @@ void PythonPersistentStorageDelegate::GetKeyValue(const char * key)
     auto val = mStorage.find(key);
     if (val == mStorage.end())
     {
-        mDelegate->OnStatus(key, PersistentStorageResultDelegate::Operation::kGET, CHIP_ERROR_KEY_NOT_FOUND);
+        mDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kGET, CHIP_ERROR_KEY_NOT_FOUND);
         return;
     }
 
-    mDelegate->OnValue(key, val->second.c_str());
+    mDelegate->OnPertistentStorageValue(key, val->second.c_str());
 }
 
 CHIP_ERROR PythonPersistentStorageDelegate::GetKeyValue(const char * key, char * value, uint16_t & size)
@@ -83,13 +83,13 @@ void PythonPersistentStorageDelegate::SetKeyValue(const char * key, const char *
 {
     mStorage[key] = value;
     ChipLogDetail(Controller, "SetKeyValue: %s=%s", key, value);
-    mDelegate->OnStatus(key, PersistentStorageResultDelegate::Operation::kSET, CHIP_NO_ERROR);
+    mDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kSET, CHIP_NO_ERROR);
 }
 
 void PythonPersistentStorageDelegate::DeleteKeyValue(const char * key)
 {
     mStorage.erase(key);
-    mDelegate->OnStatus(key, PersistentStorageResultDelegate::Operation::kDELETE, CHIP_NO_ERROR);
+    mDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kDELETE, CHIP_NO_ERROR);
 }
 
 } // namespace Controller

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -43,7 +43,7 @@ void PythonPersistentStorageDelegate::AsyncGetKeyValue(const char * key)
         return;
     }
 
-    mDelegate->OnPertistentStorageValue(key, val->second.c_str());
+    mDelegate->OnPersistentStorageValue(key, val->second.c_str());
 }
 
 CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, char * value, uint16_t & size)

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -34,7 +34,7 @@ void PythonPersistentStorageDelegate::SetDelegate(PersistentStorageResultDelegat
     mDelegate = delegate;
 }
 
-void PythonPersistentStorageDelegate::GetKeyValue(const char * key)
+void PythonPersistentStorageDelegate::AsyncGetKeyValue(const char * key)
 {
     auto val = mStorage.find(key);
     if (val == mStorage.end())
@@ -46,7 +46,7 @@ void PythonPersistentStorageDelegate::GetKeyValue(const char * key)
     mDelegate->OnPertistentStorageValue(key, val->second.c_str());
 }
 
-CHIP_ERROR PythonPersistentStorageDelegate::GetKeyValue(const char * key, char * value, uint16_t & size)
+CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, char * value, uint16_t & size)
 {
     auto val = mStorage.find(key);
     if (val == mStorage.end())
@@ -79,14 +79,14 @@ CHIP_ERROR PythonPersistentStorageDelegate::GetKeyValue(const char * key, char *
     return CHIP_NO_ERROR;
 }
 
-void PythonPersistentStorageDelegate::SetKeyValue(const char * key, const char * value)
+void PythonPersistentStorageDelegate::AsyncSetKeyValue(const char * key, const char * value)
 {
     mStorage[key] = value;
-    ChipLogDetail(Controller, "SetKeyValue: %s=%s", key, value);
+    ChipLogDetail(Controller, "AsyncSetKeyValue: %s=%s", key, value);
     mDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kSET, CHIP_NO_ERROR);
 }
 
-void PythonPersistentStorageDelegate::DeleteKeyValue(const char * key)
+void PythonPersistentStorageDelegate::AsyncDeleteKeyValue(const char * key)
 {
     mStorage.erase(key);
     mDelegate->OnPersistentStorageStatus(key, PersistentStorageResultDelegate::Operation::kDELETE, CHIP_NO_ERROR);

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -29,7 +29,7 @@
 namespace chip {
 namespace Controller {
 
-void PythonPersistentStorageDelegate::SetDelegate(PersistentStorageResultDelegate * delegate)
+void PythonPersistentStorageDelegate::SetStorageDelegate(PersistentStorageResultDelegate * delegate)
 {
     mDelegate = delegate;
 }

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -36,7 +36,7 @@ class PythonPersistentStorageDelegate : public PersistentStorageDelegate
 {
 public:
     PythonPersistentStorageDelegate() {}
-    void SetDelegate(PersistentStorageResultDelegate * delegate) override;
+    void SetStorageDelegate(PersistentStorageResultDelegate * delegate) override;
     void GetKeyValue(const char * key) override;
     CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
     void SetKeyValue(const char * key, const char * value) override;

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -37,10 +37,10 @@ class PythonPersistentStorageDelegate : public PersistentStorageDelegate
 public:
     PythonPersistentStorageDelegate() {}
     void SetStorageDelegate(PersistentStorageResultDelegate * delegate) override;
-    void GetKeyValue(const char * key) override;
-    CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
-    void SetKeyValue(const char * key, const char * value) override;
-    void DeleteKeyValue(const char * key) override;
+    void AsyncGetKeyValue(const char * key) override;
+    CHIP_ERROR SyncGetKeyValue(const char * key, char * value, uint16_t & size) override;
+    void AsyncSetKeyValue(const char * key, const char * value) override;
+    void AsyncDeleteKeyValue(const char * key) override;
 
 private:
     PersistentStorageResultDelegate * mDelegate;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -28,7 +28,7 @@ namespace {
 class ServerStorageDelegate : public chip::PersistentStorageDelegate
 {
 public:
-    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override { mAsyncDelegate = delegate; }
+    void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override { mAsyncDelegate = delegate; }
 
     void GetKeyValue(const char * key) override
     {

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -42,11 +42,11 @@ public:
         if (err == CHIP_NO_ERROR)
         {
             buffer[bufferSize] = 0;
-            mAsyncDelegate->OnValue(key, reinterpret_cast<const char *>(buffer));
+            mAsyncDelegate->OnPersistentStorageValue(key, reinterpret_cast<const char *>(buffer));
         }
         else
         {
-            mAsyncDelegate->OnStatus(key, chip::PersistentStorageResultDelegate::Operation::kGET, err);
+            mAsyncDelegate->OnPersistentStorageStatus(key, chip::PersistentStorageResultDelegate::Operation::kGET, err);
         }
     }
 
@@ -57,7 +57,7 @@ public:
 
         if (err != CHIP_NO_ERROR)
         {
-            mAsyncDelegate->OnStatus(key, chip::PersistentStorageResultDelegate::Operation::kSET, err);
+            mAsyncDelegate->OnPersistentStorageStatus(key, chip::PersistentStorageResultDelegate::Operation::kSET, err);
         }
     }
 

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -30,14 +30,14 @@ class ServerStorageDelegate : public chip::PersistentStorageDelegate
 public:
     void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override { mAsyncDelegate = delegate; }
 
-    void GetKeyValue(const char * key) override
+    void AsyncGetKeyValue(const char * key) override
     {
         // TODO: Async Get/Set are implemented synchronously here.
         // We need to figure out a standard way to implement this - this implementation
         // was based on an example that just returned and that seemed even less useful.
         uint8_t buffer[kMaxKeyValueSize];
         uint16_t bufferSize = sizeof(buffer) - 1;
-        CHIP_ERROR err      = GetKeyValue(key, buffer, bufferSize);
+        CHIP_ERROR err      = SyncGetKeyValue(key, buffer, bufferSize);
 
         if (err == CHIP_NO_ERROR)
         {
@@ -50,10 +50,10 @@ public:
         }
     }
 
-    void SetKeyValue(const char * key, const char * value) override
+    void AsyncSetKeyValue(const char * key, const char * value) override
     {
 
-        CHIP_ERROR err = SetKeyValue(key, value, strlen(value));
+        CHIP_ERROR err = SyncSetKeyValue(key, value, strlen(value));
 
         if (err != CHIP_NO_ERROR)
         {
@@ -62,17 +62,17 @@ public:
     }
 
     CHIP_ERROR
-    GetKeyValue(const char * key, void * buffer, uint16_t & size) override
+    SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
         return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(key, buffer, size);
     }
 
-    CHIP_ERROR SetKeyValue(const char * key, const void * value, uint16_t size) override
+    CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override
     {
         return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
     }
 
-    void DeleteKeyValue(const char * key) override { chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key); }
+    void AsyncDeleteKeyValue(const char * key) override { chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key); }
 
 private:
     static constexpr size_t kMaxKeyValueSize = 1024;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -167,11 +167,11 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     uint16_t idStringLen = 32;
     char deviceIdString[idStringLen];
     if (CHIP_NO_ERROR
-        != _persistentStorageDelegateBridge->GetKeyValue(CHIP_COMMISSIONER_DEVICE_ID_KEY, deviceIdString, idStringLen)) {
+        != _persistentStorageDelegateBridge->SyncGetKeyValue(CHIP_COMMISSIONER_DEVICE_ID_KEY, deviceIdString, idStringLen)) {
         _localDeviceId = arc4random();
         _localDeviceId = _localDeviceId << 32 | arc4random();
         CHIP_LOG_ERROR("Assigned %llx node ID to the controller", _localDeviceId);
-        _persistentStorageDelegateBridge->SetKeyValue(
+        _persistentStorageDelegateBridge->AsyncSetKeyValue(
             CHIP_COMMISSIONER_DEVICE_ID_KEY, [[NSString stringWithFormat:@"%llx", _localDeviceId] UTF8String]);
     } else {
         NSScanner * scanner = [NSScanner scannerWithString:[NSString stringWithUTF8String:deviceIdString]];

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -32,13 +32,13 @@ public:
 
     void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
 
-    void GetKeyValue(const char * key) override;
+    void AsyncGetKeyValue(const char * key) override;
 
-    CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) override;
+    CHIP_ERROR SyncGetKeyValue(const char * key, char * value, uint16_t & size) override;
 
-    void SetKeyValue(const char * key, const char * value) override;
+    void AsyncSetKeyValue(const char * key, const char * value) override;
 
-    void DeleteKeyValue(const char * key) override;
+    void AsyncDeleteKeyValue(const char * key) override;
 
 private:
     id<CHIPPersistentStorageDelegate> mDelegate;

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -30,7 +30,7 @@ public:
 
     void setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue);
 
-    void SetDelegate(chip::PersistentStorageResultDelegate * delegate) override;
+    void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
 
     void GetKeyValue(const char * key) override;
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -82,7 +82,7 @@ void CHIPPersistentStorageDelegateBridge::SetStorageDelegate(chip::PersistentSto
     });
 }
 
-void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
+void CHIPPersistentStorageDelegateBridge::AsyncGetKeyValue(const char * key)
 {
     NSString * keyString = [NSString stringWithUTF8String:key];
     dispatch_async(mWorkQueue, ^{
@@ -103,7 +103,7 @@ void CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key)
     });
 }
 
-CHIP_ERROR CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key, char * value, uint16_t & size)
+CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key, char * value, uint16_t & size)
 {
     __block CHIP_ERROR error = CHIP_NO_ERROR;
     NSString * keyString = [NSString stringWithUTF8String:key];
@@ -138,7 +138,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::GetKeyValue(const char * key, ch
     return error;
 }
 
-void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const char * value)
+void CHIPPersistentStorageDelegateBridge::AsyncSetKeyValue(const char * key, const char * value)
 {
     NSString * keyString = [NSString stringWithUTF8String:key];
     NSString * valueString = [NSString stringWithUTF8String:value];
@@ -159,7 +159,7 @@ void CHIPPersistentStorageDelegateBridge::SetKeyValue(const char * key, const ch
     });
 }
 
-void CHIPPersistentStorageDelegateBridge::DeleteKeyValue(const char * key)
+void CHIPPersistentStorageDelegateBridge::AsyncDeleteKeyValue(const char * key)
 {
     NSString * keyString = [NSString stringWithUTF8String:key];
     dispatch_async(mWorkQueue, ^{

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -39,7 +39,7 @@ void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(id<CHIPPersistent
     });
 }
 
-void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::PersistentStorageResultDelegate * delegate)
+void CHIPPersistentStorageDelegateBridge::SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate)
 {
     dispatch_async(mWorkQueue, ^{
         if (delegate) {

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -49,7 +49,7 @@ void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::PersistentStorageRes
                 chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
-                        callback->OnValue([key UTF8String], [value UTF8String]);
+                        callback->OnPeristentStorageValue([key UTF8String], [value UTF8String]);
                     });
                 }
             };
@@ -58,7 +58,7 @@ void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::PersistentStorageRes
                 chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
-                        callback->OnStatus([key UTF8String], chip::PersistentStorageResultDelegate::Operation::kSET,
+                        callback->OnPeristentStorageStatus([key UTF8String], chip::PersistentStorageResultDelegate::Operation::kSET,
                             [CHIPError errorToCHIPErrorCode:status]);
                     });
                 }
@@ -68,8 +68,8 @@ void CHIPPersistentStorageDelegateBridge::SetDelegate(chip::PersistentStorageRes
                 chip::PersistentStorageResultDelegate * callback = mCallback;
                 if (callback) {
                     dispatch_async(mWorkQueue, ^{
-                        callback->OnStatus([key UTF8String], chip::PersistentStorageResultDelegate::Operation::kDELETE,
-                            [CHIPError errorToCHIPErrorCode:status]);
+                        callback->OnPeristentStorageStatus([key UTF8String],
+                            chip::PersistentStorageResultDelegate::Operation::kDELETE, [CHIPError errorToCHIPErrorCode:status]);
                     });
                 }
             };

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -38,7 +38,7 @@ public:
     /**
      * @brief
      *   Called when a value is returned from the storage.
-     *   This is useful for GetKeyValue() API call.
+     *   This is useful for AsyncGetKeyValue() API call.
      *
      * @param[in] key Key for which the value is being returned
      * @param[in] value Value or nullptr if not found.
@@ -76,7 +76,7 @@ public:
      *
      * @param[in] key Key to lookup
      */
-    virtual void GetKeyValue(const char * key) = 0;
+    virtual void AsyncGetKeyValue(const char * key) = 0;
 
     /**
      * @brief
@@ -95,7 +95,7 @@ public:
      *                 The output size could be larger than input value. In
      *                 such cases, the user should allocate the buffer large
      *                 enough (>= output size), and call the API again.  In this
-     *                 case GetKeyValue will place as many bytes as it can in
+     *                 case SyncGetKeyValue will place as many bytes as it can in
      *                 the buffer and return CHIP_ERROR_NO_MEMORY.
      *
      *                 If value is null, the input size is treated as 0.
@@ -104,7 +104,7 @@ public:
      * @return CHIP_ERROR_NO_MEMORY if the input buffer is not big enough for
      *                              the value.
      */
-    virtual CHIP_ERROR GetKeyValue(const char * key, char * value, uint16_t & size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR SyncGetKeyValue(const char * key, char * value, uint16_t & size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     /**
      * @brief
@@ -121,7 +121,7 @@ public:
      *                 such cases, the user should allocate the buffer large
      *                 enough (>= output length), and call the API again.
      */
-    virtual CHIP_ERROR GetKeyValue(const char * key, void * buffer, uint16_t & size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     /**
      * @brief
@@ -130,7 +130,7 @@ public:
      * @param[in] key Key to be set
      * @param[in] value Value to be set
      */
-    virtual void SetKeyValue(const char * key, const char * value) = 0;
+    virtual void AsyncSetKeyValue(const char * key, const char * value) = 0;
 
     /**
      * @brief
@@ -140,7 +140,7 @@ public:
      * @param[in] value Value to be set
      * @param[in] size Size of the Value
      */
-    virtual CHIP_ERROR SetKeyValue(const char * key, const void * value, uint16_t size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     /**
      * @brief
@@ -148,7 +148,7 @@ public:
      *
      * @param[in] key Key to be deleted
      */
-    virtual void DeleteKeyValue(const char * key) = 0;
+    virtual void AsyncDeleteKeyValue(const char * key) = 0;
 };
 
 } // namespace chip

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -68,7 +68,7 @@ public:
      *
      * @param[in] delegate The callback object
      */
-    virtual void SetDelegate(PersistentStorageResultDelegate * delegate) = 0;
+    virtual void SetStorageDelegate(PersistentStorageResultDelegate * delegate) = 0;
 
     /**
      * @brief

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -43,7 +43,7 @@ public:
      * @param[in] key Key for which the value is being returned
      * @param[in] value Value or nullptr if not found.
      */
-    virtual void OnValue(const char * key, const char * value) = 0;
+    virtual void OnPersistentStorageValue(const char * key, const char * value) = 0;
 
     /**
      * @brief
@@ -53,7 +53,7 @@ public:
      * @param[in] op Operation that was being performed on the key
      * @param[in] result CHIP_NO_ERROR or corresponding error code
      */
-    virtual void OnStatus(const char * key, Operation op, CHIP_ERROR result) = 0;
+    virtual void OnPersistentStorageStatus(const char * key, Operation op, CHIP_ERROR result) = 0;
 };
 
 class DLL_EXPORT PersistentStorageDelegate

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -37,7 +37,7 @@ CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate & kvs)
     info.mNodeId = Encoding::LittleEndian::HostSwap64(mNodeId);
     info.mAdmin  = Encoding::LittleEndian::HostSwap16(mAdmin);
 
-    return kvs.SetKeyValue(key, &info, sizeof(info));
+    return kvs.SyncSetKeyValue(key, &info, sizeof(info));
 }
 
 CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate & kvs)
@@ -48,7 +48,7 @@ CHIP_ERROR AdminPairingInfo::FetchFromKVS(PersistentStorageDelegate & kvs)
     StorableAdminPairingInfo info;
 
     uint16_t size = sizeof(info);
-    ReturnErrorOnFailure(kvs.GetKeyValue(key, &info, size));
+    ReturnErrorOnFailure(kvs.SyncGetKeyValue(key, &info, size));
 
     mNodeId    = Encoding::LittleEndian::HostSwap64(info.mNodeId);
     AdminId id = Encoding::LittleEndian::HostSwap16(info.mAdmin);
@@ -62,7 +62,7 @@ CHIP_ERROR AdminPairingInfo::DeleteFromKVS(PersistentStorageDelegate & kvs, Admi
     char key[KeySize()];
     ReturnErrorOnFailure(GenerateKey(id, key, sizeof(key)));
 
-    kvs.DeleteKeyValue(key);
+    kvs.AsyncDeleteKeyValue(key);
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/StorablePeerConnection.cpp
+++ b/src/transport/StorablePeerConnection.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR StorablePeerConnection::StoreIntoKVS(PersistentStorageDelegate & kvs)
     char key[KeySize()];
     ReturnErrorOnFailure(GenerateKey(mKeyId, key, sizeof(key)));
 
-    return kvs.SetKeyValue(key, &mSession, sizeof(mSession));
+    return kvs.SyncSetKeyValue(key, &mSession, sizeof(mSession));
 }
 
 CHIP_ERROR StorablePeerConnection::FetchFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
@@ -43,7 +43,7 @@ CHIP_ERROR StorablePeerConnection::FetchFromKVS(PersistentStorageDelegate & kvs,
     ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
 
     uint16_t size = sizeof(mSession);
-    return kvs.GetKeyValue(key, &mSession, size);
+    return kvs.SyncGetKeyValue(key, &mSession, size);
 }
 
 CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs, uint16_t keyId)
@@ -51,7 +51,7 @@ CHIP_ERROR StorablePeerConnection::DeleteFromKVS(PersistentStorageDelegate & kvs
     char key[KeySize()];
     ReturnErrorOnFailure(GenerateKey(keyId, key, sizeof(key)));
 
-    kvs.DeleteKeyValue(key);
+    kvs.AsyncDeleteKeyValue(key);
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
 #### Problem
Existing persistent storage API provides both sync and async operation support which are not consistently implemented and used across the platforms.

Working towards #5349 we need to be able to idenfity usages to properly unify storage usage.

 #### Summary of Changes
 Renames persistent storage setDelegate/setkey/getkey/etc with more unique and clearer naming (sync/async prefix). This highlights some awkwardness that needs to be addressed including:
   - DeviceController has empty callback implementations (errors in api would not be logged, no async key reads would be used)
   - AdminPairingTable does synchronous setting of values, but asynchronous deleting (and many implementations seem to only provide one side of the sync/async api).
   
  