### PR TITLE
Use SecureSessionHandle to indicate if the peer's group key message c…

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -233,7 +233,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     UnsolicitedMessageHandler * matchingUMH = nullptr;
     bool sendAckAndCloseExchange            = false;
 
-    if (!IsMsgCounterSyncMessage(payloadHeader) && packetHeader.IsPeerGroupMsgIdNotSynchronized())
+    if (!IsMsgCounterSyncMessage(payloadHeader) && session.IsPeerGroupMsgIdNotSynchronized())
     {
         Transport::PeerConnectionState * state = mSessionMgr->GetPeerConnectionState(session);
         VerifyOrReturn(state != nullptr);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -327,6 +327,7 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
     PacketBufferHandle origMsg;
     PayloadHeader payloadHeader;
 
+    bool peerGroupMsgIdNotSynchronized  = false;
     Transport::AdminPairingInfo * admin = nullptr;
 
     VerifyOrExit(!msg.IsNull(), ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
@@ -375,14 +376,17 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         // For all group messages, Set flag if peer group key message counter is not synchronized.
         if (ChipKeyId::IsAppGroupKey(packetHeader.GetEncryptionKeyID()))
         {
-            const_cast<PacketHeader &>(packetHeader).SetPeerGroupMsgIdNotSynchronized(true);
+            peerGroupMsgIdNotSynchronized = true;
         }
     }
 
     if (mCB != nullptr)
     {
-        mCB->OnMessageReceived(packetHeader, payloadHeader, { state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId() },
-                               std::move(msg), this);
+        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId());
+
+        session.SetPeerGroupMsgIdNotSynchronized(peerGroupMsgIdNotSynchronized);
+
+        mCB->OnMessageReceived(packetHeader, payloadHeader, session, std::move(msg), this);
     }
 
 exit:

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -57,6 +57,9 @@ public:
     Transport::AdminId GetAdminId() const { return mAdmin; }
     void SetAdminId(Transport::AdminId adminId) { mAdmin = adminId; }
 
+    bool IsPeerGroupMsgIdNotSynchronized() const { return mPeerGroupMsgIdNotSynchronized; }
+    void SetPeerGroupMsgIdNotSynchronized(bool value) { mPeerGroupMsgIdNotSynchronized = value; }
+
     bool operator==(const SecureSessionHandle & that) const
     {
         return mPeerNodeId == that.mPeerNodeId && mPeerKeyId == that.mPeerKeyId && mAdmin == that.mAdmin;
@@ -74,6 +77,8 @@ private:
     //       to identify an approach that'll allow looking up the corresponding information for
     //       such sessions.
     Transport::AdminId mAdmin;
+
+    bool mPeerGroupMsgIdNotSynchronized = false;
 };
 
 /**

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -73,12 +73,6 @@ enum class ExFlagValues : uint8_t
     kExchangeFlag_VendorIdPresent = 0x10,
 };
 
-enum class InternalFlagValues : uint8_t
-{
-    // Header flag indicates that the peer's group key message counter is not synchronized.
-    kPeerGroupMsgIdNotSynchronized = 0x01,
-};
-
 enum class FlagValues : uint16_t
 {
     /// Header flag specifying that a destination node id is included in the header.
@@ -95,9 +89,8 @@ enum class FlagValues : uint16_t
 
 };
 
-using Flags         = BitFlags<FlagValues>;
-using ExFlags       = BitFlags<ExFlagValues>;
-using InternalFlags = BitFlags<InternalFlagValues>;
+using Flags   = BitFlags<FlagValues>;
+using ExFlags = BitFlags<ExFlagValues>;
 
 // Header is a 16-bit value of the form
 //  |  4 bit  | 4 bit |8 bit Security Flags|
@@ -149,23 +142,11 @@ public:
     /** Check if it's a secure session control message. */
     bool IsSecureSessionControlMsg() const { return mFlags.Has(Header::FlagValues::kSecureSessionControlMessage); }
 
-    /** Check if the peer's group key message counter is not synchronized. */
-    bool IsPeerGroupMsgIdNotSynchronized() const
-    {
-        return mInternalFlags.Has(Header::InternalFlagValues::kPeerGroupMsgIdNotSynchronized);
-    }
-
     Header::EncryptionType GetEncryptionType() const { return mEncryptionType; }
 
     PacketHeader & SetSecureSessionControlMsg(bool value)
     {
         mFlags.Set(Header::FlagValues::kSecureSessionControlMessage, value);
-        return *this;
-    }
-
-    PacketHeader & SetPeerGroupMsgIdNotSynchronized(bool value)
-    {
-        mInternalFlags.Set(Header::InternalFlagValues::kPeerGroupMsgIdNotSynchronized, value);
         return *this;
     }
 
@@ -327,9 +308,6 @@ private:
 
     /// Message flags read from the message.
     Header::Flags mFlags;
-
-    /// Message flags not encoded into the packet sent over wire.
-    Header::InternalFlags mInternalFlags;
 
     /// Represents encryption type used for encrypting current packet
     Header::EncryptionType mEncryptionType = Header::EncryptionType::kAESCCMTagLen16;


### PR DESCRIPTION
…ounter is not synchronized.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
This is the follow-up of one of review comments in #4932, we are storing the IsPeerGroupMsgIdNotSynchronized state in the PacketHeader, which seems like as lightly odd place to put it and requires const_cast. We should not be adding const_cast to the code.

    // For all group messages, Set flag if peer group key message counter is not synchronized.
    if (ChipKeyId::IsAppGroupKey(packetHeader.GetEncryptionKeyID()))
    {
        const_cast<PacketHeader &>(packetHeader).SetPeerGroupMsgIdNotSynchronized(true);
    }

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Use SecureSessionHandle to indicate if the peer's group key message counter is not synchronized.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5367

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
