### PR TITLE
[bluez] Fix UnsubscribeCharacteristic

### DIFF
--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1705,7 +1705,7 @@ static gboolean UnsubscribeCharacteristicImpl(BluezConnection * connection)
     VerifyOrExit(connection != nullptr, ChipLogError(DeviceLayer, "BluezConnection is NULL in %s", __func__));
     VerifyOrExit(connection->mpC2 != nullptr, ChipLogError(DeviceLayer, "C2 is NULL in %s", __func__));
 
-    bluez_gatt_characteristic1_call_start_notify(connection->mpC2, nullptr, UnsubscribeCharacteristicDone, connection);
+    bluez_gatt_characteristic1_call_stop_notify(connection->mpC2, nullptr, UnsubscribeCharacteristicDone, connection);
 
 exit:
     return G_SOURCE_REMOVE;


### PR DESCRIPTION
 #### Problem
Fix a copy and paste error in UnsubscribeCharacteristic which would call `bluez_gatt_characteristic1_call_start_notify()` instead of `bluez_gatt_characteristic1_call_stop_notify()` Bluez function. As a result an application such as Python CHIP controller was unable to commission multiple devices in a single run.

 #### Summary of Changes
Make UnsubscribeCharacteristic call `bluez_gatt_characteristic1_call_stop_notify()`.
