### PR TITLE
Persist controller's key ID across reboots

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -44,8 +44,8 @@
 #include <core/CHIPCore.h>
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
-#include <support/CHIPArgParser.hpp>
 #include <support/Base64.h>
+#include <support/CHIPArgParser.hpp>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
@@ -509,10 +509,9 @@ CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, PersistentStorageDeleg
     ReturnErrorOnFailure(DeviceController::Init(localDeviceId, storageDelegate, systemLayer, inetLayer));
 
     char keyIDStr[kMaxKeyIDStringSize];
-    uint16_t size = sizeof(keyIDStr);
-    CHIP_ERROR err  = CHIP_NO_ERROR;
-    PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key,
-                        err = mStorageDelegate->GetKeyValue(key, keyIDStr, size));
+    uint16_t size  = sizeof(keyIDStr);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key, err = mStorageDelegate->GetKeyValue(key, keyIDStr, size));
     if (err != CHIP_NO_ERROR || !ArgParser::ParseInt(keyIDStr, mNextKeyId))
     {
         // If the persistent storage didn't have a stored KeyID value
@@ -825,8 +824,7 @@ void DeviceCommissioner::PersistDeviceList()
 
         char keyIDStr[kMaxKeyIDStringSize];
         snprintf(keyIDStr, sizeof(keyIDStr), "%d", mNextKeyId);
-        PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key,
-                          mStorageDelegate->SetKeyValue(key, keyIDStr));
+        PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key, mStorageDelegate->SetKeyValue(key, keyIDStr));
     }
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -509,7 +509,7 @@ CHIP_ERROR DeviceCommissioner::LoadKeyId(PersistentStorageDelegate * delegate, u
     // TODO: Consider storing value in binary representation instead of converting to string
     char keyIDStr[kMaxKeyIDStringSize];
     uint16_t size = sizeof(keyIDStr);
-    ReturnErrorOnFailure(delegate->GetKeyValue(kNextAvailableKeyID, keyIDStr, size));
+    ReturnErrorOnFailure(delegate->SyncGetKeyValue(kNextAvailableKeyID, keyIDStr, size));
 
     ReturnErrorCodeIf(!ArgParser::ParseInt(keyIDStr, out), CHIP_ERROR_INTERNAL);
 
@@ -827,7 +827,7 @@ void DeviceCommissioner::PersistDeviceList()
         // TODO: Consider storing value in binary representation instead of converting to string
         char keyIDStr[kMaxKeyIDStringSize];
         snprintf(keyIDStr, sizeof(keyIDStr), "%d", mNextKeyId);
-        mStorageDelegate->SetKeyValue(kNextAvailableKeyID, keyIDStr);
+        mStorageDelegate->AsyncSetKeyValue(kNextAvailableKeyID, keyIDStr);
     }
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -502,7 +502,7 @@ DeviceCommissioner::DeviceCommissioner()
     mPairedDevicesUpdated = false;
 }
 
-CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out)
+CHIP_ERROR DeviceCommissioner::LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out)
 {
     VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -508,13 +508,22 @@ CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, PersistentStorageDeleg
 {
     ReturnErrorOnFailure(DeviceController::Init(localDeviceId, storageDelegate, systemLayer, inetLayer));
 
-    char keyIDStr[kMaxKeyIDStringSize];
-    uint16_t size  = sizeof(keyIDStr);
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key, err = mStorageDelegate->GetKeyValue(key, keyIDStr, size));
-    if (err != CHIP_NO_ERROR || !ArgParser::ParseInt(keyIDStr, mNextKeyId))
+    if (mStorageDelegate != nullptr)
     {
-        // If the persistent storage didn't have a stored KeyID value
+        char keyIDStr[kMaxKeyIDStringSize];
+        uint16_t size  = sizeof(keyIDStr);
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key,
+                          err = mStorageDelegate->GetKeyValue(key, keyIDStr, size));
+        if (err != CHIP_NO_ERROR || !ArgParser::ParseInt(keyIDStr, mNextKeyId))
+        {
+            // If the persistent storage didn't have a stored KeyID value
+            mNextKeyId = 0;
+        }
+    }
+    else
+    {
+        // If there is no persistent storage
         mNextKeyId = 0;
     }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -827,7 +827,7 @@ void DeviceCommissioner::PersistDeviceList()
         // TODO: Consider storing value in binary representation instead of converting to string
         char keyIDStr[kMaxKeyIDStringSize];
         snprintf(keyIDStr, sizeof(keyIDStr), "%d", mNextKeyId);
-        PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key, mStorageDelegate->SetKeyValue(key, keyIDStr));
+        mStorageDelegate->SetKeyValue(kNextAvailableKeyID, keyIDStr);
     }
 }
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -502,13 +502,14 @@ DeviceCommissioner::DeviceCommissioner()
     mPairedDevicesUpdated = false;
 }
 
-CHIP_ERROR LoadKeyId(PersistentStorageDelegate * storageDelegate, uint16_t & out)
+CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out)
 {
-    VerifyOrReturnError(storageDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(delegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    // TODO: Consider storing value in binary representation instead of converting to string
     char keyIDStr[kMaxKeyIDStringSize];
     uint16_t size = sizeof(keyIDStr);
-    ReturnErrorOnFailure(storageDelegate->GetKeyValue(kNextAvailableKeyID, keyIDStr, size));
+    ReturnErrorOnFailure(delegate->GetKeyValue(kNextAvailableKeyID, keyIDStr, size));
 
     ReturnErrorCodeIf(!ArgParser::ParseInt(keyIDStr, out), CHIP_ERROR_INTERNAL);
 
@@ -823,6 +824,7 @@ void DeviceCommissioner::PersistDeviceList()
             chip::Platform::MemoryFree(serialized);
         }
 
+        // TODO: Consider storing value in binary representation instead of converting to string
         char keyIDStr[kMaxKeyIDStringSize];
         snprintf(keyIDStr, sizeof(keyIDStr), "%d", mNextKeyId);
         PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kNextAvailableKeyID, key, mStorageDelegate->SetKeyValue(key, keyIDStr));

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -337,6 +337,8 @@ private:
     DeviceCommissionerRendezvousAdvertisementDelegate mRendezvousAdvDelegate;
 
     void PersistDeviceList();
+
+    uint16_t mNextKeyId = 0;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -338,6 +338,10 @@ private:
 
     void PersistDeviceList();
 
+    void FreeRendezvousSession();
+
+    CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out);
+
     uint16_t mNextKeyId = 0;
 };
 


### PR DESCRIPTION
- Controller initialized rendezvous session with the key ID. Currently,
  the sessions established via rendezvous get persisted across controller
  reboots, and are used for storing encryption key. This change enables
  controller to remember the next key ID that should be used for further
  device pairing so that key ID will be across all paired devices.

 #### Problem
The commissioner is unable to process/decrypt the response from devices if multiple devices have been paired with it.

 #### Summary of Changes
The commissioner was not storing the key ID assigned to the PASE session keys (currently, it uses PASE session for secure communication with the device). Multiple devices were being assigned the same key ID, and the response processing was looking up the incorrect state for all except one of the devices.
