### PR TITLE
[nordic] Fix compilation if NFC commissioning is disabled

### DIFF
--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -45,7 +45,6 @@ target_sources(app PRIVATE
                ${LIGHTING_COMMON}/gen/call-command-handler.cpp
                ${LIGHTING_COMMON}/gen/callback-stub.cpp
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp
-               ${NRFCONNECT_COMMON}/util/NFCWidget.cpp
                ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
                ${NRFCONNECT_COMMON}/app/Service.cpp
                ${CHIP_ROOT}/src/app/server/DataModelHandler.cpp
@@ -70,6 +69,12 @@ target_sources(app PRIVATE
                ${CHIP_ROOT}/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
                ${CHIP_ROOT}/src/app/clusters/network-commissioning/network-commissioning.cpp
                )
+
+if (CONFIG_CHIP_NFC_COMMISSIONING)
+target_sources(app PRIVATE
+               ${NRFCONNECT_COMMON}/util/NFCWidget.cpp
+)
+endif(CONFIG_CHIP_NFC_COMMISSIONING)
 
 if (CONFIG_CHIP_PW_RPC)
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -383,6 +383,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
         return;
     }
 
+#ifdef CONFIG_CHIP_NFC_COMMISSIONING
     if (!sNFC.IsTagEmulationStarted())
     {
         if (!(GetAppTask().StartNFCTag() < 0))
@@ -398,6 +399,7 @@ void AppTask::StartBLEAdvertisementHandler(AppEvent * aEvent)
     {
         LOG_INF("NFC Tag emulation is already started");
     }
+#endif
 
     if (ConnectivityMgr().IsBLEAdvertisingEnabled())
     {


### PR DESCRIPTION
If NFC commissioning is disabled, build breaks because
* sNFC variable is used unconditionally
* NFCWidget.cpp is built unconditionally

Signed-off-by: Markus Becker <markus.becker@tridonic.com>
