### PR TITLE
Qualify path for util.h to avoid conflicts with other SDK's

### DIFF
--- a/src/app/zap-templates/templates/app/call-command-handler-src.zapt
+++ b/src/app/zap-templates/templates/app/call-command-handler-src.zapt
@@ -7,7 +7,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 using namespace chip;
 

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -8,7 +8,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 #include <app/InteractionModelEngine.h>
 


### PR DESCRIPTION
Qualifying the path to util.h in the templates.  Certain micro-controllers SDK's also have their own util.h.  Qualifying the path avoids conflict between them. 