### PR TITLE
Qualify path for util.h to avoid conflicts with other micro-controller sdks

### DIFF
--- a/src/app/zap-templates/templates/app/call-command-handler-src.zapt
+++ b/src/app/zap-templates/templates/app/call-command-handler-src.zapt
@@ -7,7 +7,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 using namespace chip;
 

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -8,7 +8,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 #include <app/InteractionModelEngine.h>
 


### PR DESCRIPTION
util.h is used by micro controller SDK's and conflicts with util.h for chip. Qualifying the path in the template to resolve.