### PR TITLE
specify path for util.h

### DIFF
--- a/src/app/zap-templates/templates/app/call-command-handler-src.zapt
+++ b/src/app/zap-templates/templates/app/call-command-handler-src.zapt
@@ -7,7 +7,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 using namespace chip;
 

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -8,7 +8,7 @@
 #include "callback.h"
 #include "cluster-id.h"
 #include "command-id.h"
-#include "util.h"
+#include "app/util/util.h"
 
 #include <app/InteractionModelEngine.h>
 


### PR DESCRIPTION
Qualifying path to util.h in templates.  
The file name util.h is used my other micro-controller SDK.  
Qualifying the location of CHIP's util.h resolves this issue.