### PR TITLE
Document some additional package dependencies on Debian

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -43,7 +43,9 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following:
 
 ```
-sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip
+sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev \
+     libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
+     python3-pip unzip libgirepository1.0-dev libcairo2-dev
 ```
 
 #### How to install prerequisites on macOS


### PR DESCRIPTION
These are transitive dependencies of the python module. Cairo is pretty
surprising, but pygobject needs it.