### PR TITLE
Add group of certification tools to root BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -96,6 +96,7 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
 
     if (chip_build_tools) {
       deps += [
+        ":certification",
         "${chip_root}/examples/shell/standalone:chip-shell",
         "${chip_root}/src/app/tests/integration:chip-im-initiator",
         "${chip_root}/src/app/tests/integration:chip-im-responder",
@@ -114,6 +115,18 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
         "${chip_root}/src/controller/java",
         "${chip_root}/src/setup_payload/java",
       ]
+    }
+  }
+
+  if (chip_build_tools) {
+    group("certification") {
+      data_deps = [ "${chip_root}/examples/chip-tool" ]
+
+      if (chip_enable_python_modules) {
+        data_deps += [ "${chip_root}/src/controller/python" ]
+      }
+
+      write_runtime_deps = "${root_out_dir}/certification.runtime_deps"
     }
   }
 


### PR DESCRIPTION
The goal is just to be able to do

```
source scripts/activate.sh
gn gen out/host
ninja -C out/host certification
```
on a Raspberry Pi 4 to build the right bits in 2m20s instead of 10
minutes. The group contents can change as tools are added or removed.