### PR TITLE
Remove redundancy args in chip-tool setup payload usgae

### DIFF
--- a/examples/chip-tool/README.md
+++ b/examples/chip-tool/README.md
@@ -136,7 +136,7 @@ and the `parse-setup-payload` command
 
 #### QR Code with optional Vendor Info
 
-    $ chip-tool chip-tool payload parse-setup-payload "CH:#####"
+    $ chip-tool payload parse-setup-payload "CH:#####"
 
 #### Manual Setup Code
 


### PR DESCRIPTION
 #### Problem

 Fix

"chip-tool chip-tool payload parse-setup-payload "CH:#####""

to:

"chip-tool payload parse-setup-payload "CH:#####""

 #### Summary of Changes
 
 Fixes #5450

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Signed-off-by: Bo YU <yubo@eswin.com>
