### PR TITLE
[cirque] Add mobile device test for testing python binding

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -29,6 +29,7 @@ CIRQUE_TESTS=(
     "EchoTest"
     "InteractionModelTest"
     "OnOffClusterTest"
+    "MobileDeviceTest"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"

--- a/src/controller/python/test/Dockerfile
+++ b/src/controller/python/test/Dockerfile
@@ -1,0 +1,16 @@
+
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY /whl/python/*.whl /whl/
+COPY entrypoint.sh /entrypoint.sh
+COPY mobile-device-test.py /usr/bin/
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libglib2.0-dev avahi-daemon libavahi-client3 \
+    python3 python3-dev python3-pip libcairo2-dev libdbus-1-dev libgirepository1.0-dev \
+    libjpeg-dev libgif-dev && \
+    pip3 install /whl/*.whl
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/src/controller/python/test/entrypoint.sh
+++ b/src/controller/python/test/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+service dbus start
+sleep 1
+service avahi-daemon start
+sleep infinity

--- a/src/controller/python/test/mobile-device-test.py
+++ b/src/controller/python/test/mobile-device-test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+from chip import ChipDeviceCtrl
+from chip import exceptions
+from optparse import OptionParser, OptionValueError
+import threading
+import os
+import sys
+import logging
+import time
+
+logger = logging.getLogger('CHIPMobileDevice')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+sh.setStream(sys.stdout)
+logger.addHandler(sh)
+
+# The thread network dataset tlv for testing, splited into T-L-V.
+TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
+                "000300000c" + \
+                "35060004001fffe0" + \
+                "0208fedcba9876543210" + \
+                "0708fd00000000001234" + \
+                "0510ffeeddccbbaa99887766554433221100" + \
+                "030e54657374696e674e6574776f726b" + \
+                "0102d252" + \
+                "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
+# Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
+TEST_THREAD_NETWORK_ID = "0123456789abcdef"
+
+
+def TestFail(message):
+    logger.fatal("Testfail: {}".format(message))
+    os._exit(1)
+
+
+def FailIfNot(cond, message):
+    if not cond:
+        TestFail(message)
+
+
+class TestTimeout(threading.Thread):
+    def __init__(self, timeout: int):
+        threading.Thread.__init__(self)
+        self._timeout = timeout
+        self._should_stop = False
+        self._cv = threading.Condition()
+
+    def stop(self):
+        with self._cv:
+            self._should_stop = True
+            self._cv.notify_all()
+        self.join()
+
+    def run(self):
+        stop_time = time.time() + self._timeout
+        logger.info("Test timeout set to {} seconds".format(self._timeout))
+        with self._cv:
+            wait_time = stop_time - time.time()
+            while wait_time > 0 and not self._should_stop:
+                self._cv.wait(wait_time)
+                wait_time = stop_time - time.time()
+        if time.time() > stop_time:
+            TestFail("Timeout")
+
+
+class MobileDeviceTests():
+    def __init__(self, nodeid: int):
+        self.devCtrl = ChipDeviceCtrl.ChipDeviceController(
+            controllerNodeId=nodeid)
+        self.logger = logger
+
+    def TestKeyExchange(self, ip: str, setuppin: int, nodeid: int):
+        self.logger.info("Conducting key exchange with device {}".format(ip))
+        if not self.devCtrl.ConnectIP(ip.encode("utf-8"), setuppin, nodeid):
+            self.logger.info(
+                "Failed to finish key exchange with device {}".format(ip))
+            return False
+        self.logger.info("Device finished key exchange.")
+        return True
+
+    def TestNetworkCommissioning(self, nodeid: int):
+        self.logger.info("Commissioning network to device {}".format(nodeid))
+        try:
+            self.devCtrl.ZCLSend("NetworkCommissioning", "AddThreadNetwork", nodeid, 1, 0, {
+                "operationalDataset": bytes.fromhex(TEST_THREAD_NETWORK_DATASET_TLV),
+                "breadcrumb": 0,
+                "timeoutMs": 1000})
+        except Exception as ex:
+            self.logger.exception("Failed to send AddThreadNetwork command")
+            return False
+        # TODO: ZCLSend should be synchronous, currently, IM does not pass IM status response to upper layer.
+        time.sleep(1)
+        try:
+            self.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", nodeid, 1, 0, {
+                "networkID": bytes.fromhex(TEST_THREAD_NETWORK_ID),
+                "breadcrumb": 0,
+                "timeoutMs": 1000})
+        except Exception as ex:
+            self.logger.exception("Failed to send EnableNetwork command")
+            return False
+        # Wait for thread network join
+        time.sleep(45)
+        return True
+
+    def TestOnOffCluster(self, nodeid: int):
+        self.logger.info("Sending On/Off commands to device {}".format(nodeid))
+        try:
+            self.devCtrl.ZCLSend("OnOff", "On", nodeid, 1, 0, {})
+        except Exception as ex:
+            self.logger.exception("Failed to send On command")
+            return False
+        time.sleep(1)
+        try:
+            self.devCtrl.ZCLSend("OnOff", "Off", nodeid, 1, 0, {})
+        except Exception as ex:
+            self.logger.exception("Failed to send Off command")
+            return False
+        time.sleep(1)
+        return True
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=75,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+        metavar="<device-addr>",
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = MobileDeviceTests(112233)
+
+    FailIfNot(test.TestKeyExchange(options.deviceAddress,
+                                   12345678, 1), "Failed to finish key exchange")
+    # Temporary disable NetworkCommissioning test, see pr/5317
+    # FailIfNot(test.TestNetworkCommissioning(1), "Failed to finish network commissioning")
+    FailIfNot(test.TestOnOffCluster(1), "Failed to test on off cluster")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test_driver/linux-cirque/MobileDeviceTest.sh
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$SOURCE_DIR/../../../"
+
+test_script_dir=$REPO_DIR/src/controller/python
+chip_light_dir=$REPO_DIR/examples/lighting-app/linux
+
+function build_chip_controller() {
+    # These files should be successfully compiled elsewhere.
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$test_script_dir"
+    gn gen --check --fail-on-unused-args out/debug >/dev/null
+    run_ninja -C out/debug
+    mkdir -p "$test_script_dir/test/whl/"
+    cp -R "$test_script_dir/out/debug/controller/python/" "$test_script_dir/test/whl/"
+    cd "$test_script_dir/test"
+    docker build -t chip_mobile_device -f Dockerfile . 2>&1
+}
+
+function build_chip_lighting() {
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$chip_light_dir"
+    gn gen --check --fail-on-unused-args out/debug
+    run_ninja -C out/debug
+    docker build -t chip_server -f Dockerfile . 2>&1
+    set +x
+}
+
+function main() {
+    pushd .
+    build_chip_controller
+    build_chip_lighting
+    popd
+    python3 "$SOURCE_DIR/test-mobile-device.py"
+}
+
+source "$SOURCE_DIR"/shell-helpers.sh
+main

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+logger = logging.getLogger('CHIPInteractionModelTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'MobileDevice',
+        'base_image': 'chip_mobile_device',
+        'capability': ['Interactive'],
+        'rcp_mode': True,
+    },
+    'device1': {
+        'type': 'CHIPEndDevice',
+        'base_image': 'chip_server',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    }
+}
+
+CHIP_PORT = 11097
+
+CIRQUE_URL = "http://localhost:5000"
+
+
+class TestPythonController(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+
+    def test_routine(self):
+        self.run_controller_test()
+
+    def run_controller_test(self):
+        ethernet_ip = [device['description']['ipv4_addr'] for device in self.non_ap_devices
+                       if device['type'] == 'CHIPEndDevice'][0]
+        server_ids = [device['id'] for device in self.non_ap_devices
+                      if device['type'] == 'CHIPEndDevice']
+        req_ids = [device['id'] for device in self.non_ap_devices
+                   if device['type'] == 'MobileDevice']
+
+        for device_id in server_ids:
+            # Clear default Thread network commissioning data
+            reply = self.execute_device_cmd(device_id, 'ot-ctl factoryreset')
+
+        req_device_id = req_ids[0]
+
+        time.sleep(5)
+
+        command = "mobile-device-test.py -t 75 -a {}".format(ethernet_ip)
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+        roles = set()
+
+        for device_id in server_ids:
+            reply = self.execute_device_cmd(device_id, 'ot-ctl state')
+            roles.add(reply['output'].split()[0])
+        self.assertTrue('leader' in roles)
+
+        for device_id in server_ids:
+            self.logger.info("checking device log for {}".format(
+                self.get_device_pretty_id(device_id)))
+            self.assertTrue(self.sequenceMatch(self.get_device_log(device_id).decode('utf-8'), ["LightingManager::InitiateAction(ON_ACTION)", "LightingManager::InitiateAction(OFF_ACTION)"]),
+                            "Datamodel test failed: cannot find matching string from device {}".format(device_id))
+
+
+if __name__ == "__main__":
+    sys.exit(TestPythonController(DEVICE_CONFIG).run_test())


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

We are missing some tests for Python binding of chip device controller, this test adds them.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Add cirque test for python device controller.

This is a resubmit of #5317 , which met some issues of ThreadStackManager, that PR will preserved for debugging.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #<<<<<FILL ME IN  - issue number(s). If no issue, please create one>>>>>

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
