### PR TITLE
Remove EMBER_AF_PLUGIN_REPORTING macro and considers that reporting i…

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -41,6 +41,7 @@
 
 #include <app/util/af.h>
 
+#include <app/reporting/reporting.h>
 #include <app/util/af-event.h>
 #include <app/util/attribute-storage.h>
 #include <assert.h>
@@ -49,10 +50,6 @@
 #include "gen/attribute-id.h"
 #include "gen/attribute-type.h"
 #include "gen/cluster-id.h"
-
-#ifdef EMBER_AF_PLUGIN_REPORTING
-#include <app/reporting/reporting.h>
-#endif
 
 using namespace chip;
 

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -50,9 +50,7 @@
 #include "gen/cluster-id.h"
 #include "gen/command-id.h"
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
 #include <app/reporting/reporting.h>
-#endif
 
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>

--- a/src/app/clusters/on-off-server/on-off.cpp
+++ b/src/app/clusters/on-off-server/on-off.cpp
@@ -48,9 +48,7 @@
 #include "gen/cluster-id.h"
 #include "gen/command-id.h"
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
 #include <app/reporting/reporting.h>
-#endif
 
 #ifdef EMBER_AF_PLUGIN_SCENES
 #include <app/clusters/scenes/scenes.h>

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -50,9 +50,7 @@
 #include "app/util/common.h"
 #include "gen/callback.h"
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
 #include <app/reporting/reporting.h>
-#endif // EMBER_AF_PLUGIN_REPORTING
 
 using namespace chip;
 
@@ -602,9 +600,7 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
         // Function itself will weed out tokens that are not tokenized.
         emAfSaveAttributeToToken(data, endpoint, cluster, metadata);
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
         emberAfReportingAttributeChangeCallback(endpoint, cluster, attributeID, mask, manufacturerCode, dataType, data);
-#endif // EMBER_AF_PLUGIN_REPORTING
 
         // Post write attribute callback for all attributes changes, regardless
         // of cluster.

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -42,11 +42,8 @@
 #include "af.h"
 
 #include <app/clusters/ias-zone-client/ias-zone-client.h>
-#include <app/util/common.h>
-
-#ifdef EMBER_AF_PLUGIN_REPORTING
 #include <app/reporting/reporting.h>
-#endif // EMBER_AF_PLUGIN_REPORTING
+#include <app/util/common.h>
 
 #include "gen/attribute-id.h"
 #include "gen/attribute-type.h"
@@ -479,7 +476,6 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         return true;
     }
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
     case ZCL_CONFIGURE_REPORTING_COMMAND_ID:
         if (emberAfConfigureReportingCommandCallback(cmd))
         {
@@ -493,7 +489,6 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             return true;
         }
         break;
-#endif // EMBER_AF_PLUGIN_REPORTING
 
     // ([attribute id:2] [status:1] [type:0/1] [value:0/V])+
     case ZCL_READ_ATTRIBUTES_RESPONSE_COMMAND_ID:
@@ -579,7 +574,6 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
         }
         return true;
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
     // ([status:1] [direction:1] [attribute id:2])+
     case ZCL_CONFIGURE_REPORTING_RESPONSE_COMMAND_ID:
         if (!emberAfConfigureReportingResponseCallback(clusterId, message + msgIndex, static_cast<uint16_t>(msgLen - msgIndex)))
@@ -598,7 +592,6 @@ bool emAfProcessGlobalCommand(EmberAfClusterCommand * cmd)
             emberAfSendDefaultResponse(cmd, EMBER_ZCL_STATUS_SUCCESS);
         }
         return true;
-#endif // EMBER_AF_PLUGIN_REPORTING
 
     // ([attribute id:2] [type:1] [data:V])+
     case ZCL_REPORT_ATTRIBUTES_COMMAND_ID:

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -44,6 +44,7 @@
 #include "af-main.h"
 #include "af.h"
 #include "app/util/common.h"
+#include <app/reporting/reporting.h>
 
 #include "gen/attribute-id.h"
 #include "gen/attribute-type.h"
@@ -55,10 +56,6 @@
 #ifdef EMBER_AF_PLUGIN_GROUPS_SERVER
 #include <app/clusters/groups-server/groups-server.h>
 #endif // EMBER_AF_PLUGIN_GROUPS_SERVER
-
-#ifdef EMBER_AF_PLUGIN_REPORTING
-#include <app/reporting/reporting.h>
-#endif // EMBER_AF_PLUGIN_REPORTING
 
 using namespace chip;
 
@@ -289,9 +286,9 @@ void emberAfInit(void)
     // initialize event management system
     emAfInitEvents();
 
-#ifdef EMBER_AF_PLUGIN_REPORTING
+    // Initialize the reporting plugin
     emberAfPluginReportingInitCallback();
-#endif
+
 #ifdef EMBER_AF_PLUGIN_TEMPERATURE_MEASUREMENT_SERVER
     emberAfPluginTemperatureMeasurementServerInitCallback();
 #endif
@@ -333,12 +330,10 @@ void emberAfStackDown(void)
         // && emberNetworkState() == EMBER_NO_NETWORK
     )
     {
-#ifdef EMBER_AF_PLUGIN_REPORTING
         // the report table should be cleared when the stack comes down.
         // going to a new network means new report devices should be discovered.
         // if the table isnt cleared the device keeps trying to send messages.
         emberAfClearReportTableCallback();
-#endif // EMBER_AF_PLUGIN_REPORTING
     }
 
     emberAfRegistrationAbortCallback();

--- a/src/app/zap-templates/templates/app/endpoint_config.zapt
+++ b/src/app/zap-templates/templates/app/endpoint_config.zapt
@@ -103,13 +103,9 @@
 #define ZRD(x) EMBER_ZCL_REPORTING_DIRECTION_ ## x
 #define ZAP_REPORT_DIRECTION(x) ZRD(x)
 
-{{#if (endpoint_reporting_config_default_count)}}
-// Use this macro to check if Reporting plugin is included
-#define EMBER_AF_PLUGIN_REPORTING
 // User options for plugin Reporting
 #define EMBER_AF_PLUGIN_REPORTING_TABLE_SIZE ({{endpoint_reporting_config_default_count}})
 #define EMBER_AF_PLUGIN_REPORTING_ENABLE_GROUP_BOUND_REPORTS
-{{/if}}
 
 #define EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS_TABLE_SIZE ({{endpoint_reporting_config_default_count}})
 #define EMBER_AF_GENERATED_REPORTING_CONFIG_DEFAULTS {{endpoint_reporting_config_defaults}}


### PR DESCRIPTION
…s always enabled

#### Problem

My understanding of CHIP specification is that reporting should always be enabled. This PR removes the `EMBER_AF_PLUGIN_REPORTING` macro and its usage.

The underlying reason for that is for controllers. At the moment the macro is conditionally defines based on the number of attributes that are reportable. But in the current state, some controllers does not have any reportable attributes and we end up in a situation where reporting responses are not handled properly.

I can probably fix that a different way, but since reporting is used by `List` attributes, and the `Descriptor` cluster is mandatory and uses `List`, it just seems useless to conditionally includes reporting.
 
 #### Summary of Changes
* Remove `EMBER_AF_PLUGIN_REPORTING` macro
* Remove its usage
