### PR TITLE
[K32W] Increase the BLE Indication timeout

### DIFF
--- a/src/platform/K32W/BLEManagerImpl.cpp
+++ b/src/platform/K32W/BLEManagerImpl.cpp
@@ -62,7 +62,7 @@ namespace {
  * Macros & Constants definitions
  *******************************************************************************/
 /* Timeout of BLE commands */
-#define CHIP_BLE_KW_EVNT_TIMEOUT 300
+#define CHIP_BLE_KW_EVNT_TIMEOUT 1000
 
 /** BLE advertisment state changed */
 #define CHIP_BLE_KW_EVNT_ADV_CHANGED 0x0001


### PR DESCRIPTION
This is a fix needed to avoid losing BLE packets.