### PR TITLE
ESP32: Add RPA for BLE

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -38,6 +38,7 @@
 #include "esp_log.h"
 #include "esp_nimble_hci.h"
 #include "host/ble_hs.h"
+#include "host/ble_hs_pvcy.h"
 #include "host/ble_uuid.h"
 #include "host/util/util.h"
 #include "nimble/nimble_port.h"
@@ -526,20 +527,9 @@ void BLEManagerImpl::bleprph_on_reset(int reason)
 
 void BLEManagerImpl::bleprph_on_sync(void)
 {
-    int rc;
-
     sInstance.mFlags.Set(Flags::kESPBLELayerInitialized);
     sInstance.mFlags.Set(Flags::kGATTServiceStarted);
     ESP_LOGI(TAG, "BLE host-controller synced");
-
-    uint8_t own_addr_type = BLE_OWN_ADDR_PUBLIC;
-
-    rc = ble_hs_id_infer_auto(0, &own_addr_type);
-    if (rc != 0)
-    {
-        ESP_LOGE(TAG, "Error determining address type; rc=%d\n", rc);
-        return;
-    }
 }
 
 void BLEManagerImpl::bleprph_host_task(void * param)
@@ -567,9 +557,12 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     nimble_port_init();
 
     /* Initialize the NimBLE host configuration. */
-    ble_hs_cfg.reset_cb        = bleprph_on_reset;
-    ble_hs_cfg.sync_cb         = bleprph_on_sync;
-    ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
+    ble_hs_cfg.reset_cb          = bleprph_on_reset;
+    ble_hs_cfg.sync_cb           = bleprph_on_sync;
+    ble_hs_cfg.store_status_cb   = ble_store_util_status_rr;
+    ble_hs_cfg.sm_bonding        = 1;
+    ble_hs_cfg.sm_our_key_dist   = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
+    ble_hs_cfg.sm_their_key_dist = BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID;
 
     // Register the CHIPoBLE GATT attributes with the ESP BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled)
@@ -1014,7 +1007,14 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     ble_gap_adv_params adv_params;
     memset(&adv_params, 0, sizeof(adv_params));
-    uint8_t own_addr_type = BLE_OWN_ADDR_PUBLIC;
+    uint8_t own_addr_type = BLE_OWN_ADDR_RANDOM;
+
+    ret = ble_hs_pvcy_rpa_config(NIMBLE_HOST_ENABLE_RPA);
+    if (ret != 0)
+    {
+        ChipLogError(DeviceLayer, "RPA not set: %d", ret);
+        return CHIP_ERROR_INTERNAL;
+    }
 
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 


### PR DESCRIPTION

 #### Problem
As per the CHIP spec, the device should use a different address on each successful/unsuccessful commissioning attempt

 #### Summary of Changes
Enable RPA functionality

Fixes #5425 for ESP32