### PR TITLE
Ensure paired device list is always initialized before use

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -270,7 +270,6 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
     CHIP_ERROR err  = CHIP_NO_ERROR;
     Device * device = nullptr;
     uint16_t index  = 0;
-    char * buffer   = nullptr;
 
     VerifyOrExit(out_device != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     index = FindDeviceIndex(deviceId);
@@ -281,24 +280,8 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
     }
     else
     {
-        VerifyOrExit(mStorageDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-
-        if (!mPairedDevicesInitialized)
-        {
-            constexpr uint16_t max_size = CHIP_MAX_SERIALIZED_SIZE_U64(kNumMaxPairedDevices);
-            buffer                      = static_cast<char *>(chip::Platform::MemoryAlloc(max_size));
-            uint16_t size               = max_size;
-
-            VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-            PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kPairedDeviceListKeyPrefix, key,
-                              err = mStorageDelegate->SyncGetKeyValue(key, buffer, size));
-            SuccessOrExit(err);
-            VerifyOrExit(size <= max_size, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
-
-            err = SetPairedDeviceList(buffer);
-            SuccessOrExit(err);
-        }
+        err = InitializePairedDeviceList();
+        SuccessOrExit(err);
 
         VerifyOrExit(mPairedDevices.Contains(deviceId), err = CHIP_ERROR_NOT_CONNECTED);
 
@@ -325,10 +308,6 @@ CHIP_ERROR DeviceController::GetDevice(NodeId deviceId, Device ** out_device)
     *out_device = device;
 
 exit:
-    if (buffer != nullptr)
-    {
-        chip::Platform::MemoryFree(buffer);
-    }
     if (err != CHIP_NO_ERROR && device != nullptr)
     {
         ReleaseDevice(device);
@@ -469,6 +448,47 @@ uint16_t DeviceController::FindDeviceIndex(NodeId id)
     return i;
 }
 
+CHIP_ERROR DeviceController::InitializePairedDeviceList()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    char * buffer  = nullptr;
+
+    VerifyOrExit(mStorageDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    if (!mPairedDevicesInitialized)
+    {
+        constexpr uint16_t max_size = CHIP_MAX_SERIALIZED_SIZE_U64(kNumMaxPairedDevices);
+        buffer                      = static_cast<char *>(chip::Platform::MemoryAlloc(max_size));
+        uint16_t size               = max_size;
+
+        VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+        CHIP_ERROR lookupError = CHIP_NO_ERROR;
+        PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kPairedDeviceListKeyPrefix, key,
+                          lookupError = mStorageDelegate->SyncGetKeyValue(key, buffer, size));
+
+        // It's ok to not have an entry for the Paired Device list. We treat it the same as having an empty list.
+        if (lookupError != CHIP_ERROR_KEY_NOT_FOUND)
+        {
+            VerifyOrExit(size <= max_size, err = CHIP_ERROR_INVALID_DEVICE_DESCRIPTOR);
+            err = SetPairedDeviceList(buffer);
+            SuccessOrExit(err);
+        }
+    }
+
+exit:
+    if (buffer != nullptr)
+    {
+        chip::Platform::MemoryFree(buffer);
+    }
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to initialize the device list\n");
+    }
+
+    return err;
+}
+
 CHIP_ERROR DeviceController::SetPairedDeviceList(const char * serialized)
 {
     CHIP_ERROR err  = CHIP_NO_ERROR;
@@ -557,6 +577,9 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     VerifyOrExit(mState == State::Initialized, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mDeviceBeingPaired == kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(admin != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = InitializePairedDeviceList();
+    SuccessOrExit(err);
 
     params.SetAdvertisementDelegate(&mRendezvousAdvDelegate);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -199,6 +199,7 @@ protected:
     uint16_t FindDeviceIndex(NodeId id);
     void ReleaseDevice(uint16_t index);
     void ReleaseDeviceById(NodeId remoteDeviceId);
+    CHIP_ERROR InitializePairedDeviceList();
     CHIP_ERROR SetPairedDeviceList(const char * pairedDeviceSerializedSet);
 
     Transport::AdminId mAdminId = 0;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The paired device list is not always initialized before it was used. 
It required a call to `GetDevice` to set the list. `PairDevice` depends on some values that are gathered from initializing the paired device list and so calling `PairDevice` without first calling `GetDevice` could result in us overwriting some pairings. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Ensure the paired device list is populated whenever needed
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
