### PR TITLE
Somewhat unify protocol id representations in libCHIP.

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -221,7 +221,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR Command::AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
+CHIP_ERROR Command::AddStatusCode(const uint16_t aGeneralCode, Protocols::Id aProtocolId, const uint16_t aProtocolCode,
                                   const chip::ClusterId aClusterId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -230,7 +230,8 @@ CHIP_ERROR Command::AddStatusCode(const uint16_t aGeneralCode, const uint32_t aP
     err = statusElementBuilder.Init(mInvokeCommandBuilder.GetWriter());
     SuccessOrExit(err);
 
-    statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId, aProtocolCode, aProtocolCode).EndOfStatusElement();
+    statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), aProtocolCode, aProtocolCode)
+        .EndOfStatusElement();
     err = statusElementBuilder.GetError();
 
     MoveToState(CommandState::AddCommand);

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -119,7 +119,7 @@ public:
     CHIP_ERROR AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
                           chip::CommandId aCommandId, BitFlags<CommandPathFlags> Flags);
     CHIP_ERROR AddCommand(CommandParams & aCommandParams);
-    CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, const uint32_t aProtocolId, const uint16_t aProtocolCode,
+    CHIP_ERROR AddStatusCode(const uint16_t aGeneralCode, Protocols::Id aProtocolId, const uint16_t aProtocolCode,
                              const chip::ClusterId aClusterId);
 
     /**

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -94,7 +94,7 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
         // Empty Command, Add status code in invoke command response, notify cluster handler to hand it further.
         err = CHIP_NO_ERROR;
         ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-        AddStatusCode(static_cast<uint16_t>(GeneralStatusCode::kSuccess), Protocols::kProtocol_SecureChannel,
+        AddStatusCode(static_cast<uint16_t>(GeneralStatusCode::kSuccess), Protocols::SecureChannel::Id,
                       Protocols::SecureChannel::kProtocolCodeSuccess, clusterId);
     }
     else if (CHIP_NO_ERROR == err)

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -147,7 +147,7 @@ CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser &
         {
             err = CHIP_NO_ERROR;
             ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-            AddStatusCode(static_cast<uint16_t>(GeneralStatusCode::kSuccess), Protocols::kProtocol_SecureChannel,
+            AddStatusCode(static_cast<uint16_t>(GeneralStatusCode::kSuccess), Protocols::SecureChannel::Id,
                           Protocols::SecureChannel::kProtocolCodeSuccess, clusterId);
         }
         // TODO(#4503): Should call callbacks of cluster that sends the command.

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     mpExchangeMgr = apExchangeMgr;
     mpDelegate    = apDelegate;
 
-    err = mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::kProtocol_InteractionModel, this);
+    err = mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this);
     SuccessOrExit(err);
 
 exit:

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -338,7 +338,7 @@ public:
 
         // TODO: This code is temporary, and must be updated to use the Cluster API.
         // Issue: https://github.com/project-chip/connectedhomeip/issues/4725
-        if (payloadHeader.GetProtocolID() == chip::Protocols::kProtocol_ServiceProvisioning)
+        if (payloadHeader.HasProtocol(chip::Protocols::ServiceProvisioning::Id))
         {
             CHIP_ERROR err = CHIP_NO_ERROR;
             uint32_t timeout;
@@ -348,7 +348,7 @@ public:
             ChipLogProgress(AppServer, "Received service provisioning message. Treating it as OpenPairingWindow request");
             chip::System::PacketBufferTLVReader reader;
             reader.Init(std::move(buffer));
-            reader.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
+            reader.ImplicitProfileId = chip::Protocols::ServiceProvisioning::Id.ToTLVProfileId();
 
             SuccessOrExit(reader.Next(kTLVType_UnsignedInteger, TLV::ProfileTag(reader.ImplicitProfileId, 1)));
             SuccessOrExit(reader.Get(timeout));

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -262,7 +262,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption optio
     System::PacketBufferTLVWriter writer;
 
     writer.Init(std::move(buf));
-    writer.ImplicitProfileId = chip::Protocols::kProtocol_ServiceProvisioning;
+    writer.ImplicitProfileId = chip::Protocols::ServiceProvisioning::Id.ToTLVProfileId();
 
     ReturnErrorOnFailure(writer.Put(TLV::ProfileTag(writer.ImplicitProfileId, 1), timeout));
 
@@ -282,7 +282,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption optio
 
     PayloadHeader header;
 
-    header.SetMessageType(chip::Protocols::kProtocol_ServiceProvisioning, 0);
+    header.SetMessageType(chip::Protocols::ServiceProvisioning::Id, 0);
 
     ReturnErrorOnFailure(SendMessage(std::move(outBuffer), header));
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -149,9 +149,9 @@ CHIP_ERROR ChipCertificateSet::LoadCert(const uint8_t * chipCert, uint32_t chipC
     TLVReader reader;
 
     reader.Init(chipCert, chipCertLen);
-    reader.ImplicitProfileId = kProtocol_OpCredentials;
+    reader.ImplicitProfileId = Protocols::OpCredentials::Id.ToTLVProfileId();
 
-    err = reader.Next(kTLVType_Structure, ProfileTag(kProtocol_OpCredentials, kTag_ChipCertificate));
+    err = reader.Next(kTLVType_Structure, ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate));
     SuccessOrExit(err);
 
     err = LoadCert(reader, decodeFlags);
@@ -254,7 +254,7 @@ CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chi
     uint64_t tag;
 
     reader.Init(chipCerts, chipCertsLen);
-    reader.ImplicitProfileId = kProtocol_OpCredentials;
+    reader.ImplicitProfileId = Protocols::OpCredentials::Id.ToTLVProfileId();
 
     err = reader.Next();
     SuccessOrExit(err);
@@ -262,9 +262,10 @@ CHIP_ERROR ChipCertificateSet::LoadCerts(const uint8_t * chipCerts, uint32_t chi
     type = reader.GetType();
     tag  = reader.GetTag();
 
-    VerifyOrExit((type == kTLVType_Structure && tag == ProfileTag(kProtocol_OpCredentials, kTag_ChipCertificate)) ||
-                     (type == kTLVType_Array && tag == ProfileTag(kProtocol_OpCredentials, kTag_ChipCertificateArray)),
-                 err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    VerifyOrExit(
+        (type == kTLVType_Structure && tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate)) ||
+            (type == kTLVType_Array && tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificateArray)),
+        err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     err = LoadCerts(reader, decodeFlags);
 

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -505,7 +505,8 @@ static CHIP_ERROR ConvertCertificate(ASN1Reader & reader, TLVWriter & writer)
     OID sigAlgoOID;
     TLVType containerType;
 
-    err = writer.StartContainer(ProfileTag(kProtocol_OpCredentials, kTag_ChipCertificate), kTLVType_Structure, containerType);
+    err = writer.StartContainer(ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate), kTLVType_Structure,
+                                containerType);
     SuccessOrExit(err);
 
     // Certificate ::= SEQUENCE

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -833,7 +833,7 @@ static CHIP_ERROR DecodeConvertCert(TLVReader & reader, ASN1Writer & writer, Chi
     }
     VerifyOrExit(reader.GetType() == kTLVType_Structure, err = CHIP_ERROR_WRONG_TLV_TYPE);
     tag = reader.GetTag();
-    VerifyOrExit(tag == ProfileTag(kProtocol_OpCredentials, kTag_ChipCertificate) || tag == AnonymousTag,
+    VerifyOrExit(tag == ProfileTag(Protocols::OpCredentials::Id.ToTLVProfileId(), kTag_ChipCertificate) || tag == AnonymousTag,
                  err = CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 
     err = reader.EnterContainer(containerType);

--- a/src/lib/core/CHIPVendorIdentifiers.hpp
+++ b/src/lib/core/CHIPVendorIdentifiers.hpp
@@ -26,17 +26,19 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace chip {
 
 //
 // CHIP Vendor Identifiers (16 bits max)
 //
 
-enum ChipVendorId
+enum VendorId : uint16_t
 {
-    kChipVendor_Common       = 0x0000,
-    kChipVendor_NestLabs     = 0x235A,
-    kChipVendor_NotSpecified = 0xFFFF
+    Common       = 0x0000u,
+    NestLabs     = 0x235Au,
+    NotSpecified = 0xFFFFu
 };
 
 } // namespace chip

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -35,7 +35,7 @@ template <class T>
 class Optional
 {
 public:
-    Optional() : mHasValue(false) {}
+    constexpr Optional() : mHasValue(false) {}
     explicit Optional(const T & value) : mValue(value), mHasValue(true) {}
 
     constexpr Optional(const Optional & other) = default;
@@ -47,7 +47,7 @@ public:
      * NOTE: Manually implemented instead of =default  since other::mValue may not be initialized
      * if it has no value.
      */
-    Optional & operator=(const Optional & other)
+    constexpr Optional & operator=(const Optional & other)
     {
         if (other.HasValue())
         {
@@ -61,14 +61,14 @@ public:
     }
 
     /** Make the optional contain a specific value */
-    void SetValue(const T & value)
+    constexpr void SetValue(const T & value)
     {
         mValue    = value;
         mHasValue = true;
     }
 
     /** Invalidate the value inside the optional. Optional now has no value */
-    void ClearValue() { mHasValue = false; }
+    constexpr void ClearValue() { mHasValue = false; }
 
     /** Gets the current value of the optional. Valid IFF `HasValue`. */
     const T & Value() const
@@ -89,7 +89,7 @@ public:
     }
 
     /** Checks if the optional contains a value or not */
-    bool HasValue() const { return mHasValue; }
+    constexpr bool HasValue() const { return mHasValue; }
 
     /** Comparison operator, handling missing values. */
     bool operator==(const Optional & other) const

--- a/src/lib/support/BitFlags.h
+++ b/src/lib/support/BitFlags.h
@@ -46,7 +46,7 @@ public:
     static_assert(sizeof(StorageType) >= sizeof(FlagsEnum), "All flags should fit in the storage type");
     using IntegerType = StorageType;
 
-    BitFlags() : mValue(0) {}
+    constexpr BitFlags() : mValue(0) {}
     BitFlags(const BitFlags & other) = default;
     BitFlags & operator=(const BitFlags &) = default;
 
@@ -81,7 +81,7 @@ public:
      *
      * @param flag      Typed flag(s) to set. Any flags not in @a v are unaffected.
      */
-    BitFlags & Set(FlagsEnum flag)
+    constexpr BitFlags & Set(FlagsEnum flag)
     {
         mValue |= static_cast<IntegerType>(flag);
         return *this;
@@ -93,7 +93,7 @@ public:
      * @param flag      Typed flag(s) to set or clear. Any flags not in @a flag are unaffected.
      * @param isSet     If true, set the flag; if false, clear it.
      */
-    BitFlags & Set(FlagsEnum flag, bool isSet) { return isSet ? Set(flag) : Clear(flag); }
+    constexpr BitFlags & Set(FlagsEnum flag, bool isSet) { return isSet ? Set(flag) : Clear(flag); }
 
     /**
      * Clear flag(s).
@@ -111,7 +111,7 @@ public:
      *
      * @param flag  Typed flag(s) to clear. Any flags not in @a flag are unaffected.
      */
-    BitFlags & Clear(FlagsEnum flag)
+    constexpr BitFlags & Clear(FlagsEnum flag)
     {
         mValue &= static_cast<IntegerType>(~static_cast<IntegerType>(flag));
         return *this;

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -76,7 +76,7 @@ void ExchangeContext::SetResponseTimeout(Timeout timeout)
     mResponseTimeout = timeout;
 }
 
-CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
+CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
                                         const SendFlags & sendFlags)
 {
     CHIP_ERROR err                         = CHIP_NO_ERROR;
@@ -111,7 +111,7 @@ CHIP_ERROR ExchangeContext::SendMessage(uint16_t protocolId, uint8_t msgType, Pa
     return err;
 }
 
-CHIP_ERROR ExchangeContext::SendMessageImpl(uint16_t protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
+CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
                                             const SendFlags & sendFlags, Transport::PeerConnectionState * state)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -28,6 +28,7 @@
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/Flags.h>
 #include <messaging/ReliableMessageContext.h>
+#include <protocols/Protocols.h>
 #include <support/BitFlags.h>
 #include <support/DLLUtil.h>
 #include <system/SystemTimer.h>
@@ -107,7 +108,7 @@ public:
      *  @retval  #CHIP_NO_ERROR                             if the CHIP layer successfully sent the message down to the
      *                                                       network layer.
      */
-    CHIP_ERROR SendMessage(uint16_t protocolId, uint8_t msgType, System::PacketBufferHandle msgPayload,
+    CHIP_ERROR SendMessage(Protocols::Id protocolId, uint8_t msgType, System::PacketBufferHandle msgPayload,
                            const SendFlags & sendFlags);
 
     /**
@@ -117,7 +118,7 @@ public:
     CHIP_ERROR SendMessage(MessageType msgType, System::PacketBufferHandle && msgPayload, const SendFlags & sendFlags)
     {
         static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId, static_cast<uint8_t>(msgType),
+        return SendMessage(Protocols::MessageTypeTraits<MessageType>::ProtocolId(), static_cast<uint8_t>(msgType),
                            std::move(msgPayload), sendFlags);
     }
 
@@ -227,8 +228,8 @@ private:
      * A subset of SendMessage functionality that does not perform message
      * counter sync for group keys.
      */
-    CHIP_ERROR SendMessageImpl(uint16_t protocolId, uint8_t msgType, System::PacketBufferHandle msgBuf, const SendFlags & sendFlags,
-                               Transport::PeerConnectionState * state = nullptr);
+    CHIP_ERROR SendMessageImpl(Protocols::Id protocolId, uint8_t msgType, System::PacketBufferHandle msgBuf,
+                               const SendFlags & sendFlags, Transport::PeerConnectionState * state = nullptr);
     void CancelResponseTimer();
     static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState, System::Error aError);
 

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -117,23 +117,23 @@ ExchangeContext * ExchangeManager::NewContext(SecureSessionHandle session, Excha
     return AllocContext(mNextExchangeId++, session, true, delegate);
 }
 
-CHIP_ERROR ExchangeManager::RegisterUnsolicitedMessageHandlerForProtocol(uint32_t protocolId, ExchangeDelegate * delegate)
+CHIP_ERROR ExchangeManager::RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, ExchangeDelegate * delegate)
 {
     return RegisterUMH(protocolId, kAnyMessageType, delegate);
 }
 
-CHIP_ERROR ExchangeManager::RegisterUnsolicitedMessageHandlerForType(uint32_t protocolId, uint8_t msgType,
+CHIP_ERROR ExchangeManager::RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType,
                                                                      ExchangeDelegate * delegate)
 {
     return RegisterUMH(protocolId, static_cast<int16_t>(msgType), delegate);
 }
 
-CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForProtocol(uint32_t protocolId)
+CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId)
 {
     return UnregisterUMH(protocolId, kAnyMessageType);
 }
 
-CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForType(uint32_t protocolId, uint8_t msgType)
+CHIP_ERROR ExchangeManager::UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType)
 {
     return UnregisterUMH(protocolId, static_cast<int16_t>(msgType));
 }
@@ -160,7 +160,7 @@ ExchangeContext * ExchangeManager::AllocContext(uint16_t ExchangeId, SecureSessi
     return nullptr;
 }
 
-CHIP_ERROR ExchangeManager::RegisterUMH(uint32_t protocolId, int16_t msgType, ExchangeDelegate * delegate)
+CHIP_ERROR ExchangeManager::RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate)
 {
     UnsolicitedMessageHandler * umh      = UMHandlerPool;
     UnsolicitedMessageHandler * selected = nullptr;
@@ -191,7 +191,7 @@ CHIP_ERROR ExchangeManager::RegisterUMH(uint32_t protocolId, int16_t msgType, Ex
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ExchangeManager::UnregisterUMH(uint32_t protocolId, int16_t msgType)
+CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgType)
 {
     UnsolicitedMessageHandler * umh = UMHandlerPool;
 
@@ -294,7 +294,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
 
         for (int i = 0; i < CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS; i++, umh++)
         {
-            if (umh->Delegate != nullptr && umh->ProtocolId == payloadHeader.GetProtocolID())
+            if (umh->Delegate != nullptr && payloadHeader.HasProtocol(umh->ProtocolId))
             {
                 if (umh->MessageType == payloadHeader.GetMessageType())
                 {

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -31,6 +31,7 @@
 #include <messaging/ExchangeContext.h>
 #include <messaging/MessageCounterSync.h>
 #include <messaging/ReliableMessageMgr.h>
+#include <protocols/Protocols.h>
 #include <support/DLLUtil.h>
 #include <support/Pool.h>
 #include <transport/SecureSessionMgr.h>
@@ -112,7 +113,7 @@ public:
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(uint32_t protocolId, ExchangeDelegate * delegate);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId, ExchangeDelegate * delegate);
 
     /**
      *  Register an unsolicited message handler for a given protocol identifier and message type.
@@ -127,7 +128,7 @@ public:
      *                                                             is full and a new one cannot be allocated.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(uint32_t protocolId, uint8_t msgType, ExchangeDelegate * delegate);
+    CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType, ExchangeDelegate * delegate);
 
     /**
      * A strongly-message-typed version of RegisterUnsolicitedMessageHandlerForType.
@@ -136,7 +137,7 @@ public:
     CHIP_ERROR RegisterUnsolicitedMessageHandlerForType(MessageType msgType, ExchangeDelegate * delegate)
     {
         static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return RegisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId,
+        return RegisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
                                                         static_cast<uint8_t>(msgType), delegate);
     }
 
@@ -149,7 +150,7 @@ public:
      *                                                       is not found.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForProtocol(uint32_t protocolId);
+    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::Id protocolId);
 
     /**
      *  Unregister an unsolicited message handler for a given protocol identifier and message type.
@@ -162,7 +163,7 @@ public:
      *                                                       is not found.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(uint32_t protocolId, uint8_t msgType);
+    CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(Protocols::Id protocolId, uint8_t msgType);
 
     /**
      * A strongly-message-typed version of UnregisterUnsolicitedMessageHandlerForType.
@@ -171,7 +172,7 @@ public:
     CHIP_ERROR UnregisterUnsolicitedMessageHandlerForType(MessageType msgType)
     {
         static_assert(std::is_same<std::underlying_type_t<MessageType>, uint8_t>::value, "Enum is wrong size; cast is not safe");
-        return UnregisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId,
+        return UnregisterUnsolicitedMessageHandlerForType(Protocols::MessageTypeTraits<MessageType>::ProtocolId(),
                                                           static_cast<uint8_t>(msgType));
     }
 
@@ -230,8 +231,9 @@ private:
 
     struct UnsolicitedMessageHandler
     {
+        UnsolicitedMessageHandler() : ProtocolId(Protocols::NotSpecified) {}
         ExchangeDelegate * Delegate;
-        uint32_t ProtocolId;
+        Protocols::Id ProtocolId;
         int16_t MessageType;
     };
 
@@ -255,8 +257,8 @@ private:
 
     ExchangeContext * AllocContext(uint16_t ExchangeId, SecureSessionHandle session, bool Initiator, ExchangeDelegate * delegate);
 
-    CHIP_ERROR RegisterUMH(uint32_t protocolId, int16_t msgType, ExchangeDelegate * delegate);
-    CHIP_ERROR UnregisterUMH(uint32_t protocolId, int16_t msgType);
+    CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate);
+    CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
     static bool IsMsgCounterSyncMessage(const PayloadHeader & payloadHeader);
 

--- a/src/messaging/MessageCounterSync.cpp
+++ b/src/messaging/MessageCounterSync.cpp
@@ -45,7 +45,7 @@ CHIP_ERROR MessageCounterSyncMgr::Init(Messaging::ExchangeManager * exchangeMgr)
     mExchangeMgr = exchangeMgr;
 
     // Register to receive unsolicited Secure Channel Request messages from the exchange manager.
-    err = mExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::kProtocol_SecureChannel, this);
+    err = mExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::SecureChannel::Id, this);
 
     ReturnErrorOnFailure(err);
 
@@ -56,7 +56,7 @@ void MessageCounterSyncMgr::Shutdown()
 {
     if (mExchangeMgr != nullptr)
     {
-        mExchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::kProtocol_SecureChannel);
+        mExchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::SecureChannel::Id);
         mExchangeMgr = nullptr;
     }
 }
@@ -93,7 +93,7 @@ void MessageCounterSyncMgr::OnResponseTimeout(Messaging::ExchangeContext * excha
         exchangeContext->Close();
 }
 
-CHIP_ERROR MessageCounterSyncMgr::AddToRetransmissionTable(uint16_t protocolId, uint8_t msgType, const SendFlags & sendFlags,
+CHIP_ERROR MessageCounterSyncMgr::AddToRetransmissionTable(Protocols::Id protocolId, uint8_t msgType, const SendFlags & sendFlags,
                                                            System::PacketBufferHandle msgBuf,
                                                            Messaging::ExchangeContext * exchangeContext)
 {
@@ -269,7 +269,7 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncReq(SecureSessionHandle sess
     exchangeContext->SetResponseTimeout(kMsgCounterSyncTimeout);
 
     // Send the message counter synchronization request in a Secure Channel Protocol::MsgCounterSyncReq message.
-    err = exchangeContext->SendMessageImpl(Protocols::kProtocol_SecureChannel,
+    err = exchangeContext->SendMessageImpl(Protocols::SecureChannel::Id,
                                            static_cast<uint8_t>(Protocols::SecureChannel::MsgType::MsgCounterSyncReq),
                                            std::move(msgBuf), sendFlags);
     SuccessOrExit(err);
@@ -318,7 +318,7 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncResp(Messaging::ExchangeCont
     msgBuf->SetDataLength(kMsgCounterSyncRespMsgSize);
 
     // Send message counter synchronization response message.
-    err = exchangeContext->SendMessageImpl(Protocols::kProtocol_SecureChannel,
+    err = exchangeContext->SendMessageImpl(Protocols::SecureChannel::Id,
                                            static_cast<uint8_t>(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp),
                                            std::move(msgBuf), Messaging::SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
 

--- a/src/messaging/MessageCounterSync.h
+++ b/src/messaging/MessageCounterSync.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <protocols/Protocols.h>
 #include <system/SystemPacketBuffer.h>
 
 namespace chip {
@@ -72,7 +73,7 @@ public:
      *  @retval  #CHIP_ERROR_NO_MEMORY If there is no empty slot left in the table for addition.
      *  @retval  #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR AddToRetransmissionTable(uint16_t protocolId, uint8_t msgType, const SendFlags & sendFlags,
+    CHIP_ERROR AddToRetransmissionTable(Protocols::Id protocolId, uint8_t msgType, const SendFlags & sendFlags,
                                         System::PacketBufferHandle msgBuf, Messaging::ExchangeContext * exchangeContext);
 
     /**
@@ -103,11 +104,12 @@ private:
      */
     struct RetransTableEntry
     {
+        RetransTableEntry() : protocolId(Protocols::NotSpecified) {}
         ExchangeContext * exchangeContext; /**< The ExchangeContext for the stored CHIP message.
                                                 Non-null if and only if this entry is in use. */
         System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the CHIP message. */
         SendFlags sendFlags;               /**< Flags set by the application for the CHIP message being sent. */
-        uint16_t protocolId;               /**< The protocol identifier of the CHIP message to be sent. */
+        Protocols::Id protocolId;          /**< The protocol identifier of the CHIP message to be sent. */
         uint8_t msgType;                   /**< The message type of the CHIP message to be sent. */
     };
 

--- a/src/messaging/tests/TestChannel.cpp
+++ b/src/messaging/tests/TestChannel.cpp
@@ -98,7 +98,8 @@ void CheckExchangeChannels(nlTestSuite * inSuite, void * inContext)
 
     // create unsolicited exchange
     MockAppDelegate mockUnsolicitedAppDelegate;
-    CHIP_ERROR err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
+    CHIP_ERROR err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::Id(VendorId::Common, 0x0001),
+                                                                                       0x0001, &mockUnsolicitedAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // create the channel

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -111,22 +111,24 @@ void CheckUmhRegistrationTest(nlTestSuite * inSuite, void * inContext)
     CHIP_ERROR err;
     MockAppDelegate mockAppDelegate;
 
-    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(0x0001, &mockAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(Protocols::Id(VendorId::Common, 0x0001),
+                                                                                &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(0x0002, 0x0001, &mockAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::Id(VendorId::Common, 0x0002), 0x0001,
+                                                                            &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(0x0001);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::Id(VendorId::Common, 0x0001));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(0x0002);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::Id(VendorId::Common, 0x0002));
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 
-    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(0x0002, 0x0001);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Id(VendorId::Common, 0x0002), 0x0001);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(0x0002, 0x0002);
+    err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Protocols::Id(VendorId::Common, 0x0002), 0x0002);
     NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
 }
 
@@ -142,7 +144,8 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
 
     // create unsolicited exchange
     MockAppDelegate mockUnsolicitedAppDelegate;
-    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(0x0001, 0x0001, &mockUnsolicitedAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::Id(VendorId::Common, 0x0001), 0x0001,
+                                                                            &mockUnsolicitedAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // send a malicious packet
@@ -152,7 +155,8 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet
-    ec1->SendMessage(0x0001, 0x0001, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+    ec1->SendMessage(Protocols::Id(VendorId::Common, 0x0001), 0x0001,
+                     System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
                      SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 }

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -182,8 +182,7 @@ void CheckReceiveMsgCounterSyncReq(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, sm != nullptr);
 
     // Register to receive unsolicited Secure Channel Request messages from the exchange manager.
-    err =
-        ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(Protocols::kProtocol_SecureChannel, &mockAppDelegate);
+    err = ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(Protocols::SecureChannel::Id, &mockAppDelegate);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
@@ -224,7 +223,7 @@ void CheckAddRetransTable(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
     CHIP_ERROR err =
-        sm->AddToRetransmissionTable(Protocols::kProtocol_Echo, static_cast<uint8_t>(Protocols::Echo::MsgType::EchoRequest),
+        sm->AddToRetransmissionTable(Protocols::Echo::Id, static_cast<uint8_t>(Protocols::Echo::MsgType::EchoRequest),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kNone), std::move(buffer), exchange);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }

--- a/src/protocols/Protocols.h
+++ b/src/protocols/Protocols.h
@@ -32,26 +32,55 @@ namespace Protocols {
 //
 // CHIP Protocol Ids (32-bits max)
 //
-
-enum CHIPProtocolId
+class Id
 {
-    // Common Protocols
-    //
-    // NOTE: Do not attempt to allocate these values yourself.
+public:
+    constexpr Id(VendorId aVendorId, uint16_t aProtocolId) : mVendorId(aVendorId), mProtocolId(aProtocolId) {}
 
-    kProtocol_SecureChannel       = (kChipVendor_Common << 16) | 0x0000, // Secure Channel Protocol
-    kProtocol_Echo                = (kChipVendor_Common << 16) | 0x0002, // Echo Protocol
-    kProtocol_BDX                 = (kChipVendor_Common << 16) | 0x0003, // Bulk Data Exchange Protocol
-    kProtocol_NetworkProvisioning = (kChipVendor_Common << 16) | 0x0004, // Network Provisioning Protocol
-    kProtocol_InteractionModel    = (kChipVendor_Common << 16) | 0x0005, // Interaction Model Protocol
-    kProtocol_FabricProvisioning  = (kChipVendor_Common << 16) | 0x0006, // Fabric Provisioning Protocol
-    kProtocol_ServiceProvisioning = (kChipVendor_Common << 16) | 0x0007, // Service Provisioning Protocol
-    kProtocol_OpCredentials       = (kChipVendor_Common << 16) | 0x0008, // Operational Credentials
+    constexpr bool operator==(const Id & aOther) { return mVendorId == aOther.mVendorId && mProtocolId == aOther.mProtocolId; }
 
-    // Protocols reserved for internal protocol use
+    // Convert the Protocols::Id to a TLV profile id.
+    // NOTE: We may want to change the TLV reader/writer to take Protocols::Id
+    // directly later on and get rid of this method.
+    constexpr uint32_t ToTLVProfileId() const { return ToUint32(); }
 
-    kProtocol_NotSpecified = (kChipVendor_NotSpecified << 16) | 0xFFFF, // The profile ID is either not specified or a wildcard
+    // Convert the protocol id to a 32-bit unsigned integer "fully qualified"
+    // form as defined in the spec.  This should only be used in the places
+    // where the spec defines a 32-bit unsigned in as a wire representation of
+    // protocol id.
+    constexpr uint32_t ToFullyQualifiedSpecForm() const { return ToUint32(); }
+
+    constexpr VendorId GetVendorId() const { return mVendorId; }
+    constexpr uint16_t GetProtocolId() const { return mProtocolId; }
+
+private:
+    constexpr uint32_t ToUint32() const { return (static_cast<uint32_t>(mVendorId) << 16) | mProtocolId; }
+
+    chip::VendorId mVendorId;
+    uint16_t mProtocolId;
 };
+
+// Common Protocols
+//
+// NOTE: Do not attempt to allocate these values yourself.
+#define CHIP_STANDARD_PROTOCOL(name, id)                                                                                           \
+    namespace name {                                                                                                               \
+    static constexpr Protocols::Id Id(VendorId::Common, id);                                                                       \
+    } // namespace name.
+
+CHIP_STANDARD_PROTOCOL(SecureChannel, 0x0000)       // Secure Channel Protocol
+CHIP_STANDARD_PROTOCOL(Echo, 0x0002)                // Echo Protocol
+CHIP_STANDARD_PROTOCOL(BDX, 0x0003)                 // Bulk Data Exchange Protocol
+CHIP_STANDARD_PROTOCOL(NetworkProvisioning, 0x0004) // Network Provisioning Protocol
+CHIP_STANDARD_PROTOCOL(InteractionModel, 0x0005)    // Interaction Model Protocol
+CHIP_STANDARD_PROTOCOL(FabricProvisioning, 0x0006)  // Fabric Provisioning Protocol
+CHIP_STANDARD_PROTOCOL(ServiceProvisioning, 0x0007) // Service Provisioning Protocol
+CHIP_STANDARD_PROTOCOL(OpCredentials, 0x0008)       // Operational Credentials
+
+#undef CHIP_STANDARD_PROTOCOL
+
+// Protocols reserved for internal protocol use
+static constexpr Id NotSpecified(VendorId::NotSpecified, 0xFFFF); // The profile ID is either not specified or a wildcard
 
 // Pre-delare our MessageTypeTraits so message type headers know what they are
 // specializing.

--- a/src/protocols/bdx/BdxMessages.h
+++ b/src/protocols/bdx/BdxMessages.h
@@ -286,7 +286,7 @@ namespace Protocols {
 template <>
 struct MessageTypeTraits<bdx::MessageType>
 {
-    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_BDX;
+    static constexpr const Protocols::Id & ProtocolId() { return BDX::Id; }
 };
 } // namespace Protocols
 

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -138,7 +138,7 @@ void VerifyStatusReport(nlTestSuite * inSuite, void * inContext, const System::P
     err = reader.Skip(headerSize).Read16(&generalCode).Read32(&protocolId).Read16(protocolCode.RawStorage()).StatusCode();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, generalCode == static_cast<uint16_t>(Protocols::SecureChannel::GeneralStatusCode::kFailure));
-    NL_TEST_ASSERT(inSuite, protocolId == Protocols::kProtocol_BDX);
+    NL_TEST_ASSERT(inSuite, protocolId == Protocols::BDX::Id.ToFullyQualifiedSpecForm());
     NL_TEST_ASSERT(inSuite, protocolCode == code);
 }
 

--- a/src/protocols/echo/Echo.h
+++ b/src/protocols/echo/Echo.h
@@ -154,7 +154,7 @@ private:
 template <>
 struct MessageTypeTraits<Echo::MsgType>
 {
-    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_Echo;
+    static constexpr const Protocols::Id & ProtocolId() { return Echo::Id; }
 };
 
 } // namespace Protocols

--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -60,7 +60,7 @@ enum class MsgType : uint8_t
 template <>
 struct MessageTypeTraits<InteractionModel::MsgType>
 {
-    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_InteractionModel;
+    static constexpr const Protocols::Id & ProtocolId() { return InteractionModel::Id; }
 };
 
 } // namespace Protocols

--- a/src/protocols/secure_channel/Constants.h
+++ b/src/protocols/secure_channel/Constants.h
@@ -116,7 +116,7 @@ enum class StatusCode
 template <>
 struct MessageTypeTraits<SecureChannel::MsgType>
 {
-    static constexpr uint16_t ProtocolId = chip::Protocols::kProtocol_SecureChannel;
+    static constexpr const Protocols::Id & ProtocolId() { return SecureChannel::Id; }
 };
 
 } // namespace Protocols

--- a/src/transport/CASESession.cpp
+++ b/src/transport/CASESession.cpp
@@ -357,7 +357,7 @@ CHIP_ERROR CASESession::HandlePeerMessage(const PacketHeader & packetHeader, con
     err = payloadHeader.DecodeAndConsume(msg);
     SuccessOrExit(err);
 
-    VerifyOrExit(payloadHeader.GetProtocolID() == Protocols::kProtocol_SecureChannel, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    VerifyOrExit(payloadHeader.HasProtocol(Protocols::SecureChannel::Id), err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
     msgType = static_cast<Protocols::SecureChannel::MsgType>(payloadHeader.GetMessageType());
     VerifyOrExit(msgType == mNextExpectedMsg, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -188,7 +188,7 @@ CHIP_ERROR NetworkProvisioning::SendIPAddress(const Inet::IPAddress & addr)
     VerifyOrExit(mDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(addrStr != nullptr, err = CHIP_ERROR_INVALID_ADDRESS);
 
-    err = mDelegate->SendSecureMessage(Protocols::kProtocol_NetworkProvisioning, NetworkProvisioning::MsgTypes::kIPAddressAssigned,
+    err = mDelegate->SendSecureMessage(Protocols::NetworkProvisioning::Id, NetworkProvisioning::MsgTypes::kIPAddressAssigned,
                                        std::move(buffer));
     SuccessOrExit(err);
 
@@ -233,7 +233,7 @@ CHIP_ERROR NetworkProvisioning::SendNetworkCredentials(const char * ssid, const 
         SuccessOrExit(EncodeString(passwd, bbuf));
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
-        err = mDelegate->SendSecureMessage(Protocols::kProtocol_NetworkProvisioning,
+        err = mDelegate->SendSecureMessage(Protocols::NetworkProvisioning::Id,
                                            NetworkProvisioning::MsgTypes::kWiFiAssociationRequest, bbuf.Finalize());
         SuccessOrExit(err);
     }
@@ -276,8 +276,8 @@ CHIP_ERROR NetworkProvisioning::SendThreadCredentials(const DeviceLayer::Interna
     bbuf.Put(static_cast<uint8_t>(threadData.FieldPresent.ThreadPSKc));
 
     VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
-    err = mDelegate->SendSecureMessage(Protocols::kProtocol_NetworkProvisioning,
-                                       NetworkProvisioning::MsgTypes::kThreadAssociationRequest, bbuf.Finalize());
+    err = mDelegate->SendSecureMessage(Protocols::NetworkProvisioning::Id, NetworkProvisioning::MsgTypes::kThreadAssociationRequest,
+                                       bbuf.Finalize());
 
 exit:
     if (CHIP_NO_ERROR != err)

--- a/src/transport/NetworkProvisioning.h
+++ b/src/transport/NetworkProvisioning.h
@@ -48,7 +48,7 @@ public:
      * @param msgBuf the new message that should be sent to the peer
      * @return CHIP_ERROR Error thrown when sending the message
      */
-    virtual CHIP_ERROR SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBufferHandle msgBuf)
+    virtual CHIP_ERROR SendSecureMessage(Protocols::Id protocol, uint8_t msgType, System::PacketBufferHandle msgBuf)
     {
         return CHIP_NO_ERROR;
     }

--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -35,6 +35,7 @@
 #include <core/CHIPEncoding.h>
 #include <core/CHIPSafeCasts.h>
 #include <protocols/Protocols.h>
+#include <protocols/secure_channel/Constants.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/BufferWriter.h>
 #include <support/CHIPMem.h>
@@ -788,8 +789,7 @@ CHIP_ERROR PASESession::HandlePeerMessage(const PacketHeader & packetHeader, con
     err = payloadHeader.DecodeAndConsume(msg);
     SuccessOrExit(err);
 
-    VerifyOrExit(payloadHeader.GetProtocolID() == Protocols::kProtocol_SecureChannel, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
-    VerifyOrExit(payloadHeader.GetMessageType() == (uint8_t) mNextExpectedMsg, err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    VerifyOrExit(payloadHeader.HasMessageType(mNextExpectedMsg), err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
     mConnectionState.SetPeerAddress(peerAddress);
 

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -155,13 +155,12 @@ CHIP_ERROR RendezvousSession::SendSessionEstablishmentMessage(const PacketHeader
     }
 }
 
-CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType,
-                                                System::PacketBufferHandle msgBuf)
+CHIP_ERROR RendezvousSession::SendSecureMessage(Protocols::Id protocol, uint8_t msgType, System::PacketBufferHandle msgBuf)
 {
     VerifyOrReturnError(mPairingSessionHandle != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     PayloadHeader payloadHeader;
-    payloadHeader.SetMessageType(static_cast<uint16_t>(protocol), msgType);
+    payloadHeader.SetMessageType(protocol, msgType);
 
     return mSecureSessionMgr->SendMessage(*mPairingSessionHandle, payloadHeader, std::move(msgBuf));
 }
@@ -415,7 +414,7 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
         mParams.SetRemoteNodeId(packetHeader.GetSourceNodeId().Value());
     }
 
-    if (payloadHeader.GetProtocolID() == Protocols::kProtocol_NetworkProvisioning)
+    if (payloadHeader.HasProtocol(Protocols::NetworkProvisioning::Id))
     {
         ReturnErrorOnFailure(mNetworkProvision.HandleNetworkProvisioningMessage(payloadHeader.GetMessageType(), msgBuf));
     }

--- a/src/transport/RendezvousSession.h
+++ b/src/transport/RendezvousSession.h
@@ -125,7 +125,7 @@ public:
     void SendOperationalCredentials() override;
 
     //////////// NetworkProvisioningDelegate Implementation ///////////////
-    CHIP_ERROR SendSecureMessage(Protocols::CHIPProtocolId protocol, uint8_t msgType, System::PacketBufferHandle msgBug) override;
+    CHIP_ERROR SendSecureMessage(Protocols::Id protocol, uint8_t msgType, System::PacketBufferHandle msgBug) override;
     void OnNetworkProvisioningError(CHIP_ERROR error) override;
     void OnNetworkProvisioningComplete() override;
 

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -22,6 +22,7 @@
  *      the Message Header class within the transport layer
  *
  */
+#include <protocols/Protocols.h>
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/UnitTestRegistration.h>
@@ -50,8 +51,7 @@ void TestPayloadHeaderInitialState(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 0);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == static_cast<uint16_t>(Protocols::kProtocol_NotSpecified));
-    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.HasProtocol(Protocols::NotSpecified));
 }
 
 void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
@@ -146,13 +146,13 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     uint16_t encodeLen;
     uint16_t decodeLen;
 
-    header.SetMessageType(0, 112).SetExchangeID(2233);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 0), 112).SetExchangeID(2233);
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
 
-    header.SetMessageType(1221, 112).SetExchangeID(2233).SetInitiator(true);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 1221), 112).SetExchangeID(2233).SetInitiator(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
-    header.SetMessageType(4567, 221).SetExchangeID(3322);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 4567), 221).SetExchangeID(3322);
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
@@ -161,19 +161,19 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
     NL_TEST_ASSERT(inSuite, header.IsInitiator());
 
-    header.SetMessageType(1221, 112).SetExchangeID(2233);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 1221), 112).SetExchangeID(2233);
     header.SetVendorId(6789);
 
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
-    header.SetMessageType(0, 111).SetExchangeID(222);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 0), 111).SetExchangeID(222);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
     NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
 
-    header.SetMessageType(4567, 221).SetExchangeID(3322);
+    header.SetMessageType(Protocols::Id(VendorId::Common, 4567), 221).SetExchangeID(3322);
     header.SetVendorId(8976);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);


### PR DESCRIPTION
Before this change we have 4 different ways of representing protocol
ids, with some of those (e.g. just a uint16_t) clearly broken.  As a
result we had bugs where we ignored the vendor id when checking
protocol ids in various places in the code.

After this change we generally use Protocols::Id except in the places
where we end up with a uint32_t because we are reading/writing
spec-defined wire formats that involve encoding a protocol id as a
32-bit unsigned integer.

There's more cleanup possible (see TODO comments in MessageHeader.h),
but that will happen in followups.

Fixes https://github.com/project-chip/connectedhomeip/issues/5468