### PR TITLE
ESP32: Set Rendezvous BLE as the default

### DIFF
--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -39,7 +39,7 @@ menu "Demo"
 
     choice
       prompt "Rendezvous Mode"
-      default RENDEZVOUS_MODE_WIFI
+      default RENDEZVOUS_MODE_BLE
       help
           Specifies the Rendezvous mode of the peripheral.
 

--- a/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
+++ b/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
@@ -37,7 +37,7 @@ menu "Demo"
 
     choice
       prompt "Rendezvous Mode"
-      default RENDEZVOUS_MODE_WIFI
+      default RENDEZVOUS_MODE_BLE
       help
           Specifies the Rendezvous mode of the peripheral.
 


### PR DESCRIPTION

 #### Problem
The ESP32 examples use Rendezvous Wi-Fi as default. The spec mentions that BLE should be chosen, if supported.

 #### Summary of Changes
 Set `RENDEZVOUS_MODE_BLE` as the default value in example Kconfig.projbuild
