### PR TITLE
ESP32: Add cmake support to temperature-measurement-app and persistent-storage.

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -32,11 +32,6 @@ endif()
 idf_component_register(SRCS chip.c chip.cpp
                        PRIV_REQUIRES freertos lwip bt mdns mbedtls)
 
-# Override some build specifications
-set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
-set(CMAKE_BUILD_TYPE MinSizeRel)
-target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")
-
 # Prepare initial args file (lacking compile flags)
 # This will be saved as args.gn.in
 set(chip_gn_args "import(\"//args.gni\")\n")
@@ -52,10 +47,10 @@ chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 
 if(CONFIG_ENABLE_PW_RPC)
     chip_gn_arg_append("chip_build_pw_rpc_lib"              "true")
-    chip_gn_arg_append("pw_log_BACKEND"                     "true")
-    chip_gn_arg_append("pw_assert_BACKEND"                  "true")
-    chip_gn_arg_append("pw_sys_io_BACKEND"                  "true")
-    chip_gn_arg_append("dir_pw_third_party_nanopb"          "true")
+    chip_gn_arg_append("pw_log_BACKEND"                     "\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic\"")
+    chip_gn_arg_append("pw_assert_BACKEND"                  "\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log\"")
+    chip_gn_arg_append("pw_sys_io_BACKEND"                  "\"//third_party/connectedhomeip/examples/platform/esp32/pw_sys_io:pw_sys_io_esp32\"")
+    chip_gn_arg_append("dir_pw_third_party_nanopb"          "\"//third_party/connectedhomeip/third_party/nanopb/repo\"")
 endif()
 
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
@@ -109,7 +104,7 @@ externalproject_add(
     chip_gn
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
-    CONFIGURE_COMMAND       gn --root=${GN_ROOT_TARGET} gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
+    CONFIGURE_COMMAND       ${GN_EXECUTABLE} --root=${GN_ROOT_TARGET} gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
     BUILD_COMMAND           ninja
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
@@ -138,7 +133,6 @@ target_include_directories(${COMPONENT_LIB} INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/gen/include"
 )
 
-idf_component_get_property(bt_lib bt COMPONENT_LIB)
 idf_component_get_property(esp32_mbedtls_lib esp32_mbedtls COMPONENT_LIB)
 
 set(chip_libraries "-lCHIP")
@@ -147,10 +141,14 @@ if(CONFIG_ENABLE_PW_RPC)
     list(APPEND chip_libraries "-lPwRpc")
 endif()
 
+if(CONFIG_BT_ENABLED)
+    idf_component_get_property(bt_lib bt COMPONENT_LIB)
+    list(APPEND chip_libraries $<TARGET_FILE:${bt_lib}> -lbtdm_app)
+endif()
+
 target_link_libraries(${COMPONENT_LIB} INTERFACE "-L${CMAKE_CURRENT_BINARY_DIR}/lib")
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group 
                                                 ${chip_libraries}
-                                                $<TARGET_FILE:${bt_lib}> -lbtdm_app 
                                                 $<TARGET_FILE:mbedcrypto> $<TARGET_FILE:${esp32_mbedtls_lib}> 
                                                 -Wl,--end-group)
 

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -53,17 +53,32 @@ step. To install these components manually, follow these steps:
 Currently building in VSCode _and_ deploying from native is not supported, so
 make sure the IDF_PATH has been exported(See the manual setup steps above).
 
--   In the root of the example directory, sync the CHIP tree's submodules and
-    source `idf.sh`. Note: This does not have to be repeated for incremental
-    builds.
+-   Setting up the environment
 
-          $ source idf.sh
+To download and install packages.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/bootstrap.sh
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
+
+If packages are already installed then simply activate it.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
 
 -   Configuration Options
 
         To choose from the different configuration options, run menuconfig
 
-          $ idf make menuconfig
+          $ idf.py menuconfig
 
         Select ESP32 based `Device Type` through `Demo`->`Device Type`.
         The device types that are currently supported include `ESP32-DevKitC` (default),
@@ -77,13 +92,9 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         `Component config`->`CHIP Device Layer`->`WiFi Station Options`->`Default WiFi SSID` and
         `Default WiFi Password` respectively.
 
-        To use the default configuration options, run the default config
+-   To build the demo application.
 
-          $ idf make defconfig
-
--   Run make to build the demo application.
-
-          $ idf make
+          $ idf.py build
 
 -   After building the application, to flash it outside of VSCode, connect your
     device via USB. Then run the following command to flash the demo application
@@ -94,7 +105,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     before flashing. For ESP32-DevKitC devices this is labeled in the
     [functional description diagram](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html#functional-description).
 
-          $ idf make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
     Note: Some users might have to install the
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
@@ -107,7 +118,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 -   If desired, the monitor can be run again like so:
 
-          $ idf make monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
 ## Using the Echo Server
 

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -14,9 +14,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-#    Description:
-#      Component makefile for the ESP32 demo application.
-#
+
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
 # The list of src and include dirs must be in sync with that in all-clusters-app/esp32/main/component.mk
 idf_component_register(PRIV_INCLUDE_DIRS 
@@ -37,9 +35,11 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/barrier-control-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/color-control-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/content-launch-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/low-power-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/media-playback-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/temperature-measurement-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/scenes"

--- a/examples/persistent-storage/esp32/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/CMakeLists.txt
@@ -14,19 +14,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-# The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-# The list of extra component dirs must be in sync with that in all-clusters-app/esp32/Makefile
+# The list of extra component dirs must be in sync with that in persistent-storage/esp32/Makefile
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/QRCode"
-    "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework"
 )
 
-project(chip-all-clusters-app)
+project(persistent-storage)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=c++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)

--- a/examples/persistent-storage/esp32/README.md
+++ b/examples/persistent-storage/esp32/README.md
@@ -59,21 +59,36 @@ step. To install these components manually, follow these steps:
 Currently building in VSCode _and_ deploying from native is not supported, so
 make sure the IDF_PATH has been exported(See the manual setup steps above).
 
--   In the root of the example directory, sync the CHIP tree's submodules and
-    source `idf.sh`. Note: This does not have to be repeated for incremental
-    builds.
+-   Setting up the environment
 
-          $ source idf.sh
+To download and install packages.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/bootstrap.sh
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
+
+If packages are already installed then simply activate it.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
 
 -   Configuration Options
 
-        To use the default configuration options, run the default config
+        To choose from the different configuration options, run menuconfig
 
-          $ idf make defconfig
+          $ idf.py menuconfig
 
--   Run make to build the demo application.
+-   To build the demo application.
 
-          $ idf make
+          $ idf.py build
 
 <a name="flashing"></a>
 
@@ -88,7 +103,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     before flashing. For ESP32-DevKitC devices this is labeled in the
     [functional description diagram](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html#functional-description).
 
-          $ idf make flash ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
     Note: Some users might have to install the
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)

--- a/examples/persistent-storage/esp32/main/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/main/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# The list of src and include dirs must be in sync with that in persistent-storage/esp32/main/component.mk
+idf_component_register(PRIV_INCLUDE_DIRS 
+                      "${CMAKE_CURRENT_LIST_DIR}"
+                      "${CMAKE_SOURCE_DIR}/.."
+                      SRC_DIRS
+                      "${CMAKE_CURRENT_LIST_DIR}"
+                      "${CMAKE_SOURCE_DIR}/.."
+                      PRIV_REQUIRES chip nvs_flash)
+
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14)
+target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -19,7 +19,7 @@
 cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-# The list of extra component dirs must be in sync with that in all-clusters-app/esp32/Makefile
+# The list of extra component dirs must be in sync with that in temperature-measurement-app/esp32/Makefile
 set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
     "${CMAKE_CURRENT_LIST_DIR}/../../common/m5stack-tft/repo/components"
@@ -27,6 +27,6 @@ set(EXTRA_COMPONENT_DIRS
     "${CMAKE_CURRENT_LIST_DIR}/../../common/screen-framework"
 )
 
-project(chip-all-clusters-app)
+project(chip-temperature-measurement-app)
 idf_build_set_property(CXX_COMPILE_OPTIONS "-std=c++14;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
 idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -28,17 +28,32 @@ step. To install these components manually, follow these steps:
 Currently building in VSCode _and_ deploying from native is not supported, so
 make sure the IDF_PATH has been exported(See the manual setup steps above).
 
--   In the root of the example directory, sync the CHIP tree's submodules and
-    source `idf.sh`. Note: This does not have to be repeated for incremental
-    builds.
+-   Setting up the environment
 
-          $ source idf.sh
+To download and install packages.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/bootstrap.sh
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
+
+If packages are already installed then simply activate it.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
 
 -   Configuration Options
 
         To choose from the different configuration options, run menuconfig
 
-          $ idf make menuconfig
+          $ idf.py menuconfig
 
         Select ESP32 based `Device Type` through `Demo`->`Device Type`.
         The device types that are currently supported include `ESP32-DevKitC` (default),
@@ -52,12 +67,9 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         `Component config`->`CHIP Device Layer`->`WiFi Station Options`->`Default WiFi SSID` and
         `Default WiFi Password` respectively.
 
-        To use the default configuration options, run the default config
-          $ idf make defconfig
+-   To build the demo application.
 
--   Run make to build the demo application.
-
-          $ idf make
+          $ idf.py build
 
 -   After building the application, to flash it outside of VSCode, connect your
     device via USB. Then run the following command to flash the demo application
@@ -68,7 +80,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     before flashing. For ESP32-DevKitC devices this is labeled in the
     [functional description diagram](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html#functional-description).
 
-          $ idf make flash monitor ESPPORT=/dev/ttyUSB0
+          $ idf.py flash monitor ESPPORT=/dev/ttyUSB0
 
     Note: Some users might have to install the
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
@@ -81,7 +93,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
 -   If desired, the monitor can be run again like so:
 
-          $ idf make monitor ESPPORT=/dev/ttyUSB0
+          $ idf.py monitor ESPPORT=/dev/ttyUSB0
 
 ## Using the Echo Server
 

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -1,0 +1,42 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#
+# (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
+# The list of src and include dirs must be in sync with that in temperature-measurement-app/esp32/main/component.mk
+idf_component_register(PRIV_INCLUDE_DIRS 
+                      "${CMAKE_CURRENT_LIST_DIR}"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/nlio/repo/include"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
+                      "${CMAKE_CURRENT_LIST_DIR}/include"
+                      SRC_DIRS
+                      "${CMAKE_CURRENT_LIST_DIR}"
+                      "${CMAKE_CURRENT_LIST_DIR}/gen"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/basic"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/temperature-measurement-server"
+                      PRIV_REQUIRES chip QRCode tft spidriver bt screen-framework)
+
+set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 14) 
+target_compile_options(${COMPONENT_LIB} PRIVATE "-DLWIP_IPV6_SCOPES=0" "-DCHIP_HAVE_CONFIG_H")


### PR DESCRIPTION
 #### Problem
 Add CMake support to esp32 temperature-measurement-app and persistent-storage.

 #### Summary of Changes
1. Added `CMakeLists.txt`.
2. Updated `README.md.`