### PR TITLE
[bluez] Handle ConnectDevice failure/timeout

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -52,17 +52,18 @@ struct BLEAdvConfig
     const char * mpAdvertisingUUID;
 };
 
-enum class BleScanState
+enum class BleScanState : uint8_t
 {
     kNotScanning,
     kScanForDiscriminator,
     kScanForAddress,
+    kConnecting,
 };
 
 struct BLEScanConfig
 {
-    // If a active scan for connection is being performed
-    BleScanState bleScanState = BleScanState::kNotScanning;
+    // If an active scan for connection is being performed
+    BleScanState mBleScanState = BleScanState::kNotScanning;
 
     // If scanning by discriminator, what are we scanning for
     uint16_t mDiscriminator = 0;
@@ -93,6 +94,7 @@ public:
 
     // Driven by BlueZ IO
     static void HandleNewConnection(BLE_CONNECTION_OBJECT conId);
+    static void HandleConnectFailed(CHIP_ERROR error);
     static void HandleWriteComplete(BLE_CONNECTION_OBJECT conId);
     static void HandleSubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool subscribed);
     static void HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
@@ -100,7 +102,6 @@ public:
     static void CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
-    static bool WoBLEz_TimerCb(BLE_CONNECTION_OBJECT user_data);
 
     static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
     static void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
@@ -192,6 +193,7 @@ private:
 
     void InitiateScan(BleScanState scanType);
     static void InitiateScan(intptr_t arg);
+    void CleanScanConfig();
 
     CHIPoBLEServiceMode mServiceMode;
     BLEAdvConfig mBLEAdvConfig;

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -45,6 +45,7 @@ enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
     kPlatformLinuxBLECentralConnected,
+    kPlatformLinuxBLECentralConnectFailed,
     kPlatformLinuxBLEWriteComplete,
     kPlatformLinuxBLESubscribeOpComplete,
     kPlatformLinuxBLEIndicationReceived,
@@ -69,6 +70,10 @@ struct ChipDevicePlatformEvent
         {
             BLE_CONNECTION_OBJECT mConnection;
         } BLECentralConnected;
+        struct
+        {
+            CHIP_ERROR mError;
+        } BLECentralConnectFailed;
         struct
         {
             BLE_CONNECTION_OBJECT mConnection;

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -1728,8 +1728,7 @@ struct ConnectParams
     BluezEndpoint * mEndpoint;
 };
 
-static void
-ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer)
+static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer)
 {
     BluezDevice1 * device = BLUEZ_DEVICE1(aObject);
     GError * error        = nullptr;

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -54,9 +54,11 @@
 #include <protocols/Protocols.h>
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
 #include <support/BitFlags.h>
+#include <support/CHIPMem.h>
 #include <support/CHIPMemString.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#include <cassert>
 #include <errno.h>
 #include <gio/gunixfdlist.h>
 #include <limits>
@@ -1163,7 +1165,7 @@ void EndpointCleanup(BluezEndpoint * apEndpoint)
             g_free(apEndpoint->mpPeerDevicePath);
             apEndpoint->mpPeerDevicePath = nullptr;
         }
-
+        g_free(apEndpoint->mpConnectCancellable);
         g_free(apEndpoint);
     }
 }
@@ -1554,7 +1556,8 @@ CHIP_ERROR InitBluezBleLayer(bool aIsCentral, char * apBleAddr, BLEAdvConfig & a
     }
     else
     {
-        endpoint->mAdapterId = aBleAdvConfig.mAdapterId;
+        endpoint->mAdapterId           = aBleAdvConfig.mAdapterId;
+        endpoint->mpConnectCancellable = g_cancellable_new();
     }
 
     err = MainLoop::Instance().EnsureStarted();
@@ -1718,13 +1721,27 @@ bool BluezUnsubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn)
 
 // ConnectDevice callbacks
 
-static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer)
+struct ConnectParams
+{
+    ConnectParams(BluezDevice1 * device, BluezEndpoint * endpoint) : mDevice(device), mEndpoint(endpoint) {}
+    BluezDevice1 * mDevice;
+    BluezEndpoint * mEndpoint;
+};
+
+static void
+ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer)
 {
     BluezDevice1 * device = BLUEZ_DEVICE1(aObject);
     GError * error        = nullptr;
     gboolean success      = bluez_device1_call_connect_finish(device, aResult, &error);
 
-    VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: ConnectDevice : %s", error->message));
+    if (!success)
+    {
+        ChipLogError(DeviceLayer, "FAIL: ConnectDevice : %s", error->message);
+        BLEManagerImpl::HandleConnectFailed(CHIP_ERROR_INTERNAL);
+        ExitNow();
+    }
+
     ChipLogDetail(DeviceLayer, "ConnectDevice complete");
 
 exit:
@@ -1732,30 +1749,42 @@ exit:
         g_error_free(error);
 }
 
-static gboolean ConnectDeviceImpl(BluezDevice1 * device)
+static gboolean ConnectDeviceImpl(ConnectParams * apParams)
 {
-    VerifyOrExit(device != nullptr, ChipLogError(DeviceLayer, "device is NULL in %s", __func__));
+    BluezDevice1 * device    = apParams->mDevice;
+    BluezEndpoint * endpoint = apParams->mEndpoint;
 
-    bluez_device1_call_connect(device, nullptr, ConnectDeviceDone, nullptr);
+    assert(device != nullptr);
+    assert(endpoint != nullptr);
+
+    g_cancellable_reset(endpoint->mpConnectCancellable);
+    bluez_device1_call_connect(device, endpoint->mpConnectCancellable, ConnectDeviceDone, nullptr);
     g_object_unref(device);
+    chip::Platform::Delete(apParams);
 
-exit:
     return G_SOURCE_REMOVE;
 }
 
-CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice)
+CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice, BluezEndpoint * apEndpoint)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
+    auto params = chip::Platform::New<ConnectParams>(apDevice, apEndpoint);
     g_object_ref(apDevice);
 
-    if (!MainLoop::Instance().Schedule(ConnectDeviceImpl, apDevice))
+    if (!MainLoop::Instance().Schedule(ConnectDeviceImpl, params))
     {
         ChipLogError(Ble, "Failed to schedule ConnectDeviceImpl() on CHIPoBluez thread");
         g_object_unref(apDevice);
-        error = CHIP_ERROR_INCORRECT_STATE;
+        chip::Platform::Delete(params);
+        return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    return error;
+    return CHIP_NO_ERROR;
+}
+
+void CancelConnect(BluezEndpoint * apEndpoint)
+{
+    assert(apEndpoint->mpConnectCancellable != nullptr);
+    g_cancellable_cancel(apEndpoint->mpConnectCancellable);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/Helper.h
+++ b/src/platform/Linux/bluez/Helper.h
@@ -74,7 +74,8 @@ bool BluezSubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
 /// Unsubscribe from the CHIP TX characteristic on the remote peripheral device
 bool BluezUnsubscribeCharacteristic(BLE_CONNECTION_OBJECT apConn);
 
-CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice);
+CHIP_ERROR ConnectDevice(BluezDevice1 * apDevice, BluezEndpoint * apEndpoint);
+void CancelConnect(BluezEndpoint * apEndpoint);
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -164,6 +164,7 @@ struct BluezEndpoint
     uint16_t mDuration; ///< Advertisement interval (in ms).
     bool mIsAdvertising;
     char * mpPeerDevicePath;
+    GCancellable * mpConnectCancellable = nullptr;
 };
 
 struct BluezConnection


### PR DESCRIPTION
 #### Problem
Currently, there is a timeout for device scanning operation in the Linux platform, but in case `ConnectDevice` fails or hangs (e.g. if a device gets out of range or turns off in the meantime) no event is ever reported to the controller application.

 #### Summary of Changes
Set 5s timeout for the ConnectDevice operation and report failure back to the requestor.