### PR TITLE
ESP32: Random BSSID after every bootup for the SoftAP interface

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -57,6 +57,11 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
     wifi_init_config_t cfg;
+    uint8_t ap_mac[6];
+
+    esp_fill_random(ap_mac, sizeof(ap_mac));
+    /* Bit 0 of the first octet of MAC Address should always be 0 */
+    ap_mac[0] &= (uint8_t) ~0x01;
 
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();
@@ -80,6 +85,9 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the ESP WiFi layer.
     cfg = WIFI_INIT_CONFIG_DEFAULT();
     err = esp_wifi_init(&cfg);
+    SuccessOrExit(err);
+
+    err = esp_wifi_set_mac(ESP_IF_WIFI_AP, ap_mac);
     SuccessOrExit(err);
 
     // Call _InitChipStack() on the generic implementation base class


### PR DESCRIPTION

 #### Problem
As per the spec, section 5.2.3.9.3,
BSSID: SHALL be randomly generated on each boot for privacy/tracking reasons.

Currently, it is not done for ESP32 SoftAP

 #### Summary of Changes
Add support to set random BSSID for ESP32 platform

Fixes #5490 