### PR TITLE
Close TCP connection when errors prevent handling messages

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -1391,7 +1391,12 @@ void TCPEndPoint::DriveReceiving()
         // Acknowledgement is done after handling the buffers to allow the
         // application processing to throttle flow.
         uint16_t ackLength = mRcvQueue->TotalLength();
-        OnDataReceived(this, std::move(mRcvQueue));
+        INET_ERROR err     = OnDataReceived(this, std::move(mRcvQueue));
+        if (err != INET_NO_ERROR)
+        {
+            DoClose(err, false);
+            return;
+        }
         AckReceive(ackLength);
     }
 

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -431,19 +431,21 @@ public:
     /**
      * @brief   Type of data reception event handling function.
      *
-     * @param[in]   endPoint    The TCP endpoint associated with the event.
-     * @param[in]   data        The data received.
+     * @param[in]   endPoint        The TCP endpoint associated with the event.
+     * @param[in]   data            The data received.
+     *
+     * @retval      INET_NO_ERROR   If the received data can be handled by higher layers.
+     * @retval      other           If the received data can not be used, and higher layers will not see it.
      *
      * @details
      *  Provide a function of this type to the \c OnDataReceived delegate
      *  member to process data reception events on \c endPoint where \c data
      *  is the message text received.
      *
-     *  A data reception event handler must acknowledge data processed using
-     *  the \c AckReceive method. The \c Free method on the data buffer must
-     *  also be invoked unless the \c PutBackReceivedData is used instead.
+     *  If this function returns an error, the connection will be closed, since higher layers
+     *  are not able to process the data for a better response.
      */
-    typedef void (*OnDataReceivedFunct)(TCPEndPoint * endPoint, chip::System::PacketBufferHandle data);
+    typedef INET_ERROR (*OnDataReceivedFunct)(TCPEndPoint * endPoint, chip::System::PacketBufferHandle data);
 
     /**
      * The endpoint's message text reception event handling function delegate.

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -595,7 +595,7 @@ static void HandleTCPConnectionClosed(TCPEndPoint * aEndPoint, INET_ERROR aError
 
 static void HandleTCPDataSent(TCPEndPoint * aEndPoint, uint16_t len) {}
 
-static void HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBufferHandle aBuffer)
+static INET_ERROR HandleTCPDataReceived(TCPEndPoint * aEndPoint, PacketBufferHandle aBuffer)
 {
     const uint32_t lFirstValueReceived = sTestState.mStats.mReceive.mActual;
     const uint8_t lFirstValue          = uint8_t(lFirstValueReceived);
@@ -638,6 +638,7 @@ exit:
     {
         SetStatusFailed(sTestState.mStatus);
     }
+    return lStatus;
 }
 
 static void HandleTCPAcceptError(TCPEndPoint * aEndPoint, INET_ERROR aError)

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -110,17 +110,15 @@ protected:
     {
         void Init(Inet::TCPEndPoint * endPoint)
         {
-            mEndPoint    = endPoint;
-            mReceived    = nullptr;
-            mDiscardSize = 0;
+            mEndPoint = endPoint;
+            mReceived = nullptr;
         }
 
         void Free()
         {
             mEndPoint->Free();
-            mEndPoint    = nullptr;
-            mReceived    = nullptr;
-            mDiscardSize = 0;
+            mEndPoint = nullptr;
+            mReceived = nullptr;
         }
         bool InUse() const { return mEndPoint != nullptr; }
 
@@ -129,23 +127,6 @@ protected:
 
         // Buffers received but not yet consumed.
         System::PacketBufferHandle mReceived;
-
-        // Length of incoming data that must be discard to resynchronize.
-        // TODO: This can be removed once issue #5438 guarantees that the
-        //       connection is closed on any error.
-        uint16_t mDiscardSize;
-        CHIP_ERROR Discard()
-        {
-            VerifyOrReturnError((mDiscardSize != 0) && !mReceived.IsNull(), CHIP_NO_ERROR);
-            uint16_t initialLength = mReceived->TotalLength();
-            mReceived.Consume(mDiscardSize);
-            uint16_t remainingLength = mReceived.IsNull() ? 0 : mReceived->TotalLength();
-            VerifyOrReturnError(remainingLength <= initialLength, CHIP_ERROR_INTERNAL);
-            uint16_t discardedLength = static_cast<uint16_t>(initialLength - remainingLength);
-            VerifyOrReturnError(discardedLength <= mDiscardSize, CHIP_ERROR_INTERNAL);
-            mDiscardSize = static_cast<uint16_t>(mDiscardSize - discardedLength);
-            return CHIP_NO_ERROR;
-        }
     };
 
 public:
@@ -231,7 +212,7 @@ private:
      * Ownership of buffer is taken over and will be freed (or re-enqueued to the endPoint receive queue)
      * as needed during processing.
      */
-    CHIP_ERROR ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddress,
+    INET_ERROR ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddress,
                                      System::PacketBufferHandle buffer);
 
     /**
@@ -243,11 +224,11 @@ private:
      *                              is no other data).
      * @param[in]     messageSize   Size of the single message.
      */
-    CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
+    INET_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
 
     // Callback handler for TCPEndPoint. TCP message receive handler.
     // @see TCPEndpoint::OnDataReceivedFunct
-    static void OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBufferHandle buffer);
+    static INET_ERROR OnTcpReceive(Inet::TCPEndPoint * endPoint, System::PacketBufferHandle buffer);
 
     // Callback handler for TCPEndPoint. Called when a connection has been completed.
     // @see TCPEndpoint::OnConnectCompleteFunct

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -212,7 +212,7 @@ private:
      * Ownership of buffer is taken over and will be freed (or re-enqueued to the endPoint receive queue)
      * as needed during processing.
      */
-    INET_ERROR ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddress,
+    CHIP_ERROR ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const PeerAddress & peerAddress,
                                      System::PacketBufferHandle buffer);
 
     /**
@@ -224,7 +224,7 @@ private:
      *                              is no other data).
      * @param[in]     messageSize   Size of the single message.
      */
-    INET_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
+    CHIP_ERROR ProcessSingleMessage(const PeerAddress & peerAddress, ActiveConnectionState * state, uint16_t messageSize);
 
     // Callback handler for TCPEndPoint. TCP message receive handler.
     // @see TCPEndpoint::OnDataReceivedFunct

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -387,7 +387,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     Inet::TCPEndPoint * lEndPoint = state->mEndPoint;
     NL_TEST_ASSERT(inSuite, lEndPoint != nullptr);
 
-    INET_ERROR err = INET_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TestData testData[2];
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, testData);
 
@@ -395,14 +395,14 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     NL_TEST_ASSERT(inSuite, testData[0].Init((const uint16_t[]){ 111, 0 }));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 1);
 
     // Test a message in a chain of three packet buffers. The message length is split accross buffers.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     NL_TEST_ASSERT(inSuite, testData[0].Init((const uint16_t[]){ 1, 122, 123, 0 }));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 1);
 
     // Test two messages in a chain.
@@ -411,7 +411,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     NL_TEST_ASSERT(inSuite, testData[1].Init((const uint16_t[]){ 132, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 2);
 
     // Test a chain of two messages, each a chain.
@@ -420,7 +420,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     NL_TEST_ASSERT(inSuite, testData[1].Init((const uint16_t[]){ 143, 144, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 2);
 
     // Test a message that is too large to coalesce into a single packet buffer.
@@ -430,7 +430,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     // Sending only the first buffer of the long chain. This should be enough to trigger the error.
     System::PacketBufferHandle head = testData[0].mHandle.PopHead();
     err                             = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(head));
-    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INBOUND_MESSAGE_TOO_BIG);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_MESSAGE_TOO_LONG);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 0);
 
     gMockTransportMgrDelegate.FinalizeMessageTest(tcp, addr);

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -344,27 +344,21 @@ void TestData::Free()
 
 int TestDataCallbackCheck(const uint8_t * message, size_t length, int count, void * data)
 {
-    printf("--> callback %p %zu %d %p\n", message, length, count, data);
     if (data == nullptr)
     {
-        printf(" -> callback data null\n");
         return -1;
     }
     TestData * currentData = static_cast<TestData *>(data) + count;
-    printf(" -> payload %p total=%zu message=%zu\n", currentData->mPayload, currentData->mTotalLength, currentData->mMessageLength);
     if (currentData->mPayload == nullptr)
     {
-        printf(" -> payload null\n");
         return -2;
     }
     if (currentData->mMessageLength != length)
     {
-        printf(" -> length expect %zu got %zu\n", currentData->mMessageLength, length);
         return -3;
     }
     if (memcmp(currentData->mPayload + currentData->mMessageOffset, message, length) != 0)
     {
-        printf(" -> payload mismatch\n");
         return -4;
     }
     return 0;
@@ -393,7 +387,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     Inet::TCPEndPoint * lEndPoint = state->mEndPoint;
     NL_TEST_ASSERT(inSuite, lEndPoint != nullptr);
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    INET_ERROR err = INET_NO_ERROR;
     TestData testData[2];
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, testData);
 
@@ -401,14 +395,14 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     NL_TEST_ASSERT(inSuite, testData[0].Init((const uint16_t[]){ 111, 0 }));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 1);
 
     // Test a message in a chain of three packet buffers. The message length is split accross buffers.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     NL_TEST_ASSERT(inSuite, testData[0].Init((const uint16_t[]){ 1, 122, 123, 0 }));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 1);
 
     // Test two messages in a chain.
@@ -417,7 +411,7 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     NL_TEST_ASSERT(inSuite, testData[1].Init((const uint16_t[]){ 132, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 2);
 
     // Test a chain of two messages, each a chain.
@@ -426,25 +420,18 @@ void chip::Transport::TCPTest::CheckProcessReceivedBuffer(nlTestSuite * inSuite,
     NL_TEST_ASSERT(inSuite, testData[1].Init((const uint16_t[]){ 143, 144, 0 }));
     testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
     err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 2);
 
-    // Test a chain that is too large to coalesce into a single packet buffer, followed by a normal message.
-    // We expect to receive only the latter.
+    // Test a message that is too large to coalesce into a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, &testData[1]);
     NL_TEST_ASSERT(inSuite, testData[0].Init((const uint16_t[]){ 51, System::PacketBuffer::kMaxSizeWithoutReserve, 0 }));
-    NL_TEST_ASSERT(inSuite, testData[1].Init((const uint16_t[]){ 153, 154, 0 }));
-    testData[0].mHandle->AddToEnd(std::move(testData[1].mHandle));
-    // Start by sending only the first buffer of the long chain. This should be enough to trigger the error.
+    // Sending only the first buffer of the long chain. This should be enough to trigger the error.
     System::PacketBufferHandle head = testData[0].mHandle.PopHead();
     err                             = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(head));
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_MESSAGE_TOO_LONG);
+    NL_TEST_ASSERT(inSuite, err == INET_ERROR_INBOUND_MESSAGE_TOO_BIG);
     NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 0);
-    // Now send the rest, confirming that the second message arrives.
-    err = tcp.ProcessReceivedBuffer(lEndPoint, lPeerAddress, std::move(testData[0].mHandle));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gMockTransportMgrDelegate.mReceiveHandlerCallCount == 1);
 
     gMockTransportMgrDelegate.FinalizeMessageTest(tcp, addr);
 }


### PR DESCRIPTION
#### Problem

Under `TCPBase::ProcessReceivedBuffer()`, it may not be possible to
pass a message to higher layers, e.g. if memory allocation fails or the
message is too long. In such cases there is currently no signal to the
sender that the message will not be handled.

#### Summary of Changes

- Close TCP connection in `TCPEndPoint::DriveReceiving` if the
  `OnDataReceived` handler returns an error.
- Introduce `kMaxMessageSize` for the message length limit,
  current based on the maximum packet buffer length (pending #5487).
- Remove `TCPBase` discard state since there will be nothing to discard.

Fixes #5438 - Close TCP connection when errors prevent handling messages
Fixes #5488 - This can be removed once issue #5438 guarantees that the…
