### PR TITLE
Remove `exit: return` idiom from src/lib

### DIFF
--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -38,6 +38,7 @@
 #include <core/CHIPEncoding.h>
 #include <core/CHIPTLV.h>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 
 namespace chip {
 namespace ASN1 {
@@ -140,18 +141,14 @@ ASN1_ERROR ASN1Writer::PutInteger(int64_t val)
 
 ASN1_ERROR ASN1Writer::PutBoolean(bool val)
 {
-    ASN1_ERROR err;
-
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
-    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_Boolean, false, 1);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_Boolean, false, 1));
 
     *mWritePoint++ = (val) ? 0xFF : 0;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::PutObjectId(const uint8_t * val, uint16_t valLen)
@@ -221,11 +218,10 @@ static uint8_t HighestBit(uint32_t v)
 
 ASN1_ERROR ASN1Writer::PutBitString(uint32_t val)
 {
-    ASN1_ERROR err;
     uint8_t len;
 
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     if (val == 0)
         len = 1;
@@ -238,8 +234,7 @@ ASN1_ERROR ASN1Writer::PutBitString(uint32_t val)
     else
         len = 5;
 
-    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, len);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, len));
 
     if (val == 0)
         mWritePoint[0] = 0;
@@ -266,49 +261,41 @@ ASN1_ERROR ASN1Writer::PutBitString(uint32_t val)
 
     mWritePoint += len;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, const uint8_t * encodedBits, uint16_t encodedBitsLen)
 {
-    ASN1_ERROR err;
-
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
-    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1));
 
     *mWritePoint++ = unusedBitCount;
 
     memcpy(mWritePoint, encodedBits, encodedBitsLen);
     mWritePoint += encodedBitsLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::PutBitString(uint8_t unusedBitCount, chip::TLV::TLVReader & encodedBits)
 {
-    ASN1_ERROR err;
     uint32_t encodedBitsLen;
 
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     encodedBitsLen = encodedBits.GetLength();
 
-    err = EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(kASN1TagClass_Universal, kASN1UniversalTag_BitString, false, encodedBitsLen + 1));
 
     *mWritePoint++ = unusedBitCount;
 
     encodedBits.GetBytes(mWritePoint, encodedBitsLen);
     mWritePoint += encodedBitsLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 static void itoa2(uint32_t val, uint8_t * buf)
@@ -359,13 +346,10 @@ ASN1_ERROR ASN1Writer::EndConstructedType()
 
 ASN1_ERROR ASN1Writer::StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bitStringEncoding)
 {
-    ASN1_ERROR err;
-
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
-    err = EncodeHead(cls, tag, false, kUnkownLength);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(cls, tag, false, kUnkownLength));
 
     // If the encapsulating type is BIT STRING, encode the unused bit count field.  Since the BIT
     // STRING contains an ASN.1 DER encoding, and ASN.1 DER encodings are always multiples of 8 bits,
@@ -377,8 +361,7 @@ ASN1_ERROR ASN1Writer::StartEncapsulatedType(uint8_t cls, uint32_t tag, bool bit
         *mWritePoint++ = 0;
     }
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::EndEncapsulatedType()
@@ -388,55 +371,47 @@ ASN1_ERROR ASN1Writer::EndEncapsulatedType()
 
 ASN1_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, const uint8_t * val, uint16_t valLen)
 {
-    ASN1_ERROR err;
-
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
-    err = EncodeHead(cls, tag, isConstructed, valLen);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(cls, tag, isConstructed, valLen));
 
     memcpy(mWritePoint, val, valLen);
     mWritePoint += valLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::PutValue(uint8_t cls, uint32_t tag, bool isConstructed, chip::TLV::TLVReader & val)
 {
-    ASN1_ERROR err;
     uint32_t valLen;
 
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     valLen = val.GetLength();
 
-    err = EncodeHead(cls, tag, isConstructed, valLen);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(EncodeHead(cls, tag, isConstructed, valLen));
 
     val.GetBytes(mWritePoint, valLen);
     mWritePoint += valLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed, int32_t len)
 {
-    ASN1_ERROR err = ASN1_NO_ERROR;
     uint8_t bytesForLen;
     uint32_t totalLen;
 
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     // Only tags <= 31 supported. The implication of this is that encoded tags are exactly 1 byte long.
-    VerifyOrExit(tag <= 0x1F, err = ASN1_ERROR_UNSUPPORTED_ENCODING);
+    VerifyOrReturnError(tag <= 0x1F, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
     // Only positive and kUnkownLength values are supported for len input.
-    VerifyOrExit(len >= 0 || len == kUnkownLength, err = ASN1_ERROR_UNSUPPORTED_ENCODING);
+    VerifyOrReturnError(len >= 0 || len == kUnkownLength, ASN1_ERROR_UNSUPPORTED_ENCODING);
 
     // Compute the number of bytes required to encode the length.
     bytesForLen = BytesForLength(len);
@@ -456,7 +431,7 @@ ASN1_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed,
     // Make sure there's enough space to encode the entire value without bumping into the deferred length
     // list at the end of the buffer.
     totalLen = 1 + bytesForLen + (len != kUnkownLength ? len : 0);
-    VerifyOrExit((mWritePoint + totalLen) <= reinterpret_cast<uint8_t *>(mDeferredLengthList), err = ASN1_ERROR_OVERFLOW);
+    VerifyOrReturnError((mWritePoint + totalLen) <= reinterpret_cast<uint8_t *>(mDeferredLengthList), ASN1_ERROR_OVERFLOW);
 
     // Write the tag byte.
     *mWritePoint++ = cls | (isConstructed ? 0x20 : 0) | tag;
@@ -475,18 +450,16 @@ ASN1_ERROR ASN1Writer::EncodeHead(uint8_t cls, uint32_t tag, bool isConstructed,
 
     mWritePoint += bytesForLen;
 
-exit:
-    return err;
+    return ASN1_NO_ERROR;
 }
 
 ASN1_ERROR ASN1Writer::WriteDeferredLength()
 {
-    ASN1_ERROR err = ASN1_NO_ERROR;
     uint8_t ** listEntry;
     uint32_t lenAdj;
 
     // Do nothing for a null writer.
-    VerifyOrExit(mBuf != nullptr, err = ASN1_NO_ERROR);
+    VerifyOrReturnError(mBuf != nullptr, ASN1_NO_ERROR);
 
     lenAdj = kLengthFieldReserveSize;
 
@@ -509,7 +482,7 @@ ASN1_ERROR ASN1Writer::WriteDeferredLength()
 
             // Return an error if the length exceeds the maximum value that can be encoded in the
             // space reserved for the length.
-            VerifyOrExit(elemLen <= kMaxElementLength, err = ASN1_ERROR_LENGTH_OVERFLOW);
+            VerifyOrReturnError(elemLen <= kMaxElementLength, ASN1_ERROR_LENGTH_OVERFLOW);
 
             // Encode the final length of the element, overwriting the unknown length marker
             // in the process.  Note that the number of bytes consumed by the final length field
@@ -518,7 +491,7 @@ ASN1_ERROR ASN1Writer::WriteDeferredLength()
             uint8_t bytesForLen = BytesForLength(static_cast<int32_t>(elemLen));
             EncodeLength(lenField, bytesForLen, elemLen);
 
-            ExitNow(err = ASN1_NO_ERROR);
+            return ASN1_NO_ERROR;
         }
         else
         {
@@ -527,10 +500,7 @@ ASN1_ERROR ASN1Writer::WriteDeferredLength()
         }
     }
 
-    err = ASN1_ERROR_INVALID_STATE;
-
-exit:
-    return err;
+    return ASN1_ERROR_INVALID_STATE;
 }
 
 /**

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -37,6 +37,7 @@
 #include <core/CHIPTLV.h>
 
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 
 #include <stdint.h>
 
@@ -119,19 +120,16 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
     CircularTLVReader reader;
     uint8_t * newHead;
     uint32_t newLen;
-    CHIP_ERROR err;
 
     // find the boundaries of an event to throw away
     reader.Init(*this);
     reader.ImplicitProfileId = mImplicitProfileId;
 
     // position the reader on the first element
-    err = reader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next());
 
     // skip to the next element
-    err = reader.Skip();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Skip());
 
     // record the state of the queue post-call
     newLen  = mQueueLength - (reader.GetLengthRead());
@@ -145,16 +143,14 @@ CHIP_ERROR CHIPCircularTLVBuffer::EvictHead()
         reader.Init(*this);
         reader.ImplicitProfileId = mImplicitProfileId;
 
-        err = mProcessEvictedElement(*this, mAppData, reader);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(mProcessEvictedElement(*this, mAppData, reader));
     }
 
     // update queue state
     mQueueLength = newLen;
     mQueueHead   = newHead;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 /**
@@ -186,14 +182,12 @@ CHIP_ERROR CHIPCircularTLVBuffer::OnInit(TLVWriter & writer, uint8_t *& bufStart
 
 CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& outBufStart, uint32_t & outBufLen)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t * tail = QueueTail();
 
     if (mQueueLength >= mQueueSize)
     {
         // Queue is out of space, need to evict an element
-        err = EvictHead();
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(EvictHead());
     }
 
     // set the output values, returned buffer must be contiguous
@@ -208,8 +202,7 @@ CHIP_ERROR CHIPCircularTLVBuffer::GetNewBuffer(TLVWriter & ioWriter, uint8_t *& 
         outBufLen = static_cast<uint32_t>(mQueueHead - tail);
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/lib/core/CHIPKeyIds.cpp
+++ b/src/lib/core/CHIPKeyIds.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2016-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 
 #include <core/CHIPCore.h>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 
 namespace chip {
 
@@ -182,13 +183,12 @@ uint32_t ChipKeyId::UpdateEpochKeyId(uint32_t keyId, uint32_t epochKeyId)
  */
 bool ChipKeyId::IsValidKeyId(uint32_t keyId)
 {
-    bool retval;
     unsigned int usedBits = kMask_KeyType;
 
     switch (GetType(keyId))
     {
     case kType_None:
-        ExitNow(retval = false);
+        return false;
     case kType_General:
     case kType_Session:
         usedBits |= kMask_KeyNumber;
@@ -224,19 +224,16 @@ bool ChipKeyId::IsValidKeyId(uint32_t keyId)
         usedBits |= kMask_GroupLocalNumber;
         break;
     default:
-        ExitNow(retval = false);
+        return false;
     }
 
     if (IncorporatesRootKey(keyId))
     {
         uint32_t rootKeyId = GetRootKeyId(keyId);
-        VerifyOrExit(rootKeyId == kFabricRootKey || rootKeyId == kClientRootKey || rootKeyId == kServiceRootKey, retval = false);
+        VerifyOrReturnError(rootKeyId == kFabricRootKey || rootKeyId == kClientRootKey || rootKeyId == kServiceRootKey, false);
     }
 
-    retval = (keyId & ~usedBits) == 0;
-
-exit:
-    return retval;
+    return (keyId & ~usedBits) == 0;
 }
 
 /**

--- a/src/lib/core/CHIPTLVDebug.cpp
+++ b/src/lib/core/CHIPTLVDebug.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2015-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +35,7 @@
 #include <core/CHIPTLVDebug.hpp>
 #include <core/CHIPTLVUtilities.hpp>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 #include <support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -333,19 +334,17 @@ CHIP_ERROR DumpIterator(DumpWriter aWriter, const TLVReader & aReader)
 CHIP_ERROR DumpHandler(const TLVReader & aReader, size_t aDepth, void * aContext)
 {
     static const char indent[] = "    ";
-    CHIP_ERROR retval          = CHIP_NO_ERROR;
     DumpContext * context;
 
-    VerifyOrExit(aContext != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(aContext != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     context = static_cast<DumpContext *>(aContext);
 
-    VerifyOrExit(context->mWriter != nullptr, retval = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(context->mWriter != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     DumpHandler(context->mWriter, indent, aReader, aDepth);
 
-exit:
-    return retval;
+    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -29,6 +29,7 @@
 #include <core/CHIPTLV.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 
 namespace chip {
@@ -798,7 +799,6 @@ CHIP_ERROR TLVReader::EnsureData(CHIP_ERROR noDataErr)
  */
 CHIP_ERROR TLVReader::GetElementHeadLength(uint8_t & elemHeadBytes) const
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t tagBytes;
     uint8_t valOrLenBytes;
     TLVTagControl tagControl;
@@ -806,7 +806,7 @@ CHIP_ERROR TLVReader::GetElementHeadLength(uint8_t & elemHeadBytes) const
     TLVElementType elemType = ElementType();
 
     // Verify element is of valid TLVType.
-    VerifyOrExit(IsValidTLVType(elemType), err = CHIP_ERROR_INVALID_TLV_ELEMENT);
+    VerifyOrReturnError(IsValidTLVType(elemType), CHIP_ERROR_INVALID_TLV_ELEMENT);
 
     // Extract the tag control from the control byte.
     tagControl = static_cast<TLVTagControl>(mControlByte & kTLVTagControlMask);
@@ -824,11 +824,10 @@ CHIP_ERROR TLVReader::GetElementHeadLength(uint8_t & elemHeadBytes) const
     // control byte, the tag bytes (if present), the length bytes (if present),
     // and for elements that don't have a length (e.g. integers), the value
     // bytes.
-    VerifyOrExit(CanCastTo<uint8_t>(1 + tagBytes + valOrLenBytes), err = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(CanCastTo<uint8_t>(1 + tagBytes + valOrLenBytes), CHIP_ERROR_INTERNAL);
     elemHeadBytes = static_cast<uint8_t>(1 + tagBytes + valOrLenBytes);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/lib/core/CHIPTLVUpdater.cpp
+++ b/src/lib/core/CHIPTLVUpdater.cpp
@@ -27,6 +27,7 @@
 #include <core/CHIPEncoding.h>
 #include <core/CHIPTLV.h>
 #include <support/CodeUtils.h>
+#include <support/ReturnMacros.h>
 
 namespace chip {
 namespace TLV {
@@ -35,12 +36,11 @@ using namespace chip::Encoding;
 
 CHIP_ERROR TLVUpdater::Init(uint8_t * buf, uint32_t dataLen, uint32_t maxLen)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     uint32_t freeLen;
 
-    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(maxLen >= dataLen, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(maxLen >= dataLen, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // memmove the buffer data to end of the buffer
     freeLen = maxLen - dataLen;
@@ -54,30 +54,27 @@ CHIP_ERROR TLVUpdater::Init(uint8_t * buf, uint32_t dataLen, uint32_t maxLen)
     mUpdaterWriter.SetCloseContainerReserved(false);
     mElementStartAddr = buf + freeLen;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
 {
-    CHIP_ERROR err            = CHIP_NO_ERROR;
     uint8_t * buf             = const_cast<uint8_t *>(aReader.GetReadPoint());
     uint32_t remainingDataLen = aReader.GetRemainingLength();
     uint32_t readDataLen      = aReader.GetLengthRead();
 
     // TLVUpdater does not support backing stores yet
-    VerifyOrExit(aReader.mBackingStore == 0, err = CHIP_ERROR_NOT_IMPLEMENTED);
+    VerifyOrReturnError(aReader.mBackingStore == 0, CHIP_ERROR_NOT_IMPLEMENTED);
 
     // TLVReader should point to a non-NULL buffer
-    VerifyOrExit(buf != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     // If reader is already on an element, reset it to start of element
     if (aReader.ElementType() != TLVElementType::NotSpecified)
     {
         uint8_t elemHeadLen;
 
-        err = aReader.GetElementHeadLength(elemHeadLen);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(aReader.GetElementHeadLength(elemHeadLen));
 
         buf -= elemHeadLen;
         remainingDataLen += elemHeadLen;
@@ -122,8 +119,7 @@ CHIP_ERROR TLVUpdater::Init(TLVReader & aReader, uint32_t freeLen)
     // use the original TLVReader object anymore.
     aReader.Init(static_cast<const uint8_t *>(nullptr), 0);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void TLVUpdater::SetImplicitProfileId(uint32_t profileId)
@@ -134,36 +130,29 @@ void TLVUpdater::SetImplicitProfileId(uint32_t profileId)
 
 CHIP_ERROR TLVUpdater::Next()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     // Skip current element if the reader is already positioned on an element
-    err = mUpdaterReader.Skip();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterReader.Skip());
 
     AdjustInternalWriterFreeSpace();
 
     // Move the reader to next element
-    err = mUpdaterReader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterReader.Next());
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVUpdater::Move()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     const uint8_t * elementEnd;
     uint32_t copyLen;
 
-    VerifyOrExit(static_cast<TLVElementType>((mUpdaterReader.mControlByte & kTLVTypeMask)) != TLVElementType::EndOfContainer,
-                 err = CHIP_END_OF_TLV);
+    VerifyOrReturnError(static_cast<TLVElementType>((mUpdaterReader.mControlByte & kTLVTypeMask)) != TLVElementType::EndOfContainer,
+                        CHIP_END_OF_TLV);
 
-    VerifyOrExit(mUpdaterReader.GetType() != kTLVType_NotSpecified, err = CHIP_ERROR_INVALID_TLV_ELEMENT);
+    VerifyOrReturnError(mUpdaterReader.GetType() != kTLVType_NotSpecified, CHIP_ERROR_INVALID_TLV_ELEMENT);
 
     // Skip to the end of the element
-    err = mUpdaterReader.Skip();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterReader.Skip());
 
     elementEnd = mUpdaterReader.mReadPoint;
 
@@ -178,8 +167,7 @@ CHIP_ERROR TLVUpdater::Move()
     mUpdaterWriter.mLenWritten += copyLen;
     mUpdaterWriter.mMaxLen += copyLen;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void TLVUpdater::MoveUntilEnd()
@@ -210,42 +198,33 @@ void TLVUpdater::MoveUntilEnd()
 
 CHIP_ERROR TLVUpdater::EnterContainer(TLVType & outerContainerType)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     TLVType containerType;
 
-    VerifyOrExit(TLVTypeIsContainer(static_cast<TLVType>(mUpdaterReader.mControlByte & kTLVTypeMask)),
-                 err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(TLVTypeIsContainer(static_cast<TLVType>(mUpdaterReader.mControlByte & kTLVTypeMask)),
+                        CHIP_ERROR_INCORRECT_STATE);
 
     // Change the updater state
     AdjustInternalWriterFreeSpace();
 
-    err = mUpdaterWriter.StartContainer(mUpdaterReader.GetTag(), mUpdaterReader.GetType(), containerType);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterWriter.StartContainer(mUpdaterReader.GetTag(), mUpdaterReader.GetType(), containerType));
 
-    err = mUpdaterReader.EnterContainer(containerType);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterReader.EnterContainer(containerType));
 
     outerContainerType = containerType;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVUpdater::ExitContainer(TLVType outerContainerType)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    err = mUpdaterReader.ExitContainer(outerContainerType);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterReader.ExitContainer(outerContainerType));
 
     // Change the updater's state
     AdjustInternalWriterFreeSpace();
 
-    err = mUpdaterWriter.EndContainer(outerContainerType);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mUpdaterWriter.EndContainer(outerContainerType));
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 /**

--- a/src/lib/core/CHIPTLVWriter.cpp
+++ b/src/lib/core/CHIPTLVWriter.cpp
@@ -412,56 +412,50 @@ const size_t kCHIPTLVCopyChunkSize = 16;
 
 CHIP_ERROR TLVWriter::CopyElement(uint64_t tag, TLVReader & reader)
 {
-    CHIP_ERROR err          = CHIP_NO_ERROR;
     TLVElementType elemType = reader.ElementType();
     uint64_t elemLenOrVal   = reader.mElemLenOrVal;
     TLVReader readerHelper; // used to figure out the length of the element and read data of the element
     uint32_t copyDataLen;
     uint8_t chunk[kCHIPTLVCopyChunkSize];
 
-    VerifyOrExit(elemType != TLVElementType::NotSpecified && elemType != TLVElementType::EndOfContainer,
-                 err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(elemType != TLVElementType::NotSpecified && elemType != TLVElementType::EndOfContainer,
+                        CHIP_ERROR_INCORRECT_STATE);
 
     // Initialize the helper
     readerHelper.Init(reader);
 
     // Skip to the end of the element.
-    err = reader.Skip();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Skip());
 
     // Compute the amount of value data to copy from the reader.
     copyDataLen = reader.GetLengthRead() - readerHelper.GetLengthRead();
 
     // Write the head of the new element with the same type and length/value, but using the
     // specified tag.
-    err = WriteElementHead(elemType, tag, elemLenOrVal);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(WriteElementHead(elemType, tag, elemLenOrVal));
 
     while (copyDataLen > 0)
     {
         uint32_t chunkSize = copyDataLen > kCHIPTLVCopyChunkSize ? kCHIPTLVCopyChunkSize : copyDataLen;
-        err                = readerHelper.ReadData(chunk, chunkSize);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(readerHelper.ReadData(chunk, chunkSize));
 
-        err = WriteData(chunk, chunkSize);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(WriteData(chunk, chunkSize));
 
         copyDataLen -= chunkSize;
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWriter & containerWriter)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(TLVTypeIsContainer(containerType), err = CHIP_ERROR_WRONG_TLV_TYPE);
+    VerifyOrReturnError(TLVTypeIsContainer(containerType), CHIP_ERROR_WRONG_TLV_TYPE);
 
     if (IsCloseContainerReserved())
     {
-        VerifyOrExit(mMaxLen >= kEndOfContainerMarkerSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+        VerifyOrReturnError(mMaxLen >= kEndOfContainerMarkerSize, CHIP_ERROR_BUFFER_TOO_SMALL);
         mMaxLen -= kEndOfContainerMarkerSize;
     }
     err = WriteElementHead(static_cast<TLVElementType>(containerType), tag, 0);
@@ -472,7 +466,7 @@ CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWrit
         if (IsCloseContainerReserved())
             mMaxLen += kEndOfContainerMarkerSize;
 
-        ExitNow();
+        return err;
     }
 
     containerWriter.mBackingStore  = mBackingStore;
@@ -488,8 +482,7 @@ CHIP_ERROR TLVWriter::OpenContainer(uint64_t tag, TLVType containerType, TLVWrit
 
     SetContainerOpen(true);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVWriter::CloseContainer(TLVWriter & containerWriter)
@@ -521,11 +514,11 @@ CHIP_ERROR TLVWriter::StartContainer(uint64_t tag, TLVType containerType, TLVTyp
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    VerifyOrExit(TLVTypeIsContainer(containerType), err = CHIP_ERROR_WRONG_TLV_TYPE);
+    VerifyOrReturnError(TLVTypeIsContainer(containerType), CHIP_ERROR_WRONG_TLV_TYPE);
 
     if (IsCloseContainerReserved())
     {
-        VerifyOrExit(mMaxLen >= kEndOfContainerMarkerSize, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+        VerifyOrReturnError(mMaxLen >= kEndOfContainerMarkerSize, CHIP_ERROR_BUFFER_TOO_SMALL);
         mMaxLen -= kEndOfContainerMarkerSize;
     }
 
@@ -536,15 +529,14 @@ CHIP_ERROR TLVWriter::StartContainer(uint64_t tag, TLVType containerType, TLVTyp
         if (IsCloseContainerReserved())
             mMaxLen += kEndOfContainerMarkerSize;
 
-        ExitNow();
+        return err;
     }
     outerContainerType = mContainerType;
     mContainerType     = containerType;
 
     SetContainerOpen(false);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVWriter::EndContainer(TLVType outerContainerType)
@@ -605,19 +597,15 @@ CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, TLVReader & container)
 
 CHIP_ERROR TLVWriter::CopyContainer(uint64_t tag, const uint8_t * encodedContainer, uint16_t encodedContainerLen)
 {
-    CHIP_ERROR err;
     TLVReader reader;
 
     reader.Init(encodedContainer, encodedContainerLen);
 
-    err = reader.Next();
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next());
 
-    err = PutPreEncodedContainer(tag, reader.GetType(), reader.GetReadPoint(), reader.GetRemainingLength());
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(PutPreEncodedContainer(tag, reader.GetType(), reader.GetReadPoint(), reader.GetRemainingLength()));
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TLVWriter::WriteElementHead(TLVElementType elemType, uint64_t tag, uint64_t lenOrVal)
@@ -765,22 +753,18 @@ CHIP_ERROR TLVWriter::WriteElementWithData(TLVType type, uint64_t tag, const uin
 
 CHIP_ERROR TLVWriter::WriteData(const uint8_t * p, uint32_t len)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    VerifyOrExit((mLenWritten + len) <= mMaxLen, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError((mLenWritten + len) <= mMaxLen, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     while (len > 0)
     {
         if (mRemainingLen == 0)
         {
-            VerifyOrExit(mBackingStore != nullptr, err = CHIP_ERROR_NO_MEMORY);
+            VerifyOrReturnError(mBackingStore != nullptr, CHIP_ERROR_NO_MEMORY);
 
-            VerifyOrExit(CanCastTo<uint32_t>(mWritePoint - mBufStart), err = CHIP_ERROR_INCORRECT_STATE);
-            err = mBackingStore->FinalizeBuffer(*this, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart));
-            SuccessOrExit(err);
+            VerifyOrReturnError(CanCastTo<uint32_t>(mWritePoint - mBufStart), CHIP_ERROR_INCORRECT_STATE);
+            ReturnErrorOnFailure(mBackingStore->FinalizeBuffer(*this, mBufStart, static_cast<uint32_t>(mWritePoint - mBufStart)));
 
-            err = mBackingStore->GetNewBuffer(*this, mBufStart, mRemainingLen);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(mBackingStore->GetNewBuffer(*this, mBufStart, mRemainingLen));
 
             mWritePoint = mBufStart;
 
@@ -800,8 +784,7 @@ CHIP_ERROR TLVWriter::WriteData(const uint8_t * p, uint32_t len)
         len -= writeLen;
     }
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 } // namespace TLV

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -36,6 +36,7 @@
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/RandUtils.h>
+#include <support/ReturnMacros.h>
 #include <support/ScopedBuffer.h>
 #include <support/UnitTestRegistration.h>
 
@@ -1461,8 +1462,7 @@ static CHIP_ERROR FindContainerWithElement(const TLVReader & aReader, size_t aDe
 
     if (TLVTypeIsContainer(reader.GetType()))
     {
-        err = reader.EnterContainer(containerType);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.EnterContainer(containerType));
 
         err = chip::TLV::Utilities::Find(reader, *tag, result, false);
 
@@ -1477,7 +1477,6 @@ static CHIP_ERROR FindContainerWithElement(const TLVReader & aReader, size_t aDe
             err = CHIP_NO_ERROR;
         }
     }
-exit:
     return err;
 }
 
@@ -3533,51 +3532,40 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
     do                                                                                                                             \
     {                                                                                                                              \
         TYPE val;                                                                                                                  \
-        err = reader.Get(val);                                                                                                     \
-        SuccessOrExit(err);                                                                                                        \
-        VerifyOrExit(val == (VAL), err = CHIP_ERROR_INVALID_ARGUMENT);                                                             \
+        ReturnErrorOnFailure(reader.Get(val));                                                                                     \
+        VerifyOrReturnError(val == (VAL), CHIP_ERROR_INVALID_ARGUMENT);                                                            \
     } while (0)
 
 #define FUZZ_CHECK_STRING(VAL)                                                                                                     \
     do                                                                                                                             \
     {                                                                                                                              \
         char buf[sizeof(VAL)];                                                                                                     \
-        VerifyOrExit(reader.GetLength() == strlen(VAL), err = CHIP_ERROR_INVALID_ADDRESS);                                         \
-        err = reader.GetString(buf, sizeof(buf));                                                                                  \
-        SuccessOrExit(err);                                                                                                        \
-        VerifyOrExit(strcmp(buf, (VAL)) == 0, err = CHIP_ERROR_INVALID_ADDRESS);                                                   \
+        VerifyOrReturnError(reader.GetLength() == strlen(VAL), CHIP_ERROR_INVALID_ADDRESS);                                        \
+        ReturnErrorOnFailure(reader.GetString(buf, sizeof(buf)));                                                                  \
+        VerifyOrReturnError(strcmp(buf, (VAL)) == 0, CHIP_ERROR_INVALID_ADDRESS);                                                  \
     } while (0)
 
-    err = reader.Next(kTLVType_Structure, ProfileTag(TestProfile_1, 1));
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(reader.Next(kTLVType_Structure, ProfileTag(TestProfile_1, 1)));
 
     {
         TLVType outerContainer1Type;
 
-        err = reader.EnterContainer(outerContainer1Type);
-        SuccessOrExit(err);
-
-        err = reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_1, 2));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.EnterContainer(outerContainer1Type));
+        ReturnErrorOnFailure(reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_1, 2)));
 
         FUZZ_CHECK_VAL(bool, true);
 
-        err = reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_2, 2));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Next(kTLVType_Boolean, ProfileTag(TestProfile_2, 2)));
 
         FUZZ_CHECK_VAL(bool, false);
 
-        err = reader.Next(kTLVType_Array, ContextTag(0));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Next(kTLVType_Array, ContextTag(0)));
 
         {
             TLVType outerContainer2Type;
 
-            err = reader.EnterContainer(outerContainer2Type);
-            SuccessOrExit(err);
-
-            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.EnterContainer(outerContainer2Type));
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
 
             FUZZ_CHECK_VAL(int8_t, 42);
             FUZZ_CHECK_VAL(int16_t, 42);
@@ -3588,108 +3576,80 @@ static CHIP_ERROR ReadFuzzedEncoding1(nlTestSuite * inSuite, TLVReader & reader)
             FUZZ_CHECK_VAL(uint32_t, 42);
             FUZZ_CHECK_VAL(uint64_t, 42);
 
-            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
 
             FUZZ_CHECK_VAL(int8_t, -17);
             FUZZ_CHECK_VAL(int16_t, -17);
             FUZZ_CHECK_VAL(int32_t, -17);
             FUZZ_CHECK_VAL(int64_t, -17);
 
-            err = reader.Next(kTLVType_SignedInteger, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.Next(kTLVType_SignedInteger, AnonymousTag));
 
             FUZZ_CHECK_VAL(int32_t, -170000);
             FUZZ_CHECK_VAL(int64_t, -170000);
 
-            err = reader.Next(kTLVType_UnsignedInteger, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.Next(kTLVType_UnsignedInteger, AnonymousTag));
 
             FUZZ_CHECK_VAL(int64_t, 40000000000ULL);
             FUZZ_CHECK_VAL(uint64_t, 40000000000ULL);
 
-            err = reader.Next(kTLVType_Structure, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.Next(kTLVType_Structure, AnonymousTag));
 
             {
                 TLVType outerContainer3Type;
 
-                err = reader.EnterContainer(outerContainer3Type);
-                SuccessOrExit(err);
-
-                err = reader.ExitContainer(outerContainer3Type);
-                SuccessOrExit(err);
+                ReturnErrorOnFailure(reader.EnterContainer(outerContainer3Type));
+                ReturnErrorOnFailure(reader.ExitContainer(outerContainer3Type));
             }
 
-            err = reader.Next(kTLVType_List, AnonymousTag);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.Next(kTLVType_List, AnonymousTag));
 
             {
                 TLVType outerContainer3Type;
 
-                err = reader.EnterContainer(outerContainer3Type);
-                SuccessOrExit(err);
-
-                err = reader.Next(kTLVType_Null, ProfileTag(TestProfile_1, 17));
-                SuccessOrExit(err);
-
-                err = reader.Next(kTLVType_Null, ProfileTag(TestProfile_2, 900000));
-                SuccessOrExit(err);
-
-                err = reader.Next(kTLVType_Null, AnonymousTag);
-                SuccessOrExit(err);
-
-                err = reader.Next(kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL));
-                SuccessOrExit(err);
+                ReturnErrorOnFailure(reader.EnterContainer(outerContainer3Type));
+                ReturnErrorOnFailure(reader.Next(kTLVType_Null, ProfileTag(TestProfile_1, 17)));
+                ReturnErrorOnFailure(reader.Next(kTLVType_Null, ProfileTag(TestProfile_2, 900000)));
+                ReturnErrorOnFailure(reader.Next(kTLVType_Null, AnonymousTag));
+                ReturnErrorOnFailure(reader.Next(kTLVType_Structure, ProfileTag(TestProfile_2, 4000000000ULL)));
 
                 {
                     TLVType outerContainer4Type;
 
-                    err = reader.EnterContainer(outerContainer4Type);
-                    SuccessOrExit(err);
-
-                    err = reader.Next(kTLVType_UTF8String, CommonTag(70000));
-                    SuccessOrExit(err);
+                    ReturnErrorOnFailure(reader.EnterContainer(outerContainer4Type));
+                    ReturnErrorOnFailure(reader.Next(kTLVType_UTF8String, CommonTag(70000)));
 
                     FUZZ_CHECK_STRING(sLargeString);
 
-                    err = reader.ExitContainer(outerContainer4Type);
-                    SuccessOrExit(err);
+                    ReturnErrorOnFailure(reader.ExitContainer(outerContainer4Type));
                 }
 
-                err = reader.ExitContainer(outerContainer3Type);
-                SuccessOrExit(err);
+                ReturnErrorOnFailure(reader.ExitContainer(outerContainer3Type));
             }
 
-            err = reader.ExitContainer(outerContainer2Type);
-            SuccessOrExit(err);
+            ReturnErrorOnFailure(reader.ExitContainer(outerContainer2Type));
         }
 
-        err = reader.Next(kTLVType_UTF8String, ProfileTag(TestProfile_1, 5));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Next(kTLVType_UTF8String, ProfileTag(TestProfile_1, 5)));
 
         FUZZ_CHECK_STRING("This is a test");
 
-        err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65535)));
 
         FUZZ_CHECK_VAL(double, (float) 17.9);
 
-        err = reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536));
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.Next(kTLVType_FloatingPointNumber, ProfileTag(TestProfile_2, 65536)));
 
         FUZZ_CHECK_VAL(double, (double) 17.9);
 
-        err = reader.ExitContainer(outerContainer1Type);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(reader.ExitContainer(outerContainer1Type));
     }
 
     err = reader.Next();
     if (err == CHIP_END_OF_TLV)
         err = CHIP_NO_ERROR;
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 static time_t sFuzzTestDurationSecs = 5;

--- a/src/lib/support/ReturnMacros.h
+++ b/src/lib/support/ReturnMacros.h
@@ -34,6 +34,20 @@
         }                                                                                                                          \
     } while (false)
 
+/// Returns if the expression returns something different than CHIP_NO_ERROR
+///
+/// Use like:
+///   ReturnOnFailure(channel->SendMsg(msg));
+#define ReturnOnFailure(expr)                                                                                                      \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        CHIP_ERROR __err = (expr);                                                                                                 \
+        if (__err != CHIP_NO_ERROR)                                                                                                \
+        {                                                                                                                          \
+            return;                                                                                                                \
+        }                                                                                                                          \
+    } while (false)
+
 /// Returns from the void function if expression evaluates to false
 ///
 /// Use like:


### PR DESCRIPTION
#### Problem

The `Exit` group of error-handling macros inhibit scoping, and
are unnecessary when there is no cleanup at the `exit:` label.

#### Summary of Changes

- Remove `exit: return` idiom from `src/lib`, replacing `Exit` macros
  with corresponding `Return` macros.
- Add `ReturnOnFailure` macro
