### PR TITLE
Add reporting engine to generate reports

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -82,6 +82,7 @@ static_library("app") {
     "ReadHandler.cpp",
     "decoder.cpp",
     "encoder.cpp",
+    "reporting/Engine.cpp",
   ]
 
   public_deps = [

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -50,6 +50,9 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     err = mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this);
     SuccessOrExit(err);
 
+    mReportingEngine.Init();
+    SuccessOrExit(err);
+
 exit:
     return err;
 }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -43,6 +43,7 @@
 #include <app/InteractionModelDelegate.h>
 #include <app/ReadClient.h>
 #include <app/ReadHandler.h>
+#include <app/reporting/Engine.h>
 
 #define CHIP_MAX_NUM_COMMAND_HANDLER 1
 #define CHIP_MAX_NUM_COMMAND_SENDER 1
@@ -124,7 +125,10 @@ public:
      */
     uint16_t GetReadClientArrayIndex(const ReadClient * const apReadClient) const;
 
+    reporting::Engine & GetReportingEngine() { return mReportingEngine; }
+
 private:
+    friend class reporting::Engine;
     void OnUnknownMsgType(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
     void OnInvokeCommandRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
@@ -146,6 +150,7 @@ private:
     CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER];
     ReadClient mReadClients[CHIP_MAX_NUM_READ_CLIENT];
     ReadHandler mReadHandlers[CHIP_MAX_NUM_READ_HANDLER];
+    reporting::Engine mReportingEngine;
 };
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -95,6 +95,7 @@ public:
     CHIP_ERROR SendReportData(System::PacketBufferHandle aPayload);
 
     bool IsFree() const { return mState == HandlerState::Uninitialized; }
+    bool IsReportable() const { return mState == HandlerState::Reportable; }
 
     virtual ~ReadHandler() = default;
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -1,0 +1,175 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements reporting engine for CHIP
+ *      Data Model profile.
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/reporting/Engine.h>
+
+namespace chip {
+namespace app {
+namespace reporting {
+CHIP_ERROR Engine::Init()
+{
+    mMoreChunkedMessages = false;
+    mNumReportsInFlight  = 0;
+    mCurReadHandlerIdx   = 0;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter reportDataWriter;
+    ReportData::Builder reportDataBuilder;
+    chip::System::PacketBufferHandle bufHandle = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
+
+    VerifyOrExit(!bufHandle.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+    reportDataWriter.Init(std::move(bufHandle));
+
+    // Create a report data.
+    err = reportDataBuilder.Init(&reportDataWriter);
+    SuccessOrExit(err);
+
+    // TODO: Fill in the EventList.
+    // err = BuildSingleReportDataEventList(reportDataBuilder, apReadHandler);
+    // SuccessOrExit(err);
+
+    // TODO: Add mechanism to set mSuppressResponse to handle status reports for multiple reports
+    // TODO: Add more chunk message support, currently mMoreChunkedMessages is always false.
+    if (mMoreChunkedMessages)
+    {
+        reportDataBuilder.MoreChunkedMessages(mMoreChunkedMessages);
+    }
+
+    reportDataBuilder.EndOfReportData();
+    SuccessOrExit(reportDataBuilder.GetError());
+
+    err = reportDataWriter.Finalize(&bufHandle);
+    SuccessOrExit(err);
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    {
+        ChipLogDetail(DataManagement, "<RE> Dumping report data...");
+        chip::System::PacketBufferTLVReader reader;
+        ReportData::Parser report;
+
+        reader.Init(bufHandle.Retain());
+        reader.Next();
+
+        err = report.Init(reader);
+        SuccessOrExit(err);
+
+        err = report.CheckSchemaValidity();
+        SuccessOrExit(err);
+    }
+#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
+    ChipLogDetail(DataManagement, "<RE> Sending report...");
+    err = SendReport(apReadHandler, std::move(bufHandle));
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DataManagement, "<RE> Error sending out report data with %d!", err));
+
+    ChipLogDetail(DataManagement, "<RE> ReportsInFlight = %u with readHandler %u, RE has %s", mNumReportsInFlight,
+                  mCurReadHandlerIdx, mMoreChunkedMessages ? "more messages" : "no more messages");
+
+    if (!mMoreChunkedMessages)
+    {
+        OnReportConfirm();
+    }
+
+exit:
+    ChipLogFunctError(err);
+    if (!mMoreChunkedMessages || err != CHIP_NO_ERROR)
+    {
+        apReadHandler->Shutdown();
+    }
+    return err;
+}
+
+void Engine::Run(System::Layer * aSystemLayer, void * apAppState, System::Error)
+{
+    Engine * const pEngine = reinterpret_cast<Engine *>(apAppState);
+    pEngine->Run();
+}
+
+CHIP_ERROR Engine::ScheduleRun()
+{
+    if (InteractionModelEngine::GetInstance()->GetExchangeManager() != nullptr)
+    {
+        return InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->ScheduleWork(Run, this);
+    }
+    else
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+}
+
+void Engine::Run()
+{
+    uint32_t numReadHandled = 0;
+
+    InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
+    ReadHandler * readHandler         = imEngine->mReadHandlers + mCurReadHandlerIdx;
+
+    while ((mNumReportsInFlight < CHIP_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_MAX_NUM_READ_HANDLER))
+    {
+        if (readHandler->IsReportable())
+        {
+            CHIP_ERROR err = BuildAndSendSingleReportData(readHandler);
+            ChipLogFunctError(err);
+            return;
+        }
+        numReadHandled++;
+        mCurReadHandlerIdx = (mCurReadHandlerIdx + 1) % CHIP_MAX_NUM_READ_HANDLER;
+        readHandler        = imEngine->mReadHandlers + mCurReadHandlerIdx;
+    }
+}
+
+CHIP_ERROR Engine::SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // We can only have 1 report in flight for any given read - increment and break out.
+    mNumReportsInFlight++;
+
+    err = apReadHandler->SendReportData(std::move(aPayload));
+
+    if (err != CHIP_NO_ERROR)
+    {
+        mNumReportsInFlight--;
+    }
+    return err;
+}
+
+void Engine::OnReportConfirm()
+{
+    VerifyOrDie(mNumReportsInFlight > 0);
+
+    mNumReportsInFlight--;
+    ChipLogDetail(DataManagement, "<RE> OnReportConfirm: NumReports = %d", mNumReportsInFlight);
+}
+
+}; // namespace reporting
+}; // namespace app
+}; // namespace chip

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -1,0 +1,121 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Reporting Engine for a CHIP Interaction Model
+ *
+ */
+
+#pragma once
+
+#include <app/MessageDef/ReportData.h>
+#include <app/ReadHandler.h>
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <util/basic-types.h>
+
+namespace chip {
+namespace app {
+namespace reporting {
+/*
+ *  @class Engine
+ *
+ *  @brief The reporting engine is responsible for generating reports to reader. It is able to find the intersection
+ * between the path interest set of each reader with what has changed in the publisher data store and generate tailored
+ * reports for each reader.
+ *
+ *         At its core, it  tries to gather and pack as much relevant attributes changes and/or events as possible into a report
+ * message before sending that to the reader. It continues to do so until it has no more work to do.
+ */
+class Engine
+{
+public:
+    /**
+     * Initializes the reporting engine. Should only be called once.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Was unable to retrieve data and write it into the writer.
+     */
+    CHIP_ERROR Init();
+
+    /**
+     * Main work-horse function that executes the run-loop.
+     */
+    void Run();
+
+    /**
+     * Main work-horse function that executes the run-loop asynchronously on the CHIP thread
+     */
+    CHIP_ERROR ScheduleRun();
+
+private:
+    friend class TestReportingEngine;
+    /**
+     * Build Single Report Data including attribute changes and event data stream, and send out
+     *
+     */
+    CHIP_ERROR BuildAndSendSingleReportData(ReadHandler * apReadHandler);
+
+    /**
+     * Send Report via ReadHandler
+     *
+     */
+    CHIP_ERROR SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload);
+
+    /**
+     * Should be invoked when the device receives a Status report, or when the Report data request times out.
+     * This allows the engine to do some clean-up.
+     *
+     */
+    void OnReportConfirm();
+
+    /**
+     * Generate and send the report data request when there exists subscription or read request
+     *
+     */
+    static void Run(System::Layer * aSystemLayer, void * apAppState, System::Error);
+
+    /**
+     * Boolean to show if more chunk message on the way
+     *
+     */
+    bool mMoreChunkedMessages = false;
+
+    /**
+     * The number of report date request in flight
+     *
+     */
+    uint32_t mNumReportsInFlight = 0;
+
+    /**
+     *  Current read handler index
+     *
+     */
+    uint32_t mCurReadHandlerIdx = 0;
+};
+
+}; // namespace reporting
+}; // namespace app
+}; // namespace chip

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
     "TestCommandInteraction.cpp",
     "TestMessageDef.cpp",
     "TestReadInteraction.cpp",
+    "TestReportingEngine.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -44,8 +44,9 @@
 
 namespace {
 // Max value for the number of message request sent.
+
 constexpr size_t kMaxCommandMessageCount    = 3;
-constexpr size_t kMaxReadMessageCount       = 0;
+constexpr size_t kMaxReadMessageCount       = 3;
 constexpr int32_t gMessageIntervalSeconds   = 1;
 constexpr chip::Transport::AdminId gAdminId = 0;
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -117,6 +117,7 @@ chip::SecurePairingUsingTestSecret gTestPairing;
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::InteractionModelDelegate mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::Transport::AdminId gAdminId = 0;
     chip::Transport::AdminPairingTable admins;
@@ -136,7 +137,7 @@ int main(int argc, char * argv[])
     err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);
     SuccessOrExit(err);
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,


### PR DESCRIPTION
Problem:
Need to implement reporting engine to generate IM reports, reporting engine would be used 
to send IM events(New feature in IM) or/and legacy zcl attribute/IM attribute)
Summary of Changes:
-- Add reporting engine to generate report for Read Handler, currently
it sends empty report.
-- Add unit test for reporting engine and enable cirque integraton test
for read client, read handler and reporting engine.


Note: This pr is cut from larger PR #4800