### PR TITLE
[EFR32] BLE Advertissement fixes and change default pin code

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -54,7 +54,7 @@ efr32_sdk("sdk") {
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
-  defines = [ 
+  defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
   ]

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -31,6 +31,7 @@ declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
   enable_pw_rpc = false
+  setupPinCode = 73141520
 }
 
 show_qr_code = true
@@ -53,7 +54,10 @@ efr32_sdk("sdk") {
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
-  defines = [ "BOARD_ID=${efr32_board}" ]
+  defines = [ 
+    "BOARD_ID=${efr32_board}",
+    "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
+  ]
 
   if (enable_pw_rpc) {
     defines += [

--- a/examples/lighting-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/efr32/include/CHIPProjectConfig.h
@@ -39,7 +39,9 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_TEST_DEVICE_IDENTITY 34
 
 // Use a default pairing code if one hasn't been provisioned in flash.
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
+#endif
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
 
 // For convenience, Chip Security Test Mode can be enabled and the
@@ -121,3 +123,43 @@
  * A size, in bytes, of the individual debug event logging buffer.
  */
 #define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
+ *
+ * The interval (in units of 0.625ms) at which the device will send BLE advertisements while
+ * in fast advertising mode.
+ *
+ * 40 (25ms).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL 40
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL
+ *
+ * The interval (in units of 0.625ms) at which the device will send BLE advertisements while
+ * in slow advertisement mode.
+ *
+ * 800 (500ms).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL 800
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT
+ *
+ * The amount of time in miliseconds after which BLE should change his advertisements 
+ * from fast interval to slow interval. 
+ *
+ * 30000 (30 secondes).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT (30 * 1000)
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT
+ *
+ * The amount of time in miliseconds after which BLE advertisement should be disabled, counting
+ * from the moment of slow advertisement commencement.
+ *
+ * Defaults to 9000000 (15 minutes).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)

--- a/examples/lighting-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/efr32/include/CHIPProjectConfig.h
@@ -147,8 +147,8 @@
 /**
  * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT
  *
- * The amount of time in miliseconds after which BLE should change his advertisements 
- * from fast interval to slow interval. 
+ * The amount of time in miliseconds after which BLE should change his advertisements
+ * from fast interval to slow interval.
  *
  * 30000 (30 secondes).
  */

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -51,7 +51,7 @@ efr32_sdk("sdk") {
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
-  defines = [ 
+  defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
   ]

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -28,6 +28,7 @@ examples_plat_dir = "${chip_root}/examples/platform/efr32"
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
+  setupPinCode = 73141520
 }
 
 show_qr_code = true
@@ -50,7 +51,10 @@ efr32_sdk("sdk") {
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
-  defines = [ "BOARD_ID=${efr32_board}" ]
+  defines = [ 
+    "BOARD_ID=${efr32_board}",
+    "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
+  ]
 }
 
 efr32_executable("lock_app") {

--- a/examples/lock-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lock-app/efr32/include/CHIPProjectConfig.h
@@ -39,7 +39,9 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_TEST_DEVICE_IDENTITY 34
 
 // Use a default pairing code if one hasn't been provisioned in flash.
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 12345678
+#endif
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
 
 // For convenience, Chip Security Test Mode can be enabled and the
@@ -121,3 +123,43 @@
  * A size, in bytes, of the individual debug event logging buffer.
  */
 #define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL
+ *
+ * The interval (in units of 0.625ms) at which the device will send BLE advertisements while
+ * in fast advertising mode.
+ *
+ * 40 (25ms).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL 40
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL
+ *
+ * The interval (in units of 0.625ms) at which the device will send BLE advertisements while
+ * in slow advertisement mode.
+ *
+ * 800 (500ms).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL 800
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT
+ *
+ * The amount of time in miliseconds after which BLE should change his advertisements 
+ * from fast interval to slow interval. 
+ *
+ * 30000 (30 secondes).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT (30 * 1000)
+
+/**
+ * CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT
+ *
+ * The amount of time in miliseconds after which BLE advertisement should be disabled, counting
+ * from the moment of slow advertisement commencement.
+ *
+ * Defaults to 9000000 (15 minutes).
+ */
+#define CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT (15 * 60 * 1000)

--- a/examples/lock-app/efr32/include/CHIPProjectConfig.h
+++ b/examples/lock-app/efr32/include/CHIPProjectConfig.h
@@ -147,8 +147,8 @@
 /**
  * CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT
  *
- * The amount of time in miliseconds after which BLE should change his advertisements 
- * from fast interval to slow interval. 
+ * The amount of time in miliseconds after which BLE should change his advertisements
+ * from fast interval to slow interval.
  *
  * 30000 (30 secondes).
  */

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
                                     (void *) this,    // init timer id = ble obj context
                                     BleAdvTimeoutHandler // timer callback handler
     );
-   
+
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
@@ -725,9 +725,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     ret = sl_bt_advertiser_start(advertising_set_handle, sl_bt_advertiser_user_data, connectableAdv);
 
     if (SL_STATUS_OK == ret)
-    {   
-        uint32_t BleAdvTimeoutMs = (mFlags.Has(Flags::kFastAdvertisingEnabled) ? 
-                                    CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT : 
+    {
+        uint32_t BleAdvTimeoutMs = (mFlags.Has(Flags::kFastAdvertisingEnabled) ?
+                                    CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_TIMEOUT :
                                     CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT);
         StartBleAdvTimeoutTimer(BleAdvTimeoutMs);
         mFlags.Set(Flags::kAdvertising);
@@ -1070,17 +1070,17 @@ void BLEManagerImpl::BleAdvTimeoutHandler(TimerHandle_t xTimer)
         ChipLogDetail(DeviceLayer,"bleAdv Timeout : Start slow advertissment");
 
         sInstance.mFlags.Clear(Flags::kFastAdvertisingEnabled);
-        
+
         //stop advertiser, change interval and restart it;
         sl_bt_advertiser_stop(sInstance.advertising_set_handle);
         ret = sl_bt_advertiser_set_timing(sInstance.advertising_set_handle,
                 CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL,
                 CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL, 0 ,0);
-        
+
         err = sInstance.MapBLEError(ret);
         SuccessOrExit(err);
 
-        uint8_t connectableAdv = (sInstance.NumConnections() < kMaxConnections) ? 
+        uint8_t connectableAdv = (sInstance.NumConnections() < kMaxConnections) ?
                                 sl_bt_advertiser_connectable_scannable : sl_bt_advertiser_scannable_non_connectable;
         ret = sl_bt_advertiser_start(sInstance.advertising_set_handle, sl_bt_advertiser_user_data, connectableAdv);
         err = sInstance.MapBLEError(ret);

--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -1064,7 +1064,7 @@ void BLEManagerImpl::BleAdvTimeoutHandler(TimerHandle_t xTimer)
     CHIP_ERROR err;
     sl_status_t ret;
 
-    if (sInstance._IsFastAdvertisingEnabled())
+    if (sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertissment");
 

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -25,10 +25,10 @@
 #pragma once
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include "FreeRTOS.h"
 #include "gatt_db.h"
 #include "sl_bgapi.h"
 #include "sl_bt_api.h"
-#include "FreeRTOS.h"
 #include "timers.h"
 
 namespace chip {

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -28,6 +28,8 @@
 #include "gatt_db.h"
 #include "sl_bgapi.h"
 #include "sl_bt_api.h"
+#include "FreeRTOS.h"
+#include "timers.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -141,10 +143,13 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     void HandleSoftTimerEvent(volatile sl_bt_msg_t * evt);
     bool RemoveConnection(uint8_t connectionHandle);
     void AddConnection(uint8_t connectionHandle, uint8_t bondingHandle);
+    void StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs);
+    void CancelBleAdvTimeoutTimer(void);
     CHIPoBLEConState * GetConnectionState(uint8_t conId, bool allocate = false);
     uint8_t GetTimerHandle(uint8_t connectionHandle, bool allocate = false);
     static void DriveBLEState(intptr_t arg);
     static void bluetoothStackEventHandler(void * p_arg);
+    static void BleAdvTimeoutHandler(TimerHandle_t xTimer);
 };
 
 /**


### PR DESCRIPTION
 #### Problem
Default setup Pin Code 12345678 is invalid
BLE always advertises the same address wich is the device identity address
BLE always advertises at the same interval until provisioned.
 
 #### Summary of Changes
- Change default SetupPincode value for lock and light example, can be changed by build argument
- Set random BLE advertissement address at advertissement start.
- Add Advertissement times outs -> fast advertisement (25ms)intervals from 0 to 30s, slow adv interval (500ms) from 30s to 15m, stop advertissement after that
