### PR TITLE
[Darwin] Rearrange CHIPErrors in the darwin Framework

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -23,15 +23,16 @@ FOUNDATION_EXPORT NSErrorDomain const CHIPErrorDomain;
 typedef int32_t CHIP_ERROR;
 
 typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) {
-    CHIPErrorCodeUndefinedError = 0,
-    CHIPErrorCodeInvalidStringLength = 1,
-    CHIPErrorCodeInvalidIntegerValue = 2,
-    CHIPErrorCodeInvalidArgument = 3,
-    CHIPErrorCodeInvalidMessageLength = 4,
-    CHIPErrorCodeInvalidState = 5,
-    CHIPErrorCodeWrongAddressType = 6,
-    CHIPErrorCodeIntegrityCheckFailed = 7,
-    CHIPSuccess = 8,
+    CHIPSuccess = 0,
+    CHIPErrorCodeUndefinedError = 1,
+    CHIPErrorCodeInvalidStringLength = 2,
+    CHIPErrorCodeInvalidIntegerValue = 3,
+    CHIPErrorCodeInvalidArgument = 4,
+    CHIPErrorCodeInvalidMessageLength = 5,
+    CHIPErrorCodeInvalidState = 6,
+    CHIPErrorCodeWrongAddressType = 7,
+    CHIPErrorCodeIntegrityCheckFailed = 8,
+    CHIPErrorCodeDuplicateExists = 9
 };
 
 @interface CHIPError : NSObject

--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -22,10 +22,18 @@ FOUNDATION_EXPORT NSErrorDomain const CHIPErrorDomain;
 
 typedef int32_t CHIP_ERROR;
 
-typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) { CHIPSuccess = 0, CHIPErrorCodeUndefinedError = 1,
-    CHIPErrorCodeInvalidStringLength = 2, CHIPErrorCodeInvalidIntegerValue = 3, CHIPErrorCodeInvalidArgument = 4,
-    CHIPErrorCodeInvalidMessageLength = 5, CHIPErrorCodeInvalidState = 6, CHIPErrorCodeWrongAddressType = 7,
-    CHIPErrorCodeIntegrityCheckFailed = 8, CHIPErrorCodeDuplicateExists = 9 };
+typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) {
+    CHIPSuccess = 0,
+    CHIPErrorCodeUndefinedError = 1,
+    CHIPErrorCodeInvalidStringLength = 2,
+    CHIPErrorCodeInvalidIntegerValue = 3,
+    CHIPErrorCodeInvalidArgument = 4,
+    CHIPErrorCodeInvalidMessageLength = 5,
+    CHIPErrorCodeInvalidState = 6,
+    CHIPErrorCodeWrongAddressType = 7,
+    CHIPErrorCodeIntegrityCheckFailed = 8,
+    CHIPErrorCodeDuplicateExists = 9,
+};
 
 @interface CHIPError : NSObject
 + (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;

--- a/src/darwin/Framework/CHIP/CHIPError.h
+++ b/src/darwin/Framework/CHIP/CHIPError.h
@@ -22,18 +22,10 @@ FOUNDATION_EXPORT NSErrorDomain const CHIPErrorDomain;
 
 typedef int32_t CHIP_ERROR;
 
-typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) {
-    CHIPSuccess = 0,
-    CHIPErrorCodeUndefinedError = 1,
-    CHIPErrorCodeInvalidStringLength = 2,
-    CHIPErrorCodeInvalidIntegerValue = 3,
-    CHIPErrorCodeInvalidArgument = 4,
-    CHIPErrorCodeInvalidMessageLength = 5,
-    CHIPErrorCodeInvalidState = 6,
-    CHIPErrorCodeWrongAddressType = 7,
-    CHIPErrorCodeIntegrityCheckFailed = 8,
-    CHIPErrorCodeDuplicateExists = 9
-};
+typedef NS_ERROR_ENUM(CHIPErrorDomain, CHIPErrorCode) { CHIPSuccess = 0, CHIPErrorCodeUndefinedError = 1,
+    CHIPErrorCodeInvalidStringLength = 2, CHIPErrorCodeInvalidIntegerValue = 3, CHIPErrorCodeInvalidArgument = 4,
+    CHIPErrorCodeInvalidMessageLength = 5, CHIPErrorCodeInvalidState = 6, CHIPErrorCodeWrongAddressType = 7,
+    CHIPErrorCodeIntegrityCheckFailed = 8, CHIPErrorCodeDuplicateExists = 9 };
 
 @interface CHIPError : NSObject
 + (nullable NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -19,6 +19,7 @@
 
 #import <core/CHIPError.h>
 #import <inet/InetError.h>
+#import <app/util/af-enums.h>
 
 NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
 
@@ -51,6 +52,10 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeIntegrityCheckFailed
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
+    case EMBER_ZCL_STATUS_DUPLICATE_EXISTS:
+        return [NSError errorWithDomain:CHIPErrorDomain
+                                   code:CHIPErrorCodeDuplicateExists
+                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A Duplicate entry or setting exists.", nil) }];
     case CHIP_NO_ERROR:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPSuccess
@@ -58,7 +63,7 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
     default:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeUndefinedError
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Undefined error.", nil) }];
+                               userInfo:@{ NSLocalizedDescriptionKey :[NSString stringWithFormat:NSLocalizedString(@"Undefined error:%d.", nil), errorCode ]}];
         ;
     }
 }
@@ -70,6 +75,8 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
     }
 
     switch (error.code) {
+    case CHIPErrorCodeDuplicateExists:
+        return EMBER_ZCL_STATUS_DUPLICATE_EXISTS;
     case CHIPErrorCodeInvalidStringLength:
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     case CHIPErrorCodeInvalidIntegerValue:

--- a/src/darwin/Framework/CHIP/CHIPError.mm
+++ b/src/darwin/Framework/CHIP/CHIPError.mm
@@ -17,9 +17,9 @@
 
 #import "CHIPError.h"
 
+#import <app/util/af-enums.h>
 #import <core/CHIPError.h>
 #import <inet/InetError.h>
-#import <app/util/af-enums.h>
 
 NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
 
@@ -53,9 +53,10 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
                                    code:CHIPErrorCodeIntegrityCheckFailed
                                userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Integrity check failed.", nil) }];
     case EMBER_ZCL_STATUS_DUPLICATE_EXISTS:
-        return [NSError errorWithDomain:CHIPErrorDomain
-                                   code:CHIPErrorCodeDuplicateExists
-                               userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A Duplicate entry or setting exists.", nil) }];
+        return [NSError
+            errorWithDomain:CHIPErrorDomain
+                       code:CHIPErrorCodeDuplicateExists
+                   userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A Duplicate entry or setting exists.", nil) }];
     case CHIP_NO_ERROR:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPSuccess
@@ -63,7 +64,10 @@ NSString * const CHIPErrorDomain = @"CHIPErrorDomain";
     default:
         return [NSError errorWithDomain:CHIPErrorDomain
                                    code:CHIPErrorCodeUndefinedError
-                               userInfo:@{ NSLocalizedDescriptionKey :[NSString stringWithFormat:NSLocalizedString(@"Undefined error:%d.", nil), errorCode ]}];
+                               userInfo:@{
+                                   NSLocalizedDescriptionKey :
+                                       [NSString stringWithFormat:NSLocalizedString(@"Undefined error:%d.", nil), errorCode]
+                               }];
         ;
     }
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The custom error mapping for CHIP_ERROR in the CHIPFramework has curious ordering for the error messages. The existence of CHIPSuccess as an "error" is by itself unusual but even so, it's arbitrarily assigned to "8". 
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
- Reordered the errors so that adding a new error enum only requires one addition to the enum set
- Unknown errors provide more information when they occur (print the raw underlying CHIP_ERROR)
- Added a new mapping for a ZCL error (errors are being added on demand)
 
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
