### PR TITLE
Fix and clean up examples/pigweed-app/efr32 build

### DIFF
--- a/config/efr32/lib/pw_rpc/BUILD.gn
+++ b/config/efr32/lib/pw_rpc/BUILD.gn
@@ -32,7 +32,7 @@ static_library("pw_rpc") {
 
   public_configs = [ "${dir_pigweed}/pw_hdlc:default_config" ]
 
-  deps = [
+  public_deps = [
     "$dir_pw_rpc:server",
     "$dir_pw_rpc/nanopb:echo_service",
     "${chip_root}/examples/platform/efr32/pw_sys_io:pw_sys_io_efr32",

--- a/examples/common/pigweed/BUILD.gn
+++ b/examples/common/pigweed/BUILD.gn
@@ -15,6 +15,10 @@
 import("//build_overrides/pigweed.gni")
 import("$dir_pw_build/target_types.gni")
 
+config("default_config") {
+  include_dirs = [ ".." ]
+}
+
 pw_source_set("system_rpc_server") {
   deps = [
     "$dir_pw_hdlc:pw_rpc",
@@ -24,4 +28,5 @@ pw_source_set("system_rpc_server") {
     dir_pw_log,
   ]
   sources = [ "system_rpc_server.cc" ]
+  public_configs = [ ":default_config" ]
 }

--- a/examples/common/pigweed/RpcService.cpp
+++ b/examples/common/pigweed/RpcService.cpp
@@ -30,7 +30,7 @@
 #include "pw_stream/sys_io_stream.h"
 #include "pw_sys_io/sys_io.h"
 
-#include "logging/CHIPLogging.h"
+#include "support/logging/CHIPLogging.h"
 
 #include <array>
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -38,12 +38,13 @@ efr32_sdk("sdk") {
   sources = [
     "${efr32_project_dir}/include/CHIPProjectConfig.h",
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
+    "${efr32_sdk_root}/hardware/kit/common/drivers/retargetserial.c",
   ]
 
   defines = [
     "BOARD_ID=${efr32_board}",
-    "HAL_VCOM_ENABLE = 1",
-    "EFR32_LOG_ENABLED = 1",
+    "HAL_VCOM_ENABLE=1",
+    "EFR32_LOG_ENABLED=1",
     "PW_RPC_ENABLED",
   ]
 }
@@ -58,37 +59,12 @@ efr32_executable("pigweed_app") {
     "$dir_pw_assert",
     "$dir_pw_checksum",
     "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+    "${chip_root}/examples/common/pigweed:system_rpc_server",
     "${chip_root}/src/lib",
     "${examples_plat_dir}/pw_sys_io:pw_sys_io_efr32",
   ]
 
-  include_dirs += [
-    "include",
-    "${examples_plat_dir}",
-    "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-    "${examples_plat_dir}/pw_sys_io/public",
-    "${dir_pigweed}/pw_sys_io/public",
-    "${dir_pigweed}/pw_span/public_overrides",
-    "${dir_pigweed}/pw_span/public",
-    "${dir_pigweed}/pw_polyfill/public",
-    "${dir_pigweed}/pw_polyfill/standard_library_public",
-    "${dir_pigweed}/pw_polyfill/public_overrides",
-    "${dir_pigweed}/pw_status/public",
-    "${dir_pigweed}/pw_stream/public",
-    "${dir_pigweed}/pw_preprocessor/public",
-    "${dir_pigweed}/pw_rpc/public",
-    "${dir_pigweed}/pw_rpc/nanopb/public",
-    "${dir_pigweed}/pw_rpc/raw/public",
-    "${dir_pigweed}/pw_rpc/system_server/public",
-    "${dir_pigweed}/pw_protobuf/public",
-    "${dir_pigweed}/pw_result/public",
-    "${dir_pigweed}/pw_varint/public",
-    "${chip_root}/third_party/nanopb/repo",
-    "${chip_root}/src/lib/support",
-    "${chip_root}/examples/common",
-    "${chip_root}/examples/common/pigweed/efr32",
-    "out/debug/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos",
-  ]
+  include_dirs += [ "${chip_root}/examples/common/pigweed/efr32" ]
 
   sources = [
     "${chip_root}/examples/common/pigweed/RpcService.cpp",


### PR DESCRIPTION
- Remove all of the duplicate include_dirs that were needed due
  to missing dependencies & improper use of private deps.
- Add back an retargetserial.c file which is needed for this build. It
  was removed in fc59bd2fdb ("[3rd-party] update openthread and
  ot-br-posix (#5062)")
- Remove some unusual whitespace in defines