### PR TITLE
ESP32: BLE fast and slow adv interval fix as per the spec

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -508,32 +508,32 @@ menu "CHIP Device Layer"
                 may need to be shorter.
 
         config BLE_FAST_ADVERTISING_INTERVAL_MIN
-            int "Fast Advertising Interval"
-            default 32
+            int "Fast Advertising Min Interval"
+            default 40
             depends on ENABLE_CHIPOBLE
             help
                 The minimum interval (in units of 0.625ms) at which the device will send BLE advertisements while
                 in fast advertising mode.
 
         config BLE_FAST_ADVERTISING_INTERVAL_MAX
-            int "Fast Advertising Interval"
-            default 96
+            int "Fast Advertising Max Interval"
+            default 40
             depends on ENABLE_CHIPOBLE
             help
                 The maximum interval (in units of 0.625ms) at which the device will send BLE advertisements while
                 in fast advertising mode.
 
         config BLE_SLOW_ADVERTISING_INTERVAL_MIN
-            int "Slow Advertising Interval"
-            default 240
+            int "Slow Advertising Min Interval"
+            default 800
             depends on ENABLE_CHIPOBLE
             help
                 The minimum interval (in units of 0.625ms) at which the device will send BLE advertisements while
                 in slow advertising mode.
 
         config BLE_SLOW_ADVERTISING_INTERVAL_MAX
-            int "Slow Advertising Interval"
-            default 1920
+            int "Slow Advertising Max Interval"
+            default 800
             depends on ENABLE_CHIPOBLE
             help
                 The maximum interval (in units of 0.625ms) at which the device will send BLE advertisements while

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1013,13 +1013,6 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     memset(&adv_params, 0, sizeof(adv_params));
     uint8_t own_addr_type = BLE_OWN_ADDR_RANDOM;
 
-    ret = ble_hs_pvcy_rpa_config(NIMBLE_HOST_ENABLE_RPA);
-    if (ret != 0)
-    {
-        ChipLogError(DeviceLayer, "RPA not set: %d", ret);
-        return CHIP_ERROR_INTERNAL;
-    }
-
     adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN;
 
     // Inform the ThreadStackManager that CHIPoBLE advertising is about to start.
@@ -1036,9 +1029,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     bool connectable     = (numCons < kMaxConnections);
     adv_params.conn_mode = connectable ? BLE_GAP_CONN_MODE_UND : BLE_GAP_CONN_MODE_NON;
 
-    // Advertise in fast mode if not fully provisioned and there are no CHIPoBLE connections, or
-    // if the application has expressly requested fast advertising.
-    if ((numCons == 0 && !ConfigurationMgr().IsPairedToAccount()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
+    // Advertise in fast mode if it is connectable advertisement and
+    // the application has expressly requested fast advertising.
+    if (connectable && mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
         adv_params.itvl_min = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN;
         adv_params.itvl_max = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MAX;
@@ -1053,10 +1046,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
                     (((uint32_t) adv_params.itvl_min) * 10) / 16, (connectable) ? "" : "non-", mDeviceName);
 
     {
-        ret = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &adv_params, ble_svr_gap_event, NULL);
-        if (ret == BLE_HS_EALREADY)
+        if (ble_gap_adv_active())
         {
-            /* This error code indicates that the advertising is already active. Stop and restart with the new parameters */
+            /* Advertising is already active. Stop and restart with the new parameters */
             ChipLogProgress(DeviceLayer, "Device already advertising, stop active advertisement and restart");
             ret = ble_gap_adv_stop();
             if (ret != 0)
@@ -1064,11 +1056,17 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
                 ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %d, cannot restart", ret);
                 return CHIP_ERROR_INTERNAL;
             }
-            else
+        }
+        else
+        {
+            ret = ble_hs_pvcy_rpa_config(NIMBLE_HOST_ENABLE_RPA);
+            if (ret != 0)
             {
-                ret = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &adv_params, ble_svr_gap_event, NULL);
+                ChipLogError(DeviceLayer, "RPA not set: %d", ret);
+                return CHIP_ERROR_INTERNAL;
             }
         }
+        ret = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &adv_params, ble_svr_gap_event, NULL);
 
         if (ret == 0)
         {


### PR DESCRIPTION
Note: This PR requires #5480  to be merged to take effect

 #### Problem
As per the provision made in #5480  the fast and slow intervals are not changing

 #### Summary of Changes
1. Add a fix such that the device advertises for 30 sec with fast interval and after that with slow interval
2. Set default values for fast adv interval as 25ms and slow adv interval as 500ms

Tests Done:
1. Tested that the adv interval is changed from fast to slow after 30sec
2. Secure pairing using BLE `examples/chip-tool`
