### PR TITLE
[dns-sd] Use a common function for determining CHIP service name

### DIFF
--- a/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/mdns/Advertiser_ImplMinimalMdns.cpp
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include "ServiceNaming.h"
 #include <mdns/minimal/ResponseSender.h>
 #include <mdns/minimal/Server.h>
 #include <mdns/minimal/core/FlatAllocatedQName.h>
@@ -401,12 +402,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
     char uniqueName[64] = "";
 
     /// need to set server name
-    size_t len = snprintf(uniqueName, sizeof(uniqueName), "%" PRIX64 "-%" PRIX64, params.GetFabricId(), params.GetNodeId());
-    if (len >= sizeof(uniqueName))
-    {
-        ChipLogError(Discovery, "Failed to allocate QNames.");
-        return CHIP_ERROR_NO_MEMORY;
-    }
+    ReturnErrorOnFailure(MakeInstanceName(uniqueName, sizeof(uniqueName), params.GetFabricId(), params.GetNodeId()));
 
     FullQName operationalServiceName = AllocateQName("_chip", "_tcp", "local");
     FullQName operationalServerName  = AllocateQName(uniqueName, "_chip", "_tcp", "local");

--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -26,7 +26,12 @@ static_library("mdns") {
     "${chip_root}/src/lib/support",
   ]
 
-  sources = [ "Advertiser.h" ]
+  sources = [
+    "Advertiser.h",
+    "ServiceNaming.cpp",
+    "ServiceNaming.h",
+    "Resolver.h",
+  ]
 
   if (chip_mdns == "none") {
     sources += [

--- a/src/lib/mdns/BUILD.gn
+++ b/src/lib/mdns/BUILD.gn
@@ -28,9 +28,9 @@ static_library("mdns") {
 
   sources = [
     "Advertiser.h",
+    "Resolver.h",
     "ServiceNaming.cpp",
     "ServiceNaming.h",
-    "Resolver.h",
   ]
 
   if (chip_mdns == "none") {

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -19,6 +19,7 @@
 
 #include <inttypes.h>
 
+#include "ServiceNaming.h"
 #include "lib/core/CHIPSafeCasts.h"
 #include "lib/mdns/platform/Mdns.h"
 #include "lib/support/logging/CHIPLogging.h"
@@ -270,8 +271,8 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
 
     mOperationalAdvertisingParams = params;
     // TODO: There may be multilple device/fabrid ids after multi-admin.
-    snprintf(service.mName, sizeof(service.mName), "%08X%08X-%08X%08X", (uint32_t)(params.GetNodeId() >> 32),
-             (uint32_t)(params.GetNodeId()), (uint32_t)(params.GetFabricId() >> 32), (uint32_t)(params.GetFabricId()));
+
+    ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), params.GetFabricId(), params.GetNodeId()));
     strncpy(service.mType, "_chip", sizeof(service.mType));
     service.mProtocol      = MdnsServiceProtocol::kMdnsProtocolTcp;
     service.mPort          = CHIP_PORT;
@@ -304,7 +305,7 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(uint64_t nodeId, uint64_t fabric
 
     MdnsService service;
 
-    snprintf(service.mName, sizeof(service.mName), "%" PRIX64 "-%" PRIX64, nodeId, fabricId);
+    ReturnErrorOnFailure(MakeInstanceName(service.mName, sizeof(service.mName), fabricId, nodeId));
     strncpy(service.mType, "_chip", sizeof(service.mType));
     service.mProtocol    = MdnsServiceProtocol::kMdnsProtocolTcp;
     service.mAddressType = type;

--- a/src/lib/mdns/ServiceNaming.cpp
+++ b/src/lib/mdns/ServiceNaming.cpp
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ServiceNaming.h"
+
+#include <support/CodeUtils.h>
+
+#include <cstdio>
+#include <inttypes.h>
+
+namespace chip {
+namespace Mdns {
+
+CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, uint64_t fabricId, uint64_t nodeId)
+{
+    constexpr size_t kServiceNameLen = 16 + 1 + 16; // 2 * 64-bit value in HEX + hyphen
+
+    ReturnErrorCodeIf(bufferLen <= kServiceNameLen, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    snprintf(buffer, bufferLen, "%08" PRIX32 "%08" PRIX32 "-%08" PRIX32 "%08" PRIX32, static_cast<uint32_t>(fabricId >> 32),
+             static_cast<uint32_t>(fabricId), static_cast<uint32_t>(nodeId >> 32), static_cast<uint32_t>(nodeId));
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Mdns
+} // namespace chip

--- a/src/lib/mdns/ServiceNaming.h
+++ b/src/lib/mdns/ServiceNaming.h
@@ -1,0 +1,31 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPError.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace chip {
+namespace Mdns {
+
+CHIP_ERROR MakeInstanceName(char * buffer, size_t bufferLen, uint64_t fabricId, uint64_t nodeId);
+
+} // namespace Mdns
+} // namespace chip


### PR DESCRIPTION
 #### Problem
3 copies of the same logic for determining a CHIP service name based on fabridID & nodeID are present and they have
already diverged.

 #### Summary of Changes
Extract the code to a common function and make it comply with the spec.