### PR TITLE
Fixed refreshing host address in SRP client.

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1256,9 +1256,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetupSrpHost(co
     VerifyOrExit(aHostName, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(strlen(aHostName) < SrpClient::kMaxHostNameSize, error = CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    memcpy(mSrpClient.mHostName, aHostName, strlen(aHostName) + 1);
-    error = MapOpenThreadError(otSrpClientSetHostName(mOTInst, aHostName));
-    SuccessOrExit(error);
+    // Avoid adding the same host name multiple times
+    if (strcmp(mSrpClient.mHostName, aHostName) != 0)
+    {
+        strcpy(mSrpClient.mHostName, aHostName);
+        error = MapOpenThreadError(otSrpClientSetHostName(mOTInst, aHostName));
+        SuccessOrExit(error);
+    }
 
     // Check if device has any external IPv6 assigned. If not, host will be set without IPv6 addresses
     // and updated later on.


### PR DESCRIPTION
 #### Problem
After changing device address, SRP host address is changed locally,
but update message is not sent to the server.

 #### Summary of Changes
* Added checking if we are not trying to set the same host name
multiple times, what results in treating address change, as creating
new host and prevents from sending update message.
