### PR TITLE
ESP32: Fix all-clusters-app for Rendezvous BLE

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -58,10 +58,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     CHIP_ERROR err;
     wifi_init_config_t cfg;
     uint8_t ap_mac[6];
-
-    esp_fill_random(ap_mac, sizeof(ap_mac));
-    /* Bit 0 of the first octet of MAC Address should always be 0 */
-    ap_mac[0] &= (uint8_t) ~0x01;
+    wifi_mode_t mode;
 
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();
@@ -87,8 +84,15 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = esp_wifi_init(&cfg);
     SuccessOrExit(err);
 
-    err = esp_wifi_set_mac(ESP_IF_WIFI_AP, ap_mac);
-    SuccessOrExit(err);
+    esp_wifi_get_mode(&mode);
+    if ((mode == WIFI_MODE_AP) || (mode == WIFI_MODE_APSTA))
+    {
+        esp_fill_random(ap_mac, sizeof(ap_mac));
+        /* Bit 0 of the first octet of MAC Address should always be 0 */
+        ap_mac[0] &= (uint8_t) ~0x01;
+        err = esp_wifi_set_mac(ESP_IF_WIFI_AP, ap_mac);
+        SuccessOrExit(err);
+    }
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.


### PR DESCRIPTION
When Rendezvous mode is set to BLE, the SoftAP is not required and hence
setting MAC address of the SoftAP interface gives an error

 #### Problem
For Rendezvous BLE, `esp_wifi_set_mac` fails resulting into failure for `_InitChipStack`

 #### Summary of Changes
 Set AP MAC only when the Wi-Fi mode is AP or AP+STA

Fixes #5533 