### PR TITLE
[TE2] Add a option in chip-echo-responder to enable/disable echo response

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
         mReliableMessageContext.SetAckPending(false);
 
 #if !defined(NDEBUG)
-        if (!sendFlags.Has(SendMessageFlags::kNoAutoRequestAck))
+        if (!sendFlags.Has(SendMessageFlags::kStandaloneAck))
         {
             ChipLogProgress(ExchangeManager, "Piggybacking Ack for MsgId:%08" PRIX32 " with msg",
                             mReliableMessageContext.mPendingPeerAckId);

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -157,8 +157,11 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
         mReliableMessageContext.SetAckPending(false);
 
 #if !defined(NDEBUG)
-        ChipLogProgress(ExchangeManager, "Piggybacking Ack for MsgId:%08" PRIX32 " with msg",
-                        mReliableMessageContext.mPendingPeerAckId);
+        if (!sendFlags.Has(SendMessageFlags::kNoAutoRequestAck))
+        {
+            ChipLogProgress(ExchangeManager, "Piggybacking Ack for MsgId:%08" PRIX32 " with msg",
+                            mReliableMessageContext.mPendingPeerAckId);
+        }
 #endif
     }
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
         mReliableMessageContext.SetAckPending(false);
 
 #if !defined(NDEBUG)
-        if (!sendFlags.Has(SendMessageFlags::kStandaloneAck))
+        if (!payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::StandaloneAck))
         {
             ChipLogProgress(ExchangeManager, "Piggybacking Ack for MsgId:%08" PRIX32 " with msg",
                             mReliableMessageContext.mPendingPeerAckId);

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -64,6 +64,8 @@ enum class SendMessageFlags : uint16_t
     kAutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */
     kExpectResponse = 0x0002,
+    /**< Used to indicate that the message is a Standalone Ack message. */
+    kStandaloneAck = 0x0004,
     /**< Used to indicate that the source node ID in the message header can be reused. */
     kReuseSourceId = 0x0020,
     /**< Used to indicate that the message is already encoded. */

--- a/src/messaging/Flags.h
+++ b/src/messaging/Flags.h
@@ -64,8 +64,6 @@ enum class SendMessageFlags : uint16_t
     kAutoRetrans = 0x0001,
     /**< Used to indicate that a response is expected within a specified timeout. */
     kExpectResponse = 0x0002,
-    /**< Used to indicate that the message is a Standalone Ack message. */
-    kStandaloneAck = 0x0004,
     /**< Used to indicate that the source node ID in the message header can be reused. */
     kReuseSourceId = 0x0020,
     /**< Used to indicate that the message is already encoded. */

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -259,15 +259,12 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     // Send the null message
     if (mExchange != nullptr)
     {
-        Messaging::SendFlags sendFlags;
-
 #if !defined(NDEBUG)
         ChipLogProgress(ExchangeManager, "Sending Standalone Ack for MsgId:%08" PRIX32, mPendingPeerAckId);
 #endif
 
-        sendFlags.Set(Messaging::SendMessageFlags::kStandaloneAck).Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
-
-        err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf), sendFlags);
+        err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
+                                     BitFlags<SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }
     else
     {

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -259,6 +259,9 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     // Send the null message
     if (mExchange != nullptr)
     {
+#if !defined(NDEBUG)
+        ChipLogProgress(ExchangeManager, "Sending solitary ack for MsgId:%08" PRIX32, mPendingPeerAckId);
+#endif
         err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
                                      BitFlags<SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
     }

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -259,11 +259,15 @@ CHIP_ERROR ReliableMessageContext::SendStandaloneAckMessage()
     // Send the null message
     if (mExchange != nullptr)
     {
+        Messaging::SendFlags sendFlags;
+
 #if !defined(NDEBUG)
-        ChipLogProgress(ExchangeManager, "Sending solitary ack for MsgId:%08" PRIX32, mPendingPeerAckId);
+        ChipLogProgress(ExchangeManager, "Sending Standalone Ack for MsgId:%08" PRIX32, mPendingPeerAckId);
 #endif
-        err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf),
-                                     BitFlags<SendMessageFlags>{ SendMessageFlags::kNoAutoRequestAck });
+
+        sendFlags.Set(Messaging::SendMessageFlags::kStandaloneAck).Set(Messaging::SendMessageFlags::kNoAutoRequestAck);
+
+        err = mExchange->SendMessage(Protocols::SecureChannel::MsgType::StandaloneAck, std::move(msgBuf), sendFlags);
     }
     else
     {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Test case 4.13.3.2-1: Piggybacking ACKs on responses - ACKs may be sent at the same time as data in a response. Receivers must maximally way for a time window (CRMP_STANDALONE_ACK_TIMEOUT) before sending a standalone ACK

We need a way to enable/disable piggybacking ACK.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add a option in chip-echo-responder to enable/disable echo response. If echo response is disabled, the standalong ack will be used to ack the request.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5521

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
