### PR TITLE
Change PayloadHeader to just store a ProtocolId directly.

### DIFF
--- a/src/lib/support/BitFlags.h
+++ b/src/lib/support/BitFlags.h
@@ -132,7 +132,7 @@ public:
      * @param flag      Flag(s) to test.
      * @returns         True if any flag in @a flag is set, otherwise false.
      */
-    bool Has(FlagsEnum flag) const { return (mValue & static_cast<IntegerType>(flag)) != 0; }
+    constexpr bool Has(FlagsEnum flag) const { return (mValue & static_cast<IntegerType>(flag)) != 0; }
 
     /**
      * Check that no flags outside the arguments are set.

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -49,11 +49,11 @@ using namespace chip::System;
 namespace chip {
 namespace Messaging {
 
-static void DefaultOnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, uint32_t protocolId, uint8_t msgType,
-                                     PacketBufferHandle payload)
+static void DefaultOnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, Protocols::Id protocolId,
+                                     uint8_t msgType, PacketBufferHandle payload)
 {
-    ChipLogError(ExchangeManager, "Dropping unexpected message %08" PRIX32 ":%d %04" PRIX16 " MsgId:%08" PRIX32, protocolId,
-                 msgType, ec->GetExchangeId(), packetHeader.GetMessageId());
+    ChipLogError(ExchangeManager, "Dropping unexpected message %08" PRIX32 ":%d %04" PRIX16 " MsgId:%08" PRIX32,
+                 protocolId.ToFullyQualifiedSpecForm(), msgType, ec->GetExchangeId(), packetHeader.GetMessageId());
 }
 
 bool ExchangeContext::IsInitiator() const
@@ -405,20 +405,16 @@ void ExchangeContext::HandleResponseTimeout(System::Layer * aSystemLayer, void *
 CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                                           PacketBufferHandle msgBuf)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    uint32_t messageId  = 0;
-    uint16_t protocolId = 0;
-    uint8_t messageType = 0;
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+    uint32_t messageId       = packetHeader.GetMessageId();
+    Protocols::Id protocolId = payloadHeader.GetProtocolID();
+    uint8_t messageType      = payloadHeader.GetMessageType();
 
     // We hold a reference to the ExchangeContext here to
     // guard against Close() calls(decrementing the reference
     // count) by the protocol before the CHIP Exchange
     // layer has completed its work on the ExchangeContext.
     Retain();
-
-    messageId   = packetHeader.GetMessageId();
-    protocolId  = payloadHeader.GetProtocolID();
-    messageType = payloadHeader.GetMessageType();
 
     if (payloadHeader.IsAckMsg())
     {

--- a/src/protocols/Protocols.h
+++ b/src/protocols/Protocols.h
@@ -37,7 +37,10 @@ class Id
 public:
     constexpr Id(VendorId aVendorId, uint16_t aProtocolId) : mVendorId(aVendorId), mProtocolId(aProtocolId) {}
 
-    constexpr bool operator==(const Id & aOther) { return mVendorId == aOther.mVendorId && mProtocolId == aOther.mProtocolId; }
+    constexpr bool operator==(const Id & aOther) const
+    {
+        return mVendorId == aOther.mVendorId && mProtocolId == aOther.mProtocolId;
+    }
 
     // Convert the Protocols::Id to a TLV profile id.
     // NOTE: We may want to change the TLV reader/writer to take Protocols::Id

--- a/src/transport/raw/MessageHeader.cpp
+++ b/src/transport/raw/MessageHeader.cpp
@@ -113,7 +113,7 @@ uint16_t PayloadHeader::EncodeSizeBytes() const
 {
     size_t size = kEncryptedHeaderSizeBytes;
 
-    if (mVendorId.HasValue())
+    if (HaveVendorId())
     {
         size += kVendorIdSizeBytes;
     }
@@ -221,20 +221,24 @@ CHIP_ERROR PayloadHeader::Decode(const uint8_t * const data, uint16_t size, uint
 
     mExchangeFlags.SetRaw(header);
 
-    if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_VendorIdPresent))
+    VendorId vendor_id;
+    if (HaveVendorId())
     {
-        uint16_t vendor_id;
-        err = reader.Read16(&vendor_id).StatusCode();
+        uint16_t vendor_id_raw;
+        err = reader.Read16(&vendor_id_raw).StatusCode();
         SuccessOrExit(err);
-        mVendorId.SetValue(vendor_id);
+        vendor_id = static_cast<VendorId>(vendor_id_raw);
     }
     else
     {
-        mVendorId.ClearValue();
+        vendor_id = VendorId::Common;
     }
 
-    err = reader.Read16(&mProtocolID).StatusCode();
+    uint16_t protocol_id;
+    err = reader.Read16(&protocol_id).StatusCode();
     SuccessOrExit(err);
+
+    mProtocolID = Protocols::Id(vendor_id, protocol_id);
 
     if (mExchangeFlags.Has(Header::ExFlagValues::kExchangeFlag_AckMsg))
     {
@@ -328,11 +332,11 @@ CHIP_ERROR PayloadHeader::Encode(uint8_t * data, uint16_t size, uint16_t * encod
     Write8(p, header);
     Write8(p, mMessageType);
     LittleEndian::Write16(p, mExchangeID);
-    if (mVendorId.HasValue())
+    if (HaveVendorId())
     {
-        LittleEndian::Write16(p, mVendorId.Value());
+        LittleEndian::Write16(p, static_cast<std::underlying_type_t<VendorId>>(mProtocolID.GetVendorId()));
     }
-    LittleEndian::Write16(p, mProtocolID);
+    LittleEndian::Write16(p, mProtocolID.GetProtocolId());
     if (mAckId.HasValue())
     {
         LittleEndian::Write32(p, mAckId.Value());

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -147,7 +147,7 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     uint16_t decodeLen;
 
     header.SetMessageType(Protocols::Id(VendorId::Common, 0), 112).SetExchangeID(2233);
-    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == Protocols::Id(VendorId::Common, 0));
 
     header.SetMessageType(Protocols::Id(VendorId::Common, 1221), 112).SetExchangeID(2233).SetInitiator(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
@@ -157,30 +157,26 @@ void TestPayloadHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetMessageType() == 112);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
-    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
-    NL_TEST_ASSERT(inSuite, !header.GetVendorId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == Protocols::Id(VendorId::Common, 1221));
     NL_TEST_ASSERT(inSuite, header.IsInitiator());
 
     header.SetMessageType(Protocols::Id(VendorId::Common, 1221), 112).SetExchangeID(2233);
-    header.SetVendorId(6789);
 
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
-    header.SetMessageType(Protocols::Id(VendorId::Common, 0), 111).SetExchangeID(222);
+    header.SetMessageType(Protocols::Id(VendorId::NotSpecified, 0), 111).SetExchangeID(222);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
-    NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == Protocols::Id(VendorId::Common, 1221));
 
-    header.SetMessageType(Protocols::Id(VendorId::Common, 4567), 221).SetExchangeID(3322);
-    header.SetVendorId(8976);
+    header.SetMessageType(Protocols::Id(VendorId::NotSpecified, 4567), 221).SetExchangeID(3322);
 
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, encodeLen == decodeLen);
     NL_TEST_ASSERT(inSuite, header.GetExchangeID() == 2233);
-    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == 1221);
-    NL_TEST_ASSERT(inSuite, header.GetVendorId() == Optional<uint16_t>::Value(6789));
+    NL_TEST_ASSERT(inSuite, header.GetProtocolID() == Protocols::Id(VendorId::Common, 1221));
 }
 
 void TestPacketHeaderEncodeDecodeBounds(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
The current setup with separate vendor id (maybe absent) and protocol
id makes it possible for things to get out of sync (e.g. setting a
message type, which is tied to a vendor/protocol pair, then changing
the vendor id out from under things.

In the new setup the only way to set a vendor id or protocol id via
public API is by setting a message type, and vice versa.

Unifying the storage also reduces the codesize a bit.

Fixes https://github.com/project-chip/connectedhomeip/issues/5543
