### PR TITLE
Add checkout and rollback API in IM message builder

### DIFF
--- a/src/app/MessageDef/Builder.h
+++ b/src/app/MessageDef/Builder.h
@@ -73,6 +73,21 @@ public:
      */
     chip::TLV::TLVWriter * GetWriter() { return mpWriter; };
 
+    /**
+     * Checkpoint the current tlv state into a TLVWriter
+     *
+     * @param[out] aPoint A writer to checkpoint the state of the TLV writer into.
+     *                    This writer must not outlive the builder
+     */
+    void Checkpoint(chip::TLV::TLVWriter & aPoint) { aPoint = *mpWriter; };
+
+    /**
+     * Rollback the request state to the checkpointed TLVWriter
+     *
+     * @param[in] aPoint A that captured the state via Checkpoint() at some point in the past
+     */
+    void Rollback(const chip::TLV::TLVWriter & aPoint) { *mpWriter = aPoint; }
+
 protected:
     CHIP_ERROR mError;
     chip::TLV::TLVWriter * mpWriter;


### PR DESCRIPTION
Problem:
Need checkpoint API to get the previous IM TLV buffer state, when written
data is overflowed in current buffer, need rollback API to get last good IM TLV buffer
State.

Summary of Changes:
-- Add Checkpoint API to Checkpoint the current tlv state into a TLVWriter
-- Add Rollback the request state into the checkpointed TLVWriter
-- Add unit test
Note: this is one sliced PR from PR 4800

