### PR TITLE
Fix build on gcc >= 10

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -80,7 +80,9 @@ CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transpor
     mContextsInUse = 0;
 
     for (auto & handler : UMHandlerPool)
+    {
         handler = {};
+    }
 
     mTransportMgr->SetRendezvousSession(this);
 

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -79,7 +79,8 @@ CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transpor
 
     mContextsInUse = 0;
 
-    memset(UMHandlerPool, 0, sizeof(UMHandlerPool));
+    for (auto & handler : UMHandlerPool)
+        handler = {};
 
     mTransportMgr->SetRendezvousSession(this);
 


### PR DESCRIPTION
 #### Problem
The build would fail on gcc 10 because of memset called on an array of objects whose default constructor initializes a member with a non-zero value.

 #### Summary of Changes
Clear the array using C++ value initialization so that the default constructor is called.