### PR TITLE
HotFix: Fixing build fail

### DIFF
--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -24,7 +24,6 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
-#include <support/ReturnMacros.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 


### PR DESCRIPTION
#### Problem
- Build is failing due to missing reference ReturnMacros.h in src/platform/Darwin/MdnsImpl.cpp

#### Summary of Changes
- Updated the MdnsImpl.cpp file and removed the ReturnMacros.h reference

#### Test
- Used the `./scripts/tools/zap_regen_all.py ` and `./gn_build.sh ` to verify the building is successful 