### PR TITLE
Update MdsnImpl file with CodeUtils.h reference

### DIFF
--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -24,6 +24,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
+#include <support/CodeUtils.h>
 #include <support/SafeInt.h>
 #include <support/logging/CHIPLogging.h>
 


### PR DESCRIPTION
#### Problem
- File src/platform/Darwin/MdnsImpl.cpp is using transitive include

#### Summary of Changes
- Updated the MdnsImpl.cpp file and inlcuded CodesUtil.h

#### Test
- Used the `./scripts/tools/zap_regen_all.py ` and `./gn_build.sh ` to verify the building is successful 