### PR TITLE
[hotfix] Initialize UnsolicitedMessageHandler::Delegate to nullptr to avoid bu…

### DIFF
--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -231,7 +231,7 @@ private:
 
     struct UnsolicitedMessageHandler
     {
-        UnsolicitedMessageHandler() : ProtocolId(Protocols::NotSpecified) {}
+        UnsolicitedMessageHandler() : Delegate(nullptr), ProtocolId(Protocols::NotSpecified) {}
         ExchangeDelegate * Delegate;
         Protocols::Id ProtocolId;
         int16_t MessageType;


### PR DESCRIPTION
…ild bustage

 #### Problem

Looks like `Delegate` is not set to `nullptr` since #5566 and it creates build/test issues.

 #### Summary of Changes
 * Initialize `Delegate` to `nullptr` by default 
