### PR TITLE
[TE1] Set QR Code payload version to 0

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -403,7 +403,7 @@ std::string createSetupPayload()
     }
 
     SetupPayload payload;
-    payload.version               = 1;
+    payload.version               = 0;
     payload.discriminator         = discriminator;
     payload.setUpPINCode          = setupPINCode;
     payload.rendezvousInformation = static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -122,7 +122,7 @@ CHIP_ERROR PrintQRCodeContent()
     err = ConfigurationMgr().GetProductId(productId);
     SuccessOrExit(err);
 
-    payload.version       = 1;
+    payload.version       = 0;
     payload.vendorID      = vendorId;
     payload.productID     = productId;
     payload.setUpPINCode  = setUpPINCode;

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -122,7 +122,7 @@ CHIP_ERROR PrintQRCodeContent()
     err = ConfigurationMgr().GetProductId(productId);
     SuccessOrExit(err);
 
-    payload.version       = 1;
+    payload.version       = 0;
     payload.vendorID      = vendorId;
     payload.productID     = productId;
     payload.setUpPINCode  = setUpPINCode;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -285,7 +285,7 @@ CHIP_ERROR Device::OpenPairingWindow(uint32_t timeout, PairingWindowOption optio
 
     ReturnErrorOnFailure(SendMessage(std::move(outBuffer), header));
 
-    setupPayload.version               = 1;
+    setupPayload.version               = 0;
     setupPayload.rendezvousInformation = RendezvousInformationFlags::kBLE;
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
 #### Problem
As per section 5.1.2 Table 31, the QR Code payload version should be 000 (3 bits) and it is not the case with the examples

 #### Summary of Changes
Set payload version to 0 in the examples