### PR TITLE
Initialize UnsolicitedMessageHandler::Delegate to nullptr to avoid build bustage

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -81,7 +81,10 @@ CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transpor
 
     for (auto & handler : UMHandlerPool)
     {
-        handler = {};
+        // Mark all handlers as unallocated.  This handles both initial
+        // initialization and the case when the consumer shuts us down and
+        // then re-initializes without removing registered handlers.
+        handler.Delegate = nullptr;
     }
 
     mTransportMgr->SetRendezvousSession(this);


### PR DESCRIPTION
This is a version of https://github.com/project-chip/connectedhomeip/pull/5574 modified to address my review comment.  Doing it this way to land more expediently, because @vivien-apple is busy right now.
