### PR TITLE
[hotfix] Remove #include<support/ReturnMacros.h>

### DIFF
--- a/src/protocols/secure_channel/StatusReport.cpp
+++ b/src/protocols/secure_channel/StatusReport.cpp
@@ -21,7 +21,6 @@
 
 #include <support/BufferReader.h>
 #include <support/CodeUtils.h>
-#include <support/ReturnMacros.h>
 
 #include <type_traits>
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
#5359 breaks ToT due to #5545 