### PR TITLE
Remove unused header (issue 5049)

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -31,8 +31,6 @@
 
 #include <thread>
 
-#include "MdnsImpl.h"
-
 #include <arpa/inet.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>


### PR DESCRIPTION
 #### Problem
In the filesrc\platform\Linux\PlatformManagerImpl.cpp an include of MdnsImpl.h is done.
This header file needs the installation of the avahi package.
Because this include is not necessary to build the file we can remove it.

 #### Summary of Changes
 The include has been removed.

 Fixes #5049
