### PR TITLE
Switch bluez repo to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 	branch = master
 [submodule "bluez"]
 	path = third_party/bluez/repo
-	url = https://kernel.googlesource.com/pub/scm/bluetooth/bluez.git
+	url = https://github.com/bluez/bluez.git
 	branch = master
 [submodule "ot-commissioner"]
 	path = third_party/ot-commissioner/repo


### PR DESCRIPTION
 #### Problem
Checkout in china encounters errors for the googlesource.com repo copy.

 #### Summary of Changes
Use github repository for bluez