### PR TITLE
Fix Echo end-to-end testing failure on TCP connection

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -277,7 +277,7 @@ void StartPinging(streamer_t * stream, char * destination)
         err = gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &admins);
         SuccessOrExit(err);
 
-        err = gExchangeManager.Init(kTestControllerNodeId, &gTCPManager, &gSessionManager);
+        err = gExchangeManager.Init(&gSessionManager);
         SuccessOrExit(err);
     }
     else
@@ -286,7 +286,7 @@ void StartPinging(streamer_t * stream, char * destination)
         err = gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &admins);
         SuccessOrExit(err);
 
-        err = gExchangeManager.Init(kTestControllerNodeId, &gUDPManager, &gSessionManager);
+        err = gExchangeManager.Init(&gSessionManager);
         SuccessOrExit(err);
     }
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -147,10 +147,10 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, nullptr, &admins);
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, &chip::gTransportManager, &admins);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = chip::gExchangeManager.Init(chip::kTestDeviceNodeId, &chip::gTransportManager, &chip::gSessionManager);
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -42,6 +42,7 @@
 #include <nlunit-test.h>
 
 namespace chip {
+System::Layer gSystemLayer;
 SecureSessionMgr gSessionManager;
 Messaging::ExchangeManager gExchangeManager;
 TransportMgr<Transport::UDP> gTransportManager;
@@ -135,6 +136,7 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
 } // namespace chip
 
 namespace {
+
 void InitializeChip(nlTestSuite * apSuite)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -147,7 +149,9 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, &chip::gTransportManager, &admins);
+    chip::gSystemLayer.Init(nullptr);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = chip::gExchangeManager.Init(&chip::gSessionManager);
@@ -160,12 +164,13 @@ void InitializeChip(nlTestSuite * apSuite)
 
 // clang-format off
 const nlTest sTests[] =
-        {
-                NL_TEST_DEF("CheckReadClient", chip::app::TestReadInteraction::TestReadClient),
-                NL_TEST_DEF("CheckReadHandler", chip::app::TestReadInteraction::TestReadHandler),
-                NL_TEST_SENTINEL()
-        };
+{
+    NL_TEST_DEF("CheckReadClient", chip::app::TestReadInteraction::TestReadClient),
+    NL_TEST_DEF("CheckReadHandler", chip::app::TestReadInteraction::TestReadHandler),
+    NL_TEST_SENTINEL()
+};
 // clang-format on
+
 } // namespace
 
 int TestEventLogging()

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -290,7 +290,7 @@ int main(int argc, char * argv[])
     err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &admins);
     SuccessOrExit(err);
 
-    err = gExchangeManager.Init(chip::kTestControllerNodeId, &gTransportManager, &gSessionManager);
+    err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -122,7 +122,7 @@ int main(int argc, char * argv[])
     err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &admins);
     SuccessOrExit(err);
 
-    err = gExchangeManager.Init(chip::kTestDeviceNodeId, &gTransportManager, &gSessionManager);
+    err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);

--- a/src/messaging/ChannelContext.cpp
+++ b/src/messaging/ChannelContext.cpp
@@ -254,7 +254,7 @@ void ChannelContext::HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, cons
 CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
                                                            System::PacketBufferHandle msgIn)
 {
-    return mExchangeManager->GetTransportManager()->SendMessage(header, peerAddress, std::move(msgIn));
+    return mExchangeManager->GetSessionMgr()->GetTransportManager()->SendMessage(header, peerAddress, std::move(msgIn));
 }
 
 CHIP_ERROR ChannelContext::HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
@@ -272,9 +272,9 @@ void ChannelContext::EnterCasePairingState()
     // TODO: currently only supports IP/UDP paring
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(mStateVars.mPreparing.mAddress);
-    CHIP_ERROR err = mStateVars.mPreparing.mCasePairingSession->EstablishSession(addr, mExchangeManager->GetLocalNodeId(),
-                                                                                 mStateVars.mPreparing.mBuilder.GetPeerNodeId(),
-                                                                                 mExchangeManager->GetNextKeyId(), this);
+    CHIP_ERROR err = mStateVars.mPreparing.mCasePairingSession->EstablishSession(
+        addr, mExchangeManager->GetSessionMgr()->GetLocalNodeId(), mStateVars.mPreparing.mBuilder.GetPeerNodeId(),
+        mExchangeManager->GetNextKeyId(), this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -64,15 +64,13 @@ ExchangeManager::ExchangeManager() : mReliableMessageMgr(mContextPool)
     mState = State::kState_NotInitialized;
 }
 
-CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr)
+CHIP_ERROR ExchangeManager::Init(SecureSessionMgr * sessionMgr)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrReturnError(mState == State::kState_NotInitialized, err = CHIP_ERROR_INCORRECT_STATE);
 
-    mLocalNodeId  = localNodeId;
-    mTransportMgr = transportMgr;
-    mSessionMgr   = sessionMgr;
+    mSessionMgr = sessionMgr;
 
     mNextExchangeId = GetRandU16();
     mNextKeyId      = 0;
@@ -87,7 +85,7 @@ CHIP_ERROR ExchangeManager::Init(NodeId localNodeId, TransportMgrBase * transpor
         handler.Delegate = nullptr;
     }
 
-    mTransportMgr->SetRendezvousSession(this);
+    mSessionMgr->GetTransportManager()->SetRendezvousSession(this);
 
     sessionMgr->SetDelegate(this);
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -71,7 +71,7 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(NodeId localNodeId, TransportMgrBase * transportMgr, SecureSessionMgr * sessionMgr);
+    CHIP_ERROR Init(SecureSessionMgr * sessionMgr);
 
     /**
      *  Shutdown the ExchangeManager. This terminates this instance
@@ -210,7 +210,6 @@ public:
     void IncrementContextsInUse();
     void DecrementContextsInUse();
 
-    TransportMgrBase * GetTransportManager() const { return mTransportMgr; }
     SecureSessionMgr * GetSessionMgr() const { return mSessionMgr; }
 
     ReliableMessageMgr * GetReliableMessageMgr() { return &mReliableMessageMgr; };
@@ -218,7 +217,6 @@ public:
     MessageCounterSyncMgr * GetMessageCounterSyncMgr() { return &mMessageCounterSyncMgr; };
     Transport::AdminId GetAdminId() { return mAdminId; }
 
-    NodeId GetLocalNodeId() { return mLocalNodeId; }
     uint16_t GetNextKeyId() { return ++mNextKeyId; }
     size_t GetContextsInUse() const { return mContextsInUse; }
 
@@ -237,11 +235,9 @@ private:
         int16_t MessageType;
     };
 
-    NodeId mLocalNodeId; // < Id of the current node
     uint16_t mNextExchangeId;
     uint16_t mNextKeyId;
     State mState;
-    TransportMgrBase * mTransportMgr;
     SecureSessionMgr * mSessionMgr;
     ReliableMessageMgr mReliableMessageMgr;
     MessageCounterSyncMgr mMessageCounterSyncMgr;

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -37,7 +37,7 @@ CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transp
 
     ReturnErrorOnFailure(mSecureSessionMgr.Init(GetSourceNodeId(), &GetSystemLayer(), transport, &mAdmins));
 
-    ReturnErrorOnFailure(mExchangeManager.Init(GetSourceNodeId(), transport, &mSecureSessionMgr));
+    ReturnErrorOnFailure(mExchangeManager.Init(&mSecureSessionMgr));
 
     ReturnErrorOnFailure(mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer,
                                                       SecureSessionMgr::PairingDirection::kInitiator, mSrcAdminId));

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -255,7 +255,7 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    err = gExchangeManager.Init(chip::kTestControllerNodeId, &gUDPManager, &gSessionManager);
+    err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
     // Start the CHIP connection to the CHIP echo responder.

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -102,7 +102,7 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    err = gExchangeManager.Init(chip::kTestDeviceNodeId, &gUDPManager, &gSessionManager);
+    err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
     err = gEchoServer.Init(&gExchangeManager);

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -404,7 +404,7 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
         ChipLogProgress(Ble, "Received rendezvous message for %llu", packetHeader.GetDestinationNodeId().Value());
         mAdmin->SetNodeId(packetHeader.GetDestinationNodeId().Value());
         mParams.SetLocalNodeId(packetHeader.GetDestinationNodeId().Value());
-        mSecureSessionMgr->SetLocalNodeID(packetHeader.GetDestinationNodeId().Value());
+        mSecureSessionMgr->SetLocalNodeId(packetHeader.GetDestinationNodeId().Value());
     }
 
     if (packetHeader.GetSourceNodeId().HasValue() && !mParams.HasRemoteNodeId())

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -288,7 +288,9 @@ public:
      *
      * @param nodeId    Node id for the current node
      */
-    void SetLocalNodeID(NodeId nodeId) { mLocalNodeId = nodeId; }
+    void SetLocalNodeId(NodeId nodeId) { mLocalNodeId = nodeId; }
+
+    NodeId GetLocalNodeId() { return mLocalNodeId; }
 
     /**
      * @brief
@@ -297,6 +299,8 @@ public:
      *   peer node does not exist.
      */
     Transport::Type GetTransportType(NodeId peerNodeId);
+
+    TransportMgrBase * GetTransportManager() const { return mTransportMgr; }
 
 protected:
     /**


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Echo end-to-end testing on TCP was broken, the regression was introduced by https://github.com/project-chip/connectedhomeip/pull/4019.

With this change, NodeId localNodeId, TransportMgrBase * transportMgr were also added to ExchangeMgr::Init, which are previously owned by SecureSessionMgr. Now both ExchangeMgr and SecureSessionMgr own the reference to localNodeId and transportMgr objects, if those two objects are updated in one place, the change will not get reflected in another place. 

In case of this error,  SecureSessionMgr was initialized to use TCP Transport, but  ExchangeMgr was initialized to use UDP Transport. 

localNodeId, transportMgr objects are owned by SecureSessionMgr and we have already set those two objects to it, so we should not set them to ExchangeMgr again.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Initialize  localNodeId, transportMgr objects only in SecureSessionMgr to avoid discrepancy.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
