### PR TITLE
* Replacement %llu and %zu format specifiers

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#include <inttypes.h>
+
 #include <app/server/Server.h>
 
 #include <app/InteractionModelEngine.h>
@@ -130,7 +132,8 @@ CHIP_ERROR RestoreAllAdminPairingsFromKVS(AdminPairingTable & adminPairings, Adm
         }
         else
         {
-            ChipLogProgress(AppServer, "Found admin pairing for %d, node ID %llu", admin->GetAdminId(), admin->GetNodeId());
+            ChipLogProgress(AppServer, "Found admin pairing for %d, node ID 0x%08" PRIx32 "%08" PRIx32, admin->GetAdminId(),
+                            static_cast<uint32_t>(admin->GetNodeId() >> 32), static_cast<uint32_t>(admin->GetNodeId()));
         }
     }
 
@@ -166,7 +169,9 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr, Rende
         {
             connection.GetPASESession(session);
 
-            ChipLogProgress(AppServer, "Fetched the session information: from %llu", session->PeerConnection().GetPeerNodeId());
+            ChipLogProgress(AppServer, "Fetched the session information: from 0x%08" PRIx32 "%08" PRIx32,
+                            static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId() >> 32),
+                            static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId()));
             sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->PeerConnection().GetPeerAddress()),
                                   session->PeerConnection().GetPeerNodeId(), session,
                                   SecureSessionMgr::PairingDirection::kResponder, connection.GetAdminId(), nullptr);
@@ -315,8 +320,7 @@ public:
     void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
                            System::PacketBufferHandle buffer, SecureSessionMgr * mgr) override
     {
-        auto state            = mgr->GetPeerConnectionState(session);
-        const size_t data_len = buffer->DataLength();
+        auto state = mgr->GetPeerConnectionState(session);
         char src_addr[PeerAddress::kMaxToStringSize];
 
         // as soon as a client connects, assume it is connected
@@ -327,7 +331,7 @@ public:
 
         state->GetPeerAddress().ToString(src_addr);
 
-        ChipLogProgress(AppServer, "Packet received from %s: %zu bytes", src_addr, static_cast<size_t>(data_len));
+        ChipLogProgress(AppServer, "Packet received from %s: %u bytes", src_addr, buffer->DataLength());
 
         // TODO: This code is temporary, and must be updated to use the Cluster API.
         // Issue: https://github.com/project-chip/connectedhomeip/issues/4725

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -440,7 +440,8 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & header, const Trans
         {
             CHIP_ERROR err = context->HandlePairingMessage(header, source, std::move(msgBuf));
             if (err != CHIP_NO_ERROR)
-                ChipLogError(ExchangeManager, "HandlePairingMessage error %s from node %llu.", chip::ErrorStr(err), node);
+                ChipLogError(ExchangeManager, "HandlePairingMessage error %s from node 0x%08" PRIx32 "%08" PRIx32 ".",
+                             chip::ErrorStr(err), static_cast<uint32_t>(node >> 32), static_cast<uint32_t>(node));
             return false;
         }
         return true;
@@ -450,8 +451,9 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & header, const Trans
     {
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
         source.ToString(addrBuffer, sizeof(addrBuffer));
-        ChipLogError(ExchangeManager, "Unencrypted message from %s is dropped since no session found for node %llu.", addrBuffer,
-                     node);
+        ChipLogError(ExchangeManager,
+                     "Unencrypted message from %s is dropped since no session found for node 0x%08" PRIx32 "%08" PRIx32 ".",
+                     addrBuffer, static_cast<uint32_t>(node >> 32), static_cast<uint32_t>(node));
         return;
     }
 }

--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -14,6 +14,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <inttypes.h>
+
 #include <transport/RendezvousSession.h>
 
 #include <core/CHIPEncoding.h>
@@ -351,8 +354,10 @@ void RendezvousSession::OnRendezvousMessageReceived(const PacketHeader & packetH
         // already know the local node id).
         if (packetHeader.GetDestinationNodeId().HasValue())
         {
-            ChipLogProgress(Ble, "Received pairing message for %llu", packetHeader.GetDestinationNodeId().Value());
-            mAdmin->SetNodeId(packetHeader.GetDestinationNodeId().Value());
+            NodeId destNodeId = packetHeader.GetDestinationNodeId().Value();
+            ChipLogProgress(Ble, "Received pairing message for 0x%08" PRIx32 "%08" PRIx32, static_cast<uint32_t>(destNodeId >> 32),
+                            static_cast<uint32_t>(destNodeId));
+            mAdmin->SetNodeId(destNodeId);
         }
 
         err = HandlePairingMessage(packetHeader, peerAddress, std::move(msgBuf));
@@ -401,16 +406,20 @@ CHIP_ERROR RendezvousSession::HandleSecureMessage(const PacketHeader & packetHea
     // Use the node IDs from the packet header only after it's successfully decrypted
     if (packetHeader.GetDestinationNodeId().HasValue() && !mParams.HasLocalNodeId())
     {
-        ChipLogProgress(Ble, "Received rendezvous message for %llu", packetHeader.GetDestinationNodeId().Value());
-        mAdmin->SetNodeId(packetHeader.GetDestinationNodeId().Value());
-        mParams.SetLocalNodeId(packetHeader.GetDestinationNodeId().Value());
-        mSecureSessionMgr->SetLocalNodeId(packetHeader.GetDestinationNodeId().Value());
+        NodeId destNodeId = packetHeader.GetDestinationNodeId().Value();
+        ChipLogProgress(Ble, "Received rendezvous message for 0x%08" PRIx32 "%08" PRIx32, static_cast<uint32_t>(destNodeId >> 32),
+                        static_cast<uint32_t>(destNodeId));
+        mAdmin->SetNodeId(destNodeId);
+        mParams.SetLocalNodeId(destNodeId);
+        mSecureSessionMgr->SetLocalNodeId(destNodeId);
     }
 
     if (packetHeader.GetSourceNodeId().HasValue() && !mParams.HasRemoteNodeId())
     {
-        ChipLogProgress(Ble, "Received rendezvous message from %llu", packetHeader.GetSourceNodeId().Value());
-        mParams.SetRemoteNodeId(packetHeader.GetSourceNodeId().Value());
+        NodeId sourceNodeId = packetHeader.GetSourceNodeId().Value();
+        ChipLogProgress(Ble, "Received rendezvous message from  0x%08" PRIx32 "%08" PRIx32,
+                        static_cast<uint32_t>(sourceNodeId >> 32), static_cast<uint32_t>(sourceNodeId));
+        mParams.SetRemoteNodeId(sourceNodeId);
     }
 
     if (payloadHeader.HasProtocol(Protocols::NetworkProvisioning::Id))

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -75,7 +75,8 @@ CHIP_ERROR SecureSessionMgr::Init(NodeId localNodeId, System::Layer * systemLaye
     mTransportMgr = transportMgr;
     mAdmins       = admins;
 
-    ChipLogProgress(Inet, "local node id is %llu\n", mLocalNodeId);
+    ChipLogProgress(Inet, "local node id is 0x%08" PRIx32 "%08" PRIx32, static_cast<uint32_t>(mLocalNodeId >> 32),
+                    static_cast<uint32_t>(mLocalNodeId));
 
     ScheduleExpiryTimer();
 
@@ -199,7 +200,9 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
         encryptedMsg.mMsgId = packetHeader.GetMessageId();
     }
 
-    ChipLogProgress(Inet, "Sending msg from %llu to %llu", localNodeId, state->GetPeerNodeId());
+    ChipLogProgress(Inet, "Sending msg from 0x%08" PRIx32 "%08" PRIx32 "to 0x%08" PRIx32 "%08" PRIx32,
+                    static_cast<uint32_t>(localNodeId >> 32), static_cast<uint32_t>(localNodeId),
+                    static_cast<uint32_t>(state->GetPeerNodeId() >> 32), static_cast<uint32_t>(state->GetPeerNodeId()));
 
     if (state->GetTransport() != nullptr)
     {
@@ -250,8 +253,8 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
             state, [this](const Transport::PeerConnectionState & state1) { HandleConnectionExpired(state1); });
     }
 
-    ChipLogDetail(Inet, "New pairing for device %llu, key %d!!", peerNodeId, peerKeyId);
-
+    ChipLogDetail(Inet, "New pairing for device 0x%08" PRIx32 "%08" PRIx32 ", key %d!!", static_cast<uint32_t>(peerNodeId >> 32),
+                  static_cast<uint32_t>(peerNodeId), peerKeyId);
     state = nullptr;
     ReturnErrorOnFailure(
         mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));


### PR DESCRIPTION
#### Problem
* 64-bit %llu format specifier not supported for newlib nano printf library.
Only used currently to print 64-bit NodeId type.

* size_t %zu format specifier also not supported.
Only used in non test code for an actual 16-bit defined value.

Note:
Remaining cases still exist for code not used on constrained devices.
Should not pose an issue there as larger printf libraries are used.

 #### Summary of Changes
* Replaced prints of NodeId with hex 32-bit counterparts
* Replaced %zu specifier to %u as sufficient for the type

Fixes #5314