### PR TITLE
Fix typo in build file of lighting-app EFR32

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -148,7 +148,7 @@ efr32_executable("lighting_app") {
 
     sources += [
       "${chip_root}/examples/common/pigweed/RpcService.cpp",
-      "${chip_root}/examples/common/pigweed/efr32/PigeedLoggerMutex.cpp",
+      "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
       "${examples_plat_dir}/PigweedLogger.cpp",
       "${examples_plat_dir}/uart.c",
       "src/Rpc.cpp",


### PR DESCRIPTION
Fix typo which breaks the RPC EFR32 lighting app build.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Typo in lighting app build file causes RPC build to fail: 
ninja: error: '../../third_party/connectedhomeip/examples/common/pigweed/efr32/PigeedLoggerMutex.cpp', needed by 'obj/third_party/connectedhomeip/examples/common/pigweed/efr32/chip-efr32-lighting-example.out.PigeedLoggerMutex.cpp.o', missing and no known rule to make it

 #### Summary of Changes
Fix Typo.
