### PR TITLE
Fix potential use of uninitialized value on linux

### DIFF
--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -39,14 +39,15 @@ KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
 CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,
                                           size_t offset_bytes)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
     size_t read_size;
-    size_t copy_size;
+
+    // Copy data into value buffer
+    VerifyOrReturnError(value != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     // On linux read first without a buffer which returns the size, and then
     // use a local buffer to read the entire object, which allows partial and
     // offset reads.
-    err = mStorage.ReadValueBin(key, nullptr, 0, read_size);
+    CHIP_ERROR err = mStorage.ReadValueBin(key, nullptr, 0, read_size);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
     {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -59,17 +60,14 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     uint8_t buf[read_size];
     ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf, read_size, read_size));
 
-    // Copy data into value buffer
-    if (!value)
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-    copy_size = std::min(value_size, read_size - offset_bytes);
-    if (read_bytes_size)
+    size_t copy_size = std::min(value_size, read_size - offset_bytes);
+    if (read_bytes_size != nullptr)
     {
         *read_bytes_size = copy_size;
     }
     ::memcpy(value, buf + offset_bytes, copy_size);
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -47,11 +47,12 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     // use a local buffer to read the entire object, which allows partial and
     // offset reads.
     err = mStorage.ReadValueBin(key, nullptr, 0, read_size);
-    uint8_t buf[read_size];
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
     {
         ExitNow(err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     }
+
+    uint8_t buf[read_size];
     err = mStorage.ReadValueBin(key, buf, read_size, read_size);
     SuccessOrExit(err);
 

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -49,17 +49,20 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     err = mStorage.ReadValueBin(key, nullptr, 0, read_size);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
     {
-        ExitNow(err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+    else if (err != CHIP_NO_ERROR)
+    {
+        return err;
     }
 
     uint8_t buf[read_size];
-    err = mStorage.ReadValueBin(key, buf, read_size, read_size);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf, read_size, read_size));
 
     // Copy data into value buffer
     if (!value)
     {
-        ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     copy_size = std::min(value_size, read_size - offset_bytes);
     if (read_bytes_size)
@@ -67,9 +70,6 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
         *read_bytes_size = copy_size;
     }
     ::memcpy(value, buf + offset_bytes, copy_size);
-
-exit:
-    return err;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)


### PR DESCRIPTION
 #### Problem
When kvs read gets an error (e.g. KEY_NOT_FOUND), the linux implementation still tries to allocate a buffer on the stack before returning failure, which can result in SEGV (on my system I had the uninitialized value quite large).

 #### Summary of Changes
Memory allocate on the stack post error checking.