### PR TITLE
Remove non-standard BLE advertisement opcode "1"

### DIFF
--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -47,13 +47,7 @@ struct ChipBLEDeviceIdentificationInfo
 {
     constexpr static uint16_t kDiscriminatorMask = 0xfff;
 
-    enum
-    {
-        kPairingStatus_Unpaired = 0,
-        kPairingStatus_Paired   = 1,
-    };
-
-    uint8_t PairingStatus;
+    uint8_t OpCode;
     uint8_t DeviceDiscriminator[2];
     uint8_t DeviceVendorId[2];
     uint8_t DeviceProductId[2];

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.cpp
@@ -829,20 +829,6 @@ GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble:
     SuccessOrExit(err);
     deviceIdInfo.SetDeviceDiscriminator(discriminator);
 
-    // TODO: Update when CHIP service/fabric provision is implemented
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    deviceIdInfo.PairingStatus = ThreadStackMgr().IsThreadAttached()
-        ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
-        : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
-#elif CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    deviceIdInfo.PairingStatus = ConnectivityMgr().IsWiFiStationConnected()
-        ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
-        : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
-#else
-    deviceIdInfo.PairingStatus = Impl()->_IsPairedToAccount() ? Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Paired
-                                                              : Ble::ChipBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
-#endif
-
 exit:
     return err;
 }


### PR DESCRIPTION
Opcode is always zero per spec, and the advertisement shall not made at
all once a device is commissioned.

Remove logic in ChipBLEDeviceIdentificationInfo to specify an opcode of
"1" once the device is commissioned.