### PR TITLE
Add initial Cluster Attribute Management support during Read Interaction

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -82,6 +82,7 @@ static_library("app") {
     "ReadHandler.cpp",
     "decoder.cpp",
     "encoder.cpp",
+    "reporting/ReportingEngine.cpp",
   ]
 
   public_deps = [

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -28,10 +28,14 @@ static_library("app") {
   output_name = "libCHIPDataModel"
 
   sources = [
+    "ClusterCatalog.cpp",
+    "ClusterCatalog.ipp",
+    "ClusterData.cpp",
     "Command.cpp",
     "Command.h",
     "CommandHandler.cpp",
     "CommandSender.cpp",
+    "InteractionModelDelegate.h",
     "InteractionModelEngine.cpp",
     "MessageDef/AttributeDataElement.cpp",
     "MessageDef/AttributeDataElement.h",

--- a/src/app/Catalog.h
+++ b/src/app/Catalog.h
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *    Defines catalogs that are used to house cluster data sources/sinks and can be used with the
+ *    various Interaction Model engines to correctly map to/from path to actual cluster
+ *    data instances.
+ *
+ */
+
+#pragma once
+
+#include <app/ClusterData.h>
+#include <app/MessageDef/AttributePath.h>
+
+namespace chip {
+namespace app {
+
+/* A structure representing a path to a property or set of attributes within a cluster instance */
+struct AttributePathParams
+{
+    AttributePathParams() {}
+    AttributePathParams(ClusterDataHandle aDataHandle, AttributePathHandle aAttributePathHandle) :
+        mClusterDataHandle(aDataHandle), mAttributePathHandle(aAttributePathHandle)
+    {}
+    bool operator==(const AttributePathParams & aClusterPathParams) const
+    {
+        return ((aClusterPathParams.mClusterDataHandle == mClusterDataHandle) &&
+                (aClusterPathParams.mAttributePathHandle == mAttributePathHandle));
+    }
+    bool IsValid() { return !(mAttributePathHandle == kNullAttributePathHandle); }
+    ClusterDataHandle mClusterDataHandle     = 0;
+    AttributePathHandle mAttributePathHandle = kNullAttributePathHandle;
+};
+
+/*
+ *  @class CatalogInterface
+ *
+ *  @brief A catalog interface that all concrete catalogs need to adhere to.
+ *
+ */
+template <typename T>
+class CatalogInterface
+{
+public:
+    /**
+     * Given a AttributePath Parser
+     * and return the matching handle to the cluster.
+     */
+    virtual CHIP_ERROR LocateClusterDataHandle(AttributePath::Parser & aParser, ClusterDataHandle & aClusterDataHandle) const = 0;
+    /**
+     * Given a cluster id and endpoint id, return a reference to the matching cluster data instance.
+     */
+    virtual CHIP_ERROR LocateClusterDataHandle(ClusterId aClusterId, EndpointId aEndpointId, ClusterDataHandle & aHandle) const = 0;
+    /**
+     * Given a handle, return a reference to the matching cluster data instance.
+     */
+    virtual CHIP_ERROR LocateClusterInstance(ClusterDataHandle aClusterDataHandle, T ** aClusterInstance) const = 0;
+
+    virtual CHIP_ERROR GetClusterId(ClusterDataHandle aHandle, ClusterId & aClusterId) const    = 0;
+    virtual CHIP_ERROR GetEndpointId(ClusterDataHandle aHandle, EndpointId & aEndpointId) const = 0;
+    virtual CHIP_ERROR GetNodeId(ClusterDataHandle aHandle, NodeId & aNodeId) const             = 0;
+
+    virtual ~CatalogInterface() = default;
+};
+
+}; // namespace app
+}; // namespace chip

--- a/src/app/ClusterCatalog.cpp
+++ b/src/app/ClusterCatalog.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/ClusterCatalog.ipp>
+#include <app/ClusterData.h>
+
+namespace chip {
+namespace app {
+
+template class ClusterCatalog<ClusterDataSink>;
+template class ClusterCatalog<ClusterDataSource>;
+
+}; // namespace app
+}; // namespace chip

--- a/src/app/ClusterCatalog.h
+++ b/src/app/ClusterCatalog.h
@@ -1,0 +1,87 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020 Google, LLC.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/Catalog.h>
+#include <app/util/basic-types.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+
+namespace chip {
+namespace app {
+/*
+ *  @class ClusterCatalog
+ *
+ *  @brief A Chip provided reference implementation of the Catalog interface for a collection of cluster data instances
+ *         that all refer to the same node Id. It provides an array-backed, bounded storage for these instances.
+ */
+template <typename T>
+class ClusterCatalog : public CatalogInterface<T>
+{
+public:
+    struct CatalogItem
+    {
+        EndpointId mEndpointId;
+        T * mpCluster;
+    };
+
+    /*
+     * Instances a cluster catalog given a pointer to the underlying array store.
+     */
+    ClusterCatalog(NodeId aNodeId, CatalogItem * apCatalogStore, uint16_t aNumMaxCatalogItems);
+
+    /*
+     * Add a new cluster data instance into the catalog for a particular endpoint and return a data handle to it.
+     */
+    CHIP_ERROR Add(EndpointId aEndpointId, T * aItem, ClusterDataHandle & aHandle);
+
+    /*
+     * Add a new cluster data instance bound to a user-selected cluster handle for a particular endpoint (which in this particular
+     * implementation, denotes the offset in the array). The handle is to be between 0 and the size of the array. Also, the caller
+     * should ensure no gaps form after every call made to this method.
+     */
+    CHIP_ERROR AddAt(EndpointId aEndpointId, T * aItem, ClusterDataHandle aHandle);
+
+    /**
+     * Removes a cluster instance from the catalog.
+     */
+    CHIP_ERROR Remove(ClusterDataHandle aHandle);
+
+    CHIP_ERROR LocateClusterDataHandle(AttributePath::Parser & aParser, ClusterDataHandle & aClusterDataHandle) const;
+    CHIP_ERROR LocateClusterDataHandle(ClusterId aClusterId, EndpointId aEndpointId, ClusterDataHandle & aHandle) const;
+    CHIP_ERROR LocateClusterInstance(ClusterDataHandle aClusterDataHandle, T ** aClusterInstance) const;
+
+    CHIP_ERROR GetClusterId(ClusterDataHandle aHandle, ClusterId & aClusterId) const;
+    CHIP_ERROR GetEndpointId(ClusterDataHandle aHandle, EndpointId & aEndpointId) const;
+    CHIP_ERROR GetNodeId(ClusterDataHandle aHandle, chip::NodeId & aNodeId) const;
+
+private:
+    CatalogItem * mpCatalogStore    = nullptr;
+    chip::NodeId mNodeId            = 0;
+    uint16_t mNumMaxCatalogItems    = 0;
+    uint16_t mNumOfUsedCatalogItems = 0;
+};
+
+typedef ClusterCatalog<ClusterDataSink> ClusterDataSinkCatalog;
+typedef ClusterCatalog<ClusterDataSource> ClusterDataSourceCatalog;
+
+}; // namespace app
+}; // namespace chip

--- a/src/app/ClusterCatalog.ipp
+++ b/src/app/ClusterCatalog.ipp
@@ -1,0 +1,171 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020 Google, LLC.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/ClusterCatalog.h>
+#include <app/MessageDef/AttributePath.h>
+
+namespace chip {
+namespace app {
+template <typename T>
+ClusterCatalog<T>::ClusterCatalog(NodeId aNodeId, CatalogItem * aCatalogStore, uint16_t aNumMaxCatalogItems)
+{
+    mNodeId = aNodeId;
+    mpCatalogStore          = aCatalogStore;
+    mNumMaxCatalogItems    = aNumMaxCatalogItems;
+    mNumOfUsedCatalogItems = 0;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::Add(EndpointId aEndpointId, T * aItem, ClusterDataHandle & aHandle)
+{
+    if (mNumOfUsedCatalogItems >= mNumMaxCatalogItems)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+
+    mpCatalogStore[mNumOfUsedCatalogItems].mEndpointId = aEndpointId;
+    mpCatalogStore[mNumOfUsedCatalogItems].mpCluster   = aItem;
+    aHandle                                            = mNumOfUsedCatalogItems++;
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::AddAt(chip::EndpointId aEndpointId, T * aItem, ClusterDataHandle aHandle)
+{
+    if (aHandle >= mNumMaxCatalogItems)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mpCatalogStore[aHandle].mEndpointId = aEndpointId;
+    mpCatalogStore[aHandle].mpCluster       = aItem;
+    mNumOfUsedCatalogItems++;
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::Remove(ClusterDataHandle aHandle)
+{
+    if (aHandle >= mNumOfUsedCatalogItems)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    mpCatalogStore[aHandle].mpCluster = nullptr;
+
+    return CHIP_NO_ERROR;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::LocateClusterDataHandle(app::AttributePath::Parser & aParser, ClusterDataHandle & aClusterDataHandle) const
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    ClusterId clusterId  = 0;
+    EndpointId endpointId = 0;
+
+    err = aParser.GetClusterId(&clusterId);
+    SuccessOrExit(err);
+
+    err = aParser.GetEndpointId(&endpointId);
+    if ((CHIP_NO_ERROR != err) && (CHIP_END_OF_TLV != err))
+    {
+        ExitNow();
+    }
+
+    VerifyOrExit(clusterId != 0, err = CHIP_ERROR_TLV_TAG_NOT_FOUND);
+
+    err = LocateClusterDataHandle(clusterId, endpointId, aClusterDataHandle);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::LocateClusterDataHandle(ClusterId aClusterId, EndpointId aEndpointId, ClusterDataHandle & aHandle) const
+{
+    for (uint16_t i = 0; i < mNumOfUsedCatalogItems; i++)
+    {
+        if (mpCatalogStore[i].mpCluster != nullptr)
+        {
+            if ((mpCatalogStore[i].mpCluster->GetSchemaEngine()->GetClusterId() == aClusterId) &&
+                (mpCatalogStore[i].mEndpointId == aEndpointId))
+            {
+                aHandle = i;
+                return CHIP_NO_ERROR;
+            }
+        }
+    }
+
+    return CHIP_ERROR_INVALID_PROFILE_ID;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::LocateClusterInstance(ClusterDataHandle aHandle, T ** aClusterInstance) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Make sure the handle exists and mItem is not NULL
+    VerifyOrExit((aHandle < mNumOfUsedCatalogItems && mpCatalogStore[aHandle].mpCluster != nullptr), err = CHIP_ERROR_INVALID_ARGUMENT);
+    *aClusterInstance = mpCatalogStore[aHandle].mpCluster;
+
+exit:
+    return err;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::GetClusterId(ClusterDataHandle aHandle, ClusterId &aClusterId) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit((aHandle < mNumOfUsedCatalogItems && mpCatalogStore[aHandle].mpCluster != nullptr), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mpCatalogStore[aHandle].mpCluster->GetSchemaEngine()!= nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    aClusterId = mpCatalogStore[aHandle].mpCluster->GetSchemaEngine()->GetClusterId();
+
+exit:
+    return err;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::GetEndpointId(ClusterDataHandle aHandle, chip::EndpointId &aEndpointId) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Make sure the handle exists and mpCluster is not nullptr
+    VerifyOrExit((aHandle < mNumOfUsedCatalogItems && mpCatalogStore[aHandle].mpCluster != nullptr), err = CHIP_ERROR_INVALID_ARGUMENT);
+    aEndpointId = mpCatalogStore[aHandle].mEndpointId;
+
+exit:
+    return err;
+}
+
+template <typename T>
+CHIP_ERROR ClusterCatalog<T>::GetNodeId(ClusterDataHandle aHandle, chip::NodeId &aNodeId) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    aNodeId = mNodeId;
+
+    return err;
+}
+
+};
+};
+

--- a/src/app/ClusterData.cpp
+++ b/src/app/ClusterData.cpp
@@ -1,0 +1,417 @@
+/*
+ *
+ *    Copyright (c) 2016-2018 Nest Labs, Inc.
+ *    Copyright (c) 2019-2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file forms the crux of the TDM layer (Cluster data management), providing
+ *      various classes that manage and process data as it applies to Clusters and their
+ *      associated schemas.
+ *
+ */
+
+#include "support/CodeUtils.h"
+#include "support/RandUtils.h"
+#include <app/ClusterData.h>
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/AttributeDataElement.h>
+#include <app/reporting/ReportingEngine.h>
+
+namespace chip {
+namespace app {
+uint64_t ClusterSchemaEngine::GetTag(AttributePathHandle aHandle) const
+{
+    return TLV::ContextTag(GetMap(aHandle)->mContextTag);
+}
+
+CHIP_ERROR ClusterSchemaEngine::RetrieveData(AttributePathHandle aAttributePathHandle, uint64_t aTagToWrite,
+                                             chip::TLV::TLVWriter & aWriter, IGetDataDelegate * apGetDataDelegate) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (IsLeaf(aAttributePathHandle))
+    {
+        bool isPresent = true;
+
+        err = apGetDataDelegate->GetData(aAttributePathHandle, aTagToWrite, aWriter, isPresent);
+        SuccessOrExit(err);
+        VerifyOrExit(isPresent, err = CHIP_ERROR_SCHEMA_MISMATCH);
+    }
+    else
+    {
+        TLV::TLVType type;
+        err = aWriter.StartContainer(aTagToWrite, chip::TLV::kTLVType_Structure, type);
+        SuccessOrExit(err);
+        {
+            AttributePathHandle childProperty;
+            // Recursively iterate over all child nodes and call RetrieveData on them.
+            for (childProperty = GetFirstChild(aAttributePathHandle); !IsNullAttributePathHandle(childProperty);
+                 childProperty = GetNextChild(aAttributePathHandle, childProperty))
+            {
+                const AttributeInfo * childInfo = GetMap(childProperty);
+                err = RetrieveData(childProperty, TLV::ContextTag(childInfo->mContextTag), aWriter, apGetDataDelegate);
+                SuccessOrExit(err);
+            }
+        }
+
+        err = aWriter.EndContainer(type);
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR
+ClusterSchemaEngine::StoreData(AttributePathHandle aHandle, TLV::TLVReader & aReader, ISetDataDelegate * apDelegate) const
+{
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    TLV::TLVType type                = chip::TLV::kTLVType_NotSpecified;
+    AttributePathHandle curHandle    = aHandle;
+    AttributePathHandle parentHandle = kNullAttributePathHandle;
+
+    bool descending = true;
+
+    if (IsLeaf(curHandle))
+    {
+        err = apDelegate->SetData(curHandle, aReader);
+        SuccessOrExit(err);
+    }
+    else
+    {
+        // The crux of this loop is to iteratively parse out TLV and descend into the schema as necessary. The loop is bounded
+        // by the return of the iterator handle (curHandle) back to the original start point (aHandle).
+        //
+        // The loop also has a notion of ascension and descension. Descension occurs when you go deeper into the schema tree while
+        // ascension is returning back to a higher point in the tree.
+        do
+        {
+            {
+                if (!IsLeaf(curHandle))
+                {
+                    if (descending)
+                    {
+                        bool enterContainer = (aReader.GetType() != TLV::kTLVType_Null);
+                        if (enterContainer)
+                        {
+                            err = aReader.EnterContainer(type);
+                            SuccessOrExit(err);
+
+                            parentHandle = curHandle;
+                        }
+                    }
+                }
+                else
+                {
+                    err = apDelegate->SetData(curHandle, aReader);
+                    SuccessOrExit(err);
+
+                    // Setting a leaf data can be interpreted as ascension since you are evaluating another node
+                    // at the same level there-after by going back up to your parent and checking for more children.
+                    descending = false;
+                }
+            }
+
+            // Get the next element in this container.
+            err = aReader.Next();
+            VerifyOrExit((err == CHIP_NO_ERROR) || (err == CHIP_END_OF_TLV), );
+
+            if (err == CHIP_END_OF_TLV)
+            {
+                // We've hit the end of the container - exit out and point our current handle to its parent.
+                // In the process, restore the parentHandle as well.
+                err = aReader.ExitContainer(type);
+                SuccessOrExit(err);
+
+                curHandle    = parentHandle;
+                parentHandle = GetParent(curHandle);
+
+                descending = false;
+            }
+            else
+            {
+                const uint64_t tag = aReader.GetTag();
+
+                descending = true;
+
+                curHandle = GetChildHandle(parentHandle, static_cast<uint8_t>(TLV::TagNumFromTag(tag)));
+
+                if (IsNullAttributePathHandle(curHandle))
+                {
+                    err = CHIP_ERROR_TLV_TAG_NOT_FOUND;
+                    break;
+                }
+            }
+        } while (curHandle != aHandle);
+    }
+
+exit:
+    return err;
+}
+
+AttributePathHandle ClusterSchemaEngine::GetFirstChild(AttributePathHandle aParentHandle) const
+{
+    return GetNextChild(aParentHandle, kRootAttributePathHandle);
+}
+
+bool ClusterSchemaEngine::IsParent(AttributePathHandle aChildHandle, AttributePathHandle aParentHandle) const
+{
+    bool retval = false;
+
+    VerifyOrExit(aChildHandle != kNullAttributePathHandle && aParentHandle != kNullAttributePathHandle, );
+
+    do
+    {
+        aChildHandle = GetParent(aChildHandle);
+
+        if (aChildHandle == aParentHandle)
+        {
+            ExitNow(retval = true);
+        }
+    } while (aChildHandle != kNullAttributePathHandle);
+
+exit:
+    return retval;
+}
+
+AttributePathHandle ClusterSchemaEngine::GetParent(AttributePathHandle aHandle) const
+{
+    const AttributeInfo * handleMap = GetMap(aHandle);
+
+    if (handleMap == nullptr)
+    {
+        return kNullAttributePathHandle;
+    }
+    return handleMap->mParentHandle;
+}
+
+AttributePathHandle ClusterSchemaEngine::GetNextChild(AttributePathHandle aParentHandle, AttributePathHandle aChildHandle) const
+{
+    uint32_t pathHandleIndex;
+
+    // Starting from 1 root path handle after the child node that's been passed in, iterate till we find the next child belonging to
+    // aParentId.
+    for (pathHandleIndex = (uint32_t) aChildHandle - 1U; pathHandleIndex < mSchema.mNumAttributePathHandleEntries;
+         pathHandleIndex++)
+    {
+        if (mSchema.mpAttributeHandleTable[pathHandleIndex].mParentHandle == aParentHandle)
+        {
+            break;
+        }
+    }
+
+    if (pathHandleIndex == mSchema.mNumAttributePathHandleEntries)
+    {
+        return kNullAttributePathHandle;
+    }
+    else
+    {
+        return (static_cast<AttributePathHandle>(pathHandleIndex) + kHandleTableOffset);
+    }
+}
+
+AttributePathHandle ClusterSchemaEngine::GetChildHandle(AttributePathHandle aParentHandle, uint8_t aContextTag) const
+{
+    for (AttributePathHandle childProperty = GetFirstChild(aParentHandle); !IsNullAttributePathHandle(childProperty);
+         childProperty                     = GetNextChild(aParentHandle, childProperty))
+    {
+        if (mSchema.mpAttributeHandleTable[childProperty - kHandleTableOffset].mContextTag == aContextTag)
+        {
+            return childProperty;
+        }
+    }
+
+    return kNullAttributePathHandle;
+}
+
+bool ClusterSchemaEngine::IsLeaf(AttributePathHandle aHandle) const
+{
+    // Root is by definition not a leaf. This also conveniently handles the cases where we have Clusters that
+    // don't have any properties in them.
+    if (aHandle == kRootAttributePathHandle)
+    {
+        return false;
+    }
+    else
+    {
+        for (unsigned int i = 0; i < mSchema.mNumAttributePathHandleEntries; i++)
+        {
+            if (mSchema.mpAttributeHandleTable[i].mParentHandle == aHandle)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+const ClusterSchemaEngine::AttributeInfo * ClusterSchemaEngine::GetMap(AttributePathHandle aHandle) const
+{
+    if (aHandle < kHandleTableOffset || (aHandle >= (mSchema.mNumAttributePathHandleEntries + kHandleTableOffset)))
+    {
+        return nullptr;
+    }
+
+    return &mSchema.mpAttributeHandleTable[aHandle - kHandleTableOffset];
+}
+
+ClusterId ClusterSchemaEngine::GetClusterId(void) const
+{
+    return mSchema.mClusterId;
+}
+
+void ClusterDataSink::SetVersion(DataVersion aVersion)
+{
+    if (mHasValidVersion)
+    {
+        if (aVersion != mVersion)
+        {
+            ChipLogDetail(DataManagement, "Cluster version changed");
+        }
+    }
+    else
+    {
+        ChipLogDetail(DataManagement, "Cluster version not changed");
+    }
+    mVersion         = aVersion;
+    mHasValidVersion = true;
+}
+
+void ClusterDataSink::ClearVersion(void)
+{
+    ChipLogDetail(DataManagement, "Cluster %08x version: cleared", mpSchemaEngine->GetClusterId());
+    mHasValidVersion = false;
+}
+
+ClusterDataSink::ClusterDataSink(const ClusterSchemaEngine * aEngine)
+{
+    mpSchemaEngine   = aEngine;
+    mVersion         = 0;
+    mHasValidVersion = 0;
+}
+
+CHIP_ERROR ClusterDataSink::StoreDataElement(AttributePathHandle aHandle, chip::TLV::TLVReader & aReader)
+{
+    AttributeDataElement::Parser parser;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    DataVersion versionInDataElement;
+
+    VerifyOrExit(aHandle != kNullAttributePathHandle, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = parser.Init(aReader);
+    SuccessOrExit(err);
+
+    err = parser.GetDataVersion(&versionInDataElement);
+    SuccessOrExit(err);
+
+    if (IsVersionNewer(versionInDataElement))
+    {
+        err = parser.GetData(&aReader);
+        if (err == CHIP_END_OF_TLV)
+        {
+            err = CHIP_NO_ERROR;
+        }
+        else
+        {
+            SuccessOrExit(err);
+            err = mpSchemaEngine->StoreData(aHandle, aReader, this);
+        }
+        // Only update the version number if the StoreData succeeded
+        if (err == CHIP_NO_ERROR)
+        {
+            SetVersion(versionInDataElement);
+        }
+        else
+        {
+            // We need to clear this since we don't have a good version of data anymore.
+            ClearVersion();
+        }
+    }
+    else
+    {
+        ChipLogDetail(DataManagement, "<StoreData> no change");
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ClusterDataSink::SetData(AttributePathHandle aHandle, chip::TLV::TLVReader & aReader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (mpSchemaEngine->IsLeaf(aHandle))
+    {
+        err = SetLeafData(aHandle, aReader);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogDetail(DataManagement, "ahandle %u err: %d", aHandle, err);
+        }
+    }
+    return err;
+}
+
+ClusterDataSource::ClusterDataSource(const ClusterSchemaEngine * aEngine)
+{
+    // Set the version to 0, indicating the lack of a valid version.
+    SetVersion(0);
+
+    mSetDirtyCalled = false;
+    mpSchemaEngine  = aEngine;
+}
+
+uint64_t ClusterDataSource::GetVersion(void)
+{
+    // At the time of version retrieval, check to see if the version is still at the sentinel value of 0 (indicating 'no version')
+    // set at construction. If it is, it means that the data source has not over-ridden the version to something other than 0,
+    // indicating that it desires to use randomized data versions.
+    while (mVersion == 0)
+    {
+        mVersion = GetRandU64();
+    }
+
+    return mVersion;
+}
+
+void ClusterDataSource::IncrementVersion()
+{
+    // By invoking GetVersion within here, we get the benefit of checking if the version is currently 0 and if so, randomize it.
+    SetVersion(GetVersion() + 1);
+}
+
+CHIP_ERROR
+ClusterDataSource::GetData(AttributePathHandle aHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter, bool & aIsPresent)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    aIsPresent = true;
+    if (mpSchemaEngine->IsLeaf(aHandle))
+    {
+        err = GetLeafData(aHandle, aTagToWrite, aWriter);
+    }
+
+    return err;
+}
+
+CHIP_ERROR ClusterDataSource::ReadData(AttributePathHandle aHandle, uint64_t aTagToWrite, TLV::TLVWriter & aWriter)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    err            = mpSchemaEngine->RetrieveData(aHandle, aTagToWrite, aWriter, this);
+    return err;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/ClusterData.h
+++ b/src/app/ClusterData.h
@@ -1,0 +1,382 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file forms the crux of the Cluster Data Management layer, providing
+ *      various classes that manage and process data as it applies to Clusters and their
+ *      associated schemas.
+ *
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace app {
+typedef uint32_t AttributePathHandle;
+typedef uint32_t ClusterDataHandle;
+/**
+ * A AttributePathHandle is a unique 32-bit numerical hash of a IM path relative to the root of a Cluster instance. It has two parts
+ * to it:
+ *
+ * Some characteristics:
+ *  - Every Cluster has its own Attribute path handle space.
+ *  - Every unique IM attribute sub-path path will have a similarly unique AttributePathHandle.
+ *  - With this construct, consumer SDK logic never has to deal with IM paths directly. Rather, their interactions with IM are
+ *    conducted exclusively through these handles.
+ *
+ */
+
+// 0 indicates a 'NULL' handle
+constexpr AttributePathHandle kNullAttributePathHandle = 0;
+// 1 indicates a handle that points to the root of the Cluster instance.
+constexpr AttributePathHandle kRootAttributePathHandle = 1;
+/* Offset from the value of a path that provides the index into the table for that handle
+ * It is 2 since the 0 and 1 are special handles.
+ */
+constexpr AttributePathHandle kHandleTableOffset = 2;
+
+inline bool IsRootAttributePathHandle(AttributePathHandle aHandle)
+{
+    return (aHandle == kRootAttributePathHandle);
+}
+
+inline bool IsNullAttributePathHandle(AttributePathHandle aHandle)
+{
+    return (aHandle == kNullAttributePathHandle);
+}
+
+struct ClusterInfo
+{
+    void Init(void) { this->ClearDirty(); }
+    bool IsDirty(void) { return mDirty; }
+    void SetDirty(void) { mDirty = true; }
+    void ClearDirty(void) { mDirty = false; }
+
+    ClusterDataHandle mClusterDataHandle = 0;
+    bool mDirty                          = false;
+};
+
+/**
+ *  @class ClusterSchemaEngine
+ *
+ *  @brief The schema engine takes schema information associated with a particular Cluster and provides facilities to parse and
+ *         translate that into a form usable by the IM machinery. This includes methods to interpret/query the schema itself and
+ *         methods to help read/write out data to/from TLV given a handle.
+ *
+ *         The schema itself is stored in tabular form, sufficiently described to allow for generic parsing/composition of IM
+ *         paths/data for any given Cluster. These tables are what will be the eventual output of 'code-gen'
+ */
+class ClusterSchemaEngine
+{
+public:
+    /* Provides information about a particular path handle including its parent Attribute schema handle,
+     * its context tag and its name.
+     */
+    struct AttributeInfo
+    {
+        AttributePathHandle mParentHandle;
+        uint8_t mContextTag;
+    };
+
+    /**
+     *  @brief
+     *    The main schema structure that houses the schema information.
+     */
+    struct Schema
+    {
+        chip::ClusterId mClusterId;                   //< The ID of the Cluster.
+        const AttributeInfo * mpAttributeHandleTable; //< A pointer to the schema handle table, which provides parent info and
+                                                      //<context tags for each schema handle.
+        uint32_t mNumAttributePathHandleEntries;      //< The number of schema handles in this Cluster.
+        uint32_t mTreeDepth;                          //< The max depth of this schema.
+    };
+
+    /* While Clusters can have deep nested structures, consumer SDK is only expected to provide
+     * getters/setters for 'leaf' nodes in the schema. If one can visualize a schema as a tree (a directed graph where you can have
+     * at most one parent for any given node) where branches indicate the presence of a nested structure, then this analogy fits in
+     * quite nicely.
+     */
+    class ISetDataDelegate
+    {
+    public:
+        /**
+         * Given a path handle to a leaf node and a TLV reader, set the leaf data in the callee.
+         *
+         * @retval #CHIP_NO_ERROR On success.
+         * @retval other           Was unable to read out data from the reader.
+         */
+        virtual CHIP_ERROR SetLeafData(AttributePathHandle aLeafHandle, chip::TLV::TLVReader & aReader) = 0;
+
+        /**
+         * Given a path handle to a node, a TLV reader, and an indication
+         * of whether a null type was received, set the data in the callee.
+         * IM will only call this function for handles that are nullable,
+         * optional, ephemeral, or leafs. If aHandle is a non-leaf node
+         * and is nullified, IM will not call SetData for its children.
+         *
+         * @param[in] aHandle       The AttributePathHandle.
+         *
+         * @param[inout] aReader    The TLV reader to read from.
+         *
+         *
+         * @retval #CHIP_NO_ERROR On success.
+         * @retval other           Was unable to read out data from the reader.
+         */
+        virtual CHIP_ERROR SetData(AttributePathHandle aHandle, chip::TLV::TLVReader & aReader) = 0;
+
+        virtual ~ISetDataDelegate() = default;
+    };
+
+    class IGetDataDelegate
+    {
+    public:
+        /**
+         * Given a path handle to a leaf node and a TLV writer, get the data from the callee.
+         *
+         * @retval #CHIP_NO_ERROR On success.
+         * @retval other           Was unable to retrieve data and write it into the writer.
+         */
+        virtual CHIP_ERROR GetLeafData(AttributePathHandle aLeafHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter) = 0;
+
+        /**
+         * Given a path handle to a node, a TLV writer, and booleans indicating whether the
+         * value is null or not present, get the data from the Cluster source that will build a
+         * report. If the path handle is not a leaf node, IM will handle writing values to
+         * the writer (like opening containers etc). If a non-leaf
+         * node is null or not present, IM will not call GetData for its children.
+         *
+         * This function will only be called for handles that are leafs. The expectation is that any Clusters with handles that
+         * have those options enabled will implement appropriate logic to populate
+         * aIsPresent.
+         *
+         * @param[in] aHandle       The AttributePathHandle in question.
+         *
+         * @param[in] aTagToWrite   The tag to write for the aHandle.
+         *
+         * @param[inout] aWriter    The writer to write TLV elements to.
+         *
+         * @param[out] aIsPresent   Is aHandle present? If no and if aHandle
+         *                          is not a leaf, IM will skip over the
+         *                          path and its children.
+         *
+         *
+         * @retval #CHIP_NO_ERROR On success.
+         * @retval other           Was unable to retrieve data and write it into the writer.
+         */
+        virtual CHIP_ERROR GetData(AttributePathHandle aHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter,
+                                   bool & aIsPresent) = 0;
+        virtual ~IGetDataDelegate()                   = default;
+    };
+
+    /**
+     * Given a path handle and a reader positioned on the corresponding attribute data element, process the data buffer pointed to
+     * by the reader and store it into the sink by invoking the SetLeafData call whenever a leaf data item is encountered.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Encountered errors parsing/processing the data.
+     */
+    CHIP_ERROR StoreData(AttributePathHandle aHandle, chip::TLV::TLVReader & aReader, ISetDataDelegate * apSetDataDelegate) const;
+
+    /**
+     * Given a path handle and a writer position on the corresponding attribute data element, retrieve leaf data from the source and
+     * write it into the buffer pointed to by the writer in a schema compliant manner.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Encountered errors writing out the data.
+     */
+    CHIP_ERROR RetrieveData(AttributePathHandle aHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter,
+                            IGetDataDelegate * apGetDataDelegate) const;
+    /**********
+     *
+     * Schema Query Functions
+     *
+     *********/
+
+    /**
+     * Returns true if the handle refers to a leaf node in the schema tree.
+     *
+     * @retval bool
+     */
+    bool IsLeaf(AttributePathHandle aAttributeHandle) const;
+
+    /**
+     * Returns a pointer to the AttributeInfo structure describing a particular path handle.
+     *
+     * @retval AttributeInfo*
+     */
+    const AttributeInfo * GetMap(AttributePathHandle aHandle) const;
+
+    /**
+     * Returns the tag associated with a path handle. If it's a dictionary element, this function returns the ProfileTag. Otherwise,
+     * it returns context tags.
+     *
+     * @retval uint64_t
+     */
+    uint64_t GetTag(AttributePathHandle aHandle) const;
+
+    /**
+     * Returns the parent handle of a given child path handle. Dictionary keys in the handle are preserved in the case where the
+     * parent handle is also a dictionary element.
+     *
+     * @retval AttributePathHandle   Handle of the parent.
+     */
+    AttributePathHandle GetParent(AttributePathHandle aHandle) const;
+
+    /**
+     * Returns the first child handle associated with a particular parent.
+     *
+     * @retval AttributePathHandle   Handle of the first child.
+     */
+    AttributePathHandle GetFirstChild(AttributePathHandle aParentHandle) const;
+
+    /**
+     * Given a handle to an existing child, returns the next child handle associated with a particular parent.
+     *
+     * @retval AttributePathHandle   Handle of the next child.
+     */
+    AttributePathHandle GetNextChild(AttributePathHandle aParentId, AttributePathHandle aChildHandle) const;
+
+    /**
+     * Returns the cluster id of the associated Cluster.
+     *
+     * @retval Cluster id
+     */
+    ClusterId GetClusterId(void) const;
+
+    /**
+     * Checks if a given handle is a child of another handle. This can be an in-direct parent.
+     *
+     * @retval bool
+     */
+    bool IsParent(AttributePathHandle aChildHandle, AttributePathHandle aParentHandle) const;
+
+    AttributePathHandle GetChildHandle(AttributePathHandle aParentHandle, uint8_t aContextTag) const;
+
+    const Schema mSchema;
+};
+
+/*
+ * @class  ClusterDataSink
+ *
+ * @brief  Base abstract class that represents a particular instance of a Cluster on a specific external resource (client).
+ * Application developers are expected to subclass this to make a concrete sink that ingests data received from servers.
+ *
+ *         It takes in a pointer to a schema that it then uses to help decipher incoming TLV data from a publisher and invoke the
+ *         relevant data setter calls to pass the data up to subclasses.
+ */
+class ClusterDataSink : protected ClusterSchemaEngine::ISetDataDelegate
+{
+public:
+    ClusterDataSink(const ClusterSchemaEngine * apEngine);
+    virtual ~ClusterDataSink() {}
+    const ClusterSchemaEngine * GetSchemaEngine(void) const { return mpSchemaEngine; }
+
+    /**
+     * Given a reader that points to a data element conformant to a schema bound to this object, this method processes that data and
+     * invokes the relevant SetLeafData call below for all leaf items in the buffer.
+     *
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Encountered errors writing out the data.
+     */
+    CHIP_ERROR StoreDataElement(AttributePathHandle aHandle, TLV::TLVReader & aReader);
+
+    /**
+     * Retrieves the current version of the data that resides in this sink.
+     */
+    DataVersion GetVersion(void) const { return mVersion; }
+
+    /**
+     * Returns a boolean value that determines whether the version is valid.
+     */
+    bool IsVersionValid(void) const { return mHasValidVersion; }
+
+    virtual bool IsVersionNewer(DataVersion & aVersion) { return aVersion != mVersion || false == mHasValidVersion; }
+
+    /* Subclass can invoke this to clear out their version */
+    void ClearVersion(void);
+
+protected: // ISetDataDelegate
+    virtual CHIP_ERROR SetLeafData(AttributePathHandle aLeafHandle, chip::TLV::TLVReader & aReader) __OVERRIDE = 0;
+
+    /*
+     * Defaults to calling SetLeafData if aHandle is a leaf.
+     */
+    virtual CHIP_ERROR SetData(AttributePathHandle aHandle, chip::TLV::TLVReader & aReader) __OVERRIDE;
+
+    // Set current version of the data in this sink.
+    void SetVersion(uint64_t version);
+    const ClusterSchemaEngine * mpSchemaEngine;
+
+private:
+    bool mHasValidVersion;
+    DataVersion mVersion = 0;
+};
+
+class ClusterDataSource : private ClusterSchemaEngine::IGetDataDelegate
+{
+public:
+    ClusterDataSource(const ClusterSchemaEngine * aEngine);
+    virtual ~ClusterDataSource() {}
+    const ClusterSchemaEngine * GetSchemaEngine(void) const { return mpSchemaEngine; }
+
+    uint64_t GetVersion(void);
+
+    CHIP_ERROR ReadData(AttributePathHandle aHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter);
+
+    /* Interactions with the underlying data has to always be done within a locked context. This applies to both the app logic
+     * (e.g., a server when modifying its source data) as well as to the core IM logic (when trying to access that published
+     * data).  This is required of both servers and clients.
+     */
+    CHIP_ERROR Lock(void);
+    CHIP_ERROR Unlock(void);
+
+    // Set current version of the data in this source.
+    void SetVersion(uint64_t version) { mVersion = version; }
+
+protected: // IGetDataDelegate
+    /*
+     * Defaults to calling GetLeafData if aHandle is a leaf.
+     */
+    virtual CHIP_ERROR GetData(AttributePathHandle aHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter,
+                               bool & aIsPresent) __OVERRIDE;
+
+    virtual CHIP_ERROR GetLeafData(AttributePathHandle aLeafHandle, uint64_t aTagToWrite,
+                                   chip::TLV::TLVWriter & aWriter) __OVERRIDE = 0;
+
+    // Increment current version of the data in this source.
+    void IncrementVersion(void);
+
+    const ClusterSchemaEngine * mpSchemaEngine;
+
+private:
+    DataVersion mVersion;
+    // Tracks whether SetDirty was called within a Lock/Unlock 'session'
+    bool mSetDirtyCalled = false;
+    bool mRootIsDirty    = false;
+};
+}; // namespace app
+}; // namespace chip

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -50,6 +50,9 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     err = mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this);
     SuccessOrExit(err);
 
+    mReportingEngine.Init();
+    SuccessOrExit(err);
+
 exit:
     return err;
 }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -37,6 +37,7 @@
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemPacketBuffer.h>
 
+#include <app/ClusterCatalog.h>
 #include <app/Command.h>
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
@@ -50,6 +51,7 @@
 #define CHIP_MAX_NUM_READ_CLIENT 1
 #define CHIP_MAX_NUM_READ_HANDLER 1
 #define CHIP_MAX_REPORTS_IN_FLIGHT 1
+#define IM_PUBLISHER_MAX_NUM_PATH_GROUPS 128
 
 namespace chip {
 namespace app {
@@ -88,7 +90,8 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                    CatalogInterface<ClusterDataSource> * apSourceCatalog);
 
     void Shutdown();
 
@@ -114,7 +117,7 @@ public:
      *  @retval #CHIP_ERROR_INCORRECT_STATE If there is no ReadClient available
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient);
+    CHIP_ERROR NewReadClient(ReadClient ** const apReadClient, CatalogInterface<ClusterDataSink> * apCatalog);
 
     /**
      *  Get read client index in mReadClients
@@ -126,6 +129,12 @@ public:
     uint16_t GetReadClientArrayIndex(const ReadClient * const apReadClient) const;
 
     reporting::ReportingEngine * GetReportingEngine(void) { return &mReportingEngine; }
+
+    void ReleaseClusterInfoListToPool(ReadHandler * const apReadHandler);
+
+    CatalogInterface<ClusterDataSource> * mpSourceCatalog = nullptr;
+    size_t mNumClusterInfosInPool                         = 0;
+    ClusterInfo mClusterInfoPool[IM_PUBLISHER_MAX_NUM_PATH_GROUPS];
 
 private:
     friend class reporting::ReportingEngine;
@@ -150,6 +159,7 @@ private:
     CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER];
     ReadClient mReadClients[CHIP_MAX_NUM_READ_CLIENT];
     ReadHandler mReadHandlers[CHIP_MAX_NUM_READ_HANDLER];
+
     reporting::ReportingEngine mReportingEngine;
 };
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -43,6 +43,7 @@
 #include <app/InteractionModelDelegate.h>
 #include <app/ReadClient.h>
 #include <app/ReadHandler.h>
+#include <app/reporting/ReportingEngine.h>
 
 #define CHIP_MAX_NUM_COMMAND_HANDLER 1
 #define CHIP_MAX_NUM_COMMAND_SENDER 1
@@ -124,7 +125,10 @@ public:
      */
     uint16_t GetReadClientArrayIndex(const ReadClient * const apReadClient) const;
 
+    reporting::ReportingEngine * GetReportingEngine(void) { return &mReportingEngine; }
+
 private:
+    friend class reporting::ReportingEngine;
     void OnUnknownMsgType(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                           const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload);
     void OnInvokeCommandRequest(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
@@ -146,6 +150,7 @@ private:
     CommandSender mCommandSenderObjs[CHIP_MAX_NUM_COMMAND_SENDER];
     ReadClient mReadClients[CHIP_MAX_NUM_READ_CLIENT];
     ReadHandler mReadHandlers[CHIP_MAX_NUM_READ_HANDLER];
+    reporting::ReportingEngine mReportingEngine;
 };
 
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -72,7 +72,8 @@ public:
      *  @retval #CHIP_NO_ERROR On success.
      */
     CHIP_ERROR SendReadRequest(NodeId aNodeId, Transport::AdminId aAdminId, EventPathParams * apEventPathParamsList,
-                               size_t aEventPathParamsListSize);
+                               size_t aEventPathParamsListSize, AttributePathParams * apClusterPathList,
+                               size_t aClusterPathListSize);
 
 private:
     friend class TestReadInteraction;
@@ -98,7 +99,8 @@ private:
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, InteractionModelDelegate * apDelegate,
+                    CatalogInterface<ClusterDataSink> * apClusterSinkCatalog);
 
     virtual ~ReadClient() = default;
 
@@ -112,15 +114,18 @@ private:
      */
     bool IsFree() const { return mState == ClientState::Uninitialized; };
 
+    CHIP_ERROR ProcessAttributeDataList(TLV::TLVReader & aAttributeDataListReader);
+
     void MoveToState(const ClientState aTargetState);
     CHIP_ERROR ProcessReportData(System::PacketBufferHandle aPayload);
     CHIP_ERROR ClearExistingExchangeContext();
     const char * GetStateStr() const;
 
-    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
-    InteractionModelDelegate * mpDelegate      = nullptr;
-    ClientState mState                         = ClientState::Uninitialized;
+    Messaging::ExchangeManager * mpExchangeMgr               = nullptr;
+    Messaging::ExchangeContext * mpExchangeCtx               = nullptr;
+    InteractionModelDelegate * mpDelegate                    = nullptr;
+    ClientState mState                                       = ClientState::Uninitialized;
+    CatalogInterface<ClusterDataSink> * mpClusterSinkCatalog = nullptr;
 };
 
 }; // namespace app

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -25,6 +25,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPath.h>
 #include <app/ReadHandler.h>
+#include <app/reporting/ReportingEngine.h>
 
 namespace chip {
 namespace app {
@@ -34,7 +35,6 @@ CHIP_ERROR ReadHandler::Init(InteractionModelDelegate * apDelegate)
     // Error if already initialized.
     VerifyOrExit(apDelegate != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-
     mpExchangeCtx     = nullptr;
     mpDelegate        = apDelegate;
     mSuppressResponse = true;
@@ -91,11 +91,7 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle aPayload)
 
     err = mpExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(aPayload),
                                      Messaging::SendFlags(Messaging::SendMessageFlags::kNone));
-    SuccessOrExit(err);
-
-    // Todo: Once status report support is added, we would shutdown only when there is error or when this is last chunk of report
 exit:
-    Shutdown();
     return err;
 }
 
@@ -146,6 +142,10 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle aPayload)
     {
         err = CHIP_NO_ERROR;
     }
+
+    MoveToState(HandlerState::Reportable);
+
+    InteractionModelEngine::GetInstance()->GetReportingEngine()->ScheduleRun();
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -99,6 +99,14 @@ public:
 
     virtual ~ReadHandler() = default;
 
+    ClusterInfo * GetClusterInfoList(void) { return mpClusterInfoList; }
+
+    size_t GetNumClusterInfos(void) { return mNumClusterInfos; }
+
+    ClusterInfo * mpClusterInfoList     = nullptr;
+    size_t mNumClusterInfos             = 0;
+    size_t mCurProcessingClusterInfoIdx = 0;
+
 private:
     enum class HandlerState
     {
@@ -108,6 +116,8 @@ private:
     };
 
     CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle aPayload);
+
+    CHIP_ERROR ProcessAttributePathList(AttributePathList::Parser & aAttributePathListParser);
 
     void MoveToState(const HandlerState aTargetState);
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -95,6 +95,7 @@ public:
     CHIP_ERROR SendReportData(System::PacketBufferHandle aPayload);
 
     bool IsFree() const { return mState == HandlerState::Uninitialized; }
+    bool IsReportable() const { return mState == HandlerState::Reportable; }
 
     virtual ~ReadHandler() = default;
 

--- a/src/app/reporting/ReportingEngine.cpp
+++ b/src/app/reporting/ReportingEngine.cpp
@@ -1,0 +1,173 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements reporting engine for CHIP
+ *      Data Model profile.
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/reporting/ReportingEngine.h>
+
+namespace chip {
+namespace app {
+namespace reporting {
+CHIP_ERROR ReportingEngine::Init()
+{
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    mMoreChunkedMessages = false;
+    mNumReportsInFlight  = 0;
+    mCurReadHandlerIdx   = 0;
+    return err;
+}
+
+CHIP_ERROR ReportingEngine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter reportDataWriter;
+    ReportData::Builder reportDataBuilder;
+    chip::System::PacketBufferHandle bufHandle = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
+
+    VerifyOrExit(!bufHandle.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+
+    reportDataWriter.Init(std::move(bufHandle));
+
+    // Create a report data.
+    err = reportDataBuilder.Init(&reportDataWriter);
+    SuccessOrExit(err);
+
+    // TODO: Fill in the EventList.
+    // err = BuildSingleReportDataEventList(reportDataBuilder, apReadHandler);
+    // SuccessOrExit(err);
+
+    // TODO: Add mechanism to set mSuppressResponse to handle status reports for multiple reports
+    // TODO: Add more chunk message support, currently mMoreChunkedMessages is always false.
+    if (mMoreChunkedMessages)
+    {
+        reportDataBuilder.MoreChunkedMessages(mMoreChunkedMessages);
+    }
+
+    reportDataBuilder.EndOfReportData();
+    SuccessOrExit(reportDataBuilder.GetError());
+
+    err = reportDataWriter.Finalize(&bufHandle);
+    SuccessOrExit(err);
+
+#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+    {
+        ChipLogDetail(DataManagement, "<RE> Dumping report data...");
+        chip::System::PacketBufferTLVReader reader;
+        ReportData::Parser report;
+
+        reader.Init(bufHandle.Retain());
+        reader.Next();
+
+        err = report.Init(reader);
+        SuccessOrExit(err);
+
+        err = report.CheckSchemaValidity();
+        SuccessOrExit(err);
+    }
+#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+
+    ChipLogDetail(DataManagement, "<RE> Sending report...");
+    err = SendReport(apReadHandler, std::move(bufHandle));
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DataManagement, "<RE> Error sending out report data with %d!", err));
+
+    ChipLogDetail(DataManagement, "<RE> ReportsInFlight = %u with readHandler %u, RE has %s", mNumReportsInFlight,
+                  mCurReadHandlerIdx, mMoreChunkedMessages ? "more messages" : "no more messages");
+
+    if (!mMoreChunkedMessages)
+    {
+        OnReportConfirm();
+    }
+
+exit:
+    ChipLogFunctError(err);
+    if (!mMoreChunkedMessages || err != CHIP_NO_ERROR)
+    {
+        apReadHandler->Shutdown();
+    }
+    return err;
+}
+
+void ReportingEngine::Run(System::Layer * aSystemLayer, void * apAppState, System::Error)
+{
+    ReportingEngine * const pEngine = reinterpret_cast<ReportingEngine *>(apAppState);
+    pEngine->Run();
+}
+
+void ReportingEngine::ScheduleRun()
+{
+    if (InteractionModelEngine::GetInstance()->GetExchangeManager() != nullptr)
+    {
+        InteractionModelEngine::GetInstance()->GetExchangeManager()->GetSessionMgr()->SystemLayer()->ScheduleWork(Run, this);
+    }
+}
+
+void ReportingEngine::Run()
+{
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    uint32_t numReadHandled = 0;
+
+    InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
+    ReadHandler * readHandler         = imEngine->mReadHandlers + mCurReadHandlerIdx;
+
+    while ((mNumReportsInFlight < CHIP_MAX_REPORTS_IN_FLIGHT) && (numReadHandled < CHIP_MAX_NUM_READ_HANDLER))
+    {
+        if (readHandler->IsReportable())
+        {
+            err = BuildAndSendSingleReportData(readHandler);
+            ChipLogFunctError(err);
+            return;
+        }
+        numReadHandled++;
+        mCurReadHandlerIdx = (mCurReadHandlerIdx + 1) % CHIP_MAX_NUM_READ_HANDLER;
+        readHandler        = imEngine->mReadHandlers + mCurReadHandlerIdx;
+    }
+}
+
+CHIP_ERROR ReportingEngine::SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // We can only have 1 report in flight for any given read - increment and break out.
+    mNumReportsInFlight++;
+
+    err = apReadHandler->SendReportData(std::move(aPayload));
+
+    if (err != CHIP_NO_ERROR)
+    {
+        mNumReportsInFlight--;
+    }
+    return err;
+}
+
+void ReportingEngine::OnReportConfirm()
+{
+    VerifyOrDie(mNumReportsInFlight > 0);
+
+    ChipLogDetail(DataManagement, "<RE> OnReportConfirm: NumReports-- = %d", mNumReportsInFlight - 1);
+    mNumReportsInFlight--;
+}
+
+}; // namespace reporting
+}; // namespace app
+}; // namespace chip

--- a/src/app/reporting/ReportingEngine.h
+++ b/src/app/reporting/ReportingEngine.h
@@ -1,0 +1,138 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Reporting Engine for a CHIP Interaction Model
+ *
+ */
+
+#pragma once
+
+#include <app/MessageDef/ReportData.h>
+#include <app/ReadHandler.h>
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <protocols/Protocols.h>
+#include <support/CodeUtils.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <util/basic-types.h>
+
+namespace chip {
+namespace app {
+namespace reporting {
+/*
+ *  @class ReportingEngine
+ *
+ *  @brief The reporting engine is responsible for generating reports to subscriber and reader. It is able to find the intersection
+ * between the path interest set of each subscriber/reader with what has changed in the publisher data store and generate tailored
+ * reports for each subscriber/reader.
+ *
+ *         At its core, it  tries to gather and pack as much relevant attributes changes and/or events as possible into a report
+ * message before sending that to the subscriber/reader. It continues to do so until it has no more work to do. This could be due to
+ * a couple of reasons:
+ *
+ *         - Reports are in flight to the subscribers/readers
+ *         - We have exceeded the maximum number of reports that can be flight across all subscribers/readers.
+ *         - We have no more space in the packet to stuff in more data.
+ *         - We have no more dirty data to process.
+ *
+ *         Once it surmises there is no more work to be done, it returns. If all work for a read has been completed, it will
+ *         invoke a method in the ReadHandler to finish processing.
+ *
+ */
+class ReportingEngine
+{
+public:
+    /**
+     * Initializes the reporting engine. Should only be called once.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Was unable to retrieve data and write it into the writer.
+     */
+    CHIP_ERROR Init();
+
+    /**
+     * Main work-horse function that executes the run-loop.
+     */
+    void Run();
+
+    /**
+     * Main work-horse function that executes the run-loop asynchronously on the CHIP thread
+     */
+    void ScheduleRun();
+
+private:
+    friend class TestReportingEngine;
+    /**
+     * Build Single Report Data including attribute changes and event data stream, and send out
+     *
+     * @param[in]    apReadHandler    A pointer to the RenaderHandler object
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Was unable to retrieve data and write it into the writer.
+     */
+    CHIP_ERROR BuildAndSendSingleReportData(ReadHandler * apReadHandler);
+
+    /**
+     * Send Report via ReadHandler
+     *
+     * @param[in]    apReadHandler    A pointer to the RenaderHandler object
+     * @param[in]    aPayload        A payload that has report data
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval other           Was unable to send report
+     */
+    CHIP_ERROR SendReport(ReadHandler * apReadHandler, System::PacketBufferHandle && aPayload);
+
+    /**
+     * Should be invoked when the device receives a Status report, or when the Report data request times out.
+     * This allows the engine to do some clean-up.
+     *
+     */
+    void OnReportConfirm();
+
+    /**
+     * Generate and send the report data request when there exists subscription or read request
+     *
+     */
+    static void Run(System::Layer * aSystemLayer, void * apAppState, System::Error);
+
+    /**
+     * Boolean to show if more chunk message on the way
+     *
+     */
+    bool mMoreChunkedMessages = false;
+
+    /**
+     * The number of report date request in flight
+     *
+     */
+    uint32_t mNumReportsInFlight = 0;
+
+    /**
+     *  Current read handler index
+     *
+     */
+    uint32_t mCurReadHandlerIdx = 0;
+};
+
+}; // namespace reporting
+}; // namespace app
+}; // namespace chip

--- a/src/app/reporting/ReportingEngine.h
+++ b/src/app/reporting/ReportingEngine.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <app/ClusterData.h>
 #include <app/MessageDef/ReportData.h>
 #include <app/ReadHandler.h>
 #include <core/CHIPCore.h>
@@ -36,6 +37,7 @@
 #include <system/TLVPacketBufferBackingStore.h>
 #include <util/basic-types.h>
 
+#define IM_PUBLISHER_MAX_ITEMS_IN_CLUSTER_DIRTY_STORE 128
 namespace chip {
 namespace app {
 namespace reporting {
@@ -80,6 +82,8 @@ public:
      */
     void ScheduleRun();
 
+    CHIP_ERROR SetDirty(ClusterDataHandle aDataHandle, AttributePathHandle aAttributePathHandle);
+
 private:
     friend class TestReportingEngine;
     /**
@@ -91,6 +95,7 @@ private:
      */
     CHIP_ERROR BuildAndSendSingleReportData(ReadHandler * apReadHandler);
 
+    CHIP_ERROR BuildSingleReportDataAttributeDataList(ReportData::Builder & reportDataBuilder, ReadHandler * apReadHandler);
     /**
      * Send Report via ReadHandler
      *
@@ -114,6 +119,7 @@ private:
      */
     static void Run(System::Layer * aSystemLayer, void * apAppState, System::Error);
 
+    CHIP_ERROR RetrieveClusterData(AttributeDataElement::Builder & aAttributeDataElementBuilder, ClusterInfo & aClusterInfo);
     /**
      * Boolean to show if more chunk message on the way
      *

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
   test_sources = [
     "TestMessageDef.cpp",
     "TestReadInteraction.cpp",
+    "TestReportingEngine.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -173,12 +173,12 @@ const nlTest sTests[] =
 
 } // namespace
 
-int TestEventLogging()
+int TestReadInteraction()
 {
     // clang-format off
     nlTestSuite theSuite =
 	{
-        "InteractionMessage",
+        "TestReadInteraction",
         &sTests[0],
         nullptr,
         nullptr
@@ -192,4 +192,4 @@ int TestEventLogging()
     return (nlTestRunnerStats(&theSuite));
 }
 
-CHIP_REGISTER_TEST_SUITE(TestEventLogging)
+CHIP_REGISTER_TEST_SUITE(TestReadInteraction)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -90,10 +90,10 @@ void TestReadInteraction::TestReadClient(nlTestSuite * apSuite, void * apContext
     app::ReadClient readClient;
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                            = readClient.Init(&gExchangeManager, nullptr);
+    err                            = readClient.Init(&gExchangeManager, nullptr, nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = readClient.SendReadRequest(kTestDeviceNodeId, gAdminId, nullptr, 0);
+    err = readClient.SendReadRequest(kTestDeviceNodeId, gAdminId, nullptr, 0, nullptr, 0);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
 
     GenerateReportData(apSuite, apContext, buf);

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -1,0 +1,140 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Reporting Engine
+ *
+ */
+
+#include <app/InteractionModelEngine.h>
+#include <app/reporting/ReportingEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/PASESession.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+
+#include <nlunit-test.h>
+
+namespace chip {
+static SecureSessionMgr gSessionManager;
+static Messaging::ExchangeManager gExchangeManager;
+static TransportMgr<Transport::UDP> gTransportManager;
+static const Transport::AdminId gAdminId = 0;
+
+namespace app {
+namespace reporting {
+class TestReportingEngine
+{
+public:
+    static void TestBuildAndSendSingleReportData(nlTestSuite * apSuite, void * apContext);
+};
+
+void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    app::ReadHandler readHandler;
+    ReportingEngine reportingEngine;
+    System::PacketBufferTLVWriter writer;
+    System::PacketBufferHandle readRequestbuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+    ReadRequest::Builder readRequestBuilder;
+
+    Messaging::ExchangeContext * exchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    writer.Init(std::move(readRequestbuf));
+    err = readRequestBuilder.Init(&writer);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    readRequestBuilder.EventNumber(1);
+    NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
+    readRequestBuilder.EndOfReadRequest();
+    NL_TEST_ASSERT(apSuite, readRequestBuilder.GetError() == CHIP_NO_ERROR);
+    err = writer.Finalize(&readRequestbuf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    readHandler.OnReadRequest(exchangeCtx, std::move(readRequestbuf));
+    reportingEngine.Init();
+    err = reportingEngine.BuildAndSendSingleReportData(&readHandler);
+    NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);
+}
+} // namespace reporting
+} // namespace app
+} // namespace chip
+
+namespace {
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, nullptr, &admins);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::gExchangeManager.Init(chip::kTestDeviceNodeId, &chip::gTransportManager, &chip::gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+        {
+                NL_TEST_DEF("CheckBuildAndSendSingleReportData", chip::app::reporting::TestReportingEngine::TestBuildAndSendSingleReportData),
+                NL_TEST_SENTINEL()
+        };
+// clang-format on
+} // namespace
+
+int TestReportingEngine()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "TestReportingEngine",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestReportingEngine)

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -43,6 +43,7 @@
 #include <nlunit-test.h>
 
 namespace chip {
+static System::Layer gSystemLayer;
 static SecureSessionMgr gSessionManager;
 static Messaging::ExchangeManager gExchangeManager;
 static TransportMgr<Transport::UDP> gTransportManager;
@@ -98,10 +99,12 @@ void InitializeChip(nlTestSuite * apSuite)
     err = chip::Platform::MemoryInit();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, nullptr, nullptr, &admins);
+    chip::gSystemLayer.Init(nullptr);
+
+    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    err = chip::gExchangeManager.Init(chip::kTestDeviceNodeId, &chip::gTransportManager, &chip::gSessionManager);
+    err = chip::gExchangeManager.Init(&chip::gSessionManager);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -21,6 +21,7 @@ assert(chip_build_tools)
 
 executable("chip-im-initiator") {
   sources = [
+    "MockCluster.cpp",
     "chip_im_initiator.cpp",
     "common.cpp",
   ]
@@ -39,6 +40,7 @@ executable("chip-im-initiator") {
 
 executable("chip-im-responder") {
   sources = [
+    "MockCluster.cpp",
     "chip_im_responder.cpp",
     "common.cpp",
   ]

--- a/src/app/tests/integration/MockCluster.cpp
+++ b/src/app/tests/integration/MockCluster.cpp
@@ -1,0 +1,110 @@
+/*
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares mock event generator and example
+ *
+ */
+
+#include "MockCluster.h"
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace TestCluster {
+chip::app::ClusterSchemaEngine::AttributeInfo gSchemaMap[] = {
+    /*  ParentHandle                ContextTag */
+    { kAttributeHandle_Root, 1 },
+    { kAttributeHandle_Root, 2 }
+};
+
+chip::app::ClusterSchemaEngine ClusterSchema = { {
+    kClusterId,
+    gSchemaMap,
+    sizeof(gSchemaMap) / sizeof(gSchemaMap[0]),
+    1,
+} };
+}; // namespace TestCluster
+
+MockClusterDataSink::MockClusterDataSink(const chip::app::ClusterSchemaEngine * apClusterSchemaEngine) :
+    ClusterDataSink(apClusterSchemaEngine)
+{}
+
+MockClusterDataSource::MockClusterDataSource(const chip::app::ClusterSchemaEngine * apClusterSchemaEngine) :
+    ClusterDataSource(apClusterSchemaEngine)
+{}
+
+TestClusterDataSink::TestClusterDataSink(void) : MockClusterDataSink(&TestCluster::ClusterSchema) {}
+
+CHIP_ERROR
+TestClusterDataSink::SetLeafData(chip::app::AttributePathHandle aLeafHandle, chip::TLV::TLVReader & aReader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    switch (aLeafHandle)
+    {
+    case TestCluster::kAttributeHandle_ValueA:
+        err = aReader.Get(mValueA);
+        SuccessOrExit(err);
+        ChipLogDetail(DataManagement, "<<  TestCluster kAttributeHandle_ValueA is = %d", mValueA);
+        break;
+    case TestCluster::kAttributeHandle_ValueB:
+        err = aReader.Get(mValueB);
+        SuccessOrExit(err);
+        ChipLogDetail(DataManagement, "<<  TestCluster kAttributeHandle_ValueB is = %d", mValueB);
+        break;
+    default:
+        ChipLogDetail(DataManagement, "<<  UNKNOWN!");
+        err = CHIP_ERROR_TLV_TAG_NOT_FOUND;
+    }
+
+exit:
+    return err;
+}
+
+TestClusterDataSource::TestClusterDataSource(void) : MockClusterDataSource(&TestCluster::ClusterSchema) {}
+
+CHIP_ERROR
+TestClusterDataSource::GetLeafData(chip::app::AttributePathHandle aLeafHandle, uint64_t aTagToWrite, chip::TLV::TLVWriter & aWriter)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    switch (aLeafHandle)
+    {
+    case TestCluster::kAttributeHandle_ValueA:
+        err = aWriter.Put(aTagToWrite, mValueA);
+        SuccessOrExit(err);
+
+        ChipLogDetail(DataManagement, ">>  TestCluster kAttributeHandle_ValueA is = %d", mValueA);
+        break;
+    case TestCluster::kAttributeHandle_ValueB:
+        err = aWriter.Put(aTagToWrite, mValueB);
+        SuccessOrExit(err);
+
+        ChipLogDetail(DataManagement, ">>  TestCluster kAttributeHandle_ValueB is = %d", mValueB);
+        break;
+
+    default:
+        ChipLogDetail(DataManagement, ">>  UNKNOWN!");
+        ExitNow(err = CHIP_ERROR_TLV_TAG_NOT_FOUND);
+    }
+
+exit:
+    return err;
+}

--- a/src/app/tests/integration/MockCluster.h
+++ b/src/app/tests/integration/MockCluster.h
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares mock event generator and example
+ *
+ */
+#pragma once
+
+#include <app/ClusterCatalog.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+
+namespace TestCluster {
+extern chip::app::ClusterSchemaEngine ClusterSchema;
+
+enum
+{
+    kClusterId = 0x00000014
+};
+
+enum
+{
+    kAttributeHandle_Root   = 1,
+    kAttributeHandle_ValueA = 2,
+    kAttributeHandle_ValueB = 3,
+};
+}; // namespace TestCluster
+
+class MockClusterDataSink : public chip::app::ClusterDataSink
+{
+public:
+    MockClusterDataSink(const chip::app::ClusterSchemaEngine * apClusterSchemaEngine);
+    void ResetDataSink(void) { ClearVersion(); };
+};
+
+class MockClusterDataSource : public chip::app::ClusterDataSource
+{
+public:
+    MockClusterDataSource(const chip::app::ClusterSchemaEngine * apClusterSchemaEngine);
+};
+
+class TestClusterDataSink : public MockClusterDataSink
+{
+public:
+    TestClusterDataSink();
+    int mValueA = 1;
+    int mValueB = 2;
+
+private:
+    CHIP_ERROR SetLeafData(chip::app::AttributePathHandle aLeafHandle, chip::TLV::TLVReader & aReader) __OVERRIDE;
+};
+
+class TestClusterDataSource : public MockClusterDataSource
+{
+public:
+    TestClusterDataSource();
+    int mValueA = 1;
+    int mValueB = 2;
+
+private:
+    CHIP_ERROR GetLeafData(chip::app::AttributePathHandle aLeafHandle, uint64_t aTagToWrite,
+                           chip::TLV::TLVWriter & aWriter) __OVERRIDE;
+};

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -42,7 +42,7 @@
 namespace {
 // Max value for the number of message request sent.
 constexpr size_t kMaxCommandMessageCount = 3;
-constexpr size_t kMaxReadMessageCount    = 0;
+constexpr size_t kMaxReadMessageCount    = 3;
 
 // The CHIP Message interval time in milliseconds.
 constexpr int32_t gMessageInterval = 1000;

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -106,6 +106,7 @@ chip::SecurePairingUsingTestSecret gTestPairing;
 int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::app::InteractionModelDelegate mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::Transport::AdminId gAdminId = 0;
     chip::Transport::AdminPairingTable admins;
@@ -125,7 +126,7 @@ int main(int argc, char * argv[])
     err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);
     SuccessOrExit(err);
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -24,6 +24,8 @@
  *
  */
 
+#include "MockCluster.h"
+#include <app/ClusterCatalog.h>
 #include <app/CommandHandler.h>
 #include <app/CommandSender.h>
 #include <app/InteractionModelEngine.h>
@@ -112,6 +114,20 @@ int main(int argc, char * argv[])
     chip::Transport::AdminPairingTable admins;
     chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
 
+    chip::app::ClusterDataSourceCatalog::CatalogItem mSourceCatalogStore[4];
+    chip::app::ClusterDataSourceCatalog sourceCatalog(0, mSourceCatalogStore,
+                                                      sizeof(mSourceCatalogStore) / sizeof(mSourceCatalogStore[0]));
+    chip::EndpointId endpointId = 0;
+
+    chip::app::ClusterDataHandle mClusterHandleSet[1];
+    TestClusterDataSource mTestClusterDataSource;
+    sourceCatalog.Add(endpointId, &mTestClusterDataSource, mClusterHandleSet[0]);
+
+    mTestClusterDataSource.mValueA = 6;
+    mTestClusterDataSource.mValueB = 7;
+    // mTestClusterDataSource.SetDirty(TestCluster::kAttributeHandle_ValueA);
+    // mTestClusterDataSource.SetDirty(TestCluster::kAttributeHandle_ValueB);
+
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     InitializeChip();
@@ -126,7 +142,7 @@ int main(int argc, char * argv[])
     err = gExchangeManager.Init(&gSessionManager);
     SuccessOrExit(err);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate, &sourceCatalog);
     SuccessOrExit(err);
 
     err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,


### PR DESCRIPTION
Summary of Changes:
-- Add attribute management to read a set of the entire of cluster without delta from responder.
-- Provide catalog interface and simple clusterClaarray-backed, bounded storage cluster to store cluster's data, consumer sdk can also use catalog interface  to implement their particular catalog.
-- Provide cluster data sink and data source, data sink in client can receive data from data source in handler via reportData message,  if dataSink wanna update the dataSource in handler, it need to create subclass with updatability.
this has minimum functionality to read the whole cluster data without delta
no chunking, no version comparison functionality
--reporting engine is used to retrieve attributes from data source stored in catalog and send out report data via read handler

Note: This PR is to provide the minimum functionality for feature parity as zcl ember has, this PR currently only provide attribute capability during read interaction. Currently it don't support delta, chunking message. 

Reporting Engine is in https://github.com/project-chip/connectedhomeip/pull/5502

I will add unit tests in this PR, and update all doxygen later.

For this attribute management large PR, I will split 4 small PRs, the first PR would have only API and interface, 

https://github.com/project-chip/connectedhomeip/pull/5634

#4803
