### PR TITLE
Add is_ubsan flag to turn on the Undefined Behavior Sanitizer

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -258,6 +258,9 @@ declare_args() {
   # Enable memory sanitizer
   is_msan = false
 
+  # enable undefined behavior sanitizer
+  is_ubsan = false
+
   # Exit on sanitize error. Generally standard libraries may get errors
   # so not stopping on the first error is often useful
   is_sanitize_fatal = true
@@ -280,6 +283,18 @@ config("sanitize_memory") {
   ldflags = cflags
 }
 
+config("sanitize_undefined_behavior") {
+  cflags = [
+    "-fvisibility=hidden",
+    "-fsanitize=undefined",
+    "-fsanitize=float-divide-by-zero",
+    "-fsanitize=unsigned-integer-overflow",
+    "-fsanitize=implicit-conversion",
+    "-fsanitize=nullability",
+  ]
+  ldflags = cflags
+}
+
 config("sanitize_recover_all") {
   cflags = [ "-fsanitize-recover=all" ]
   ldflags = cflags
@@ -294,6 +309,10 @@ config("sanitize_default") {
 
   if (is_msan) {
     configs += [ ":sanitize_memory" ]
+  }
+
+  if (is_ubsan) {
+    configs += [ ":sanitize_undefined_behavior" ]
   }
 
   if (!is_sanitize_fatal) {

--- a/src/lib/support/BufferWriter.cpp
+++ b/src/lib/support/BufferWriter.cpp
@@ -55,11 +55,12 @@ BufferWriter & BufferWriter::Put(uint8_t c)
 
 LittleEndian::BufferWriter & LittleEndian::BufferWriter::EndianPut(uint64_t x, size_t size)
 {
-    while (size-- > 0)
+    while (size > 0)
     {
         uint8_t c = x & 0xff;
         Put(c);
         x >>= 8;
+        size--;
     }
     return *this;
 }


### PR DESCRIPTION
 #### Problem
 This PR adds a `is_ubsan` option to the `build/config/compiler/BUILD.gn` and fix one occurrence of undefined behavior in `src/lib/support/BufferWriter.cpp` found while running `chi-tool onoff on 1`.
