### PR TITLE
[apk] Fix sendWiFiCredentials()

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -345,7 +345,10 @@ JNI_METHOD(void, sendWiFiCredentials)(JNIEnv * env, jobject self, jlong handle, 
     JniUtfString passwordStr(env, password);
 
     ChipLogProgress(Controller, "Sending Wi-Fi credentials for: %s", ssidStr.c_str());
-    AndroidDeviceControllerWrapper::FromJNIHandle(handle)->SendNetworkCredentials(ssidStr.c_str(), passwordStr.c_str());
+    {
+        ScopedPthreadLock lock(&sStackLock);
+        AndroidDeviceControllerWrapper::FromJNIHandle(handle)->SendNetworkCredentials(ssidStr.c_str(), passwordStr.c_str());
+    }
 }
 
 JNI_METHOD(void, sendThreadCredentials)


### PR DESCRIPTION
 #### Problem

See: #5643

Unlike other methods, `sendWiFiCredentials()` was not acquiring a mutex. This resulted in an incomplete BLE transmission. Only the first packet fragment was received by the device and the whole flow was interrupted by a timeout on the device side.

 #### Summary of Changes
Add a missing `ScopedPthreadLock`. This fixes the Wi-Fi provisioning flow. The device is able to reassemble the whole packet since it receives all the fragments now.

Fixes: #5643