### PR TITLE
[EFR32] Rework uart api used for Pigweed and fix conflict with Openthread  

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -98,6 +98,7 @@ efr32_executable("lighting_app") {
     "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/Service.cpp",
     "${examples_plat_dir}/init_efrPlatform.cpp",
+    "${examples_plat_dir}/uart.c",
     "src/AppTask.cpp",
     "src/ButtonHandler.cpp",
     "src/LightingManager.cpp",
@@ -131,7 +132,6 @@ efr32_executable("lighting_app") {
       "${chip_root}/examples/common/pigweed/RpcService.cpp",
       "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
       "${examples_plat_dir}/PigweedLogger.cpp",
-      "${examples_plat_dir}/uart.c",
       "src/Rpc.cpp",
     ]
   }

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -285,7 +285,7 @@ combination with JLinkRTTClient as follows:
     the example by UART using the RPC LightingService. Call the following
     command in your terminal
 
-    `python -m pw_hdlc.rpc_console --device /dev/tty.<SERIALDEVICE> -b 115200 /<CHIP_ROOT>/examples/lighting-app/lighting-common//lighting_service/pigweed_lighting.proto -o /<YourFolder>/pw_log.out`
+    `python -m pw_hdlc.rpc_console --device /dev/tty.<SERIALDEVICE> -b 115200 /<CHIP_ROOT>/examples/lighting-app/lighting-common/lighting_service/pigweed_lighting.proto -o /<YourFolder>/pw_log.out`
 
 -   Then you can simulate a button press or realease using the following command
     where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for

--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -285,7 +285,7 @@ combination with JLinkRTTClient as follows:
     the example by UART using the RPC LightingService. Call the following
     command in your terminal
 
-    `python -m pw_hdlc.rpc_console --device /dev/tty.<SERIALDEVICE> -b 115200 /<CHIP_ROOT>/examples/lighting-app/lighting-common/pigweed_lighting.proto -o /<YourFolder>/pw_log.out`
+    `python -m pw_hdlc.rpc_console --device /dev/tty.<SERIALDEVICE> -b 115200 /<CHIP_ROOT>/examples/lighting-app/lighting-common//lighting_service/pigweed_lighting.proto -o /<YourFolder>/pw_log.out`
 
 -   Then you can simulate a button press or realease using the following command
     where : idx = 0 or 1 for Button PB0 or PB1 action = 0 for PRESSED, 1 for

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -86,6 +86,7 @@ efr32_executable("lock_app") {
     "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/Service.cpp",
     "${examples_plat_dir}/init_efrPlatform.cpp",
+    "${examples_plat_dir}/uart.c",
     "src/AppTask.cpp",
     "src/BoltLockManager.cpp",
     "src/ButtonHandler.cpp",

--- a/examples/persistent-storage/efr32/BUILD.gn
+++ b/examples/persistent-storage/efr32/BUILD.gn
@@ -66,6 +66,7 @@ efr32_executable("persistent_storage") {
   sources = [
     "${efr32_project_dir}/../KeyValueStorageTest.cpp",
     "${examples_plat_dir}/init_efrPlatform.cpp",
+    "${examples_plat_dir}/uart.c",
     "main.cpp",
   ]
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -38,7 +38,6 @@ efr32_sdk("sdk") {
   sources = [
     "${efr32_project_dir}/include/CHIPProjectConfig.h",
     "${efr32_project_dir}/include/FreeRTOSConfig.h",
-    "${efr32_sdk_root}/hardware/kit/common/drivers/retargetserial.c",
   ]
 
   defines = [

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -69,10 +69,10 @@ efr32_executable("pigweed_app") {
   sources = [
     "${chip_root}/examples/common/pigweed/RpcService.cpp",
     "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-    "${examples_plat_dir}/LEDWidget.cpp",
     "${examples_plat_dir}/PigweedLogger.cpp",
-    "${examples_plat_dir}/init_efrPlatform.cpp",
     "${examples_plat_dir}/uart.c",
+    "${examples_plat_dir}/LEDWidget.cpp",
+    "${examples_plat_dir}/init_efrPlatform.cpp",
     "src/main.cpp",
   ]
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -68,10 +68,10 @@ efr32_executable("pigweed_app") {
   sources = [
     "${chip_root}/examples/common/pigweed/RpcService.cpp",
     "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-    "${examples_plat_dir}/PigweedLogger.cpp",
-    "${examples_plat_dir}/uart.c",
     "${examples_plat_dir}/LEDWidget.cpp",
+    "${examples_plat_dir}/PigweedLogger.cpp",
     "${examples_plat_dir}/init_efrPlatform.cpp",
+    "${examples_plat_dir}/uart.c",
     "src/main.cpp",
   ]
 

--- a/examples/platform/efr32/efr32mg12/BRD4163A/hal-config.h
+++ b/examples/platform/efr32/efr32mg12/BRD4163A/hal-config.h
@@ -101,7 +101,9 @@
 #define HAL_USART1_ENABLE (1)
 #define HAL_USART1_FREQUENCY (1000000UL)
 
+#ifndef HAL_VCOM_ENABLE
 #define HAL_VCOM_ENABLE (1)
+#endif
 
 // $[BTL_BUTTON]
 

--- a/examples/platform/efr32/pw_sys_io/sys_io_efr32.cc
+++ b/examples/platform/efr32/pw_sys_io/sys_io_efr32.cc
@@ -25,7 +25,14 @@
 
 int16_t console_getchar(char * chr)
 {
-    return uartConsoleRead(chr, 1);
+    int16_t retVal = 0;
+    
+    // Busy wait for pw_rcp reads
+    while (retVal == 0)
+    {
+        retVal = uartConsoleRead(chr, 1);
+    }
+    return retVal;
 }
 
 int16_t console_putchar(const char * chr)

--- a/examples/platform/efr32/pw_sys_io/sys_io_efr32.cc
+++ b/examples/platform/efr32/pw_sys_io/sys_io_efr32.cc
@@ -26,7 +26,7 @@
 int16_t console_getchar(char * chr)
 {
     int16_t retVal = 0;
-    
+
     // Busy wait for pw_rcp reads
     while (retVal == 0)
     {

--- a/examples/platform/efr32/uart.c
+++ b/examples/platform/efr32/uart.c
@@ -20,13 +20,189 @@
 #include "em_usart.h"
 #include "hal-config.h"
 #include "uartdrv.h"
-#include <retargetserial.h>
 #include <stddef.h>
+#include "assert.h"
+#include "AppConfig.h"
+#include <string.h>
+
+#if !defined(min)
+#define min(A,B) ( (A) < (B) ? (A):(B))
+#endif
+
+DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_RX_BUFS, sUartRxQueue);
+DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_TX_BUFS, sUartTxQueue);
+
+static UARTDRV_HandleData_t sUartHandleData;
+static UARTDRV_Handle_t sUartHandle = &sUartHandleData;
+
+typedef struct ReceiveFifo_t
+{
+    // The data buffer
+    uint8_t *pBuffer;
+    // The offset of the first item written to the list.
+    volatile uint16_t Head;
+    // The offset of the next item to be written to the list.
+    volatile uint16_t Tail;
+    // Maxium size of data that can be hold in buffer before overwriting
+    uint16_t MaxSize;
+} ReceiveFifo_t;
+
+#define MAX_BUFFER_SIZE 128
+// In order to reduce the probability of data loss during the dmaFull callback handler we use
+// two duplicate receive buffers so we can always have one "active" receive queue.
+static uint8_t sRxDmaBuffer[MAX_BUFFER_SIZE];
+static uint8_t sRxDmaBuffer2[MAX_BUFFER_SIZE];
+static uint8_t sRxFifoBuffer[MAX_BUFFER_SIZE];
+static uint16_t lastCount;
+static ReceiveFifo_t sReceiveFifo;
+
+//static void UART_tx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t *data, UARTDRV_Count_t transferCount);
+static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t *data, UARTDRV_Count_t transferCount);
+
+static bool InitFifo(ReceiveFifo_t *fifo, uint8_t* pDataBuffer, uint16_t bufferSize)
+{
+    if (fifo == NULL || pDataBuffer == NULL)
+    {
+        return false;
+    }
+
+    fifo->pBuffer = pDataBuffer;
+    fifo->MaxSize = bufferSize;
+    fifo->Tail = fifo->Head = 0;
+
+    return true;
+}
+
+static uint16_t AvailableDataCount(ReceiveFifo_t *fifo)
+{
+    uint16_t size = 0;
+    
+    // if equal there is no data return 0 directly
+    if (fifo->Tail != fifo->Head)
+    {
+        // determine if a wrap around occured to get the right data size avalaible.
+        size = (fifo->Tail < fifo->Head) ? (fifo->MaxSize - fifo->Head + fifo->Tail) : (fifo->Tail - fifo->Head) ;
+    }
+
+    return size;
+}
+
+static uint16_t RemainingSpace(ReceiveFifo_t *fifo)
+{
+    return fifo->MaxSize - AvailableDataCount(fifo);
+}
+
+static void WriteToFifo(ReceiveFifo_t *fifo, uint8_t* pDataToWrite, uint16_t SizeToWrite)
+{
+    assert(fifo);
+    assert(pDataToWrite);
+    assert(SizeToWrite <= fifo->MaxSize);
+
+    // Overwrite is not allowed
+    if ( RemainingSpace(fifo) >= SizeToWrite )
+    {
+        uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Tail);
+        if (SizeToWrite > nBytesBeforWrap)
+        {
+            // The number of bytes to write is bigger than the remaining bytes
+            // in the buffer, we have to wrap around 
+            memcpy(fifo->pBuffer + fifo->Tail, pDataToWrite, nBytesBeforWrap);
+            memcpy(fifo->pBuffer, pDataToWrite + nBytesBeforWrap, SizeToWrite - nBytesBeforWrap);
+        }
+        else
+        {
+            memcpy(fifo->pBuffer + fifo->Tail, pDataToWrite, SizeToWrite);
+        }
+
+        fifo->Tail = (fifo->Tail + SizeToWrite) % fifo->MaxSize; // increment tail with wraparound
+    }
+}
+
+static uint8_t RetrieveFromFifo(ReceiveFifo_t *fifo, uint8_t* pData, uint16_t SizeToRead)
+{
+    assert(fifo);
+    assert(pData);
+    assert(SizeToRead <= fifo->MaxSize);
+
+    uint16_t ReadSize =  min(SizeToRead, AvailableDataCount(fifo));
+    uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Head);
+
+    if (ReadSize > nBytesBeforWrap)
+    {
+        memcpy(pData, fifo->pBuffer + fifo->Head, nBytesBeforWrap);
+        memcpy(pData + nBytesBeforWrap, fifo->pBuffer, ReadSize - nBytesBeforWrap);
+    }
+    else
+    {
+        memcpy(pData, (fifo->pBuffer + fifo->Head), ReadSize);
+    }
+
+    fifo->Head = (fifo->Head + ReadSize) % fifo->MaxSize; // increment tail with wraparound
+
+    return ReadSize;
+}
 
 void uartConsoleInit(void)
 {
-    RETARGET_SerialCrLf(0);
-    RETARGET_SerialInit();
+    UARTDRV_Init_t uartInit = {
+        .port     = USART0,
+        .baudRate = HAL_SERIAL_APP_BAUD_RATE,
+#if defined(_USART_ROUTELOC0_MASK)
+        .portLocationTx = BSP_SERIAL_APP_TX_LOC,
+        .portLocationRx = BSP_SERIAL_APP_RX_LOC,
+#elif defined(_USART_ROUTE_MASK)
+        portLocation = BSP_SERIAL_APP_PORT,
+#endif
+#if defined(USART_CTRL_MVDIS)
+        .mvdis = false,
+#endif
+        .stopBits     = (USART_Stopbits_TypeDef) USART_FRAME_STOPBITS_ONE,
+        .parity       = (USART_Parity_TypeDef) USART_FRAME_PARITY_NONE,
+        .oversampling = (USART_OVS_TypeDef) USART_CTRL_OVS_X16,
+        .fcType  = HAL_SERIAL_APP_FLOW_CONTROL,
+        .ctsPort = BSP_SERIAL_APP_CTS_PORT,
+        .ctsPin  = BSP_SERIAL_APP_CTS_PIN,
+        .rtsPort = BSP_SERIAL_APP_RTS_PORT,
+        .rtsPin  = BSP_SERIAL_APP_RTS_PIN,
+        .rxQueue = (UARTDRV_Buffer_FifoQueue_t *) &sUartRxQueue,
+        .txQueue = (UARTDRV_Buffer_FifoQueue_t *) &sUartTxQueue,
+#if defined(_USART_ROUTELOC1_MASK)
+        .portLocationCts = BSP_SERIAL_APP_CTS_LOC,
+        .portLocationRts = BSP_SERIAL_APP_RTS_LOC,
+#endif
+    };
+
+    InitFifo(&sReceiveFifo , sRxFifoBuffer, MAX_BUFFER_SIZE);
+
+    UARTDRV_InitUart(sUartHandle, &uartInit);
+    UARTDRV_Receive(sUartHandle, sRxDmaBuffer, MAX_BUFFER_SIZE, UART_rx_callback);
+    UARTDRV_Receive(sUartHandle, sRxDmaBuffer2, MAX_BUFFER_SIZE, UART_rx_callback);
+}
+
+// static void UART_tx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t *data, UARTDRV_Count_t transferCount)
+// {
+//     (void)handle;
+//     (void)transferStatus;
+//     (void)data;
+//     (void)transferCount;
+// }
+
+// Callback triggered when UARTDRV DMA has received data
+static void UART_rx_callback(UARTDRV_Handle_t handle,
+                             Ecode_t transferStatus,
+                             uint8_t *data,
+                             UARTDRV_Count_t transferCount)
+{
+    (void)transferStatus;
+
+    uint8_t writeSize = (transferCount-lastCount);
+    if ( RemainingSpace(&sReceiveFifo) >= writeSize )
+    {
+        WriteToFifo(&sReceiveFifo, data+lastCount, writeSize);
+        lastCount = 0;
+    }
+
+    UARTDRV_Receive(sUartHandle, data, transferCount, UART_rx_callback);
 }
 
 int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
@@ -36,28 +212,34 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
         return -1;
     }
 
-    for (int i = 0; i < BufLength; i++)
+    if (UARTDRV_ForceTransmit(sUartHandle, (uint8_t *) Buf, BufLength) == ECODE_EMDRV_UARTDRV_OK)
     {
-        RETARGET_WriteChar(Buf[i]);
+        return BufLength;
     }
-    return (int16_t) BufLength;
+    
+    return -1;
 }
 
 int16_t uartConsoleRead(char * Buf, uint16_t BufLength)
 {
+    uint8_t *       data;
+    UARTDRV_Count_t count, remaining;
+    
     if (Buf == NULL || BufLength < 1)
     {
         return -1;
     }
 
-    for (int i = 0; i < BufLength; i++)
+    if (BufLength > AvailableDataCount(&sReceiveFifo) )
     {
-        int readVal = -1;
-        while (readVal == -1)
-        {
-            readVal = RETARGET_ReadChar();
-        }
-        Buf[i] = (char) readVal;
+        // If there is data available in dma buffer, get it now.
+        CORE_ATOMIC_SECTION(UARTDRV_GetReceiveStatus(sUartHandle, &data, &count, &remaining);
+            if (count > lastCount) 
+            {
+                WriteToFifo(&sReceiveFifo, data + lastCount, count - lastCount);
+                lastCount = count;
+            })
     }
-    return (int16_t) BufLength;
+
+    return (int16_t)RetrieveFromFifo(&sReceiveFifo, (uint8_t*)Buf, BufLength);
 }

--- a/examples/platform/efr32/uart.c
+++ b/examples/platform/efr32/uart.c
@@ -84,7 +84,7 @@ static bool InitFifo(Fifo_t *fifo, uint8_t* pDataBuffer, uint16_t bufferSize)
 static uint16_t AvailableDataCount(Fifo_t *fifo)
 {
     uint16_t size = 0;
-    
+
     // if equal there is no data return 0 directly
     if (fifo->Tail != fifo->Head)
     {
@@ -98,7 +98,7 @@ static uint16_t AvailableDataCount(Fifo_t *fifo)
 /*
 *   @brief Get the available space in the fifo buffer to insert new data
 *   @param Ptr to the fifo
-*   @return Nb of free bytes left in te buffer 
+*   @return Nb of free bytes left in te buffer
 */
 static uint16_t RemainingSpace(Fifo_t *fifo)
 {
@@ -122,7 +122,7 @@ static void WriteToFifo(Fifo_t *fifo, uint8_t* pDataToWrite, uint16_t SizeToWrit
         if (SizeToWrite > nBytesBeforWrap)
         {
             // The number of bytes to write is bigger than the remaining bytes
-            // in the buffer, we have to wrap around 
+            // in the buffer, we have to wrap around
             memcpy(fifo->pBuffer + fifo->Tail, pDataToWrite, nBytesBeforWrap);
             memcpy(fifo->pBuffer, pDataToWrite + nBytesBeforWrap, SizeToWrite - nBytesBeforWrap);
         }
@@ -166,7 +166,7 @@ static uint8_t RetrieveFromFifo(Fifo_t *fifo, uint8_t* pData, uint16_t SizeToRea
 
 /*
 *   @brief Init the the UART for serial communication, Start DMA reception
-*          and init Fifo to handle the received data from this uart 
+*          and init Fifo to handle the received data from this uart
 *
 *   @Note This UART is used for pigweed rpc
 */
@@ -204,7 +204,7 @@ void uartConsoleInit(void)
     InitFifo(&sReceiveFifo , sRxFifoBuffer, MAX_BUFFER_SIZE);
 
     UARTDRV_InitUart(sUartHandle, &uartInit);
-    // Activate 2 dma queues to always have one active 
+    // Activate 2 dma queues to always have one active
     UARTDRV_Receive(sUartHandle, sRxDmaBuffer, MAX_DMA_BUFFER_SIZE, UART_rx_callback);
     UARTDRV_Receive(sUartHandle, sRxDmaBuffer2, MAX_DMA_BUFFER_SIZE, UART_rx_callback);
 }
@@ -247,7 +247,7 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
     {
         return BufLength;
     }
-    
+
     return UART_CONSOLE_ERR;
 }
 
@@ -261,7 +261,7 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
 {
     uint8_t *       data;
     UARTDRV_Count_t count, remaining;
-    
+
     if (Buf == NULL || NbBytesToRead < 1)
     {
         return UART_CONSOLE_ERR;
@@ -272,7 +272,7 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
         // Not enough data available in the fifo for the read size request
         // If there is data available in dma buffer, get it now.
         CORE_ATOMIC_SECTION(UARTDRV_GetReceiveStatus(sUartHandle, &data, &count, &remaining);
-            if (count > lastCount) 
+            if (count > lastCount)
             {
                 WriteToFifo(&sReceiveFifo, data + lastCount, count - lastCount);
                 lastCount = count;

--- a/examples/platform/efr32/uart.c
+++ b/examples/platform/efr32/uart.c
@@ -16,17 +16,17 @@
  *    limitations under the License.
  */
 #include "uart.h"
+#include "AppConfig.h"
+#include "assert.h"
 #include "em_core.h"
 #include "em_usart.h"
 #include "hal-config.h"
 #include "uartdrv.h"
 #include <stddef.h>
-#include "assert.h"
-#include "AppConfig.h"
 #include <string.h>
 
 #if !defined(MIN)
-#define MIN(A,B) ( (A) < (B) ? (A):(B))
+#define MIN(A, B) ((A) < (B) ? (A) : (B))
 #endif
 
 DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_RX_BUFS, sUartRxQueue);
@@ -35,7 +35,7 @@ DEFINE_BUF_QUEUE(EMDRV_UARTDRV_MAX_CONCURRENT_TX_BUFS, sUartTxQueue);
 typedef struct
 {
     // The data buffer
-    uint8_t *pBuffer;
+    uint8_t * pBuffer;
     // The offset of the first item written to the list.
     volatile uint16_t Head;
     // The offset of the next item to be written to the list.
@@ -46,12 +46,12 @@ typedef struct
 
 #define UART_CONSOLE_ERR -1 // Negative value in case of UART Console action failed. Triggers a failure for PW_RPC
 #define MAX_BUFFER_SIZE 256
-#define MAX_DMA_BUFFER_SIZE (MAX_BUFFER_SIZE/2)
+#define MAX_DMA_BUFFER_SIZE (MAX_BUFFER_SIZE / 2)
 // In order to reduce the probability of data loss during the dmaFull callback handler we use
 // two duplicate receive buffers so we can always have one "active" receive queue.
 static uint8_t sRxDmaBuffer[MAX_DMA_BUFFER_SIZE];
 static uint8_t sRxDmaBuffer2[MAX_DMA_BUFFER_SIZE];
-static uint16_t lastCount;  // Nb of bytes already processed from the active dmaBuffer
+static uint16_t lastCount; // Nb of bytes already processed from the active dmaBuffer
 
 // Rx buffer for the receive Fifo
 static uint8_t sRxFifoBuffer[MAX_BUFFER_SIZE];
@@ -60,9 +60,9 @@ static Fifo_t sReceiveFifo;
 static UARTDRV_HandleData_t sUartHandleData;
 static UARTDRV_Handle_t sUartHandle = &sUartHandleData;
 
-static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t *data, UARTDRV_Count_t transferCount);
+static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t * data, UARTDRV_Count_t transferCount);
 
-static bool InitFifo(Fifo_t *fifo, uint8_t* pDataBuffer, uint16_t bufferSize)
+static bool InitFifo(Fifo_t * fifo, uint8_t * pDataBuffer, uint16_t bufferSize)
 {
     if (fifo == NULL || pDataBuffer == NULL)
     {
@@ -77,11 +77,11 @@ static bool InitFifo(Fifo_t *fifo, uint8_t* pDataBuffer, uint16_t bufferSize)
 }
 
 /*
-*   @brief Get the amount of unprocessed bytes in the fifo buffer
-*   @param Ptr to the fifo
-*   @return Nb of "unread" bytes available in the fifo
-*/
-static uint16_t AvailableDataCount(Fifo_t *fifo)
+ *   @brief Get the amount of unprocessed bytes in the fifo buffer
+ *   @param Ptr to the fifo
+ *   @return Nb of "unread" bytes available in the fifo
+ */
+static uint16_t AvailableDataCount(Fifo_t * fifo)
 {
     uint16_t size = 0;
 
@@ -89,34 +89,34 @@ static uint16_t AvailableDataCount(Fifo_t *fifo)
     if (fifo->Tail != fifo->Head)
     {
         // determine if a wrap around occured to get the right data size avalaible.
-        size = (fifo->Tail < fifo->Head) ? (fifo->MaxSize - fifo->Head + fifo->Tail) : (fifo->Tail - fifo->Head) ;
+        size = (fifo->Tail < fifo->Head) ? (fifo->MaxSize - fifo->Head + fifo->Tail) : (fifo->Tail - fifo->Head);
     }
 
     return size;
 }
 
 /*
-*   @brief Get the available space in the fifo buffer to insert new data
-*   @param Ptr to the fifo
-*   @return Nb of free bytes left in te buffer
-*/
-static uint16_t RemainingSpace(Fifo_t *fifo)
+ *   @brief Get the available space in the fifo buffer to insert new data
+ *   @param Ptr to the fifo
+ *   @return Nb of free bytes left in te buffer
+ */
+static uint16_t RemainingSpace(Fifo_t * fifo)
 {
     return fifo->MaxSize - AvailableDataCount(fifo);
 }
 
 /*
-*   @brief Write data in the fifo as a circular buffer
-*   @param Ptr to the fifo, ptr of the data to write, nb of bytes to write
-*/
-static void WriteToFifo(Fifo_t *fifo, uint8_t* pDataToWrite, uint16_t SizeToWrite)
+ *   @brief Write data in the fifo as a circular buffer
+ *   @param Ptr to the fifo, ptr of the data to write, nb of bytes to write
+ */
+static void WriteToFifo(Fifo_t * fifo, uint8_t * pDataToWrite, uint16_t SizeToWrite)
 {
     assert(fifo);
     assert(pDataToWrite);
     assert(SizeToWrite <= fifo->MaxSize);
 
     // Overwrite is not allowed
-    if ( RemainingSpace(fifo) >= SizeToWrite )
+    if (RemainingSpace(fifo) >= SizeToWrite)
     {
         uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Tail);
         if (SizeToWrite > nBytesBeforWrap)
@@ -136,17 +136,17 @@ static void WriteToFifo(Fifo_t *fifo, uint8_t* pDataToWrite, uint16_t SizeToWrit
 }
 
 /*
-*   @brief Write data in the fifo as a circular buffer
-*   @param Ptr to the fifo, ptr to contain the data to process, nb of bytes to pull from the fifo
-*   @return Nb of bytes that were retrieved.
-*/
-static uint8_t RetrieveFromFifo(Fifo_t *fifo, uint8_t* pData, uint16_t SizeToRead)
+ *   @brief Write data in the fifo as a circular buffer
+ *   @param Ptr to the fifo, ptr to contain the data to process, nb of bytes to pull from the fifo
+ *   @return Nb of bytes that were retrieved.
+ */
+static uint8_t RetrieveFromFifo(Fifo_t * fifo, uint8_t * pData, uint16_t SizeToRead)
 {
     assert(fifo);
     assert(pData);
     assert(SizeToRead <= fifo->MaxSize);
 
-    uint16_t ReadSize =  MIN(SizeToRead, AvailableDataCount(fifo));
+    uint16_t ReadSize        = MIN(SizeToRead, AvailableDataCount(fifo));
     uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Head);
 
     if (ReadSize > nBytesBeforWrap)
@@ -165,11 +165,11 @@ static uint8_t RetrieveFromFifo(Fifo_t *fifo, uint8_t* pData, uint16_t SizeToRea
 }
 
 /*
-*   @brief Init the the UART for serial communication, Start DMA reception
-*          and init Fifo to handle the received data from this uart
-*
-*   @Note This UART is used for pigweed rpc
-*/
+ *   @brief Init the the UART for serial communication, Start DMA reception
+ *          and init Fifo to handle the received data from this uart
+ *
+ *   @Note This UART is used for pigweed rpc
+ */
 void uartConsoleInit(void)
 {
     UARTDRV_Init_t uartInit = {
@@ -187,13 +187,13 @@ void uartConsoleInit(void)
         .stopBits     = (USART_Stopbits_TypeDef) USART_FRAME_STOPBITS_ONE,
         .parity       = (USART_Parity_TypeDef) USART_FRAME_PARITY_NONE,
         .oversampling = (USART_OVS_TypeDef) USART_CTRL_OVS_X16,
-        .fcType  = HAL_SERIAL_APP_FLOW_CONTROL,
-        .ctsPort = BSP_SERIAL_APP_CTS_PORT,
-        .ctsPin  = BSP_SERIAL_APP_CTS_PIN,
-        .rtsPort = BSP_SERIAL_APP_RTS_PORT,
-        .rtsPin  = BSP_SERIAL_APP_RTS_PIN,
-        .rxQueue = (UARTDRV_Buffer_FifoQueue_t *) &sUartRxQueue,
-        .txQueue = (UARTDRV_Buffer_FifoQueue_t *) &sUartTxQueue,
+        .fcType       = HAL_SERIAL_APP_FLOW_CONTROL,
+        .ctsPort      = BSP_SERIAL_APP_CTS_PORT,
+        .ctsPin       = BSP_SERIAL_APP_CTS_PIN,
+        .rtsPort      = BSP_SERIAL_APP_RTS_PORT,
+        .rtsPin       = BSP_SERIAL_APP_RTS_PIN,
+        .rxQueue      = (UARTDRV_Buffer_FifoQueue_t *) &sUartRxQueue,
+        .txQueue      = (UARTDRV_Buffer_FifoQueue_t *) &sUartTxQueue,
 #if defined(_USART_ROUTELOC1_MASK)
         .portLocationCts = BSP_SERIAL_APP_CTS_LOC,
         .portLocationRts = BSP_SERIAL_APP_RTS_LOC,
@@ -201,7 +201,7 @@ void uartConsoleInit(void)
     };
 
     // Init a fifo for the data received on the uart
-    InitFifo(&sReceiveFifo , sRxFifoBuffer, MAX_BUFFER_SIZE);
+    InitFifo(&sReceiveFifo, sRxFifoBuffer, MAX_BUFFER_SIZE);
 
     UARTDRV_InitUart(sUartHandle, &uartInit);
     // Activate 2 dma queues to always have one active
@@ -210,19 +210,16 @@ void uartConsoleInit(void)
 }
 
 /*
-*   @brief Callback triggered when a UARTDRV DMA buffer is full
-*/
-static void UART_rx_callback(UARTDRV_Handle_t handle,
-                             Ecode_t transferStatus,
-                             uint8_t *data,
-                             UARTDRV_Count_t transferCount)
+ *   @brief Callback triggered when a UARTDRV DMA buffer is full
+ */
+static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, uint8_t * data, UARTDRV_Count_t transferCount)
 {
-    (void)transferStatus;
+    (void) transferStatus;
 
-    uint8_t writeSize = (transferCount-lastCount);
-    if ( RemainingSpace(&sReceiveFifo) >= writeSize )
+    uint8_t writeSize = (transferCount - lastCount);
+    if (RemainingSpace(&sReceiveFifo) >= writeSize)
     {
-        WriteToFifo(&sReceiveFifo, data+lastCount, writeSize);
+        WriteToFifo(&sReceiveFifo, data + lastCount, writeSize);
         lastCount = 0;
     }
 
@@ -230,10 +227,10 @@ static void UART_rx_callback(UARTDRV_Handle_t handle,
 }
 
 /*
-*   @brief Read the data available from the console Uart
-*   @param Buffer that contains the data to write, number bytes to write.
-*   @return Amount of bytes written or ERROR (-1)
-*/
+ *   @brief Read the data available from the console Uart
+ *   @param Buffer that contains the data to write, number bytes to write.
+ *   @return Amount of bytes written or ERROR (-1)
+ */
 int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
 {
     if (Buf == NULL || BufLength < 1)
@@ -251,15 +248,14 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength)
     return UART_CONSOLE_ERR;
 }
 
-
 /*
-*   @brief Read the data available from the console Uart
-*   @param Buffer for the data to be read, number bytes to read.
-*   @return Amount of bytes that was read from the rx fifo or ERROR (-1)
-*/
+ *   @brief Read the data available from the console Uart
+ *   @param Buffer for the data to be read, number bytes to read.
+ *   @return Amount of bytes that was read from the rx fifo or ERROR (-1)
+ */
 int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
 {
-    uint8_t *       data;
+    uint8_t * data;
     UARTDRV_Count_t count, remaining;
 
     if (Buf == NULL || NbBytesToRead < 1)
@@ -267,17 +263,15 @@ int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead)
         return UART_CONSOLE_ERR;
     }
 
-    if (NbBytesToRead > AvailableDataCount(&sReceiveFifo) )
+    if (NbBytesToRead > AvailableDataCount(&sReceiveFifo))
     {
         // Not enough data available in the fifo for the read size request
         // If there is data available in dma buffer, get it now.
-        CORE_ATOMIC_SECTION(UARTDRV_GetReceiveStatus(sUartHandle, &data, &count, &remaining);
-            if (count > lastCount)
-            {
-                WriteToFifo(&sReceiveFifo, data + lastCount, count - lastCount);
-                lastCount = count;
-            })
+        CORE_ATOMIC_SECTION(UARTDRV_GetReceiveStatus(sUartHandle, &data, &count, &remaining); if (count > lastCount) {
+            WriteToFifo(&sReceiveFifo, data + lastCount, count - lastCount);
+            lastCount = count;
+        })
     }
 
-    return (int16_t)RetrieveFromFifo(&sReceiveFifo, (uint8_t*)Buf, NbBytesToRead);
+    return (int16_t) RetrieveFromFifo(&sReceiveFifo, (uint8_t *) Buf, NbBytesToRead);
 }

--- a/examples/platform/efr32/uart.h
+++ b/examples/platform/efr32/uart.h
@@ -26,7 +26,11 @@ extern "C" {
 
 void uartConsoleInit(void);
 int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength);
-int16_t uartConsoleRead(char * Buf, uint16_t BufLength);
+int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead);
+
+// Implemented by in openthread code
+extern void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength);
+extern void otPlatUartSendDone(void);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/examples/platform/efr32/uart.h
+++ b/examples/platform/efr32/uart.h
@@ -29,7 +29,7 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength);
 int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead);
 
 // Implemented by in openthread code
-extern void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength);
+extern void otPlatUartReceived(const uint8_t * aBuf, uint16_t aBufLength);
 extern void otPlatUartSendDone(void);
 
 #ifdef __cplusplus

--- a/src/platform/EFR32/ThreadStackManagerImpl.cpp
+++ b/src/platform/EFR32/ThreadStackManagerImpl.cpp
@@ -135,3 +135,28 @@ extern "C" void otPlatFree(void * aPtr)
 {
     CHIPPlatformMemoryFree(aPtr);
 }
+
+extern "C" __WEAK otError otPlatUartEnable(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" __WEAK otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" __WEAK otError otPlatUartFlush(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" __WEAK otError otPlatUartDisable(void)
+{
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
+extern "C" __WEAK void efr32UartProcess(void)
+{
+    // 
+}

--- a/src/platform/EFR32/ThreadStackManagerImpl.cpp
+++ b/src/platform/EFR32/ThreadStackManagerImpl.cpp
@@ -136,7 +136,6 @@ extern "C" void otPlatFree(void * aPtr)
     CHIPPlatformMemoryFree(aPtr);
 }
 
-
 /**
  * @brief Openthread UART implementation for the CLI is conflicting
  *        with the UART implemented for Pigweed RPC as they use the same UART port
@@ -162,12 +161,12 @@ extern "C" __WEAK otError otPlatUartEnable(void)
 #endif
 }
 
-extern "C" __WEAK otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLength)
+extern "C" __WEAK otError otPlatUartSend(const uint8_t * aBuf, uint16_t aBufLength)
 {
 #ifdef PW_RPC_ENABLED
     return OT_ERROR_NOT_IMPLEMENTED;
 #else
-    if (uartConsoleWrite((const char*)aBuf, aBufLength) > 0)
+    if (uartConsoleWrite((const char *) aBuf, aBufLength) > 0)
     {
         otPlatUartSendDone();
         return OT_ERROR_NONE;
@@ -179,12 +178,12 @@ extern "C" __WEAK otError otPlatUartSend(const uint8_t *aBuf, uint16_t aBufLengt
 extern "C" __WEAK void efr32UartProcess(void)
 {
 #ifndef PW_RPC_ENABLED
-    uint8_t tempBuf[128] = {0};
-    //will read the data available up t 128bytes
-    uint16_t count = uartConsoleRead((char*)tempBuf, 128);
+    uint8_t tempBuf[128] = { 0 };
+    // will read the data available up t 128bytes
+    uint16_t count = uartConsoleRead((char *) tempBuf, 128);
     if (count > 0)
     {
-        //ot process Received data for CLI cmds
+        // ot process Received data for CLI cmds
         otPlatUartReceived(tempBuf, count);
     }
 #endif

--- a/src/platform/EFR32/ThreadStackManagerImpl.cpp
+++ b/src/platform/EFR32/ThreadStackManagerImpl.cpp
@@ -179,7 +179,7 @@ extern "C" __WEAK void efr32UartProcess(void)
 {
 #ifndef PW_RPC_ENABLED
     uint8_t tempBuf[128] = { 0 };
-    // will read the data available up t 128bytes
+    // will read the data available up to 128bytes
     uint16_t count = uartConsoleRead((char *) tempBuf, 128);
     if (count > 0)
     {

--- a/src/platform/EFR32/ThreadStackManagerImpl.cpp
+++ b/src/platform/EFR32/ThreadStackManagerImpl.cpp
@@ -140,7 +140,7 @@ extern "C" void otPlatFree(void * aPtr)
 /**
  * @brief Openthread UART implementation for the CLI is conflicting
  *        with the UART implemented for Pigweed RPC as they use the same UART port
- *        
+ *
  *        We now only build the uart as implemented in
  *        connectedhomeip/examples/platform/efr32/uart.c
  *        and remap OT functions to use our uart api.

--- a/third_party/openthread/platforms/efr32/BUILD.gn
+++ b/third_party/openthread/platforms/efr32/BUILD.gn
@@ -56,7 +56,6 @@ source_set("libopenthread-efr32") {
     "${openthread_root}/examples/platforms/efr32/src/misc.c",
     "${openthread_root}/examples/platforms/efr32/src/radio.c",
     "${openthread_root}/examples/platforms/efr32/src/system.c",
-    "${openthread_root}/examples/platforms/efr32/src/uart.c",
     "${openthread_root}/third_party/silabs/rail_config/rail_config.c",
   ]
 


### PR DESCRIPTION
 #### Problem
Pigweed rpc for efr32 used a basic uart driver (retargetserial) and it conflicts with Openthread UART implementation for the CLI as they both use the same UART port to communicate with a host. Before the last update of openthread submodule we could skip the OT Uart init when we built with pw_rpc but now it does a build error if retargetserial is used.

 #### Summary of Changes
Integrate Michael PR #5628 to clean up pigweed build in the lighting app.
Remove /third_party/openthread/repo/examples/platforms/efr32/src/uart.c from the build
Rework the uart driver that was used for pw rpc to be a bit more advanced and match what could be done from the implementation in OT. It now use DMA and a circular buffer.
Remap OT uart functions to use our uart api.

OT CLI is still not available when the examples are built with pw_rpc
