### PR TITLE
[nrfconnect] Fixed bug with stopping not started NFC tag.

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -423,10 +423,13 @@ void AppTask::ThreadProvisioningHandler(const ChipDeviceEvent * event, intptr_t 
     ARG_UNUSED(arg);
     if ((event->Type == DeviceEventType::kServiceProvisioningChange) && ConnectivityMgr().IsThreadProvisioned())
     {
-        const int result = sNFC.StopTagEmulation();
-        if (result)
+        if (sNFC.IsTagEmulationStarted())
         {
-            LOG_ERR("Stopping NFC Tag emulation failed");
+            const int result = sNFC.StopTagEmulation();
+            if (result)
+            {
+                LOG_ERR("Stopping NFC Tag emulation failed");
+            }
         }
     }
 }

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -423,10 +423,13 @@ void AppTask::ThreadProvisioningHandler(const ChipDeviceEvent * event, intptr_t 
     ARG_UNUSED(arg);
     if ((event->Type == DeviceEventType::kServiceProvisioningChange) && ConnectivityMgr().IsThreadProvisioned())
     {
-        const int result = sNFC.StopTagEmulation();
-        if (result)
+        if (sNFC.IsTagEmulationStarted())
         {
-            LOG_ERR("Stopping NFC Tag emulation failed");
+            const int result = sNFC.StopTagEmulation();
+            if (result)
+            {
+                LOG_ERR("Stopping NFC Tag emulation failed");
+            }
         }
     }
 }


### PR DESCRIPTION
 #### Problem
There is a bug in the code that NFC tag emulation is stopped after commissioning even if it wasn't started, what sometimes results in displaying stopping error.

 #### Summary of Changes
Added checking if NFC tag is started before trying to stop it.