### PR TITLE
[cirque] Improvements of chip device ctrl test

### DIFF
--- a/src/controller/python/test/Dockerfile
+++ b/src/controller/python/test/Dockerfile
@@ -10,7 +10,7 @@ COPY mobile-device-test.py /usr/bin/
 RUN apt-get update && \
     apt-get install -y ca-certificates libglib2.0-dev avahi-daemon libavahi-client3 \
     python3 python3-dev python3-pip libcairo2-dev libdbus-1-dev libgirepository1.0-dev \
-    libjpeg-dev libgif-dev && \
+    libjpeg-dev libgif-dev gdb && \
     pip3 install /whl/*.whl
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -93,7 +93,7 @@ class TestPythonController(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "catchsegv python3 /usr/bin/mobile-device-test.py -t 75 -a {}".format(ethernet_ip)
+        command = "gdb -return-child-result -q -ex run -ex bt --args python3 /usr/bin/mobile-device-test.py -t 75 -a {}".format(ethernet_ip)
         ret = self.execute_device_cmd(req_device_id, command)
 
         self.assertEqual(ret['return_code'], '0',

--- a/src/test_driver/linux-cirque/test-mobile-device.py
+++ b/src/test_driver/linux-cirque/test-mobile-device.py
@@ -75,7 +75,21 @@ class TestPythonController(CHIPVirtualHome):
         time.sleep(5)
         for device_id in server_ids:
             # Clear default Thread network commissioning data
-            reply = self.execute_device_cmd(device_id, 'ot-ctl factoryreset')
+            self.logger.info("Resetting thread network on {}".format(
+                self.get_device_pretty_id(device_id)))
+            self.execute_device_cmd(device_id, 'ot-ctl factoryreset')
+            resetResult = False
+            for i in range(10):
+                # We can only check the status of ot-agent by query its state.
+                reply = self.execute_device_cmd(device_id, 'ot-ctl state')
+                if self.sequenceMatch(reply['output'], ('disabled',)):
+                    self.logger.info("Finished resetting Thread network on {}".format(
+                        self.get_device_pretty_id(device_id)))
+                    resetResult = True
+                    break
+                time.sleep(1)
+            self.assertTrue(resetResult, "Failed to do factoryreset thread network on {}.".format(
+                self.get_device_pretty_id(device_id)))
 
         req_device_id = req_ids[0]
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

`ot-ctl factoryreset` returns immediately, but `ot-agent` takes time to finish factory reset, the test will fail if we started the test too early.

The output of catchsegv is not readable enough.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Add a check and wait for thread factoryreset finish

Use gdb to wrap the program.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #<<<<<FILL ME IN  - issue number(s). If no issue, please create one>>>>>

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
