### PR TITLE
Disable doxygen generation on every push

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -15,8 +15,7 @@
 name: Doxygen
 
 on:
-    push:
-    pull_request:
+    tag:
 
 jobs:
     doxygen:


### PR DESCRIPTION
 #### Problem

Current Doxygen generates well over 500MB of content that is pushed to `gh-pages` on every merge.  This makes our repository grow faster than it is reasonably expected, leading to slow checkout times,  and general bloat

#### Summary of Changes

Move Doxygen generation to trigger only on tags.  This should help
with the enormous bloat we're seeing in gh-pages branch


