### PR TITLE
Add OSX support in restyle-diff

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -41,6 +41,17 @@ restyle-paths() {
 cd "$CHIP_ROOT"
 declare -a paths=()
 
-readarray -t paths < <(git diff --ignore-submodules --name-only "${1:-master}")
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    (git diff --ignore-submodules --name-only "${1:-master}") >./paths.txt
+
+    paths=()
+    while IFS= read -r line; do
+        paths+=("$line")
+    done <./paths.txt
+
+    rm ./paths.txt
+else
+    readarray -t paths < <(git diff --ignore-submodules --name-only "${1:-master}")
+fi
 
 restyle-paths "${paths[@]}"

--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -39,19 +39,6 @@ restyle-paths() {
 }
 
 cd "$CHIP_ROOT"
-declare -a paths=()
-
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    (git diff --ignore-submodules --name-only "${1:-master}") >./paths.txt
-
-    paths=()
-    while IFS= read -r line; do
-        paths+=("$line")
-    done <./paths.txt
-
-    rm ./paths.txt
-else
-    readarray -t paths < <(git diff --ignore-submodules --name-only "${1:-master}")
-fi
+declare -a paths="($(git diff --ignore-submodules --name-only "${1:-master}"))"
 
 restyle-paths "${paths[@]}"


### PR DESCRIPTION
 #### Problem
restyle-diff cannot be run locally on mac because readarray is not supported on it.

 #### Summary of Changes
Add an alternative if restyle-diff is run on darwin(OSX).
Since I don't know for other OSs than linux or darwin, use the readarray method for all other cases.
