### PR TITLE
[Thread]: Fix crash in ThreadStackManager during system shutdown

### DIFF
--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -99,7 +99,11 @@ public:
 private:
     struct DBusConnectionDeleter
     {
-        void operator()(DBusConnection * aConnection) { dbus_connection_unref(aConnection); }
+        void operator()(DBusConnection * aConnection)
+        {
+            dbus_connection_close(aConnection);
+            dbus_connection_unref(aConnection);
+        }
     };
 
     using UniqueDBusConnection = std::unique_ptr<DBusConnection, DBusConnectionDeleter>;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Observe the system crash in ThreadStackManager during system shutdown.

From the backtrace, it seems the last reference on a connection was dropped without closing the connection.

(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007ffff7531859 in __GI_abort () at abort.c:79
#2  0x00007ffff7c56ed2 in  () at /lib/x86_64-linux-gnu/libdbus-1.so.3
#3  0x00007ffff7c79570 in _dbus_strdup () at /lib/x86_64-linux-gnu/libdbus-1.so.3
#4  0x000055555558c1ec in chip::DeviceLayer::ThreadStackManagerImpl::DBusConnectionDeleter::operator()(DBusConnection*) (this=0x5555555fae88 <chip::DeviceLayer::ThreadStackManagerImpl::sInstance+8>, aConnection=0x555555639860)
    at ../../src/platform/Linux/ThreadStackManagerImpl.h:102
#5  0x000055555558ccd6 in std::unique_ptr<DBusConnection, chip::DeviceLayer::ThreadStackManagerImpl::DBusConnectionDeleter>::~unique_ptr()
    (this=0x5555555fae88 <chip::DeviceLayer::ThreadStackManagerImpl::sInstance+8>, __in_chrg=<optimized out>) at /usr/include/c++/9/bits/unique_ptr.h:292
#6  0x000055555558e212 in chip::DeviceLayer::ThreadStackManagerImpl::~ThreadStackManagerImpl() (this=0x5555555fae80 <chip::DeviceLayer::ThreadStackManagerImpl::sInstance>, __in_chrg=<optimized out>)
    at ../../src/platform/Linux/ThreadStackManagerImpl.h:95
#7  0x00007ffff7555a27 in __run_exit_handlers (status=0, listp=0x7ffff76f7718 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#8  0x00007ffff7555be0 in __GI_exit (status=<optimized out>) at exit.c:139
#9  0x000055555556d6f2 in chip::Shell::cmd_exit(int, char**) (argc=0, argv=0x7fffffffdd18) at ../../src/lib/shell/commands.cpp:41
#10 0x000055555556ce75 in chip::Shell::Shell::ExecCommand(int, char**)Python Exception <class 'RecursionError'> maximum recursion depth exceeded while getting the str of an object: 
 (this=0x5555555f8140 <chip::Shell::Shell::theShellRoot>, argc=1, argv=0x7fffffffdd10) at ../../src/lib/shell/shell.cpp:141
#11 0x000055555556d1ab in chip::Shell::Shell::TaskLoop(void*) (arg=0x0) at ../../src/lib/shell/shell.cpp:223
#12 0x000055555556ca71 in chip::Shell::shell_task(void*) (arg=0x0) at ../../src/lib/shell/shell.h:187
#13 0x000055555556cae3 in main() () at ../../examples/shell/standalone/main.cpp:50


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Close the dbus connection before freeing the dbus connection.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
