### PR TITLE
Use 64-bit long type for Java layer device IDs (#5630)

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/echoclient/EchoClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/echoclient/EchoClientFragment.kt
@@ -84,7 +84,7 @@ class EchoClientFragment : Fragment() {
 
     val echoEditTextContents = inputTextEd.text.toString()
     val echoText = if (echoEditTextContents.isEmpty()) DEFAULT_ECHO_MSG else echoEditTextContents
-    deviceController.sendMessage(deviceIdEd.text.toString().toInt(), echoText)
+    deviceController.sendMessage(deviceIdEd.text.toString().toLong(), echoText)
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/DeviceIdUtil.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/util/DeviceIdUtil.kt
@@ -6,24 +6,24 @@ import android.content.SharedPreferences
 /** Utils for storing and accessing available device IDs using shared preferences. */
 object DeviceIdUtil {
   private const val PREFERENCE_FILE_KEY = "com.google.chip.chiptool.PREFERENCE_FILE_KEY"
-  private const val DEVICE_ID_PREFS_KEY = "deviceId"
-  private const val DEFAULT_DEVICE_ID = 1
+  private const val DEVICE_ID_PREFS_KEY = "device_id"
+  private const val DEFAULT_DEVICE_ID = 1L
 
-  fun getNextAvailableId(context: Context): Int {
+  fun getNextAvailableId(context: Context): Long {
     val prefs = getPrefs(context)
     return if (prefs.contains(DEVICE_ID_PREFS_KEY)) {
-      prefs.getInt(DEVICE_ID_PREFS_KEY, DEFAULT_DEVICE_ID)
+      prefs.getLong(DEVICE_ID_PREFS_KEY, DEFAULT_DEVICE_ID)
     } else {
-      prefs.edit().putInt(DEVICE_ID_PREFS_KEY, DEFAULT_DEVICE_ID).apply()
+      prefs.edit().putLong(DEVICE_ID_PREFS_KEY, DEFAULT_DEVICE_ID).apply()
       DEFAULT_DEVICE_ID
     }
   }
 
-  fun setNextAvailableId(context: Context, newId: Int) {
-    getPrefs(context).edit().putInt(DEVICE_ID_PREFS_KEY, newId).apply()
+  fun setNextAvailableId(context: Context, newId: Long) {
+    getPrefs(context).edit().putLong(DEVICE_ID_PREFS_KEY, newId).apply()
   }
 
-  fun getLastDeviceId(context: Context) = getNextAvailableId(context) - 1
+  fun getLastDeviceId(context: Context): Long = getNextAvailableId(context) - 1
 
   private fun getPrefs(context: Context): SharedPreferences {
     return context.getSharedPreferences(PREFERENCE_FILE_KEY, Context.MODE_PRIVATE)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -57,7 +57,7 @@ using namespace chip::Controller;
 
 #define CDC_JNI_CALLBACK_LOCAL_REF_COUNT 256
 
-static void GetCHIPDevice(JNIEnv * env, long wrapperHandle, int deviceId, Device ** device);
+static void GetCHIPDevice(JNIEnv * env, long wrapperHandle, uint64_t deviceId, Device ** device);
 static void HandleNotifyChipConnectionClosed(BLE_CONNECTION_OBJECT connObj);
 static bool HandleSendCharacteristic(BLE_CONNECTION_OBJECT connObj, const uint8_t * svcId, const uint8_t * charId,
                                      const uint8_t * characteristicData, uint32_t characteristicDataLen);
@@ -276,7 +276,7 @@ exit:
     return result;
 }
 
-JNI_METHOD(void, pairDevice)(JNIEnv * env, jobject self, jlong handle, jint deviceId, jint connObj, jlong pinCode)
+JNI_METHOD(void, pairDevice)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint connObj, jlong pinCode)
 {
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
@@ -301,7 +301,7 @@ JNI_METHOD(void, pairDevice)(JNIEnv * env, jobject self, jlong handle, jint devi
     }
 }
 
-JNI_METHOD(void, unpairDevice)(JNIEnv * env, jobject self, jlong handle, jint deviceId)
+JNI_METHOD(void, unpairDevice)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
@@ -320,7 +320,7 @@ JNI_METHOD(void, unpairDevice)(JNIEnv * env, jobject self, jlong handle, jint de
     }
 }
 
-JNI_METHOD(void, stopDevicePairing)(JNIEnv * env, jobject self, jlong handle, jint deviceId)
+JNI_METHOD(void, stopDevicePairing)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
@@ -403,7 +403,7 @@ JNI_METHOD(void, pairTestDeviceWithoutSecurity)(JNIEnv * env, jobject self, jlon
     }
 }
 
-JNI_METHOD(void, disconnectDevice)(JNIEnv * env, jobject self, jlong handle, jint deviceId)
+JNI_METHOD(void, disconnectDevice)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -435,7 +435,7 @@ JNI_METHOD(jboolean, isActive)(JNIEnv * env, jobject self, jlong handle)
     }
 }
 
-void GetCHIPDevice(JNIEnv * env, long wrapperHandle, int deviceId, Device ** chipDevice)
+void GetCHIPDevice(JNIEnv * env, long wrapperHandle, uint64_t deviceId, Device ** chipDevice)
 {
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(wrapperHandle);
     CHIP_ERROR err                           = CHIP_NO_ERROR;
@@ -452,7 +452,7 @@ void GetCHIPDevice(JNIEnv * env, long wrapperHandle, int deviceId, Device ** chi
     }
 }
 
-JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jint deviceId)
+JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     Device * chipDevice = nullptr;
 
@@ -472,7 +472,7 @@ JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jint
     return env->NewStringUTF(addrStr);
 }
 
-JNI_METHOD(void, sendMessage)(JNIEnv * env, jobject self, jlong handle, jint deviceId, jstring messageObj)
+JNI_METHOD(void, sendMessage)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring messageObj)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     Device * chipDevice = nullptr;
@@ -507,7 +507,7 @@ JNI_METHOD(void, sendMessage)(JNIEnv * env, jobject self, jlong handle, jint dev
     }
 }
 
-JNI_METHOD(void, sendCommand)(JNIEnv * env, jobject self, jlong handle, jint deviceId, jobject commandObj, jint aValue)
+JNI_METHOD(void, sendCommand)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jobject commandObj, jint aValue)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     Device * chipDevice = nullptr;
@@ -563,7 +563,7 @@ JNI_METHOD(void, sendCommand)(JNIEnv * env, jobject self, jlong handle, jint dev
     }
 }
 
-JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle, jint deviceId, jint duration)
+JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint duration)
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     Device * chipDevice = nullptr;

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -46,7 +46,7 @@ public class ChipDeviceController {
     return AndroidChipStack.getInstance().getCallback();
   }
 
-  public void pairDevice(BluetoothGatt bleServer, int deviceId, long setupPincode) {
+  public void pairDevice(BluetoothGatt bleServer, long deviceId, long setupPincode) {
     if (connectionId == 0) {
       bleGatt = bleServer;
 
@@ -66,7 +66,7 @@ public class ChipDeviceController {
     }
   }
 
-  public void unpairDevice(int deviceId) {
+  public void unpairDevice(long deviceId) {
     unpairDevice(deviceControllerPtr, deviceId);
   }
 
@@ -74,7 +74,7 @@ public class ChipDeviceController {
     pairTestDeviceWithoutSecurity(deviceControllerPtr, ipAddress);
   }
 
-  public void pairDevice(int deviceId, int connectionId, long pinCode) {
+  public void pairDevice(long deviceId, int connectionId, long pinCode) {
     pairDevice(deviceControllerPtr, deviceId, connectionId, pinCode);
   }
 
@@ -86,7 +86,7 @@ public class ChipDeviceController {
     sendThreadCredentials(deviceControllerPtr, channel, panId, xpanId, masterKey);
   }
 
-  public boolean disconnectDevice(int deviceId) {
+  public boolean disconnectDevice(long deviceId) {
     return disconnectDevice(deviceControllerPtr, deviceId);
   }
 
@@ -172,32 +172,32 @@ public class ChipDeviceController {
     return true;
   }
 
-  public String getIpAddress(int deviceId) {
+  public String getIpAddress(long deviceId) {
     return getIpAddress(deviceControllerPtr, deviceId);
   }
 
-  public void sendMessage(int deviceId, String message) {
+  public void sendMessage(long deviceId, String message) {
     sendMessage(deviceControllerPtr, deviceId, message);
   }
 
-  public void sendCommand(int deviceId, ChipCommandType command, int value) {
+  public void sendCommand(long deviceId, ChipCommandType command, int value) {
     sendCommand(deviceControllerPtr, deviceId, command, value);
   }
 
-  public boolean openPairingWindow(int deviceId, int duration) {
+  public boolean openPairingWindow(long deviceId, int duration) {
     return openPairingWindow(deviceControllerPtr, deviceId, duration);
   }
 
-  public boolean isActive(int deviceId) {
+  public boolean isActive(long deviceId) {
     return isActive(deviceControllerPtr, deviceId);
   }
 
   private native long newDeviceController();
 
   private native void pairDevice(
-      long deviceControllerPtr, int deviceId, int connectionId, long pinCode);
+      long deviceControllerPtr, long deviceId, int connectionId, long pinCode);
 
-  private native void unpairDevice(long deviceControllerPtr, int deviceId);
+  private native void unpairDevice(long deviceControllerPtr, long deviceId);
 
   private native void pairTestDeviceWithoutSecurity(long deviceControllerPtr, String ipAddress);
 
@@ -206,20 +206,20 @@ public class ChipDeviceController {
   private native void sendThreadCredentials(
       long deviceControllerPtr, int channel, int panId, byte[] xpanId, byte[] masterKey);
 
-  private native boolean disconnectDevice(long deviceControllerPtr, int deviceId);
+  private native boolean disconnectDevice(long deviceControllerPtr, long deviceId);
 
   private native void deleteDeviceController(long deviceControllerPtr);
 
-  private native String getIpAddress(long deviceControllerPtr, int deviceId);
+  private native String getIpAddress(long deviceControllerPtr, long deviceId);
 
-  private native void sendMessage(long deviceControllerPtr, int deviceId, String message);
+  private native void sendMessage(long deviceControllerPtr, long deviceId, String message);
 
   private native void sendCommand(
-      long deviceControllerPtr, int deviceId, ChipCommandType command, int value);
+      long deviceControllerPtr, long deviceId, ChipCommandType command, int value);
 
-  private native boolean openPairingWindow(long deviceControllerPtr, int deviceId, int duration);
+  private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 
-  private native boolean isActive(long deviceControllerPtr, int deviceId);
+  private native boolean isActive(long deviceControllerPtr, long deviceId);
 
   static {
     System.loadLibrary("CHIPController");


### PR DESCRIPTION
Tested by pairing an m5stack using a hardcoded ID of FFEE00124444AAAA.

 Fixes #5630