### PR TITLE
Pairing window

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -297,7 +297,7 @@ public:
         else if (i == 2)
         {
             app::Mdns::AdvertiseCommisioning();
-            OpenDefaultPairingWindow(ResetAdmins::kNo, true);
+            OpenDefaultPairingWindow(ResetAdmins::kNo, PairingWindowAdvertisement::kMdns);
         }
     }
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include <platform/CHIPDeviceLayer.h>
+#include <server/Mdns.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CHIPMem.h>
@@ -271,10 +272,12 @@ class SetupListModel : public ListScreen::Model
 public:
     SetupListModel()
     {
-        std::string resetWiFi      = "Reset WiFi";
-        std::string resetToFactory = "Reset to factory";
+        std::string resetWiFi              = "Reset WiFi";
+        std::string resetToFactory         = "Reset to factory";
+        std::string forceWifiCommissioning = "Force WiFi commissioning";
         options.emplace_back(resetWiFi);
         options.emplace_back(resetToFactory);
+        options.emplace_back(forceWifiCommissioning);
     }
     virtual std::string GetTitle() { return "Setup"; }
     virtual int GetItemCount() { return options.size(); }
@@ -290,6 +293,11 @@ public:
         else if (i == 1)
         {
             ConfigurationMgr().InitiateFactoryReset();
+        }
+        else if (i == 2)
+        {
+            app::Mdns::AdvertiseCommisioning();
+            OpenDefaultPairingWindow(ResetAdmins::kNo, true);
         }
     }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -243,7 +243,10 @@ class ServerRendezvousAdvertisementDelegate : public RendezvousAdvertisementDele
 public:
     CHIP_ERROR StartAdvertisement() const override
     {
-        ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
+        if (isBLE)
+        {
+            ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
+        }
         if (mDelegate != nullptr)
         {
             mDelegate->OnPairingWindowOpened();
@@ -254,7 +257,10 @@ public:
     {
         gDeviceDiscriminatorCache.RestoreDiscriminator();
 
-        ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false));
+        if (isBLE)
+        {
+            ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false));
+        }
         {
             if (mDelegate != nullptr)
                 mDelegate->OnPairingWindowClosed();
@@ -279,12 +285,13 @@ public:
     }
 
     void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; }
-
+    void SetBLE(bool ble) { isBLE = ble; }
     void SetAdminId(AdminId id) { mAdmin = id; }
 
 private:
     AppDelegate * mDelegate = nullptr;
     AdminId mAdmin;
+    bool isBLE = true;
 };
 
 DemoTransportMgr gTransports;
@@ -419,8 +426,9 @@ SecureSessionMgr & chip::SessionManager()
     return gSessions;
 }
 
-CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins)
+CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, bool onNetwork)
 {
+    // TODO(cecille): If this is re-called when the window is already open, what should happen?
     gDeviceDiscriminatorCache.RestoreDiscriminator();
 
     uint32_t pinCode;
@@ -428,13 +436,14 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins)
 
     RendezvousParameters params;
 
-#if CONFIG_NETWORK_LAYER_BLE
-    params.SetSetupPINCode(pinCode)
-        .SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer())
-        .SetPeerAddress(Transport::PeerAddress::BLE())
-        .SetAdvertisementDelegate(&gAdvDelegate);
-#else
     params.SetSetupPINCode(pinCode);
+#if CONFIG_NETWORK_LAYER_BLE
+    gAdvDelegate.SetBLE(!onNetwork);
+    params.SetAdvertisementDelegate(&gAdvDelegate);
+    if (!onNetwork)
+    {
+        params.SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer()).SetPeerAddress(Transport::PeerAddress::BLE());
+    }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     if (resetAdmins == ResetAdmins::kYes)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -426,7 +426,7 @@ SecureSessionMgr & chip::SessionManager()
     return gSessions;
 }
 
-CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, bool onNetwork)
+CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindowAdvertisement advertisementMode)
 {
     // TODO(cecille): If this is re-called when the window is already open, what should happen?
     gDeviceDiscriminatorCache.RestoreDiscriminator();
@@ -438,9 +438,9 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, bool onNetwork)
 
     params.SetSetupPINCode(pinCode);
 #if CONFIG_NETWORK_LAYER_BLE
-    gAdvDelegate.SetBLE(!onNetwork);
+    gAdvDelegate.SetBLE(advertisementMode == chip::PairingWindowAdvertisement::kBle);
     params.SetAdvertisementDelegate(&gAdvDelegate);
-    if (!onNetwork)
+    if (advertisementMode == chip::PairingWindowAdvertisement::kBle)
     {
         params.SetBleLayer(DeviceLayer::ConnectivityMgr().GetBleLayer()).SetPeerAddress(Transport::PeerAddress::BLE());
     }

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -49,9 +49,16 @@ enum class ResetAdmins
     kNo,
 };
 
+enum class PairingWindowAdvertisement
+{
+    kBle,
+    kMdns,
+};
+
 } // namespace chip
 
 /**
  * Open the pairing window using default configured parameters.
  */
-CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins, bool onNetwork = false);
+CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins,
+                                    chip::PairingWindowAdvertisement advertisementMode = chip::PairingWindowAdvertisement::kBle);

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -54,4 +54,4 @@ enum class ResetAdmins
 /**
  * Open the pairing window using default configured parameters.
  */
-CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins);
+CHIP_ERROR OpenDefaultPairingWindow(chip::ResetAdmins resetAdmins, bool onNetwork = false);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
It's convenient to have a way to trigger on-network commissioning for testing purposes

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Currently "OpenDefaultPairingWindow" assumes BLE when the device is configured for BLE, softAP otherwise. This change adds the option to start on-network pairing for devices that would normally default to BLE.

This is just triggered by a menu option directly, with no smarts at all with regards to which is the correct decision.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5712

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
