### PR TITLE
Fix compiler error when compiling for MIPS (#5722)

### DIFF
--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -167,7 +167,7 @@ CHIP_ERROR NetworkProvisioning::DecodeString(const uint8_t * input, size_t input
     bbuf.Put(&input[consumed], length);
 
     consumed += bbuf.Needed();
-    bbuf.Put('\0');
+    bbuf.Put(static_cast<uint8_t>('\0'));
 
     VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
 


### PR DESCRIPTION
 #### Problem
When compiling for MIPS the following error occurs:
chipd/sources/chip-daemon/3rdparty/connectedhomeip/src/transport/NetworkProvisioning.cpp:170:18: error: call of overloaded

 #### Summary of Changes
Explicit cast the parameter.

 Fixes #5722
