### PR TITLE
Fix EFR32 VSCode build

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -26,12 +26,12 @@ set -x
 env
 
 if [ -z "$3" ]; then
-    gn gen --check --fail-on-unused-args --root="$1" --args="chip_config_memory_management=\"platform\"" "$2"/"$EFR32_BOARD"/
+    gn gen --check --fail-on-unused-args --root="$1" --args="" "$2"/"$EFR32_BOARD"/
     ninja -v -C "$2"/"$EFR32_BOARD"/
     #print stats
     arm-none-eabi-size -A "$2"/"$EFR32_BOARD"/*.out
 else
-    gn gen --check --fail-on-unused-args --root="$1" --args="chip_config_memory_management=\"platform\" efr32_board=\"$3\"" "$2/$3"
+    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_board=\"$3\"" "$2/$3"
     ninja -v -C "$2/$3"
     #print stats
     arm-none-eabi-size -A "$2"/"$3"/*.out

--- a/src/platform/EFR32/args.gni
+++ b/src/platform/EFR32/args.gni
@@ -43,3 +43,5 @@ openthread_core_config_deps = [ "${chip_root}/examples/platform/efr32:openthread
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
+
+chip_config_memory_management = "platform"


### PR DESCRIPTION
As of 281eceadb1 ("[EFR32] RAM Optimization (#5646)") there is
an error linking EFR32 examples in VS Code:

```
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.event_groups.c.o: in function `xEventGroupCreate':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/event_groups.c:175: undefined reference to `pvPortMalloc'
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.queue.c.o: in function `xQueueGenericCreate':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/queue.c:403: undefined reference to `pvPortMalloc'
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.queue.c.o: in function `vQueueDelete':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/queue.c:2013: undefined reference to `vPortFree'
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.tasks.c.o: in function `prvDeleteTCB':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/tasks.c:3933: undefined reference to `vPortFree'
 ld:  /workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/tasks.c:3934: undefined reference to `vPortFree'
 ld:  /workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/tasks.c:3940: undefined reference to `vPortFree'
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.timers.c.o: in function `xTimerCreate':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/timers.c:303: undefined reference to `pvPortMalloc'
 ld:  obj/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/sdk.timers.c.o: in function `prvProcessReceivedCommands':
/workspaces/connectedhomeip-vscode/out/efr32_lighting_app/../../examples/lighting-app/efr32/third_party/connectedhomeip/third_party/efr32_sdk/repo/util/third_party/freertos/Source/timers.c:868: undefined reference to `vPortFree'
collect2: error: ld returned 1 exit status
```

This happens because there are now important options set in
gn_efr32_example.sh. Move them to src/platform/EFR32/args.gni
so they apply without having to use this script.