### PR TITLE
Pin code is used in the endian mode of the processor (#5726)

### DIFF
--- a/src/transport/PASESession.cpp
+++ b/src/transport/PASESession.cpp
@@ -196,7 +196,10 @@ exit:
 CHIP_ERROR PASESession::ComputePASEVerifier(uint32_t setUpPINCode, uint32_t pbkdf2IterCount, const uint8_t * salt, size_t saltLen,
                                             PASEVerifier & verifier)
 {
-    return pbkdf2_sha256(reinterpret_cast<const uint8_t *>(&setUpPINCode), sizeof(setUpPINCode), salt, saltLen, pbkdf2IterCount,
+    uint8_t littleEndianSetupPINCode[sizeof(uint32_t)];
+    Encoding::LittleEndian::Put32(littleEndianSetupPINCode, setUpPINCode);
+
+    return pbkdf2_sha256(littleEndianSetupPINCode, sizeof(littleEndianSetupPINCode), salt, saltLen, pbkdf2IterCount,
                          sizeof(PASEVerifier), &verifier[0][0]);
 }
 


### PR DESCRIPTION
 #### Problem
The 32 bits pin code is passed to the function pbkdf2_sha256 as an array of 4 bytes. This is done by passing the address of the 32 bits pin code. However, this will fail on a big endian processor.

 #### Summary of Changes
Convert the pin code to little endian format before passing to pbkdf2_sha256.

 Fixes #5726
