### PR TITLE
Update IM op codes

### DIFF
--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -46,13 +46,15 @@ namespace InteractionModel {
  */
 enum class MsgType : uint8_t
 {
-    SubscribeRequest      = 0x01,
     ReadRequest           = 0x02,
-    ReportData            = 0x03,
-    WriteRequest          = 0x04,
-    WriteResponse         = 0x05,
-    InvokeCommandRequest  = 0x06,
-    InvokeCommandResponse = 0x07,
+    SubscribeRequest      = 0x03,
+    SubscribeResponse     = 0x04,
+    ReportData            = 0x05,
+    WriteRequest          = 0x06,
+    WriteResponse         = 0x07,
+    InvokeCommandRequest  = 0x08,
+    InvokeCommandResponse = 0x09,
+    TimedRequest          = 0x0a,
 };
 
 } // namespace InteractionModel


### PR DESCRIPTION
Problems:
IM encoding protocol has updated OP codes, need to align with that.

Summary of changes:
-- Align with IM encoding spec regarding OP codes on spec here,
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/Encoding-Specification.adoc#protocol-opcodes