### PR TITLE
Add rendezvous mode ethernet in example chip-tool (#5733)

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -44,6 +44,12 @@ public:
     PairSoftAP() : PairingCommand("softap", PairingMode::SoftAP) {}
 };
 
+class Ethernet : public PairingCommand
+{
+public:
+    Ethernet() : PairingCommand("ethernet", PairingMode::Ethernet) {}
+};
+
 void registerCommandsPairing(Commands & commands)
 {
     const char * clusterName = "Pairing";
@@ -53,6 +59,7 @@ void registerCommandsPairing(Commands & commands)
         make_unique<PairBypass>(),
         make_unique<PairBle>(),
         make_unique<PairSoftAP>(),
+        make_unique<Ethernet>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -55,11 +55,8 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),
-        make_unique<PairBypass>(),
-        make_unique<PairBle>(),
-        make_unique<PairSoftAP>(),
-        make_unique<Ethernet>(),
+        make_unique<Unpair>(),     make_unique<PairBypass>(), make_unique<PairBle>(),
+        make_unique<PairSoftAP>(), make_unique<Ethernet>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -60,6 +60,9 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;
+    case PairingMode::Ethernet:
+        err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
+        break;
     }
     WaitForResponse(kWaitDurationInSeconds);
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -27,6 +27,7 @@ enum class PairingMode
     Bypass,
     Ble,
     SoftAP,
+    Ethernet,
 };
 
 class PairingCommand : public Command, public chip::Controller::DevicePairingDelegate
@@ -50,6 +51,12 @@ public:
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
         case PairingMode::SoftAP:
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            AddArgument("device-remote-ip", &mRemoteAddr);
+            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
+            break;
+        case PairingMode::Ethernet:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             AddArgument("device-remote-ip", &mRemoteAddr);


### PR DESCRIPTION
 #### Problem
The example chip-tool doesn't support the rendezvous mode ethernet.

 #### Summary of Changes
 Add the ethernet mode.

 Fixes #5733
