### PR TITLE
[cc13x2_26x2] Update BitFlags in cc13x2_26x2/BLEManagerImpl

### DIFF
--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -165,7 +165,7 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingMode(BLEAdvertisingMode mode)
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    mFlags.Set(Flags::kFlag_AdvertisingRefreshNeeded);
+    mFlags.Set(Flags::kAdvertisingRefreshNeeded);
     ret = DriveBLEState();
     return ret;
 }
@@ -805,9 +805,9 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                 Util_stopClock(&sInstance.clkAdvTimeout);
             }
             /* Other case is that advertising is already working, but should be restarted, as its settings changed */
-            else if (sInstance.mFlags.Has(Flags::kFlag_AdvertisingRefreshNeeded))
+            else if (sInstance.mFlags.Has(Flags::kAdvertisingRefreshNeeded))
             {
-                sInstance.mFlags.Clear(Flags::kFlag_AdvertisingRefreshNeeded);
+                sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
                 GapAdv_disable(sInstance.advHandleLegacy);
 
                 // Enable legacy advertising for set #1
@@ -1071,7 +1071,7 @@ void BLEManagerImpl::ProcessGapMessage(gapEventHdr_t * pMsg)
         {
             // Stop advertising since there is no room for more connections
             BLEMGR_LOG("BLEMGR: BLE event GAP_LINK_ESTABLISHED_EVENT: MAX connections");
-            sInstance.mFlags.Clear(Flags::kAdvertisingEnabled.Clear(Flags::kAdvertising);
+            sInstance.mFlags.Clear(Flags::kAdvertisingEnabled).Clear(Flags::kAdvertising);
             mFlags.Set(Flags::kFastAdvertisingEnabled, true);
         }
 
@@ -1697,7 +1697,7 @@ void BLEManagerImpl::AdvTimeoutHandler(uintptr_t arg)
         BLEMGR_LOG("BLEMGR: AdvTimeoutHandler ble adv 15 minute timeout");
 
         sInstance.mFlags.Clear(Flags::kAdvertisingEnabled);
-        mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+        sInstance.mFlags.Set(Flags::kFastAdvertisingEnabled);
 
         /* Send event to process state change request */
         DriveBLEState();

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.h
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.h
@@ -262,19 +262,19 @@ private:
     static chipOBleProfileCBs_t CHIPoBLEProfile_CBs;
     static gapBondCBs_t BLEMgr_BondMgrCBs;
 
-    enum
+    enum class Flags : uint16_t
     {
-        kFlag_AdvertisingEnabled       = 0x0001, /* App enabled CHIPoBLE advertising */
-        kFlag_FastAdvertisingEnabled   = 0x0002, /* App enabled Fash CHIPoBLE advertising */
-        kFlag_Advertising              = 0x0004, /* TI BLE stack actively advertising */
-        kFlag_BLEStackInitialized      = 0x0008, /* TI BLE Stack GAP Intilization complete */
-        kFlag_BLEStackGATTNameUpdate   = 0x0010, /* Trigger TI BLE Stack name update, must be performed prior to adv start */
-        kFlag_BLEStackGATTNameSet      = 0x0020, /* Device name has been set externally*/
-        kFlag_AdvertisingRefreshNeeded = 0x0040, /* Advertising settings changed and it should be restarted */
+        kAdvertisingEnabled       = 0x0001, /* App enabled CHIPoBLE advertising */
+        kFastAdvertisingEnabled   = 0x0002, /* App enabled Fash CHIPoBLE advertising */
+        kAdvertising              = 0x0004, /* TI BLE stack actively advertising */
+        kBLEStackInitialized      = 0x0008, /* TI BLE Stack GAP Intilization complete */
+        kBLEStackGATTNameUpdate   = 0x0010, /* Trigger TI BLE Stack name update, must be performed prior to adv start */
+        kBLEStackGATTNameSet      = 0x0020, /* Device name has been set externally*/
+        kAdvertisingRefreshNeeded = 0x0040, /* Advertising settings changed and it should be restarted */
 
     };
 
-    uint16_t mFlags;
+    BitFlags<Flags> mFlags;
     CHIPoBLEServiceMode mServiceMode;
     char mDeviceName[GAP_DEVICE_NAME_LEN];
 


### PR DESCRIPTION
#### Problem

TI cc13x2_26x2 example does not build.
Followup from 8ea423ae (PR #5319)

#### Summary of Changes

Convert `BLEManagerImpl` `mFlags` to use `enum class` and `BitFlags`.
