### PR TITLE
Remove consumed/out-of-dated callbacks from the callbacks queue

### DIFF
--- a/src/app/util/CHIPDeviceCallbacksMgr.h
+++ b/src/app/util/CHIPDeviceCallbacksMgr.h
@@ -68,6 +68,7 @@ private:
         if (CHIP_NO_ERROR == err)
         {
             ca->Cancel();
+            queue.Dequeue(ca);
         }
 
         return err;


### PR DESCRIPTION
 #### Problem
  Callbacks are not removed properly from the callbacks queue. It may ends up on the code trying to access a dangling pointer.

 #### Summary of Changes
 * Properly call `queue.Dequeue(ca);` 

 Fixes #5736

