### PR TITLE
Add verification of the range of integer values for TLVReader -- 2nd attempt 

### DIFF
--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -807,7 +807,7 @@ protected:
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
     TLVElementType ElementType() const;
 
-    template<typename int_type>
+    template <typename int_type>
     bool TLVTypeValid(uint64_t val64) const;
     CHIP_ERROR _Get(uint64_t & v);
 };

--- a/src/lib/core/CHIPTLV.h
+++ b/src/lib/core/CHIPTLV.h
@@ -806,6 +806,10 @@ protected:
     CHIP_ERROR ReadData(uint8_t * buf, uint32_t len);
     CHIP_ERROR GetElementHeadLength(uint8_t & elemHeadBytes) const;
     TLVElementType ElementType() const;
+
+    template<typename int_type>
+    bool TLVTypeValid(uint64_t val64) const;
+    CHIP_ERROR _Get(uint64_t & v);
 };
 
 /**

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -125,63 +125,94 @@ CHIP_ERROR TLVReader::Get(bool & v)
     return CHIP_NO_ERROR;
 }
 
+template<typename int_type>
+bool TLVReader::TLVTypeValid(uint64_t val64) const
+{
+    bool tlv_isSigned = GetType() == kTLVType_SignedInteger;
+
+    return tlv_isSigned == std::is_signed<int_type>::value &&
+           (tlv_isSigned ? CanCastTo<int_type>(CastToSigned(val64)) : CanCastTo<int_type>(val64));
+}
+
 CHIP_ERROR TLVReader::Get(int8_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = CastToSigned(static_cast<uint8_t>(v64));
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<int8_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = CastToSigned(static_cast<uint8_t>(v64));
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(int16_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = CastToSigned(static_cast<uint16_t>(v64));
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<int16_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = CastToSigned(static_cast<uint16_t>(v64));
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(int32_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = CastToSigned(static_cast<uint32_t>(v64));
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<int32_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = CastToSigned(static_cast<uint32_t>(v64));
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(int64_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = CastToSigned(v64);
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<int64_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = CastToSigned(v64);
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(uint8_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = static_cast<uint8_t>(v64);
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<uint8_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = static_cast<uint8_t>(v64);
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(uint16_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = static_cast<uint16_t>(v64);
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<uint16_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = static_cast<uint16_t>(v64);
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(uint32_t & v)
 {
     uint64_t v64   = 0;
-    CHIP_ERROR err = Get(v64);
-    v              = static_cast<uint32_t>(v64);
+
+    CHIP_ERROR err = _Get(v64);
+    ReturnErrorCodeIf(!TLVTypeValid<uint32_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
+    v = static_cast<uint32_t>(v64);
     return err;
 }
 
 CHIP_ERROR TLVReader::Get(uint64_t & v)
+{
+    v = 0;
+    CHIP_ERROR err = _Get(v);
+    ReturnErrorCodeIf(!TLVTypeValid<uint64_t>(v), CHIP_ERROR_WRONG_TLV_TYPE);
+    return err;
+}
+
+CHIP_ERROR TLVReader::_Get(uint64_t & v)
 {
     switch (ElementType())
     {

--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -125,18 +125,18 @@ CHIP_ERROR TLVReader::Get(bool & v)
     return CHIP_NO_ERROR;
 }
 
-template<typename int_type>
+template <typename int_type>
 bool TLVReader::TLVTypeValid(uint64_t val64) const
 {
     bool tlv_isSigned = GetType() == kTLVType_SignedInteger;
 
     return tlv_isSigned == std::is_signed<int_type>::value &&
-           (tlv_isSigned ? CanCastTo<int_type>(CastToSigned(val64)) : CanCastTo<int_type>(val64));
+        (tlv_isSigned ? CanCastTo<int_type>(CastToSigned(val64)) : CanCastTo<int_type>(val64));
 }
 
 CHIP_ERROR TLVReader::Get(int8_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<int8_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -146,7 +146,7 @@ CHIP_ERROR TLVReader::Get(int8_t & v)
 
 CHIP_ERROR TLVReader::Get(int16_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<int16_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -156,7 +156,7 @@ CHIP_ERROR TLVReader::Get(int16_t & v)
 
 CHIP_ERROR TLVReader::Get(int32_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<int32_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -166,7 +166,7 @@ CHIP_ERROR TLVReader::Get(int32_t & v)
 
 CHIP_ERROR TLVReader::Get(int64_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<int64_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -176,7 +176,7 @@ CHIP_ERROR TLVReader::Get(int64_t & v)
 
 CHIP_ERROR TLVReader::Get(uint8_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<uint8_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -186,7 +186,7 @@ CHIP_ERROR TLVReader::Get(uint8_t & v)
 
 CHIP_ERROR TLVReader::Get(uint16_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<uint16_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -196,7 +196,7 @@ CHIP_ERROR TLVReader::Get(uint16_t & v)
 
 CHIP_ERROR TLVReader::Get(uint32_t & v)
 {
-    uint64_t v64   = 0;
+    uint64_t v64 = 0;
 
     CHIP_ERROR err = _Get(v64);
     ReturnErrorCodeIf(!TLVTypeValid<uint32_t>(v64), CHIP_ERROR_WRONG_TLV_TYPE);
@@ -206,7 +206,7 @@ CHIP_ERROR TLVReader::Get(uint32_t & v)
 
 CHIP_ERROR TLVReader::Get(uint64_t & v)
 {
-    v = 0;
+    v              = 0;
     CHIP_ERROR err = _Get(v);
     ReturnErrorCodeIf(!TLVTypeValid<uint64_t>(v), CHIP_ERROR_WRONG_TLV_TYPE);
     return err;

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -49,7 +49,8 @@ using namespace chip::TLV;
 enum
 {
     TestProfile_1 = 0xAABBCCDD,
-    TestProfile_2 = 0x11223344
+    TestProfile_2 = 0x11223344,
+    TestProfile_3 = 0x11223355
 };
 
 // clang-format off
@@ -152,6 +153,21 @@ void TestGet(nlTestSuite * inSuite, S & s, TLVType type, uint64_t tag, T expecte
 
     NL_TEST_ASSERT(inSuite, val == expectedVal);
 }
+
+#define  TEST_GET(inSuite, s, type, tag, expectedVal, expectedErr) do {\
+    NL_TEST_ASSERT(inSuite, s.GetType() == type);                      \
+    NL_TEST_ASSERT(inSuite, s.GetTag() == tag);                        \
+    NL_TEST_ASSERT(inSuite, s.GetLength() == 0);                       \
+                                                                       \
+    decltype(expectedVal) __val;                                       \
+    CHIP_ERROR __err = s.Get(__val);                                   \
+    NL_TEST_ASSERT(inSuite, __err == expectedErr);                     \
+    if (__err == CHIP_NO_ERROR)                                        \
+        NL_TEST_ASSERT(inSuite, __val == expectedVal);                 \
+} while (false)
+
+#define  TEST_GET_NOERROR(inSuite, s, type, tag, expectedVal) \
+    TEST_GET(inSuite, s, type, tag, expectedVal, CHIP_NO_ERROR)
 
 void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
                     void (*cb)(nlTestSuite * inSuite, TLVReader & reader, void * context))
@@ -354,6 +370,144 @@ static const uint8_t Encoding1_DataMacro [] =
 };
 // clang-format on
 
+CHIP_ERROR WriteIntMinMax(nlTestSuite * inSuite, TLVWriter & writer)
+{
+    CHIP_ERROR err;
+
+    err = writer.Put(AnonymousTag, static_cast<int8_t>(INT8_MIN));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int8_t>(INT8_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int16_t>(INT16_MIN));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int16_t>(INT16_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int32_t>(INT32_MIN));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int32_t>(INT32_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int64_t>(INT64_MIN));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<int64_t>(INT64_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<uint8_t>(UINT8_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<uint16_t>(UINT16_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<uint32_t>(UINT32_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = writer.Put(AnonymousTag, static_cast<uint64_t>(UINT64_MAX));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    return err;
+}
+
+void CheckIntMinMax(nlTestSuite * inSuite, TLVReader & reader)
+{
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT8_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT8_MIN));
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(INT8_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(INT8_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(INT8_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(INT8_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT8_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT16_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT16_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT16_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT16_MIN));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT16_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT16_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT32_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT32_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT32_MIN));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT32_MIN));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT32_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT32_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT32_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT32_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT64_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT64_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT64_MIN), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT64_MIN));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(INT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(INT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(INT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(INT64_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int8_t>(UINT8_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int16_t>(UINT8_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int32_t>(UINT8_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(UINT8_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT8_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT8_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(UINT16_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT16_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT16_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(UINT32_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT32_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT32_MAX));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT32_MAX));
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint8_t>(UINT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint16_t>(UINT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint32_t>(UINT64_MAX), CHIP_ERROR_WRONG_TLV_TYPE);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(UINT64_MAX));
+}
+
 void WriteEncoding1(nlTestSuite * inSuite, TLVWriter & writer)
 {
     CHIP_ERROR err;
@@ -485,11 +639,11 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader2);
 
@@ -500,31 +654,31 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(42));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint8_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint16_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-17));
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-170000));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-170000));
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
-            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag,static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
 
@@ -665,7 +819,7 @@ void ReadEncoding3(nlTestSuite * inSuite, TLVReader & reader)
 
     TestNext<TLVReader>(inSuite, reader2);
 
-    TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+    TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
     TestEndAndCloseContainer(inSuite, reader, reader2);
 }
@@ -814,7 +968,7 @@ void AppendEncoding2(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uin
         TestNext<TLVUpdater>(inSuite, updater);
 
         // Read and copy the element with/without modification
-        TestGet<TLVUpdater, bool>(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
         err = updater.PutBoolean(ProfileTag(TestProfile_2, 2), false);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -1124,7 +1278,7 @@ void DeleteEncoding5(nlTestSuite * inSuite, uint8_t * buf, uint32_t dataLen, uin
         TestNext<TLVUpdater>(inSuite, updater);
 
         // Get the value to inspect and skip writing it
-        TestGet<TLVUpdater, bool>(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+        TEST_GET_NOERROR(inSuite, updater, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
         TestNext<TLVUpdater>(inSuite, updater);
 
@@ -1179,19 +1333,19 @@ void ReadAppendedEncoding2(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
 
         TestNext<TLVReader>(inSuite, reader1);
 
@@ -1202,11 +1356,11 @@ void ReadAppendedEncoding2(nlTestSuite * inSuite, TLVReader & reader)
 
             TestNext<TLVReader>(inSuite, reader2);
 
-            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+            TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
             TestNext<TLVReader>(inSuite, reader2);
 
-            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+            TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
             TestEndAndCloseContainer(inSuite, reader1, reader2);
         }
@@ -1220,11 +1374,11 @@ void ReadAppendedEncoding2(nlTestSuite * inSuite, TLVReader & reader)
 
             TestNext<TLVReader>(inSuite, reader2);
 
-            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+            TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
             TestNext<TLVReader>(inSuite, reader2);
 
-            TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+            TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
             TestEndAndCloseContainer(inSuite, reader1, reader2);
         }
@@ -1241,11 +1395,11 @@ void ReadAppendedEncoding2(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestEndAndCloseContainer(inSuite, reader, reader1);
     }
@@ -1264,11 +1418,11 @@ void ReadAppendedEncoding3(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), true);
 
         TestEndAndCloseContainer(inSuite, reader, reader1);
     }
@@ -1287,7 +1441,7 @@ void ReadAppendedEncoding4(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestEndAndCloseContainer(inSuite, reader, reader1);
     }
@@ -1306,11 +1460,11 @@ void ReadDeletedEncoding5(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestEndAndCloseContainer(inSuite, reader, reader1);
     }
@@ -1324,11 +1478,11 @@ void ReadDeletedEncoding5(nlTestSuite * inSuite, TLVReader & reader)
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader1);
 
-        TestGet<TLVReader, bool>(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader1, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestEndAndCloseContainer(inSuite, reader, reader1);
     }
@@ -1373,6 +1527,39 @@ void CheckSimpleWriteRead(nlTestSuite * inSuite, void * inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     ReadEncoding1(inSuite, reader);
+}
+
+void TestIntMinMax(nlTestSuite * inSuite, void * inContext)
+{
+    CHIP_ERROR err;
+
+    uint8_t buf[2048];
+    TLVWriter writer, writer1;
+    TLVReader reader, reader1;
+
+    writer.Init(buf, sizeof(buf));
+    writer.ImplicitProfileId = TestProfile_3;
+
+    err = writer.OpenContainer(ProfileTag(TestProfile_3, 1), kTLVType_Array, writer1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    WriteIntMinMax(inSuite, writer1);
+
+    err = writer.CloseContainer(writer1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    reader.Init(buf, sizeof(buf));
+    reader.ImplicitProfileId = TestProfile_3;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    TestAndOpenContainer(inSuite, reader, kTLVType_Array, ProfileTag(TestProfile_3, 1), reader1);
+
+    TestNext<TLVReader>(inSuite, reader1);
+
+    CheckIntMinMax(inSuite, reader1);
+
+    TestEndAndCloseContainer(inSuite, reader, reader1);
 }
 
 /**
@@ -2189,7 +2376,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
     // Check that the reader is out of data
     TestEnd<TLVReader>(inSuite, reader);
@@ -2222,7 +2409,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
         reader.ImplicitProfileId = TestProfile_2;
 
         TestNext<TLVReader>(inSuite, reader);
-        TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
         TestEnd<TLVReader>(inSuite, reader);
 
         buffer1.EvictHead();
@@ -2255,10 +2442,10 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
     TestEnd<TLVReader>(inSuite, reader);
 
@@ -2271,7 +2458,7 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
     // Check that the reader is out of data
     TestEnd<TLVReader>(inSuite, reader);
@@ -2292,10 +2479,10 @@ void CheckCircularTLVBufferEdge(nlTestSuite * inSuite, void * inContext)
     reader.ImplicitProfileId = TestProfile_2;
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), false);
 
     TestNext<TLVReader>(inSuite, reader);
-    TestGet<TLVReader, bool>(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
     TestEnd<TLVReader>(inSuite, reader);
 
@@ -2867,11 +3054,11 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
+        TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_1, 2), true);
 
         TestNext<TLVReader>(inSuite, reader2);
 
-        TestGet<TLVReader, bool>(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
+        TEST_GET_NOERROR(inSuite, reader2, kTLVType_Boolean, ProfileTag(TestProfile_2, 2), false);
 
         TestNext<TLVReader>(inSuite, reader2);
 
@@ -2882,29 +3069,29 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
-            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, 42);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(42));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(42));
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint32_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<uint64_t>(42), CHIP_ERROR_WRONG_TLV_TYPE);
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int8_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int16_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -17);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int8_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int16_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-17));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-17));
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int32_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, -170000);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int32_t>(-170000));
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_SignedInteger, AnonymousTag, static_cast<int64_t>(-170000));
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TestGet<TLVReader, int64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
-            TestGet<TLVReader, uint64_t>(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, 40000000000ULL);
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
 
@@ -3055,13 +3242,11 @@ void TestCHIPTLVReaderInPractice(nlTestSuite * inSuite)
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL),
-                                static_cast<int64_t>(40000000000ULL));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), static_cast<int64_t>(40000000000ULL));
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TestGet<TLVReader, int64_t>(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL),
-                                static_cast<int16_t>(12345));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), static_cast<int16_t>(12345));
 
     TestNext<TLVReader>(inSuite, reader);
 
@@ -3772,6 +3957,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("CHIP TLV Skip non-contiguous",        CheckCHIPTLVSkipCircular),
     NL_TEST_DEF("CHIP TLV Check reserve",              CheckCloseContainerReserve),
     NL_TEST_DEF("CHIP TLV Reader Fuzz Test",           TLVReaderFuzzTest),
+    NL_TEST_DEF("Int Min/Max Test",                    TestIntMinMax),
 
     NL_TEST_SENTINEL()
 };

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -154,20 +154,21 @@ void TestGet(nlTestSuite * inSuite, S & s, TLVType type, uint64_t tag, T expecte
     NL_TEST_ASSERT(inSuite, val == expectedVal);
 }
 
-#define  TEST_GET(inSuite, s, type, tag, expectedVal, expectedErr) do {\
-    NL_TEST_ASSERT(inSuite, s.GetType() == type);                      \
-    NL_TEST_ASSERT(inSuite, s.GetTag() == tag);                        \
-    NL_TEST_ASSERT(inSuite, s.GetLength() == 0);                       \
-                                                                       \
-    decltype(expectedVal) __val;                                       \
-    CHIP_ERROR __err = s.Get(__val);                                   \
-    NL_TEST_ASSERT(inSuite, __err == expectedErr);                     \
-    if (__err == CHIP_NO_ERROR)                                        \
-        NL_TEST_ASSERT(inSuite, __val == expectedVal);                 \
-} while (false)
+#define TEST_GET(inSuite, s, type, tag, expectedVal, expectedErr)                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        NL_TEST_ASSERT(inSuite, s.GetType() == type);                                                                              \
+        NL_TEST_ASSERT(inSuite, s.GetTag() == tag);                                                                                \
+        NL_TEST_ASSERT(inSuite, s.GetLength() == 0);                                                                               \
+                                                                                                                                   \
+        decltype(expectedVal) __val;                                                                                               \
+        CHIP_ERROR __err = s.Get(__val);                                                                                           \
+        NL_TEST_ASSERT(inSuite, __err == expectedErr);                                                                             \
+        if (__err == CHIP_NO_ERROR)                                                                                                \
+            NL_TEST_ASSERT(inSuite, __val == expectedVal);                                                                         \
+    } while (false)
 
-#define  TEST_GET_NOERROR(inSuite, s, type, tag, expectedVal) \
-    TEST_GET(inSuite, s, type, tag, expectedVal, CHIP_NO_ERROR)
+#define TEST_GET_NOERROR(inSuite, s, type, tag, expectedVal) TEST_GET(inSuite, s, type, tag, expectedVal, CHIP_NO_ERROR)
 
 void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
                     void (*cb)(nlTestSuite * inSuite, TLVReader & reader, void * context))
@@ -677,8 +678,9 @@ void ReadEncoding1(nlTestSuite * inSuite, TLVReader & reader)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL), CHIP_ERROR_WRONG_TLV_TYPE);
-            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag,static_cast<uint64_t>(40000000000ULL));
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
 
@@ -3090,7 +3092,8 @@ void TestCHIPTLVReaderDup(nlTestSuite * inSuite)
 
             TestNext<TLVReader>(inSuite, reader3);
 
-            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL), CHIP_ERROR_WRONG_TLV_TYPE);
+            TEST_GET(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<int64_t>(40000000000ULL),
+                     CHIP_ERROR_WRONG_TLV_TYPE);
             TEST_GET_NOERROR(inSuite, reader3, kTLVType_UnsignedInteger, AnonymousTag, static_cast<uint64_t>(40000000000ULL));
 
             TestNext<TLVReader>(inSuite, reader3);
@@ -3242,11 +3245,13 @@ void TestCHIPTLVReaderInPractice(nlTestSuite * inSuite)
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), static_cast<int64_t>(40000000000ULL));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL),
+                     static_cast<int64_t>(40000000000ULL));
 
     TestNext<TLVReader>(inSuite, reader);
 
-    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL), static_cast<int16_t>(12345));
+    TEST_GET_NOERROR(inSuite, reader, kTLVType_SignedInteger, ProfileTag(TestProfile_1, 4000000000ULL),
+                     static_cast<int16_t>(12345));
 
     TestNext<TLVReader>(inSuite, reader);
 


### PR DESCRIPTION
#### Problem
 Currently, TVLReader's method `Get` does not validate sizes of requested integers. In case when the size is less than size of TVL field, incorrect value is returned to caller; no error condition is indicated.

#### Summary of Changes
 Size validation is added, error conditions are handled properly.

 Fixes #5152 
[see https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/2115 and https://github.com/project-chip/connectedhomeip/pull/5286 discussions]