### PR TITLE
doxygen: Disable graph generation

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2296,7 +2296,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = YES
+HAVE_DOT               = NO
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of


### PR DESCRIPTION
These graphs are huge (400M) and were boating the repo by >2G. I don't
know if they are useful. If they are, we should find a place to host
them that doesn't explode the size of the main repository.