### PR TITLE
Add status code in IM Command Reponse

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -191,20 +191,8 @@ CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
     {
         CommandDataElement::Builder commandDataElement =
             mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
-        CommandPath::Builder commandPath = commandDataElement.CreateCommandPathBuilder();
-        if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
-        {
-            commandPath.EndpointId(aCommandParams.EndpointId);
-        }
 
-        if (aCommandParams.Flags.Has(CommandPathFlags::kGroupIdValid))
-        {
-            commandPath.GroupId(aCommandParams.GroupId);
-        }
-
-        commandPath.ClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
-
-        err = commandPath.GetError();
+        err = Command::ConstructCommandPath(aCommandParams, commandDataElement);
         SuccessOrExit(err);
 
         if (commandLen > 0 && commandData != nullptr)
@@ -229,24 +217,22 @@ exit:
     return err;
 }
 
-CHIP_ERROR Command::AddStatusCode(const Protocols::SecureChannel::GeneralStatusCode aGeneralCode, Protocols::Id aProtocolId,
-                                  const uint16_t aProtocolCode)
+CHIP_ERROR Command::ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder & aCommandDataElement)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    StatusElement::Builder statusElementBuilder;
+    CommandPath::Builder commandPath = aCommandDataElement.CreateCommandPathBuilder();
+    if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
+    {
+        commandPath.EndpointId(aCommandParams.EndpointId);
+    }
 
-    err = statusElementBuilder.Init(mInvokeCommandBuilder.GetWriter());
-    SuccessOrExit(err);
+    if (aCommandParams.Flags.Has(CommandPathFlags::kGroupIdValid))
+    {
+        commandPath.GroupId(aCommandParams.GroupId);
+    }
 
-    statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), aProtocolCode)
-        .EndOfStatusElement();
-    err = statusElementBuilder.GetError();
+    commandPath.ClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
 
-    MoveToState(CommandState::AddCommand);
-
-exit:
-    ChipLogFunctError(err);
-    return err;
+    return commandPath.GetError();
 }
 
 CHIP_ERROR Command::ClearExistingExchangeContext()

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -121,8 +121,12 @@ public:
     CHIP_ERROR AddCommand(chip::EndpointId aEndpintId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
                           chip::CommandId aCommandId, BitFlags<CommandPathFlags> Flags);
     CHIP_ERROR AddCommand(CommandParams & aCommandParams);
-    CHIP_ERROR AddStatusCode(const Protocols::SecureChannel::GeneralStatusCode aGeneralCode, Protocols::Id aProtocolId,
-                             const uint16_t aProtocolCode);
+    virtual CHIP_ERROR AddStatusCode(const CommandParams * apCommandParams,
+                                     const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
+                                     const Protocols::Id aProtocolId, const uint16_t aProtocolCode)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    };
 
     /**
      * Gets the inner exchange context object, without ownership.
@@ -144,9 +148,11 @@ protected:
     CHIP_ERROR ClearExistingExchangeContext();
     void MoveToState(const CommandState aTargetState);
     CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle && payload, CommandRoleId aCommandRoleId);
+    CHIP_ERROR ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder & aCommandDataElement);
     void ClearState();
     const char * GetStateStr() const;
 
+    InvokeCommand::Builder mInvokeCommandBuilder;
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;
@@ -156,7 +162,6 @@ protected:
 private:
     friend class TestCommandInteraction;
     chip::System::PacketBufferHandle mpBufHandle;
-    InvokeCommand::Builder mInvokeCommandBuilder;
     CommandState mState;
 
     chip::System::PacketBufferHandle mCommandDataBuf;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -82,25 +82,68 @@ CHIP_ERROR CommandHandler::ProcessCommandDataElement(CommandDataElement::Parser 
     chip::CommandId commandId;
     chip::EndpointId endpointId;
 
-    ReturnErrorOnFailure(aCommandElement.GetCommandPath(&commandPath));
-    ReturnErrorOnFailure(commandPath.GetClusterId(&clusterId));
-    ReturnErrorOnFailure(commandPath.GetCommandId(&commandId));
-    ReturnErrorOnFailure(commandPath.GetEndpointId(&endpointId));
+    SuccessOrExit(aCommandElement.GetCommandPath(&commandPath));
+    SuccessOrExit(commandPath.GetClusterId(&clusterId));
+    SuccessOrExit(commandPath.GetCommandId(&commandId));
+    SuccessOrExit(commandPath.GetEndpointId(&endpointId));
 
     err = aCommandElement.GetData(&commandDataReader);
     if (CHIP_END_OF_TLV == err)
     {
-        // Empty Command, Add status code in invoke command response, notify cluster handler to hand it further.
         err = CHIP_NO_ERROR;
         ChipLogDetail(DataManagement, "Add Status code for empty command, cluster Id is %d", clusterId);
-        AddStatusCode(GeneralStatusCode::kSuccess, Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeSuccess);
+        // The Path is not present when the CommandDataElement is used with an empty response, ResponseCommandElement would only
+        // have status code,
+        AddStatusCode(nullptr, GeneralStatusCode::kSuccess, Protocols::SecureChannel::Id,
+                      Protocols::SecureChannel::kProtocolCodeSuccess);
     }
     else if (CHIP_NO_ERROR == err)
     {
         DispatchSingleClusterCommand(clusterId, commandId, endpointId, commandDataReader, this);
     }
 
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        // The Path is not present when there is an error to be conveyed back. ResponseCommandElement would only have status code,
+        // set the error with CHIP_NO_ERROR, then continue to process rest of commands
+        AddStatusCode(nullptr, GeneralStatusCode::kInvalidArgument, Protocols::SecureChannel::Id,
+                      Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+        err = CHIP_NO_ERROR;
+    }
     return err;
 }
+
+CHIP_ERROR CommandHandler::AddStatusCode(const CommandParams * apCommandParams,
+                                         const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
+                                         const Protocols::Id aProtocolId, const uint16_t aProtocolCode)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    StatusElement::Builder statusElementBuilder;
+    CommandDataElement::Builder commandDataElement =
+        mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+
+    if (apCommandParams != nullptr)
+    {
+        err = ConstructCommandPath(*apCommandParams, commandDataElement);
+        SuccessOrExit(err);
+    }
+
+    statusElementBuilder = commandDataElement.CreateStatusElementBuilder();
+    statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), aProtocolCode)
+        .EndOfStatusElement();
+    err = statusElementBuilder.GetError();
+    SuccessOrExit(err);
+
+    commandDataElement.EndOfCommandDataElement();
+    err = commandDataElement.GetError();
+    SuccessOrExit(err);
+    MoveToState(CommandState::AddCommand);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -44,8 +44,11 @@ class CommandHandler : public Command
 public:
     void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                            System::PacketBufferHandle payload);
+    CHIP_ERROR AddStatusCode(const CommandParams * apCommandParams, const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
+                             const Protocols::Id aProtocolId, const uint16_t aProtocolCode) override;
 
 private:
+    friend class TestCommandInteraction;
     CHIP_ERROR SendCommandResponse();
     CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) override;
 };

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -123,9 +123,14 @@ public:
      * Notification that a command sender encountered an asynchronous failure.
      * @param[in]  apCommandSender A current command sender which can identify the command sender to the consumer, particularly
      * during multiple command interactions
+     * @param[in]  aError         A error that could be CHIP_ERROR_TIMEOUT when command sender fails to receive, or other error when
+     *                            fail to process command response.
      * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
      */
-    virtual CHIP_ERROR CommandResponseTimeout(const CommandSender * apCommandSender) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual CHIP_ERROR CommandResponseError(const CommandSender * apCommandSender, CHIP_ERROR aError)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
     virtual ~InteractionModelDelegate() = default;
 };

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -229,6 +229,14 @@ public:
 
     CHIP_ERROR CommandResponseProcessed(const chip::app::CommandSender * apCommandSender) override
     {
+
+        uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
+        uint32_t transitTime = respTime - gLastMessageTime;
+
+        gCommandRespCount++;
+
+        printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gCommandRespCount, gCommandCount,
+               static_cast<double>(gCommandRespCount) * 100 / gCommandCount, static_cast<double>(transitTime) / 1000);
         gCond.notify_one();
         return CHIP_NO_ERROR;
     }
@@ -239,10 +247,10 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR CommandResponseTimeout(const chip::app::CommandSender * apCommandSender) override
+    CHIP_ERROR CommandResponseError(const chip::app::CommandSender * apCommandSender, CHIP_ERROR aError) override
     {
-        printf("CommandResponseTimeout happens");
-        return CHIP_NO_ERROR;
+        printf("CommandResponseError happens with %d", aError);
+        return aError;
     }
 };
 
@@ -259,17 +267,10 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         return;
     }
 
-    uint32_t respTime    = chip::System::Timer::GetCurrentEpoch();
-    uint32_t transitTime = respTime - gLastMessageTime;
-
     if (aReader.GetLength() != 0)
     {
         chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
     }
-    gCommandRespCount++;
-
-    printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gCommandRespCount, gCommandCount,
-           static_cast<double>(gCommandRespCount) * 100 / gCommandCount, static_cast<double>(transitTime) / 1000);
 }
 } // namespace app
 } // namespace chip

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -44,7 +44,8 @@ namespace app {
 void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aCommandId, chip::EndpointId aEndPointId,
                                   chip::TLV::TLVReader & aReader, Command * apCommandObj)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    static bool statusCodeFlipper = false;
 
     if (aClusterId != kTestClusterId || aCommandId != kTestCommandId || aEndPointId != kTestEndPointId)
     {
@@ -71,24 +72,34 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
     chip::TLV::TLVWriter writer = apCommandObj->CreateCommandDataElementTLVWriter();
 
-    printf("responder constructing response");
-    err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
-    SuccessOrExit(err);
+    if (statusCodeFlipper)
+    {
+        printf("responder constructing status code in command");
+        apCommandObj->AddStatusCode(&commandParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
+                                    Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeSuccess);
+    }
+    else
+    {
+        printf("responder constructing command data in command");
+        err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+        SuccessOrExit(err);
 
-    err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
-    SuccessOrExit(err);
+        err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
+        SuccessOrExit(err);
 
-    err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
-    SuccessOrExit(err);
+        err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
+        SuccessOrExit(err);
 
-    err = writer.EndContainer(dummyType);
-    SuccessOrExit(err);
+        err = writer.EndContainer(dummyType);
+        SuccessOrExit(err);
 
-    err = writer.Finalize();
-    SuccessOrExit(err);
+        err = writer.Finalize();
+        SuccessOrExit(err);
 
-    err = apCommandObj->AddCommand(commandParams);
-    SuccessOrExit(err);
+        err = apCommandObj->AddCommand(commandParams);
+        SuccessOrExit(err);
+    }
+    statusCodeFlipper = !statusCodeFlipper;
 
 exit:
     return;


### PR DESCRIPTION
Problems:
Previously AddStatusCode is not fully implemented in IM Command Handler, in
order to enable IM command in example code, we need fully implement
AddStatusCode, Per spec, status code is put inside CommandDataElement
in Command Response.

Summary of Changes:
-- Fully Implement AddStatusCode in IM Command Response and corresponding tests
-- The StatusCode SHALL only be present if There was an error as part of invoking the command
or there are no arguments defined in the response in which case, the StatusCode will convey success.