### PR TITLE
Check for kUndefinedNodeId for optional node ID values

### DIFF
--- a/src/transport/PeerConnections.h
+++ b/src/transport/PeerConnections.h
@@ -115,7 +115,7 @@ public:
                 mStates[i].SetLocalKeyID(localKeyId);
                 mStates[i].SetLastActivityTimeMs(mTimeSource.GetCurrentMonotonicTimeMs());
 
-                if (peerNode.HasValue())
+                if (peerNode.ValueOr(kUndefinedNodeId) != kUndefinedNodeId)
                 {
                     mStates[i].SetPeerNodeId(peerNode.Value());
                 }
@@ -227,7 +227,8 @@ public:
             }
             if (peerKeyId == kAnyKeyId || iter->GetPeerKeyID() == peerKeyId)
             {
-                if (!nodeId.HasValue() || iter->GetPeerNodeId() == kUndefinedNodeId || iter->GetPeerNodeId() == nodeId.Value())
+                if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
+                    iter->GetPeerNodeId() == nodeId.Value())
                 {
                     state = iter;
                     break;
@@ -304,7 +305,8 @@ public:
             }
             if (iter->GetLocalKeyID() == localKeyId)
             {
-                if (!nodeId.HasValue() || iter->GetPeerNodeId() == kUndefinedNodeId || iter->GetPeerNodeId() == nodeId.Value())
+                if (nodeId.ValueOr(kUndefinedNodeId) == kUndefinedNodeId || iter->GetPeerNodeId() == kUndefinedNodeId ||
+                    iter->GetPeerNodeId() == nodeId.Value())
                 {
                     state = iter;
                     break;


### PR DESCRIPTION
 #### Problem
The `lighting-app` sometimes crashes with the following stack trace
```
0x0000aaaaaaaf9394 in chip::SecureSessionMgr::SendMessage (this=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>, session=..., payloadHeader=..., packetHeader=..., msgBuf=..., bufferRetainSlot=0x0, 
    encryptionState=chip::SecureSessionMgr::EncryptionState::kPayloadIsUnencrypted) at ../../third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:207
207	        err = state->GetTransport()->SendMessage(packetHeader, state->GetPeerAddress(), std::move(msgBuf));
(gdb) bt
#0  0x0000aaaaaaaf9394 in chip::SecureSessionMgr::SendMessage(chip::SecureSessionHandle, chip::PayloadHeader&, chip::PacketHeader&, chip::System::PacketBufferHandle, chip::EncryptedPacketBufferHandle*, chip::SecureSessionMgr::EncryptionState)
    (this=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>, session=..., payloadHeader=..., packetHeader=..., msgBuf=..., bufferRetainSlot=0x0, encryptionState=chip::SecureSessionMgr::EncryptionState::kPayloadIsUnencrypted)
    at ../../third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:207
#1  0x0000aaaaaaaf8058 in chip::SecureSessionMgr::SendMessage(chip::SecureSessionHandle, chip::PayloadHeader&, chip::System::PacketBufferHandle&&, chip::EncryptedPacketBufferHandle*)
    (this=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>, session=..., payloadHeader=..., msgBuf=..., bufferRetainSlot=0x0) at ../../third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:121
#2  0x0000aaaaaaaf7f20 in chip::SecureSessionMgr::SendMessage(chip::SecureSessionHandle, chip::System::PacketBufferHandle&&) (this=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>, session=..., msgBuf=...)
    at ../../third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:114
#3  0x0000aaaaaaacc55c in chipSendUnicast(unsigned long, EmberApsFrame*, unsigned short, unsigned char*) (destination=2022985920837309958, apsFrame=0xaaaaaab7db70 <emberAfResponseApsFrame>, messageLength=8, message=0xaaaaaab7db88 <appResponseData> "\b\002\001")
    at ../../third_party/connectedhomeip/src/app/util/chip-message-send.cpp:78
#4  0x0000aaaaaaac9b68 in emAfSend(unsigned char, unsigned long, EmberApsFrame*, unsigned char, unsigned char*, unsigned char*, unsigned short, unsigned char)
    (type=0 '\000', indexOrDestination=2022985920837309958, apsFrame=0xaaaaaab7db70 <emberAfResponseApsFrame>, messageLength=8 '\b', message=0xaaaaaab7db88 <appResponseData> "\b\002\001", messageTag=0xffffffffeaec "\377", alias=0, sequence=0 '\000')
    at ../../third_party/connectedhomeip/src/app/util/af-main-common.cpp:658
#5  0x0000aaaaaaac9840 in send(EmberOutgoingMessageType, uint64_t, EmberApsFrame*, uint16_t, uint8_t*, bool, EmberNodeId, uint8_t, EmberAfMessageSentFunction)
    (type=0 '\000', indexOrDestination=2022985920837309958, apsFrame=0xaaaaaab7db70 <emberAfResponseApsFrame>, messageLength=8, message=0xaaaaaab7db88 <appResponseData> "\b\002\001", broadcast=false, alias=0, sequence=0 '\000', callback=0x0)
    at ../../third_party/connectedhomeip/src/app/util/af-main-common.cpp:288
#6  0x0000aaaaaaac99ec in emberAfSendUnicastWithCallback(unsigned char, unsigned long, EmberApsFrame*, unsigned short, unsigned char*, void (*)(unsigned char, unsigned long, EmberApsFrame*, unsigned short, unsigned char*, unsigned char))
    (type=0 '\000', indexOrDestination=2022985920837309958, apsFrame=0xaaaaaab7db70 <emberAfResponseApsFrame>, messageLength=8, message=0xaaaaaab7db88 <appResponseData> "\b\002\001", callback=0x0)
    at ../../third_party/connectedhomeip/src/app/util/af-main-common.cpp:449
#7  0x0000aaaaaaacf084 in emberAfSendResponseWithCallback(void (*)(unsigned char, unsigned long, EmberApsFrame*, unsigned short, unsigned char*, unsigned char)) (callback=0x0) at ../../third_party/connectedhomeip/src/app/util/util.cpp:735
#8  0x0000aaaaaaad0130 in emberAfSendResponse() () at ../../third_party/connectedhomeip/src/app/util/util.cpp:771
#9  0x0000aaaaaaacd98c in emAfProcessGlobalCommand(EmberAfClusterCommand*) (cmd=0xaaaaaab7dbe8 <curCmd>) at ../../third_party/connectedhomeip/src/app/util/process-global-message.cpp:231
#10 0x0000aaaaaaace880 in dispatchZclMessage(EmberAfClusterCommand*) (cmd=0xaaaaaab7dbe8 <curCmd>) at ../../third_party/connectedhomeip/src/app/util/util.cpp:468
#11 0x0000aaaaaaaced30 in emberAfProcessMessage(EmberApsFrame*, unsigned char, unsigned char*, unsigned short, unsigned long, EmberAfInterpanHeader*)
    (apsFrame=0xffffffffed18, type=0 '\000', message=0xaaaaaabb38e3 "", msgLen=5, source=2022985920837309958, interPanHeader=0x0) at ../../third_party/connectedhomeip/src/app/util/util.cpp:581
#12 0x0000aaaaaaac9154 in HandleDataModelMessage(unsigned long, chip::System::PacketBufferHandle) (nodeId=2022985920837309958, buffer=...) at ../../third_party/connectedhomeip/src/app/server/DataModelHandler.cpp:85
#13 0x0000aaaaaaafcb00 in (anonymous namespace)::ServerCallback::OnMessageReceived(chip::PacketHeader const&, chip::PayloadHeader const&, chip::SecureSessionHandle, chip::System::PacketBufferHandle, chip::SecureSessionMgr*)
    (this=0xaaaaaab7d108 <(anonymous namespace)::gCallbacks>, header=..., payloadHeader=..., session=..., buffer=..., mgr=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>) at ../../third_party/connectedhomeip/src/app/server/Server.cpp:377
#14 0x0000aaaaaaaf9dd0 in chip::SecureSessionMgr::OnMessageReceived(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle)
    (this=0xaaaaaab7ea48 <(anonymous namespace)::gSessions>, packetHeader=..., peerAddress=..., msg=...) at ../../third_party/connectedhomeip/src/transport/SecureSessionMgr.cpp:390
#15 0x0000aaaaaaafab38 in chip::TransportMgrBase::HandleMessageReceived(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle)
    (this=0xaaaaaab7e9d8 <(anonymous namespace)::gTransports>, packetHeader=..., peerAddress=..., msg=...) at ../../third_party/connectedhomeip/src/transport/TransportMgrBase.cpp:54
#16 0x0000aaaaaab22c94 in chip::Transport::Base::HandleMessageReceived(chip::PacketHeader const&, chip::Transport::PeerAddress const&, chip::System::PacketBufferHandle&&)
    (this=0xaaaaaab7ea08 <(anonymous namespace)::gTransports+48>, header=..., source=..., buffer=...) at ../../third_party/connectedhomeip/src/transport/raw/Base.h:93
#17 0x0000aaaaaab231ec in chip::Transport::UDP::OnUdpReceive(chip::Inet::IPEndPointBasis*, chip::System::PacketBufferHandle, chip::Inet::IPPacketInfo const*) (endPoint=0xaaaaaab81a88 <chip::Inet::UDPEndPoint::sPool+72>, buffer=..., pktInfo=0xfffffffff1d0)
    at ../../third_party/connectedhomeip/src/transport/raw/UDP.cpp:118
#18 0x0000aaaaaab4549c in chip::Inet::IPEndPointBasis::HandlePendingIO(unsigned short) (this=0xaaaaaab81a88 <chip::Inet::UDPEndPoint::sPool+72>, aPort=11097) at ../../third_party/connectedhomeip/src/inet/IPEndPointBasis.cpp:1183
#19 0x0000aaaaaab2af14 in chip::Inet::UDPEndPoint::HandlePendingIO() (this=0xaaaaaab81a88 <chip::Inet::UDPEndPoint::sPool+72>) at ../../third_party/connectedhomeip/src/inet/UDPEndPoint.cpp:941
#20 0x0000aaaaaab285c0 in chip::Inet::InetLayer::HandleSelectResult(int, fd_set*, fd_set*, fd_set*) (this=
    0xaaaaaab7ddc8 <chip::DeviceLayer::InetLayer>, selectRes=17, readfds=0xaaaaaab7df68 <chip::DeviceLayer::PlatformManagerImpl::sInstance+16>, writefds=0xaaaaaab7dfe8 <chip::DeviceLayer::PlatformManagerImpl::sInstance+144>, exceptfds=0xaaaaaab7e068 <chip::DeviceLayer::PlatformManagerImpl::sInstance+272>) at ../../third_party/connectedhomeip/src/inet/InetLayer.cpp:1271
#21 0x0000aaaaaaadb1c8 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::SysProcess() (this=0xaaaaaab7df58 <chip::DeviceLayer::PlatformManagerImpl::sInstance>)
    at ../../third_party/connectedhomeip/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp:185
#22 0x0000aaaaaaadae08 in chip::DeviceLayer::Internal::GenericPlatformManagerImpl_POSIX<chip::DeviceLayer::PlatformManagerImpl>::_RunEventLoop() (this=0xaaaaaab7df58 <chip::DeviceLayer::PlatformManagerImpl::sInstance>)
    at ../../third_party/connectedhomeip/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp:203
#23 0x0000aaaaaaac215c in chip::DeviceLayer::PlatformManager::RunEventLoop() (this=0xaaaaaab7df58 <chip::DeviceLayer::PlatformManagerImpl::sInstance>) at ../../third_party/connectedhomeip/src/include/platform/PlatformManager.h:204
#24 0x0000aaaaaaac2a50 in main(int, char**) (argc=2, argv=0xfffffffff5c8) at ../../main.cpp:197
```

 #### Summary of Changes
- Functions using `Optional<NodeId>` values are only checking for `HasValue()` to check for valid Node IDs. Some callers are using `kUndefinedNodeId` to indicate unknown node ID. This PR updates the code to check against `kUndefinedNodeId` using `ValueOr(kUndefinedNodeId)` function of `Optional<>`
- In this particular crash, the `PeerConnectionState` lookup failed because of missing check for `kUndefinedNodeId`. 
