### PR TITLE
Fix the missing commandList container closure in IM command

### DIFF
--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -52,7 +52,7 @@ exit:
 CHIP_ERROR Command::Reset()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
+    CommandList::Builder commandListBuilder;
     ClearExistingExchangeContext();
 
     if (mCommandMessageBuf.IsNull())
@@ -66,7 +66,8 @@ CHIP_ERROR Command::Reset()
     err = mInvokeCommandBuilder.Init(&mCommandMessageWriter);
     SuccessOrExit(err);
 
-    mInvokeCommandBuilder.CreateCommandListBuilder();
+    commandListBuilder = mInvokeCommandBuilder.CreateCommandListBuilder();
+    SuccessOrExit(commandListBuilder.GetError());
     MoveToState(CommandState::Initialized);
 
     mCommandIndex = 0;
@@ -261,6 +262,9 @@ CHIP_ERROR Command::ClearExistingExchangeContext()
 CHIP_ERROR Command::FinalizeCommandsMessage()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+
+    CommandList::Builder commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();
+    SuccessOrExit(commandListBuilder.GetError());
 
     mInvokeCommandBuilder.EndOfInvokeCommand();
     err = mInvokeCommandBuilder.GetError();


### PR DESCRIPTION
Problem:
src/app/Command.h and .cpp create incomplete tlv data, the commandList array is missing the end of container byte

Calling Command::Init() followed by Command::FinalizeCommandsMessage() results in following invalid tlv data:

15 36 00 18

It should be: 15 36 00 18 18

This affects every interactive model command, they are all incomplete/invalid.

Summary of Changes:
add this to beginning of Command::FinalizeCommandsMessage():

mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList()

fixes #5789
