### PR TITLE
Fix Cirque random crash issue in CI

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -723,6 +723,8 @@ CHIP_ERROR DeviceCommissioner::UnpairDevice(NodeId remoteDeviceId)
 {
     // TODO: Send unpairing message to the remote device.
 
+    FreeRendezvousSession();
+
     if (mStorageDelegate != nullptr)
     {
         PERSISTENT_KEY_OP(remoteDeviceId, kPairedDeviceKeyPrefix, key, mStorageDelegate->AsyncDeleteKeyValue(key));


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The Cirque CI is not stable, it randomly fails due to the following crash

Traceback (most recent call last):
  File "/home/runner/work/connectedhomeip/connectedhomeip/src/test_driver/linux-cirque/helper/CHIPTestBase.py", line 62, in run_test
    self.test_routine()
  File "/home/runner/work/connectedhomeip/connectedhomeip/src/test_driver/linux-cirque/test-on-off-cluster.py", line 66, in test_routine
    self.run_data_model_test()
  File "/home/runner/work/connectedhomeip/connectedhomeip/src/test_driver/linux-cirque/test-on-off-cluster.py", line 91, in run_data_model_test
    self.assertEqual(
  File "/home/runner/work/connectedhomeip/connectedhomeip/src/test_driver/linux-cirque/helper/CHIPTestBase.py", line 222, in assertEqual
    raise AssertionError
AssertionError
2021-04-05 03:50:45,661 [CHIPOnOffTest] INFO destroying home: a322a5ee-12b0-4792-ac98-0d78d83c65c2
Cleanup Flask

It looks OnRendezvousComplete is called after RendezvousCleanup is called.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Clean up the RendezvousSession during UnpairDevice.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5686

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
