### PR TITLE
[cirque] Add "ManualTest" to set up test topology for running CHIP apps inside Cirque manually

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -37,11 +37,11 @@ BOLD_RED_TEXT="\033[1;31m"
 RESET_COLOR="\033[0m"
 
 function __screen() {
-  if [[ "x$GITHUB_ACTION_RUN" != "x1" ]]; then
-    screen -dm "$@"
-  else
-    "$@"
-  fi
+    if [[ "x$GITHUB_ACTION_RUN" != "x1" ]]; then
+        screen -dm "$@"
+    else
+        "$@"
+    fi
 }
 
 function __kill_grep() {

--- a/src/test_driver/linux-cirque/ManualTest.sh
+++ b/src/test_driver/linux-cirque/ManualTest.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the wrapper for setting up testing topology in cirque.
+# You can modify build_* part to build your own docker image.
+# This test should not be executed over CHIP.
+#
+# You SHOULD run this script by cirque test wrapper:
+#   ./scripts/tests/cirque_tests.sh run_test ManualTest
+# under CHIP checkout.
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+REPO_DIR="$SOURCE_DIR/../../../"
+
+chip_tool_dir=$REPO_DIR/examples/chip-tool
+chip_light_dir=$REPO_DIR/examples/lighting-app/linux
+
+function build_chip_tool() {
+    # These files should be successfully compiled elsewhere.
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$chip_tool_dir"
+    gn gen --check --fail-on-unused-args out/debug >/dev/null
+    run_ninja -C out/debug
+    docker build -t chip_tool -f Dockerfile . 2>&1
+}
+
+function build_chip_lighting() {
+    source "$REPO_DIR/scripts/activate.sh" >/dev/null
+    set -x
+    cd "$chip_light_dir"
+    gn gen --check --fail-on-unused-args out/debug
+    run_ninja -C out/debug
+    docker build -t chip_server -f Dockerfile . 2>&1
+    set +x
+}
+
+function main() {
+    pushd .
+    build_chip_tool
+    build_chip_lighting
+    popd
+    python3 "$SOURCE_DIR/test-manual.py"
+}
+
+source "$SOURCE_DIR"/shell-helpers.sh
+main

--- a/src/test_driver/linux-cirque/README.md
+++ b/src/test_driver/linux-cirque/README.md
@@ -88,8 +88,7 @@ You can run a ManualTest to setup test topology only:
 scripts/tests/cirque_tests.sh run_test ManualTest
 ```
 
-It will print the container id in log, you can attach to it or execute command
-inside them.
+It will print the container id in log, you can execute commands inside them.
 
 ```
 2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Finished setting up environment.
@@ -99,7 +98,21 @@ inside them.
 2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Container will be cleaned when the test finished.
 ```
 
-After you finished you test, press Ctrl-C and it will clean up testing
+> You can run docker commands with these containers, for example, to launch a
+> shell on CHIP-Tool, you can use:
+>
+> ```
+> docker exec -it c5831124e7 /bin/bash
+> ```
+>
+> For detailed command you can use, please refer to
+> [official docker documents](https://docs.docker.com/engine/reference/commandline/cli/).
+
+> It is not recommanded to run commands that can change the state of the
+> container, for example: `attach` (will stop container once you exit), `stop`
+> etc.
+
+After you finished you test, press `Ctrl-C` and it will clean up testing
 environment.
 
 Refer to `test-manual.py` and `ManualTest.sh` for detail.

--- a/src/test_driver/linux-cirque/README.md
+++ b/src/test_driver/linux-cirque/README.md
@@ -79,3 +79,27 @@ Or
 LOG_DIR=/some/log/directory scripts/tests/cirque_tests.sh run_all_tests
 LOG_DIR=/some/log/directory scripts/tests/cirque_tests.sh run_test OnOffClusterTest
 ```
+
+## Setup test topology only
+
+You can run a ManualTest to setup test topology only:
+
+```
+scripts/tests/cirque_tests.sh run_test ManualTest
+```
+
+It will print the container id in log, you can attach to it or execute command
+inside them.
+
+```
+2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Finished setting up environment.
+2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Device: CHIP-Server (Type: CHIP-Server, Container: 459c901ed9)
+2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Device: CHIP-Tool (Type: CHIP-Tool, Container: c5831124e7)
+2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Press Ctrl-C to stop the test.
+2021-04-06 15:01:57,780 [CHIPCirqueTest] INFO Container will be cleaned when the test finished.
+```
+
+After you finished you test, press Ctrl-C and it will clean up testing
+environment.
+
+Refer to `test-manual.py` and `ManualTest.sh` for detail.

--- a/src/test_driver/linux-cirque/test-manual.py
+++ b/src/test_driver/linux-cirque/test-manual.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import os
+import time
+import sys
+
+from helper.CHIPTestBase import CHIPVirtualHome
+
+#############################################################
+
+# Set your test topology here.
+#
+# type: A tag for the container, can be used for find a set of containers.
+# base_image: The image of the container.
+# capability: A list of capability of the container, Thread+Interactive should fit in most cases.
+# rcp_mode: This is used for Thread network setup, set it to True for CHIP.
+DEVICE_CONFIG = {
+    'device0': {
+        'type': 'CHIP-Server',
+        'base_image': 'chip_server',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    },
+    'device1': {
+        'type': 'CHIP-Tool',
+        'base_image': 'chip_tool',
+        'capability': ['Thread', 'Interactive'],
+        'rcp_mode': True,
+    }
+}
+
+# Set this to True to set up a test thread network if you don't want to test network commissioning.
+# Note: If you enable this, all devices MUST have Thread capability or the script may fail.
+SETUP_TEST_THREAD_NETWORK = False
+
+# You can define your own consts here.
+SETUPPINCODE = 12345678
+DISCRIMINATOR = 1  # Randomw number, not used
+CHIP_PORT = 11097
+
+#############################################################
+
+CIRQUE_URL = "http://localhost:5000"
+
+logger = logging.getLogger('CHIPCirqueTest')
+logger.setLevel(logging.INFO)
+
+sh = logging.StreamHandler()
+sh.setFormatter(
+    logging.Formatter(
+        '%(asctime)s [%(name)s] %(levelname)s %(message)s'))
+logger.addHandler(sh)
+
+class TestManually(CHIPVirtualHome):
+    def __init__(self, device_config):
+        super().__init__(CIRQUE_URL, device_config)
+        self.logger = logger
+
+    def setup(self):
+        self.initialize_home()
+        if SETUP_TEST_THREAD_NETWORK:
+            self.connect_to_thread_network()
+
+    def test_routine(self):
+        self.wait_for_interrupt()
+
+    def wait_for_interrupt(self):
+        self.logger.info("Finished setting up environment.")
+        for device in self.non_ap_devices:
+            self.logger.info("Device: {} (Type: {}, Container: {})".format(device["type"], device["type"], device["id"][:10]))
+        self.logger.info("Press Ctrl-C to stop the test.")
+        self.logger.info("Container will be cleaned when the test finished.")
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            self.logger.info("KeyboardInterrupt received, quit now")
+
+
+if __name__ == "__main__":
+    sys.exit(TestManually(DEVICE_CONFIG).run_test())


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Sometimes we would like to use cirque to bring up topology, then run chip x cirque tests among dockers locally.
Cirque will do lots of things to setup test topology, so we need a all-in-one script to help users set up it.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Add ManualTest.sh, this test won't be run in presubmit tests, but can be a template for running the tests manually (can attach to containers, can run commands inside the container, etc.).

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5758

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
