### PR TITLE
[hotfix] Revert "Use system StartEventLoopTask to drive IO during IM integration test"

### DIFF
--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -58,7 +58,45 @@ exit:
 void ShutdownChip(void)
 {
     gExchangeManager.Shutdown();
-    chip::DeviceLayer::PlatformMgr().Shutdown();
+    chip::DeviceLayer::SystemLayer.Shutdown();
+}
+
+void DriveIO(void)
+{
+    struct timeval sleepTime;
+    fd_set readFDs, writeFDs, exceptFDs;
+    int numFDs = 0;
+    int selectRes;
+
+    sleepTime.tv_sec  = 0;
+    sleepTime.tv_usec = NETWORK_SLEEP_TIME_MSECS;
+
+    FD_ZERO(&readFDs);
+    FD_ZERO(&writeFDs);
+    FD_ZERO(&exceptFDs);
+
+    if (chip::DeviceLayer::SystemLayer.State() == chip::System::kLayerState_Initialized)
+        chip::DeviceLayer::SystemLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, sleepTime);
+
+    if (chip::DeviceLayer::InetLayer.State == chip::Inet::InetLayer::kState_Initialized)
+        chip::DeviceLayer::InetLayer.PrepareSelect(numFDs, &readFDs, &writeFDs, &exceptFDs, sleepTime);
+
+    selectRes = select(numFDs, &readFDs, &writeFDs, &exceptFDs, &sleepTime);
+    if (selectRes < 0)
+    {
+        printf("select failed: %s\n", chip::ErrorStr(chip::System::MapErrorPOSIX(errno)));
+        return;
+    }
+
+    if (chip::DeviceLayer::SystemLayer.State() == chip::System::kLayerState_Initialized)
+    {
+        chip::DeviceLayer::SystemLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+    }
+
+    if (chip::DeviceLayer::InetLayer.State == chip::Inet::InetLayer::kState_Initialized)
+    {
+        chip::DeviceLayer::InetLayer.HandleSelectResult(selectRes, &readFDs, &writeFDs, &exceptFDs);
+    }
 }
 
 void TLVPrettyPrinter(const char * aFormat, ...)

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -39,4 +39,5 @@ constexpr chip::GroupId kTestGroupId       = 0;
 
 void InitializeChip(void);
 void ShutdownChip(void);
+void DriveIO(void);
 void TLVPrettyPrinter(const char * aFormat, ...);


### PR DESCRIPTION
#### Problem

Reverts project-chip/connectedhomeip#5720, refer to #5813 for fix instead of revert.

CV should be used with a check to avoid spurious awakenings. 

#### Solution

https://github.com/project-chip/connectedhomeip/blob/3c64a7ba3e7488c77dd86cafe940f8d17d786e24/examples/chip-tool/commands/common/Command.cpp#L310-L328

Fix #5807 5807