### PR TITLE
[nrfconnect] Recommend using west flash --erase

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -350,7 +350,7 @@ page.
 To flash the application to the device, use the west tool and run the following
 command from the example directory:
 
-        $ west flash
+        $ west flash --erase
 
 If you have multiple development kits connected, west will prompt you to pick
 the correct one.

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -340,7 +340,7 @@ page.
 To flash the application to the device, use the west tool and run the following
 command from the example directory:
 
-        $ west flash
+        $ west flash --erase
 
 If you have multiple development kits connected, west will prompt you to pick
 the correct one.

--- a/examples/pigweed-app/nrfconnect/README.md
+++ b/examples/pigweed-app/nrfconnect/README.md
@@ -296,17 +296,16 @@ nRF52840 Dongle.
 ### Flashing on the nRF52840 DK
 
 To flash the application to the device, use the west tool and run the following
-commands, with the _example-dir_ directory name updated for your configuration:
+command from the example directory:
 
-        $ cd example-dir
-        $ west flash
+        $ west flash --erase
 
 If you have multiple nRF52840 development kits connected, west will prompt you
 to pick the correct one.
 
-To debug the application on target, run the following commands:
+To debug the application on target, run the following command from the example
+directory:
 
-        $ cd example-dir
         $ west debug
 
 <a name="nrf52840dongle_flashing"></a>


### PR DESCRIPTION
 #### Problem
Using bare `west flash`, without erasing the entire flash
area, may lead to weird behaviour when switching between
different nRF Connect SDK/Zephyr/OpenThread revisions.
It's safer and faster to use `west flash --erase`.

 #### Summary of Changes
Recommend using `west flash --erase` in nRF Connect examples documentation.

 Fixes #5782