### PR TITLE
ESP32: Add cmake support to pigweed.

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT CHIP_ROOT)
 endif()
 
 idf_component_register(SRCS chip.c chip.cpp
-                       PRIV_REQUIRES freertos lwip bt mdns mbedtls)
+                       PRIV_REQUIRES freertos lwip bt mdns mbedtls fatfs)
 
 # Prepare initial args file (lacking compile flags)
 # This will be saved as args.gn.in
@@ -105,7 +105,7 @@ externalproject_add(
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
     CONFIGURE_COMMAND       ${GN_EXECUTABLE} --root=${GN_ROOT_TARGET} gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
-    BUILD_COMMAND           ninja
+    BUILD_COMMAND           ninja "esp32"
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
     WORKING_DIRECTORY       ${CMAKE_CURRENT_LIST_DIR}

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# The following lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# The list of extra component dirs must be in sync with that in pigweed-app/esp32/Makefile
+set(EXTRA_COMPONENT_DIRS
+    "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/config/esp32/components"
+)
+
+project(chip-pigweed-app)
+idf_build_set_property(CXX_COMPILE_OPTIONS "-std=c++17;-Os;-DLWIP_IPV6_SCOPES=0;-DCHIP_HAVE_CONFIG_H" APPEND)
+idf_build_set_property(C_COMPILE_OPTIONS "-Os;-DLWIP_IPV6_SCOPES=0" APPEND)

--- a/examples/pigweed-app/esp32/README.md
+++ b/examples/pigweed-app/esp32/README.md
@@ -56,30 +56,41 @@ step. To install these components manually, follow these steps:
 Currently building in VSCode _and_ deploying from native is not supported, so
 make sure the IDF_PATH has been exported(See the manual setup steps above).
 
--   In the root of the example directory, sync the CHIP tree's submodules and
-    source `idf.sh`. Note: This does not have to be repeated for incremental
-    builds.
+-   Setting up the environment
 
-          $ source idf.sh
+To download and install packages.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/bootstrap.sh
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
+
+If packages are already installed then simply activate it.
+
+        $ cd ${HOME}/tools/esp-idf
+        $ ./install.sh
+        $ . ./export.sh
+        $ cd {path-to-connectedhomeip}
+        $ source ./scripts/activate.sh
+        $ cd {path-to-connectedhomeip-examples}
 
 -   Configuration Options
 
         To choose from the different configuration options, run menuconfig
 
-          $ idf make menuconfig
+          $ idf.py menuconfig
 
         This example uses UART0 for serial communication. You can change this through
         `PW RPC Example Configuration`. As a result, the console has been shifted to UART1
         You can change this through `Component config` -> `Common ESP-related` ->
         `UART for console output`
 
-        To use the default configuration options, run the default config
+-   To build the demo application.
 
-          $ idf make defconfig
-
--   Run make to build the demo application.
-
-          $ idf make
+          $ idf.py build
 
 -   After building the application, to flash it outside of VSCode, connect your
     device via USB. Then run the following command to flash the demo application
@@ -90,7 +101,7 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     before flashing. For ESP32-DevKitC devices this is labeled in the
     [functional description diagram](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-devkitc.html#functional-description).
 
-          $ idf make flash ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py build flash ESPPORT=/dev/tty.SLAB_USBtoUART
 
     Note: Some users might have to install the
     [VCP driver](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)

--- a/examples/pigweed-app/esp32/main/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/main/CMakeLists.txt
@@ -1,0 +1,67 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# The list of src and include dirs must be in sync with that in pigweed-app/esp32/main/component.mk
+idf_component_register(INCLUDE_DIRS 
+                     "${CMAKE_CURRENT_LIST_DIR}"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log/public_overrides" 
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_bytes/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_checksum/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_containers/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_hdlc/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_span/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/standard_library_public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_polyfill/public_overrides"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/nanopb/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/raw/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_protobuf/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_status/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_stream/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_result/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_varint/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_preprocessor/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/system_server/public"
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/nanopb/repo"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32/pw_sys_io/public"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../../src/lib/support"
+                     "${IDF_PATH}/components/freertos/include/freertos"
+                    
+                      SRC_DIRS
+                     "${CMAKE_CURRENT_LIST_DIR}"
+                     "${CMAKE_SOURCE_DIR}/../../platform/esp32"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed"
+                     "${CMAKE_SOURCE_DIR}/../../common/pigweed/esp32"
+                      PRIV_REQUIRES bt chip)
+
+idf_component_get_property(chip_lib chip COMPONENT_LIB)
+
+set(WRAP_FUNCTIONS esp_log_write)
+target_link_libraries(${chip_lib} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
+
+set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})
+target_include_directories(${chip_lib} PUBLIC "$<TARGET_FILE_DIR:${chip_lib}>/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos")


### PR DESCRIPTION
 #### Problem
 Add CMake support to esp32 pigweed example.

 #### Summary of Changes
1. Added `CMakeLists.txt`.
2. Updated `README.md.`