### PR TITLE
Start Mdns server in the linux version of the all-clusters-app

### DIFF
--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -23,6 +23,7 @@
 #include "gen/attribute-id.h"
 #include "gen/cluster-id.h"
 #include <app/chip-zcl-zpro-codec.h>
+#include <app/server/Mdns.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/util.h>
@@ -62,6 +63,9 @@ int main(int argc, char * argv[])
 
     // Init ZCL Data Model and CHIP App Server
     InitServer();
+
+    // Init Mdns Server
+    app::Mdns::StartServer();
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -175,6 +175,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "CoreFoundation.framework",
         "CoreBluetooth.framework",
         "Foundation.framework",
+        "IOKit.framework",
       ]
     }
   }

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -33,10 +33,95 @@
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/network/IOEthernetController.h>
+#include <IOKit/network/IOEthernetInterface.h>
+#include <IOKit/network/IONetworkInterface.h>
+
 namespace chip {
 namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
+
+CHIP_ERROR FindInterfaces(io_iterator_t * primaryInterfaceIterator)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    kern_return_t kernResult;
+    CFMutableDictionaryRef matchingDict     = nullptr;
+    CFMutableDictionaryRef primaryInterface = nullptr;
+
+    matchingDict = IOServiceMatching(kIOEthernetInterfaceClass);
+    VerifyOrExit(matchingDict != nullptr, err = CHIP_ERROR_INTERNAL);
+
+    primaryInterface =
+        CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    VerifyOrExit(primaryInterface != nullptr, err = CHIP_ERROR_INTERNAL);
+
+    CFDictionarySetValue(primaryInterface, CFSTR(kIOPrimaryInterface), kCFBooleanTrue);
+    CFDictionarySetValue(matchingDict, CFSTR(kIOPropertyMatchKey), primaryInterface);
+
+    // IOServiceGetMatchingServices will consume matchingDict, so there is no need to call CFRelease afterwards
+    kernResult   = IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDict, primaryInterfaceIterator);
+    matchingDict = nullptr;
+    VerifyOrExit(KERN_SUCCESS == kernResult, err = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (matchingDict != nullptr)
+    {
+        CFRelease(matchingDict);
+    }
+
+    if (primaryInterface != nullptr)
+    {
+        CFRelease(primaryInterface);
+    }
+
+    return err;
+}
+
+CHIP_ERROR GetMACAddressFromInterfaces(io_iterator_t primaryInterfaceIterator, uint8_t * buf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    kern_return_t kernResult;
+    io_object_t interfaceService;
+    io_object_t controllerService;
+
+    while ((interfaceService = IOIteratorNext(primaryInterfaceIterator)))
+    {
+        CFTypeRef MACAddressAsCFData = nullptr;
+        kernResult                   = IORegistryEntryGetParentEntry(interfaceService, kIOServicePlane, &controllerService);
+        VerifyOrExit(KERN_SUCCESS == kernResult, err = CHIP_ERROR_INTERNAL);
+
+        MACAddressAsCFData = IORegistryEntryCreateCFProperty(controllerService, CFSTR(kIOMACAddress), kCFAllocatorDefault, 0);
+        VerifyOrExit(MACAddressAsCFData != nullptr, err = CHIP_ERROR_INTERNAL);
+
+        CFDataGetBytes((CFDataRef) MACAddressAsCFData, CFRangeMake(0, kIOEthernetAddressSize), buf);
+        CFRelease(MACAddressAsCFData);
+
+        kernResult = IOObjectRelease(controllerService);
+        VerifyOrExit(KERN_SUCCESS == kernResult, err = CHIP_ERROR_INTERNAL);
+
+        kernResult = IOObjectRelease(interfaceService);
+        VerifyOrExit(KERN_SUCCESS == kernResult, err = CHIP_ERROR_INTERNAL);
+    }
+
+exit:
+    if (IOObjectGetRetainCount(interfaceService))
+    {
+        IOObjectRelease(interfaceService);
+    }
+
+    if (IOObjectGetRetainCount(controllerService))
+    {
+        IOObjectRelease(controllerService);
+    }
+
+    return err;
+}
 
 /** Singleton instance of the ConfigurationManager implementation object.
  */
@@ -56,8 +141,16 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    // TODO(#739): add WiFi support
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    io_iterator_t primaryInterfaceIterator;
+    err = FindInterfaces(&primaryInterfaceIterator);
+    VerifyOrReturnError(CHIP_NO_ERROR == err, err);
+
+    err = GetMACAddressFromInterfaces(primaryInterfaceIterator, buf);
+    IOObjectRelease(primaryInterfaceIterator);
+
+    return err;
 }
 
 bool ConfigurationManagerImpl::_CanFactoryReset()

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -473,6 +473,12 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 
 CHIP_ERROR ChipMdnsStopPublish()
 {
+    RegisterContext * sdCtx = nullptr;
+    if (CHIP_ERROR_KEY_NOT_FOUND == MdnsContexts::GetInstance().Get(ContextType::Register, sdCtx))
+    {
+        return CHIP_NO_ERROR;
+    }
+
     return MdnsContexts::GetInstance().Removes(ContextType::Register);
 }
 


### PR DESCRIPTION
 #### Problem

The `Mdns` server is not started locally for the linux version of the `all-clusters-app` which makes it harder to develop locally.

 #### Summary of Changes
 * Call `app::Mdns::StartServer` into `examples/all-clusters-app/linux/main.cpp`
 * Add some code to make the function that generates the hostname happy under darwin.
 * Invert the order of the sequence -> `mdnsAdvertiser.Advertise(...); mdnsAdvertiser.Start();` since `Advertise` internally calls `Publish` and `Start` internally calls `StopPublish`...
 * Did a fix to the darwin implementation of `ChipMdnsStopPublish` to not return an error if it is called but it is not currently publishing anything.