### PR TITLE
Fix EFR32 lighting-app RPC build

### DIFF
--- a/examples/lighting-app/efr32/src/Rpc.cpp
+++ b/examples/lighting-app/efr32/src/Rpc.cpp
@@ -49,6 +49,8 @@ using std::byte;
 #define RPC_TASK_STACK_SIZE 4096
 #define RPC_TASK_PRIORITY 1
 static TaskHandle_t sRpcTaskHandle;
+StaticTask_t sRpcTaskBuffer;
+StackType_t sRpcTaskStack[RPC_TASK_STACK_SIZE];
 
 chip::rpc::LightingService lighting_service;
 
@@ -70,11 +72,8 @@ int Init()
     pw_sys_io_Init();
 
     // Start App task.
-    if (xTaskCreate(RunRpcService, "RPC_TASK", RPC_TASK_STACK_SIZE / sizeof(StackType_t), nullptr, RPC_TASK_PRIORITY,
-                    &sRpcTaskHandle) == pdPASS)
-    {
-        err = CHIP_NO_ERROR;
-    }
+    sRpcTaskHandle = xTaskCreateStatic(RunRpcService, "RPC_TASK", RPC_TASK_STACK_SIZE / sizeof(StackType_t), nullptr,
+                                       RPC_TASK_PRIORITY, sRpcTaskStack, &sRpcTaskBuffer);
     return err;
 }
 


### PR DESCRIPTION



<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently boots with hardfault:
   Failed do a malloc on HEAP. Is it too small ?


 #### Summary of Changes
Statically allocate the memory for the RPC task. This has already been changed for the other tasks but likely the RPC task got forgotten. 
