### PR TITLE
Call rendezvous delegate as last step of pairing

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -288,11 +288,6 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
     switch (mCurrentState)
     {
     case State::kRendezvousComplete:
-        if (mDelegate != nullptr)
-        {
-            mDelegate->OnRendezvousComplete();
-        }
-
         if (mParams.HasAdvertisementDelegate())
         {
             mParams.GetAdvertisementDelegate()->RendezvousComplete();
@@ -300,6 +295,11 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
 
         // Release the admin, as the rendezvous is complete.
         mAdmin = nullptr;
+
+        if (mDelegate != nullptr)
+        {
+            mDelegate->OnRendezvousComplete();
+        }
         break;
 
     case State::kSecurePairing:


### PR DESCRIPTION
 #### Problem
There's a use-after-free memory error in device pairing flow (as described in https://github.com/project-chip/connectedhomeip/issues/5621).

 #### Summary of Changes
The delegate call frees the rendezvous session object. The object was still being used after the delegate call.
This change moves the delegate callback to the end of the functional block.

 Fixes #5621