### PR TITLE
[cirque]: Fix cirque IM test flaky issue

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -85,10 +85,9 @@ void CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExchangeCon
         goto exit;
     }
 
-    // Remove the EC from the app state now. OnMessageReceived can call
-    // SendCommandRequest and install a new one. We abort rather than close
-    // because we no longer care whether the echo request message has been
-    // acknowledged at the transport layer.
+    // Close the current exchange after receiving the response since the response message marks the
+    // end of conversation represented by the exchange. We should create an new exchange for a new
+    // conversation defined in Interaction Model protocol.
     ClearExistingExchangeContext();
 
     err = ProcessCommandMessage(std::move(aPayload), CommandRoleId::SenderId);
@@ -96,6 +95,11 @@ void CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExchangeCon
 
 exit:
     Reset();
+
+    if (mpDelegate != nullptr)
+    {
+        mpDelegate->CommandResponseProcessed(this);
+    }
 }
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -99,6 +99,14 @@ public:
     }
 
     /**
+     * Notification that a Command Response has already been processed.
+     * @param[in]  apCommandSender A current command sender which can identify the command sender to the consumer, particularly
+     * during multiple command interactions
+     * @retval # CHIP_ERROR_NOT_IMPLEMENTED if not implemented
+     */
+    virtual CHIP_ERROR CommandResponseProcessed(const CommandSender * apCommandSender) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
      * Notification that a Command Send has received an Invoke Command Response and fails to process a command data element in that
      * command response
      * @param[in]  apCommandSender A current command sender which can identify the command sender to the consumer, particularly

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -227,6 +227,12 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    CHIP_ERROR CommandResponseProcessed(const chip::app::CommandSender * apCommandSender) override
+    {
+        gCond.notify_one();
+        return CHIP_NO_ERROR;
+    }
+
     CHIP_ERROR CommandResponseProtocolError(const chip::app::CommandSender * apCommandSender, uint8_t aCommandIndex) override
     {
         printf("CommandResponseProtocolError happens with CommandIndex %d", aCommandIndex);
@@ -264,8 +270,6 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
     printf("Command Response: %" PRIu64 "/%" PRIu64 "(%.2f%%) time=%.3fms\n", gCommandRespCount, gCommandCount,
            static_cast<double>(gCommandRespCount) * 100 / gCommandCount, static_cast<double>(transitTime) / 1000);
-
-    gCond.notify_one();
 }
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 IM test in cirque is flaky.

From the log, we can see the CommandSender moved to [Initialize] state after the app get notified the response messages is processed. That indicates there is a potential bug in our code. We should not notify the app the response message is processed if IM still have remaining work to do.

Before #5720, we use polling to check the response message before we send the next Command Request, so the delay introduced by polling is long enough to cover this problem.

With #5720, IM initiator call gCond.notify_one() immediately after it receives the delegate callback for response message is processed, if gCond.notify_one() trigger context switch, then IM initiator will send the next Command Request before CommandSender reset its state back to [Initialize]

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Notify the delegate only when Command/Read responses are fully processed.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5807

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
