### PR TITLE
ESP32: Fix for CMake build failure for M5Stack and rebuild.

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -105,6 +105,12 @@ endif()
 
 set(GN_ROOT_TARGET ${CHIP_ROOT}/config/esp32)
 
+set(chip_libraries "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a")
+
+if(CONFIG_ENABLE_PW_RPC)
+    list(APPEND chip_libraries "${CMAKE_CURRENT_BINARY_DIR}/lib/libPwRpc.a")
+endif()
+
 externalproject_add(
     chip_gn
     SOURCE_DIR              ${CHIP_ROOT}
@@ -112,7 +118,7 @@ externalproject_add(
     CONFIGURE_COMMAND       ${GN_EXECUTABLE} --root=${GN_ROOT_TARGET} gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
     BUILD_COMMAND           ninja "esp32"
     INSTALL_COMMAND         ""
-    BUILD_BYPRODUCTS        ${CHIP_LIBRARIES}
+    BUILD_BYPRODUCTS        ${chip_libraries}
     WORKING_DIRECTORY       ${CMAKE_CURRENT_LIST_DIR}
     DEPENDS                 args_gn
     BUILD_ALWAYS            1
@@ -140,12 +146,6 @@ target_include_directories(${COMPONENT_LIB} INTERFACE
 
 idf_component_get_property(esp32_mbedtls_lib esp32_mbedtls COMPONENT_LIB)
 
-set(chip_libraries "-lCHIP")
-
-if(CONFIG_ENABLE_PW_RPC)
-    list(APPEND chip_libraries "-lPwRpc")
-endif()
-
 if(CONFIG_BT_ENABLED)
     idf_component_get_property(bt_lib bt COMPONENT_LIB)
     list(APPEND chip_libraries $<TARGET_FILE:${bt_lib}> -lbtdm_app)
@@ -156,7 +156,6 @@ if(NOT CONFIG_USE_MINIMAL_MDNS)
     list(APPEND chip_libraries $<TARGET_FILE:${mdns_lib}>)
 endif()
 
-target_link_libraries(${COMPONENT_LIB} INTERFACE "-L${CMAKE_CURRENT_BINARY_DIR}/lib")
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group 
                                                 ${chip_libraries}
                                                 $<TARGET_FILE:mbedcrypto> $<TARGET_FILE:${esp32_mbedtls_lib}> 

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -132,7 +132,7 @@ There are two ways to use the Echo Server running on the device.
 2.  Now flash the device with the same command as before. (Use the right `/dev`
     device)
 
-          $ idf make flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py flash monitor ESPPORT=/dev/tty.SLAB_USBtoUART
 
 3.  The device should boot up and connect to your network. When that happens you
     will see a log like this in the monitor.
@@ -152,7 +152,7 @@ There are two ways to use the Echo Server running on the device.
 Note: The ESP32 does not support 5GHz networks. Also, the Device will persist
 your network configuration. To erase it, simply run.
 
-          $ idf make erase_flash ESPPORT=/dev/tty.SLAB_USBtoUART
+          $ idf.py erase_flash ESPPORT=/dev/tty.SLAB_USBtoUART
 
 ### Use the ESP32's Network
 

--- a/examples/common/screen-framework/CMakeLists.txt
+++ b/examples/common/screen-framework/CMakeLists.txt
@@ -2,4 +2,5 @@ idf_component_register(SRCS "Display.cpp"
                             "ScreenManager.cpp" 
                             "Screen.cpp" 
                             "ListScreen.cpp"
-                       INCLUDE_DIRS "include")
+                       INCLUDE_DIRS "include"
+                       PRIV_REQUIRES tft chip)

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -105,7 +105,7 @@ If packages are already installed then simply activate it.
 2.  Now flash the device with the same command as before. (Use the right `/dev`
     device)
 
-          $ idf make flash monitor ESPPORT=/dev/ttyUSB0
+          $ idf.py flash monitor ESPPORT=/dev/ttyUSB0
 
 3.  The device should boot up and connect to your network. When that happens you
     will see a log like this in the monitor.
@@ -125,6 +125,6 @@ If packages are already installed then simply activate it.
 Note: The ESP32 does not support 5GHz networks. Also, the Device will persist
 your network configuration. To erase it, simply run.
 
-    $ idf make erase_flash ESPPORT=/dev/ttyUSB0
+    $ idf.py erase_flash ESPPORT=/dev/ttyUSB0
 
 The demo application supports on-off cluster.

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -105,7 +105,7 @@ If packages are already installed then simply activate it.
 2.  Now flash the device with the same command as before. (Use the right `/dev`
     device)
 
-          $ idf make flash monitor ESPPORT=/dev/ttyUSB0
+          $ idf.py flash monitor ESPPORT=/dev/ttyUSB0
 
 3.  The device should boot up and connect to your network. When that happens you
     will see a log like this in the monitor.
@@ -125,7 +125,7 @@ If packages are already installed then simply activate it.
 Note: The ESP32 does not support 5GHz networks. Also, the Device will persist
 your network configuration. To erase it, simply run.
 
-    $ idf make erase_flash ESPPORT=/dev/ttyUSB0
+    $ idf.py erase_flash ESPPORT=/dev/ttyUSB0
 
 The demo application supports temperaturemeasurement and basic cluster.
 


### PR DESCRIPTION
 #### Problem
1. The CMake build failed for M5Stack.
2. The CMake rebuild failure:-
    After build if we make any changes in CHIP code, it won't get reflect or compiled. We need to clean the complete build to look for the changes.

 #### Summary of Changes
1. Added the needed changes in `/examples/common/screen-framework/CMakeLists.txt`
2. Added the fix under `config/esp32/components/chip/CMakeLists.txt`

 Fixes #5818 