### PR TITLE
Add a resolve-node-id command to chip-tool in order to get the IP/Por…

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -1,0 +1,83 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "Command.h"
+#include <mdns/Resolver.h>
+
+class Discover : public Command, public chip::Mdns::ResolverDelegate
+{
+public:
+    Discover() : Command("resolve-node-id")
+    {
+        AddArgument("nodeid", 0, UINT64_MAX, &mNodeId);
+        AddArgument("fabricid", 0, UINT64_MAX, &mFabricId);
+    }
+
+    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override
+    {
+        ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
+        ReturnErrorOnFailure(mCommissioner.Init(localId, &storage));
+        ReturnErrorOnFailure(mCommissioner.ServiceEvents());
+
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(this));
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().ResolveNodeId(mNodeId, mFabricId, chip::Inet::kIPAddressType_Any));
+
+        UpdateWaitForResponse(true);
+        WaitForResponse(mWaitDurationInSeconds);
+
+        mCommissioner.ServiceEventSignal();
+        mCommissioner.Shutdown();
+
+        VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
+
+        return CHIP_NO_ERROR;
+    }
+
+    void OnNodeIdResolved(NodeId nodeId, const chip::Mdns::ResolvedNodeData & nodeData) override
+    {
+        char addrBuffer[chip::Transport::PeerAddress::kMaxToStringSize];
+        nodeData.mAddress.ToString(addrBuffer);
+        ChipLogProgress(chipTool, "NodeId Resolution: %" PRIu64 " Address: %s, Port: %" PRIu16, nodeId, addrBuffer, nodeData.mPort);
+        SetCommandExitStatus(true);
+    };
+
+    void OnNodeIdResolutionFailed(NodeId nodeId, CHIP_ERROR error) override
+    {
+        ChipLogProgress(chipTool, "NodeId Resolution: failed!");
+        SetCommandExitStatus(false);
+    };
+
+private:
+    uint16_t mWaitDurationInSeconds = 30;
+    ChipDeviceCommissioner mCommissioner;
+    chip::NodeId mNodeId;
+    uint64_t mFabricId;
+};
+
+void registerCommandsDiscover(Commands & commands)
+{
+    const char * clusterName = "Discover";
+
+    commands_list clusterCommands = {
+        make_unique<Discover>(),
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -19,6 +19,7 @@
 #include "commands/common/Commands.h"
 
 #include "commands/clusters/Commands.h"
+#include "commands/discover/Commands.h"
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
 #include "commands/reporting/Commands.h"
@@ -33,6 +34,7 @@ int main(int argc, char * argv[])
     InitDataModelHandler();
 
     Commands commands;
+    registerCommandsDiscover(commands);
     registerCommandsPayload(commands);
     registerCommandsPairing(commands);
     registerCommandsReporting(commands);

--- a/src/platform/Darwin/MdnsImpl.h
+++ b/src/platform/Darwin/MdnsImpl.h
@@ -67,12 +67,14 @@ struct BrowseContext : public GenericContext
 struct ResolveContext : public GenericContext
 {
     MdnsResolveCallback callback;
+    char name[kMdnsNameMaxSize + 1];
 
-    ResolveContext(void * cbContext, MdnsResolveCallback cb)
+    ResolveContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName)
     {
         type     = ContextType::Resolve;
         context  = cbContext;
         callback = cb;
+        strncpy(name, cbContextName, sizeof(name));
     }
 };
 
@@ -80,14 +82,16 @@ struct GetAddrInfoContext : public GenericContext
 {
     MdnsResolveCallback callback;
     std::vector<TextEntry> textEntries;
+    char name[kMdnsNameMaxSize + 1];
     uint16_t port;
 
-    GetAddrInfoContext(void * cbContext, MdnsResolveCallback cb, uint16_t cbContextPort)
+    GetAddrInfoContext(void * cbContext, MdnsResolveCallback cb, const char * cbContextName, uint16_t cbContextPort)
     {
         type     = ContextType::GetAddrInfo;
         context  = cbContext;
         callback = cb;
         port     = cbContextPort;
+        strncpy(name, cbContextName, sizeof(name));
     }
 };
 


### PR DESCRIPTION
…t of a commissioned Chip device from a NodeId

 #### Problem

Following #5811 this command add a `resolve-node-id` command to `chip-tool` in order to get the IP/Port from a NodeId of an already commissioned device.
This is mostly preliminary work before getting `ChipTool iOS` to work with `Mdns` but `chip-tool` makes it easy to debug the missing bits in the current `Darwin` backend.

 #### Summary of Changes
 * Add `resolve-node-id` to the set of command supported by `chip-tool`
 * Fix the `darwin` implementation to return the correct name. For some reasons (the code seems to assume the `NodeId` is in the first part of the `%s-%s` name while it is in the last part here, will fix that in a followup) it is still not converting to the right nodeId when it is parsed by https://github.com/project-chip/connectedhomeip/blob/551c87c6d262ce42ff7f41a30eb6453af1a0773a/src/lib/mdns/Discovery_ImplPlatform.cpp#L331
 