### PR TITLE
[mdns] fix platform mdns on esp32

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -53,6 +53,11 @@ if(CONFIG_ENABLE_PW_RPC)
     chip_gn_arg_append("dir_pw_third_party_nanopb"          "\"//third_party/connectedhomeip/third_party/nanopb/repo\"")
 endif()
 
+if (NOT CONFIG_USE_MINIMAL_MDNS)
+    chip_gn_arg_append("chip_mdns"                          "\"platform\"")
+endif()
+
+
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
 file(GENERATE OUTPUT "${args_gn_input}" CONTENT "${chip_gn_args}")
 
@@ -144,6 +149,11 @@ endif()
 if(CONFIG_BT_ENABLED)
     idf_component_get_property(bt_lib bt COMPONENT_LIB)
     list(APPEND chip_libraries $<TARGET_FILE:${bt_lib}> -lbtdm_app)
+endif()
+
+if(NOT CONFIG_USE_MINIMAL_MDNS)
+    idf_component_get_property(mdns_lib mdns COMPONENT_LIB)
+    list(APPEND chip_libraries $<TARGET_FILE:${mdns_lib}>)
 endif()
 
 target_link_libraries(${COMPONENT_LIB} INTERFACE "-L${CMAKE_CURRENT_BINARY_DIR}/lib")

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -84,6 +84,13 @@ menu "CHIP Core"
             help
                 Link the application with the library containing Pigweed RPC functionalities
 
+        config USE_MINIMAL_MDNS
+            bool "Use the minimal mDNS implementation shipped in the CHIP library"
+            default n
+            help
+                The CHIP library is shipped with a minimal mDNS implementation,
+                enable this config to use it rather than the mDNS library in IDF.
+
         # TODO: add log level selection
 
     endmenu # "General Options"

--- a/config/esp32/components/chip/component.mk
+++ b/config/esp32/components/chip/component.mk
@@ -135,6 +135,9 @@ endif
 	  echo "pw_sys_io_BACKEND = \"//third_party/connectedhomeip/examples/platform/esp32/pw_sys_io:pw_sys_io_esp32\"" >> $(OUTPUT_DIR)/args.gn      ;\
 	  echo "dir_pw_third_party_nanopb = \"//third_party/connectedhomeip/third_party/nanopb/repo\"" >>$(OUTPUT_DIR)/args.gn         ;\
 	fi
+	if [[ "$(CONFIG_USE_MINIMAL_MDNS)" = "n" ]]; then \
+	  echo "chip_mdns = platform" >> $(OUTPUT_DIR)/args.gn ;\
+	fi
 	echo "Written file $(OUTPUT_DIR)/args.gn"
 	cd $(CHIP_ROOT) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && cd $(COMPONENT_PATH) && gn gen --check --fail-on-unused-args $(OUTPUT_DIR)
 	cd $(COMPONENT_PATH); ninja $(subst 1,-v,$(filter 1,$(V))) -C $(OUTPUT_DIR) esp32

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -110,9 +110,7 @@ CHIP_ERROR AdvertiseOperational()
 
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
 
-    ReturnErrorOnFailure(mdnsAdvertiser.Advertise(advertiseParameters));
-
-    return mdnsAdvertiser.Start(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
+    return mdnsAdvertiser.Advertise(advertiseParameters);
 }
 
 /// Set MDNS commisioning advertisement
@@ -152,9 +150,7 @@ CHIP_ERROR AdvertiseCommisioning()
 
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
 
-    ReturnErrorOnFailure(mdnsAdvertiser.Advertise(advertiseParameters));
-
-    return mdnsAdvertiser.Start(&chip::DeviceLayer::InetLayer, chip::Mdns::kMdnsPort);
+    return mdnsAdvertiser.Advertise(advertiseParameters);
 }
 
 /// (Re-)starts the minmdns server


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
ESP32 build fails when using platform mdns.

 #### Summary of Changes

- add a new Kconfig option to switch between IDF and minimal mdns
- fix build errors when using platform mdns on esp32
- remove the reduntant `Start()` call in mdns server which will cause
  the published service to be removed when using platform mdns.


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
