### PR TITLE
Fixed resolving node ID for the chip-device-controller

### DIFF
--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -337,9 +337,8 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
         if (result->mName[i] == '-')
         {
             deliminatorFound = true;
-            break;
         }
-        else
+        else if (deliminatorFound)
         {
             uint8_t val = HexToInt(result->mName[i]);
 


### PR DESCRIPTION
 #### Problem
Order of node ID and fabric ID in the mDNS service name does not match chip-device-controller assumption and because of that
resolve command fails. 
Currently for mDNS service we have:
fabric id - node id
And controller assumes to get:
node id - fabric id

 #### Summary of Changes
Aligned fabric id and node id order in the resolving method.
