### PR TITLE
Move cirque tests to manual execution only

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -15,8 +15,7 @@
 name: Cirque
 
 on:
-    push:
-    pull_request:
+    workflow_dispatch:
 
 jobs:
     cirque:


### PR DESCRIPTION
 #### Problem
 Cirque tests fail due to openthread updates.

 #### Summary of Changes
 Move cirque tests to on-demand.