### PR TITLE
Optimize memory usage by reducing the size of ReceiveTableEntry

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -211,23 +211,6 @@ CHIP_ERROR ExchangeManager::UnregisterUMH(Protocols::Id protocolId, int16_t msgT
     return CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER;
 }
 
-bool ExchangeManager::IsMsgCounterSyncMessage(const PayloadHeader & payloadHeader)
-{
-    if (payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncReq) ||
-        payloadHeader.HasMessageType(Protocols::SecureChannel::MsgType::MsgCounterSyncRsp))
-    {
-        return true;
-    }
-
-    return false;
-}
-
-void ExchangeManager::HandleGroupMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                                 const SecureSessionHandle & session, System::PacketBufferHandle msgBuf)
-{
-    OnMessageReceived(packetHeader, payloadHeader, session, std::move(msgBuf), nullptr);
-}
-
 void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                                         SecureSessionHandle session, System::PacketBufferHandle msgBuf, SecureSessionMgr * msgLayer)
 {
@@ -235,35 +218,6 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     UnsolicitedMessageHandler * umh         = nullptr;
     UnsolicitedMessageHandler * matchingUMH = nullptr;
     bool sendAckAndCloseExchange            = false;
-
-    if (!IsMsgCounterSyncMessage(payloadHeader) && session.IsPeerGroupMsgIdNotSynchronized())
-    {
-        Transport::PeerConnectionState * state = mSessionMgr->GetPeerConnectionState(session);
-        VerifyOrReturn(state != nullptr);
-
-        // Queue the message as needed for sync with destination node.
-        err = mMessageCounterSyncMgr.AddToReceiveTable(packetHeader, payloadHeader, session, std::move(msgBuf));
-        VerifyOrReturn(err == CHIP_NO_ERROR);
-
-        // Initiate message counter synchronization if no message counter synchronization is in progress.
-        if (!state->IsMsgCounterSyncInProgress())
-        {
-            err = mMessageCounterSyncMgr.SendMsgCounterSyncReq(session);
-        }
-
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(ExchangeManager,
-                         "Message counter synchronization for received message, failed to send synchronization request, err = %d",
-                         err);
-        }
-
-        // After the message that triggers message counter synchronization is stored, and a message counter
-        // synchronization exchange is initiated, we need to return immediately and re-process the original message
-        // when the synchronization is completed.
-
-        return;
-    }
 
     // Search for an existing exchange that the message applies to. If a match is found...
     for (auto & ec : mContextPool)
@@ -354,6 +308,33 @@ exit:
     {
         ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %d", err);
     }
+}
+
+CHIP_ERROR ExchangeManager::QueueReceivedMessageAndSync(Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);
+
+    // Queue the message as needed for sync with destination node.
+    err = mMessageCounterSyncMgr.AddToReceiveTable(std::move(msgBuf));
+    SuccessOrExit(err);
+
+    // Initiate message counter synchronization if no message counter synchronization is in progress.
+    if (!state->IsMsgCounterSyncInProgress())
+    {
+        SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId());
+        err = mMessageCounterSyncMgr.SendMsgCounterSyncReq(session);
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(ExchangeManager,
+                     "Message counter synchronization for received message, failed to send synchronization request, err = %d", err);
+    }
+
+    return err;
 }
 
 ChannelHandle ExchangeManager::EstablishChannel(const ChannelBuilder & builder, ChannelDelegate * delegate)

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -176,19 +176,6 @@ public:
                                                           static_cast<uint8_t>(msgType));
     }
 
-    /**
-     * @brief
-     *   Called when a cached group message that was waiting for message counter
-     *   sync shold be reprocessed.
-     *
-     * @param packetHeader  The message header
-     * @param payloadHeader The payload header
-     * @param session       The handle to the secure session
-     * @param msgBuf        The received message
-     */
-    void HandleGroupMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                    const SecureSessionHandle & session, System::PacketBufferHandle msgBuf);
-
     // Channel public APIs
     ChannelHandle EstablishChannel(const ChannelBuilder & builder, ChannelDelegate * delegate);
 
@@ -269,8 +256,6 @@ private:
     CHIP_ERROR RegisterUMH(Protocols::Id protocolId, int16_t msgType, ExchangeDelegate * delegate);
     CHIP_ERROR UnregisterUMH(Protocols::Id protocolId, int16_t msgType);
 
-    static bool IsMsgCounterSyncMessage(const PayloadHeader & payloadHeader);
-
     void OnReceiveError(CHIP_ERROR error, const Transport::PeerAddress & source, SecureSessionMgr * msgLayer) override;
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, SecureSessionHandle session,
@@ -282,6 +267,8 @@ private:
     // TransportMgrDelegate interface for rendezvous sessions
     void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
                            System::PacketBufferHandle msgBuf) override;
+
+    CHIP_ERROR QueueReceivedMessageAndSync(Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf) override;
 };
 
 } // namespace Messaging

--- a/src/messaging/MessageCounterSync.h
+++ b/src/messaging/MessageCounterSync.h
@@ -80,16 +80,12 @@ public:
      *  Add a CHIP message into the cache table to queue the incoming messages that trigger message counter synchronization
      * protocol for re-processing.
      *
-     *  @param[in]    packetHeader     The message header for the received message.
-     *  @param[in]    payloadHeader    The payload header for the received message.
-     *  @param[in]    session          The handle to the secure session.
      *  @param[in]    msgBuf           A handle to the packet buffer holding the received message.
      *
      *  @retval  #CHIP_ERROR_NO_MEMORY If there is no empty slot left in the table for addition.
      *  @retval  #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR AddToReceiveTable(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
-                                 const SecureSessionHandle & session, System::PacketBufferHandle msgBuf);
+    CHIP_ERROR AddToReceiveTable(System::PacketBufferHandle msgBuf);
 
 private:
     /**
@@ -125,9 +121,6 @@ private:
      */
     struct ReceiveTableEntry
     {
-        PacketHeader packetHeader;         /**< The packet header for the message. */
-        PayloadHeader payloadHeader;       /**< The payload header for the message. */
-        SecureSessionHandle session;       /**< The secure session the message was received on. */
         System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding
                                                 the message data. This is non-null if and only
                                                 if this entry is in use. */

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -239,10 +239,7 @@ void CheckAddToReceiveTable(nlTestSuite * inSuite, void * inContext)
     System::PacketBufferHandle buffer = MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
-    PacketHeader packetHeader;
-    PayloadHeader payloadHeader;
-
-    CHIP_ERROR err = sm->AddToReceiveTable(packetHeader, payloadHeader, { chip::kTestDeviceNodeId, 0, 0 }, std::move(buffer));
+    CHIP_ERROR err = sm->AddToReceiveTable(std::move(buffer));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -321,6 +321,14 @@ void SecureSessionMgr::CancelExpiryTimer()
     }
 }
 
+void SecureSessionMgr::HandleGroupMessageReceived(const PacketHeader & packetHeader, System::PacketBufferHandle msgBuf)
+{
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetEncryptionKeyID(), nullptr);
+    VerifyOrReturn(state != nullptr, ChipLogError(Inet, "Failed to find the peer connection state"));
+
+    OnMessageReceived(packetHeader, state->GetPeerAddress(), std::move(msgBuf));
+}
+
 void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, const PeerAddress & peerAddress,
                                          System::PacketBufferHandle msg)
 {
@@ -331,7 +339,6 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
     PacketBufferHandle origMsg;
     PayloadHeader payloadHeader;
 
-    bool peerGroupMsgIdNotSynchronized  = false;
     Transport::AdminPairingInfo * admin = nullptr;
 
     VerifyOrExit(!msg.IsNull(), ChipLogError(Inet, "Secure transport received NULL packet, discarding"));
@@ -351,6 +358,23 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
             ChipLogError(Inet, "Secure transport received message, but destination node ID doesn't match our node ID, discarding"));
     }
     mPeerConnections.MarkConnectionActive(state);
+
+    if (!packetHeader.IsSecureSessionControlMsg() && !state->IsPeerMsgCounterSynced() &&
+        ChipKeyId::IsAppGroupKey(packetHeader.GetEncryptionKeyID()))
+    {
+        // Queue the message as needed for sync with destination node.
+        if (mCB != nullptr)
+        {
+            err = mCB->QueueReceivedMessageAndSync(state, std::move(msg));
+            VerifyOrReturn(err == CHIP_NO_ERROR);
+        }
+
+        // After the message that triggers message counter synchronization is stored, and a message counter
+        // synchronization exchange is initiated, we need to return immediately and re-process the original message
+        // when the synchronization is completed.
+
+        return;
+    }
 
     // Decode the message
     VerifyOrReturn(CHIP_NO_ERROR == SecureMessageCodec::Decode(state, payloadHeader, packetHeader, msg));
@@ -376,20 +400,11 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         {
             state->SetPeerMessageIndex(packetHeader.GetMessageId());
         }
-
-        // For all group messages, Set flag if peer group key message counter is not synchronized.
-        if (ChipKeyId::IsAppGroupKey(packetHeader.GetEncryptionKeyID()))
-        {
-            peerGroupMsgIdNotSynchronized = true;
-        }
     }
 
     if (mCB != nullptr)
     {
         SecureSessionHandle session(state->GetPeerNodeId(), state->GetPeerKeyID(), state->GetAdminId());
-
-        session.SetPeerGroupMsgIdNotSynchronized(peerGroupMsgIdNotSynchronized);
-
         mCB->OnMessageReceived(packetHeader, payloadHeader, session, std::move(msg), this);
     }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
ReceiveTableEntry is 96 bytes (on both 32-bit and 64-bit). That's where most of the memory usage here is coming from. This breaks down like so, afaict:
48 bytes PacketHeader
20 bytes PayloadHeader
4 byte hole due to SecureSessionHandle alignment
16 bytes SecureSessionHandle
8 bytes PacketBufferHandle (64-bit) or 4 bytes 32-bit
4 bytes hole for alignment, 32-bit only, presumably ARM-only.

But... why are we storing all that stuff in ReceiveTableEntry? We should be able to recover the PacketHeader and PayloadHeader from the packet buffer; that's where we got them from to start with, no? So all we really need to store here is the 24 bytes of SecureSessionHandle + PacketBufferHandle (+ alignment bits on 32-bit ARM).

The following is the total save with this change on ESP32:

Total sizes:
 DRAM .data size:   0 bytes
 DRAM .bss  size:   -736 bytes
Used static DRAM:   -736 bytes (  62596 available, 49.8% used)
Used static IRAM:   0 bytes (  14405 available, 89.0% used)
      Flash code:   -175 bytes
    Flash rodata:   -48 bytes

Please note, you can not see the full change from CI report until we enable exchange layer with #5627


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Clean up unnecessary items from ReceiveTableEntry to save memory

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5847 
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
