### PR TITLE
[storage] Fix storing connections into flash

### DIFF
--- a/src/transport/RendezvousSession.cpp
+++ b/src/transport/RendezvousSession.cpp
@@ -293,9 +293,6 @@ void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERRO
             mParams.GetAdvertisementDelegate()->RendezvousComplete();
         }
 
-        // Release the admin, as the rendezvous is complete.
-        mAdmin = nullptr;
-
         if (mDelegate != nullptr)
         {
             mDelegate->OnRendezvousComplete();


### PR DESCRIPTION
 #### Problem
New connections are stored into the persistent storage in OnRendezvousComplete() callback, right after clearing
RendezvousSession::mAdmin member. As a result, the connections are stored with a wrong admin ID.

 #### Summary of Changes
Remove clearing the admin in the rendezvous session as it does not seem to be necessary and causes the aforementioned
issue.
