### PR TITLE
Use ErrorStr(err) instead of the raw error code for logging SendMessa…

### DIFF
--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -78,7 +78,7 @@ CHIP_ERROR Device::SendMessage(System::PacketBufferHandle buffer, PayloadHeader 
     CHIP_ERROR err = mSessionManager->SendMessage(mSecureSession, payloadHeader, std::move(buffer));
 
     buffer = nullptr;
-    ChipLogDetail(Controller, "SendMessage returned %d", err);
+    ChipLogDetail(Controller, "SendMessage returned %s", ErrorStr(err));
 
     // The send could fail due to network timeouts (e.g. broken pipe)
     // Try session resumption if needed

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -214,7 +214,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
         ChipLogProgress(Inet, "Sending secure msg on generic transport");
         err = mTransportMgr->SendMessage(packetHeader, state->GetPeerAddress(), std::move(msgBuf));
     }
-    ChipLogProgress(Inet, "Secure msg send status %d", err);
+    ChipLogProgress(Inet, "Secure msg send status %s", ErrorStr(err));
     SuccessOrExit(err);
 
     if (bufferRetainSlot != nullptr)


### PR DESCRIPTION
…ge errors



 #### Problem

While debugging some errors when sending messages I came across a log with `Secure msg send status 4012`. Not very helpful.

 #### Summary of Changes
  * Use `ErrorStr(err)` instead of `err` 