### PR TITLE
Persist the device info when device informations are retrieved via mdns

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -158,6 +158,8 @@ public:
      */
     CHIP_ERROR GetDevice(NodeId deviceId, Device ** device);
 
+    void PersistDevice(Device * device);
+
     CHIP_ERROR SetUdpListenPort(uint16_t listenPort);
 
     virtual void ReleaseDevice(Device * device);

--- a/src/controller/DeviceAddressUpdater.cpp
+++ b/src/controller/DeviceAddressUpdater.cpp
@@ -44,6 +44,7 @@ void DeviceAddressUpdater::OnNodeIdResolved(NodeId nodeId, const Mdns::ResolvedN
     SuccessOrExit(error = mController->GetDevice(nodeId, &device));
 
     device->UpdateAddress(Transport::PeerAddress::UDP(nodeData.mAddress, nodeData.mPort, nodeData.mInterfaceId));
+    mController->PersistDevice(device);
 
 exit:
     if (mDelegate != nullptr)


### PR DESCRIPTION
 #### Problem

When the device informations such as IP address and port are retrieved from `Mdns` and updated using the `DeviceAddressUpdater` those informations are not persisted correctly.

 #### Summary of Changes
 * Add a `DeviceController::PersistDevice(Device * device)` method and use it inside `DeviceAddressUpdater`