### PR TITLE
Set PeerConnectionState::PeerAddress to the current peerAddress when …

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -266,6 +266,10 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     {
         state->SetPeerAddress(peerAddr.Value());
     }
+    else if (peerAddr.HasValue() && peerAddr.Value().GetTransportType() == Transport::Type::kBle)
+    {
+        state->SetPeerAddress(peerAddr.Value());
+    }
     else if (peerAddr.HasValue() &&
              (peerAddr.Value().GetTransportType() == Transport::Type::kTcp ||
               peerAddr.Value().GetTransportType() == Transport::Type::kUdp))


### PR DESCRIPTION
…the transport type is of type Transport::Type::kBle

 #### Problem
While toying with #5337 I noticed that the `PeerConnectionState::PeerAddress` is not updated when the transport if of type `Transport::Type::kBle`. In fact it does not even throw an error and continue as if everything was fine. 

I know that #5337 has not landed yet, but it should not hurt to land this before it.

 #### Summary of changes
 * Call `state->SetPeerAddress(peerAddr.Value());` when the transport type is `able`