### PR TITLE
Ensure mPairingDelegate->OnPairingComplete is called as the last step…

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -751,11 +751,6 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
 {
     FreeRendezvousSession();
 
-    if (mPairingDelegate != nullptr)
-    {
-        mPairingDelegate->OnPairingComplete(status);
-    }
-
     // TODO: make mStorageDelegate mandatory once all controller applications implement the interface.
     if (mDeviceBeingPaired != kNumMaxActiveDevices && mStorageDelegate != nullptr)
     {
@@ -768,6 +763,11 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
     }
 
     mDeviceBeingPaired = kNumMaxActiveDevices;
+
+    if (mPairingDelegate != nullptr)
+    {
+        mPairingDelegate->OnPairingComplete(status);
+    }
 }
 
 void DeviceCommissioner::OnRendezvousError(CHIP_ERROR err)


### PR DESCRIPTION
… of the pairing procedure in the DeviceController

 #### Problem
 
If someone try to use `DeviceController::GetDevice` into the `DevicePairingDelegate::OnPairingComplete` step it will be able to use the retrieved `Device` object for some asynchronous operation but it won't be able to receive messages since the corresponding `Device` object will then be remove from the list of internal devices of the `DeviceController` waiting for someone to get it back using `DeviceController::GetDevice`

 #### Summary of Changes
 * clear the internal states first before calling `DevicePairingDelegate::OnPairingComplete`