### PR TITLE
Qpg6100/te1 fixes

### DIFF
--- a/src/platform/qpg6100/BLEManagerImpl.cpp
+++ b/src/platform/qpg6100/BLEManagerImpl.cpp
@@ -91,15 +91,15 @@ CHIP_ERROR BLEManagerImpl::_Init()
     qvCHIP_BleInit(&appCbacks);
 
     // Create FreeRTOS sw timer for BLE timeouts and interval change.
-     sbleAdvTimeoutTimer = xTimerCreate("BleAdvTimer",       // Just a text name, not used by the RTOS kernel
-                                         1, // == default timer period (mS)
-                                         false,               // no timer reload (==one-shot)
-                                         (void *) this,       // init timer id = ble obj context
-                                         BleAdvTimeoutHandler // timer callback handler
- 										);
-     VerifyOrExit(sbleAdvTimeoutTimer != NULL, err = CHIP_ERROR_INCORRECT_STATE);
+    sbleAdvTimeoutTimer = xTimerCreate("BleAdvTimer",       // Just a text name, not used by the RTOS kernel
+                                       1,                   // == default timer period (mS)
+                                       false,               // no timer reload (==one-shot)
+                                       (void *) this,       // init timer id = ble obj context
+                                       BleAdvTimeoutHandler // timer callback handler
+    );
+    VerifyOrExit(sbleAdvTimeoutTimer != NULL, err = CHIP_ERROR_INCORRECT_STATE);
 
-     PlatformMgr().ScheduleWork(DriveBLEState, 0);
+    PlatformMgr().ScheduleWork(DriveBLEState, 0);
 
 exit:
     ChipLogProgress(DeviceLayer, "BLEManagerImpl::Init() complete");
@@ -516,14 +516,14 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     if (mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
-        intervalMin = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN;
-        intervalMax = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MAX;
+        intervalMin   = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN;
+        intervalMax   = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MAX;
         bleAdvTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     }
     else
     {
-        intervalMin = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MIN;
-        intervalMax = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MAX;
+        intervalMin   = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MIN;
+        intervalMax   = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MAX;
         bleAdvTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT - CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     }
 
@@ -909,44 +909,43 @@ void BLEManagerImpl::_handleTXCharCCCDWrite(qvCHIP_Ble_AttsCccEvt_t * event)
 }
 
 void BLEManagerImpl::BleAdvTimeoutHandler(TimerHandle_t xTimer)
- {
-     if (BLEMgrImpl().mFlags.Has(Flags::kFastAdvertisingEnabled))
-     {
-         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertissment");
-         BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);
-     }
-     else if (BLEMgrImpl().mFlags.Has(Flags::kAdvertising))
-     {
-         // Advertisement time expired. Stop advertising
-         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Stop advertissement");
-         BLEMgr().SetAdvertisingEnabled(false);
-     }
- }
+{
+    if (BLEMgrImpl().mFlags.Has(Flags::kFastAdvertisingEnabled))
+    {
+        ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertissment");
+        BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);
+    }
+    else if (BLEMgrImpl().mFlags.Has(Flags::kAdvertising))
+    {
+        // Advertisement time expired. Stop advertising
+        ChipLogDetail(DeviceLayer, "bleAdv Timeout : Stop advertissement");
+        BLEMgr().SetAdvertisingEnabled(false);
+    }
+}
 
- void BLEManagerImpl::CancelBleAdvTimeoutTimer(void)
- {
-     if (xTimerStop(sbleAdvTimeoutTimer, 0) == pdFAIL)
-     {
-         ChipLogError(DeviceLayer, "Failed to stop BledAdv timeout timer");
-     }
- }
+void BLEManagerImpl::CancelBleAdvTimeoutTimer(void)
+{
+    if (xTimerStop(sbleAdvTimeoutTimer, 0) == pdFAIL)
+    {
+        ChipLogError(DeviceLayer, "Failed to stop BledAdv timeout timer");
+    }
+}
 
- void BLEManagerImpl::StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs)
- {
-     if (xTimerIsTimerActive(sbleAdvTimeoutTimer))
-     {
+void BLEManagerImpl::StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs)
+{
+    if (xTimerIsTimerActive(sbleAdvTimeoutTimer))
+    {
         CancelBleAdvTimeoutTimer();
-     }
+    }
 
-     // timer is not active, change its period to required value (== restart).
-     // FreeRTOS- Block for a maximum of 100 ticks if the change period command
-     // cannot immediately be sent to the timer command queue.
-     if (xTimerChangePeriod(sbleAdvTimeoutTimer, pdMS_TO_TICKS(aTimeoutInMs), 100) != pdPASS)
-     {
-         ChipLogError(DeviceLayer, "Failed to start BledAdv timeout timer");
-     }
- }
-
+    // timer is not active, change its period to required value (== restart).
+    // FreeRTOS- Block for a maximum of 100 ticks if the change period command
+    // cannot immediately be sent to the timer command queue.
+    if (xTimerChangePeriod(sbleAdvTimeoutTimer, pdMS_TO_TICKS(aTimeoutInMs), 100) != pdPASS)
+    {
+        ChipLogError(DeviceLayer, "Failed to start BledAdv timeout timer");
+    }
+}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/qpg6100/BLEManagerImpl.cpp
+++ b/src/platform/qpg6100/BLEManagerImpl.cpp
@@ -52,6 +52,9 @@ namespace {
 #define CHIP_ADV_SHORT_UUID_LEN 2
 #define CHIP_ADV_CHIP_OVER_BLE_SERVICE_UUID16 0xFEAF
 
+// FreeeRTOS sw timer
+TimerHandle_t sbleAdvTimeoutTimer;
+
 // Full service UUID - CHIP_BLE_SVC_ID - taken from BleUUID.h header
 const ChipBleUUID chipUUID_CHIPoBLEChar_RX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F,
                                                  0x9D, 0x11 } };
@@ -69,8 +72,9 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
-    mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+    mFlags.Set(Flags::kFastAdvertisingEnabled);
     mNumGAPCons = 0;
+
     for (int i = 0; i < kMaxConnections; i++)
     {
         mSubscribedConIds[i] = BLE_CONNECTION_UNINITIALIZED;
@@ -86,7 +90,17 @@ CHIP_ERROR BLEManagerImpl::_Init()
     appCbacks.cccCback      = _handleTXCharCCCDWrite;
     qvCHIP_BleInit(&appCbacks);
 
-    PlatformMgr().ScheduleWork(DriveBLEState, 0);
+    // Create FreeRTOS sw timer for BLE timeouts and interval change.
+     sbleAdvTimeoutTimer = xTimerCreate("BleAdvTimer",       // Just a text name, not used by the RTOS kernel
+                                         1, // == default timer period (mS)
+                                         false,               // no timer reload (==one-shot)
+                                         (void *) this,       // init timer id = ble obj context
+                                         BleAdvTimeoutHandler // timer callback handler
+ 										);
+     VerifyOrExit(sbleAdvTimeoutTimer != NULL, err = CHIP_ERROR_INCORRECT_STATE);
+
+     PlatformMgr().ScheduleWork(DriveBLEState, 0);
+
 exit:
     ChipLogProgress(DeviceLayer, "BLEManagerImpl::Init() complete");
 
@@ -131,10 +145,10 @@ CHIP_ERROR BLEManagerImpl::_SetAdvertisingMode(BLEAdvertisingMode mode)
     switch (mode)
     {
     case BLEAdvertisingMode::kFastAdvertising:
-        mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+        mFlags.Set(Flags::kFastAdvertisingEnabled);
         break;
     case BLEAdvertisingMode::kSlowAdvertising:
-        mFlags.Set(Flags::kFastAdvertisingEnabled, false);
+        mFlags.Clear(Flags::kFastAdvertisingEnabled);
         break;
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -162,6 +176,9 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * devName)
     if (devName != nullptr && devName[0] != 0)
     {
         err = MapBLEError(qvCHIP_BleSetDeviceName(devName));
+        SuccessOrExit(err);
+
+        mFlags.Set(Flags::kDeviceNameSet);
     }
 
 exit:
@@ -201,6 +218,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         HandleConnectionError(event->CHIPoBLEConnectionError.ConId, event->CHIPoBLEConnectionError.Reason);
     }
     break;
+
     // Generic CHIP events
     case DeviceEventType::kFabricMembershipChange:
     case DeviceEventType::kServiceProvisioningChange:
@@ -391,7 +409,7 @@ void BLEManagerImpl::DriveBLEState(void)
     }
 
     // Otherwise, stop advertising if currently active.
-    else
+    else if (mFlags.Has(Flags::kAdvertising))
     {
         err = StopAdvertising();
         SuccessOrExit(err);
@@ -472,24 +490,41 @@ exit:
 CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 {
     CHIP_ERROR err;
+    uint32_t bleAdvTimeout;
     uint16_t intervalMin;
     uint16_t intervalMax;
-    ChipLogProgress(DeviceLayer, "CHIPoBLE start advertising");
+
+    // If already advertising, stop it, before changing values
+    if (mFlags.Has(Flags::kAdvertising))
+    {
+        err = MapBLEError(qvCHIP_BleStopAdvertising());
+        SuccessOrExit(err);
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "CHIPoBLE start advertising");
+        // If necessary, inform the ThreadStackManager that CHIPoBLE advertising is about to start.
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+        ThreadStackMgr().OnCHIPoBLEAdvertisingStart();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    }
 
     err = ConfigureAdvertisingData();
     SuccessOrExit(err);
 
-    mFlags.Set(Flags::kAdvertising);
+    mFlags.Clear(Flags::kRestartAdvertising);
 
-    if ((mNumGAPCons == 0 && !ConfigurationMgr().IsPairedToAccount()) || mFlags.Has(Flags::kFastAdvertisingEnabled))
+    if (mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
         intervalMin = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN;
         intervalMax = CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MAX;
+        bleAdvTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     }
     else
     {
         intervalMin = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MIN;
         intervalMax = CHIP_DEVICE_CONFIG_BLE_SLOW_ADVERTISING_INTERVAL_MAX;
+        bleAdvTimeout = CHIP_DEVICE_CONFIG_BLE_ADVERTISING_TIMEOUT - CHIP_DEVICE_CONFIG_BLE_ADVERTISING_INTERVAL_CHANGE_TIME;
     }
 
     qvCHIP_BleSetAdvInterval(intervalMin, intervalMax);
@@ -497,6 +532,9 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     err = MapBLEError(qvCHIP_BleStartAdvertising());
     SuccessOrExit(err);
 
+    mFlags.Set(Flags::kAdvertising);
+    StartBleAdvTimeoutTimer(bleAdvTimeout);
+    
 exit:
     return err;
 }
@@ -508,11 +546,12 @@ CHIP_ERROR BLEManagerImpl::StopAdvertising(void)
     err = MapBLEError(qvCHIP_BleStopAdvertising());
     SuccessOrExit(err);
 
+    CancelBleAdvTimeoutTimer();
     // Transition to the not Advertising state...
     if (mFlags.Has(Flags::kAdvertising))
     {
         mFlags.Clear(Flags::kAdvertising);
-        mFlags.Set(Flags::kFastAdvertisingEnabled, true);
+        mFlags.Set(Flags::kFastAdvertisingEnabled);
 
         ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
 
@@ -657,7 +696,7 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
         if (pDmEvt->hdr.status != QVCHIP_HCI_SUCCESS)
         {
             ChipLogError(DeviceLayer, "QVCHIP_DM_ADV_START_IND error: %d", (int) pDmEvt->advSetStart.hdr.status);
-            ExitNow();
+            return;
         }
 
         sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
@@ -680,33 +719,10 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
         break;
     }
     case QVCHIP_DM_ADV_STOP_IND: {
-        if (pDmEvt->advSetStop.status != QVCHIP_HCI_SUCCESS)
+        if (pDmEvt->hdr.status != QVCHIP_HCI_SUCCESS)
         {
             ChipLogError(DeviceLayer, "QVCHIP_DM_ADV_STOP_IND error: %d", (int) pDmEvt->advSetStop.status);
-            ExitNow();
-        }
-
-        sInstance.mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
-
-        // Transition to the not Advertising state...
-        if (sInstance.mFlags.Has(Flags::kAdvertising))
-        {
-            sInstance.mFlags.Clear(Flags::kAdvertising);
-
-            ChipLogProgress(DeviceLayer, "CHIPoBLE advertising stopped");
-
-            // Directly inform the ThreadStackManager that CHIPoBLE advertising has stopped.
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-            ThreadStackMgr().OnCHIPoBLEAdvertisingStop();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
-            // Post a CHIPoBLEAdvertisingChange(Stopped) event.
-            {
-                ChipDeviceEvent advChange;
-                advChange.Type                             = DeviceEventType::kCHIPoBLEAdvertisingChange;
-                advChange.CHIPoBLEAdvertisingChange.Result = kActivity_Stopped;
-                PlatformMgr().PostEvent(&advChange);
-            }
+            return;
         }
         break;
     }
@@ -765,9 +781,6 @@ void BLEManagerImpl::HandleDmMsg(qvCHIP_Ble_DmEvt_t * pDmEvt)
         break;
     }
     }
-
-exit:
-    PlatformMgr().ScheduleWork(DriveBLEState, 0);
 }
 
 /* Process ATT Messages */
@@ -894,6 +907,46 @@ void BLEManagerImpl::_handleTXCharCCCDWrite(qvCHIP_Ble_AttsCccEvt_t * event)
 {
     sInstance.HandleTXCharCCCDWrite(event);
 }
+
+void BLEManagerImpl::BleAdvTimeoutHandler(TimerHandle_t xTimer)
+ {
+     if (BLEMgrImpl().mFlags.Has(Flags::kFastAdvertisingEnabled))
+     {
+         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Start slow advertissment");
+         BLEMgr().SetAdvertisingMode(BLEAdvertisingMode::kSlowAdvertising);
+     }
+     else if (BLEMgrImpl().mFlags.Has(Flags::kAdvertising))
+     {
+         // Advertisement time expired. Stop advertising
+         ChipLogDetail(DeviceLayer, "bleAdv Timeout : Stop advertissement");
+         BLEMgr().SetAdvertisingEnabled(false);
+     }
+ }
+
+ void BLEManagerImpl::CancelBleAdvTimeoutTimer(void)
+ {
+     if (xTimerStop(sbleAdvTimeoutTimer, 0) == pdFAIL)
+     {
+         ChipLogError(DeviceLayer, "Failed to stop BledAdv timeout timer");
+     }
+ }
+
+ void BLEManagerImpl::StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs)
+ {
+     if (xTimerIsTimerActive(sbleAdvTimeoutTimer))
+     {
+        CancelBleAdvTimeoutTimer();
+     }
+
+     // timer is not active, change its period to required value (== restart).
+     // FreeRTOS- Block for a maximum of 100 ticks if the change period command
+     // cannot immediately be sent to the timer command queue.
+     if (xTimerChangePeriod(sbleAdvTimeoutTimer, pdMS_TO_TICKS(aTimeoutInMs), 100) != pdPASS)
+     {
+         ChipLogError(DeviceLayer, "Failed to start BledAdv timeout timer");
+     }
+ }
+
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/qpg6100/BLEManagerImpl.cpp
+++ b/src/platform/qpg6100/BLEManagerImpl.cpp
@@ -534,7 +534,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     mFlags.Set(Flags::kAdvertising);
     StartBleAdvTimeoutTimer(bleAdvTimeout);
-    
+
 exit:
     return err;
 }

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -26,8 +26,8 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
 #include "FreeRTOS.h"
-#include "timers.h"
 #include "qvCHIP.h"
+#include "timers.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -96,8 +96,8 @@ private:
         kAdvertising              = 0x0008, /**< The system is currently CHIPoBLE advertising. */
         kAdvertisingRefreshNeeded = 0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
         kDeviceNameSet            = 0x0020, /**< The device name has been set. */
-        kRestartAdvertising       = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this
-                                                  flag is set*/
+        kRestartAdvertising = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this
+                                            flag is set*/
     };
 
     enum

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -96,7 +96,7 @@ private:
         kAdvertising              = 0x0008, /**< The system is currently CHIPoBLE advertising. */
         kAdvertisingRefreshNeeded = 0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
         kDeviceNameSet            = 0x0020, /**< The device name has been set. */
-        kRestartAdvertising       = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this 
+        kRestartAdvertising       = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this
                                                   flag is set*/
     };
 

--- a/src/platform/qpg6100/BLEManagerImpl.h
+++ b/src/platform/qpg6100/BLEManagerImpl.h
@@ -25,6 +25,8 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#include "FreeRTOS.h"
+#include "timers.h"
 #include "qvCHIP.h"
 
 namespace chip {
@@ -93,7 +95,9 @@ private:
         kFastAdvertisingEnabled   = 0x0004, /**< The application has enabled fast advertising. */
         kAdvertising              = 0x0008, /**< The system is currently CHIPoBLE advertising. */
         kAdvertisingRefreshNeeded = 0x0010, /**< The advertising state/configuration state in the BLE layer needs to be updated. */
-        kDeviceNameSet            = 0x0020,
+        kDeviceNameSet            = 0x0020, /**< The device name has been set. */
+        kRestartAdvertising       = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this 
+                                                  flag is set*/
     };
 
     enum
@@ -135,6 +139,9 @@ private:
 
     /* Handlers for stack events */
     static void _handleTXCharCCCDWrite(qvCHIP_Ble_AttsCccEvt_t * event);
+    static void BleAdvTimeoutHandler(TimerHandle_t xTimer);
+    static void CancelBleAdvTimeoutTimer(void);
+    static void StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs);
 };
 
 /**


### PR DESCRIPTION
 #### Problem
Current BLE Manager implementation for QPG6100 platform was advertising indefinitely and not using a different fast/slow interval during this time. 

This implementation fixes fail-case in this area seen during TE1.