### PR TITLE
Add hint for building cc13x2x7_26x2x7 to gn_build.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -152,6 +152,21 @@ fi
 
 echo
 
+# TI SimpleLink SDK setup
+ti_simplelink_sdk_args=""
+
+if [[ -d "${TI_SIMPLELINK_SDK_ROOT}/source" && -f "${TI_SYSCONFIG_ROOT}/sysconfig_cli.sh" ]]; then
+    ti_simplelink_sdk_args+="ti_simplelink_sdk_root=\"$TI_SIMPLELINK_SDK_ROOT\" ti_sysconfig_root=\"$TI_SYSCONFIG_ROOT\""
+    extra_args+=" $ti_simplelink_sdk_args enable_ti_simplelink_builds=true"
+
+    echo 'To build the cc13x2x7_26x2x7 lock sample as a standalone project':
+    echo "(cd $CHIP_ROOT/examples/lock-app/cc13x2x7_26x2x7; gn gen out/debug --args='$ti_simplelink_sdk_args'; ninja -C out/debug)"
+else
+    echo "Hint: Set \$TI_SIMPLELINK_SDK_ROOT and \$TI_SYSCONFIG_ROOT to enable building for cc13x2_26x2"
+fi
+
+echo
+
 _chip_banner "Build: GN configure"
 
 gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/debug" --args='target_os="all"'"$extra_args$user_args"


### PR DESCRIPTION
It's possible to build for cc13x2x7_26x2x7 by passing arguments to
gn_build.sh but unlike for other platforms, no hints about this are
provided. Add them.