### PR TITLE
ESP32: Map ESP32 error codes with CHIP error codes

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -189,6 +189,7 @@ private:
     uint16_t mTXCharCCCDAttrHandle;
     BitFlags<Flags> mFlags;
     char mDeviceName[kMaxDeviceNameLength + 1];
+    CHIP_ERROR MapBLEError(int bleErr);
 
     void DriveBLEState(void);
     CHIP_ERROR InitESPBleLayer(void);

--- a/src/platform/ESP32/CHIPDevicePlatformConfig.h
+++ b/src/platform/ESP32/CHIPDevicePlatformConfig.h
@@ -29,6 +29,7 @@
 
 #define CHIP_DEVICE_CONFIG_LWIP_WIFI_STATION_IF_NAME "st"
 
+#define CHIP_DEVICE_CONFIG_ESP32_BLE_ERROR_MIN 11000000
 // ==================== Kconfig Overrides ====================
 
 // The following values are configured via the ESP-IDF Kconfig mechanism.

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -352,7 +352,7 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     ChipLogProgress(DeviceLayer, "Closing BLE GATT connection (con %u)", conId);
 
     // Signal the ESP BLE layer to close the conntion.
-    err = esp_ble_gatts_close(mAppIf, conId);
+    err = MapBLEError(esp_ble_gatts_close(mAppIf, conId));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatts_close() failed: %s", ErrorStr(err));
@@ -387,7 +387,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 
     VerifyOrExit(conState->PendingIndBuf.IsNull(), err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = esp_ble_gatts_send_indicate(mAppIf, conId, mTXCharAttrHandle, data->DataLength(), data->Start(), false);
+    err = MapBLEError(esp_ble_gatts_send_indicate(mAppIf, conId, mTXCharAttrHandle, data->DataLength(), data->Start(), false));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatts_send_indicate() failed: %s", ErrorStr(err));
@@ -430,6 +430,23 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}
 
+CHIP_ERROR BLEManagerImpl::MapBLEError(int bleErr)
+{
+    switch (bleErr)
+    {
+    case ESP_OK:
+        return CHIP_NO_ERROR;
+    case ESP_ERR_INVALID_ARG:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case ESP_ERR_INVALID_STATE:
+        return CHIP_ERROR_INCORRECT_STATE;
+    case ESP_ERR_NO_MEM:
+        return CHIP_ERROR_NO_MEMORY;
+    default:
+        return CHIP_DEVICE_CONFIG_ESP32_BLE_ERROR_MIN + (CHIP_ERROR) bleErr;
+    }
+}
+
 void BLEManagerImpl::DriveBLEState(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -463,7 +480,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Register the CHIPoBLE application with the ESP BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
-        err = esp_ble_gatts_app_register(CHIPoBLEAppId);
+        err = MapBLEError(esp_ble_gatts_app_register(CHIPoBLEAppId));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_ble_gatts_app_register() failed: %s", ErrorStr(err));
@@ -478,7 +495,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Register the CHIPoBLE GATT attributes with the ESP BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAttrsRegistered))
     {
-        err = esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0);
+        err = MapBLEError(esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_ble_gatts_create_attr_tab() failed: %s", ErrorStr(err));
@@ -493,7 +510,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // Start the CHIPoBLE GATT service if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kGATTServiceStarted))
     {
-        err = esp_ble_gatts_start_service(mServiceAttrHandle);
+        err = MapBLEError(esp_ble_gatts_start_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_ble_gatts_start_service() failed: %s", ErrorStr(err));
@@ -538,7 +555,7 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         if (mFlags.Has(Flags::kAdvertising))
         {
-            err = esp_ble_gap_stop_advertising();
+            err = MapBLEError(esp_ble_gap_stop_advertising());
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(DeviceLayer, "esp_ble_gap_stop_advertising() failed: %s", ErrorStr(err));
@@ -556,7 +573,7 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         // TODO: what to do about existing connections??
 
-        err = esp_ble_gatts_stop_service(mServiceAttrHandle);
+        err = MapBLEError(esp_ble_gatts_stop_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_ble_gatts_stop_service() failed: %s", ErrorStr(err));
@@ -586,7 +603,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_IDLE)
     {
         // Since Chip only uses BLE, release memory held by ESP classic bluetooth stack.
-        err = esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+        err = MapBLEError(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_bt_controller_mem_release() failed: %s", ErrorStr(err));
@@ -595,7 +612,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
 
         // Initialize the ESP Bluetooth controller.
         esp_bt_controller_config_t bt_cfg = BT_CONTROLLER_INIT_CONFIG_DEFAULT();
-        err                               = esp_bt_controller_init(&bt_cfg);
+        err                               = MapBLEError(esp_bt_controller_init(&bt_cfg));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_bt_controller_init() failed: %s", ErrorStr(err));
@@ -606,7 +623,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     // If the ESP Bluetooth controller has not been enabled, enable it now.
     if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_ENABLED)
     {
-        err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+        err = MapBLEError(esp_bt_controller_enable(ESP_BT_MODE_BLE));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_bt_controller_enable() failed: %s", ErrorStr(err));
@@ -617,7 +634,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     // If the ESP Bluedroid stack has not been initialized, initialize it now.
     if (esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_UNINITIALIZED)
     {
-        err = esp_bluedroid_init();
+        err = MapBLEError(esp_bluedroid_init());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_bluedroid_init() failed: %s", ErrorStr(err));
@@ -628,7 +645,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     // If the ESP Bluedroid stack has not been enabled, enable it now.
     if (esp_bluedroid_get_status() != ESP_BLUEDROID_STATUS_ENABLED)
     {
-        err = esp_bluedroid_enable();
+        err = MapBLEError(esp_bluedroid_enable());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "esp_bluedroid_enable() failed: %s", ErrorStr(err));
@@ -637,7 +654,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     }
 
     // Register a callback to receive GATT events.
-    err = esp_ble_gatts_register_callback(HandleGATTEvent);
+    err = MapBLEError(esp_ble_gatts_register_callback(HandleGATTEvent));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatts_register_callback() failed: %s", ErrorStr(err));
@@ -645,7 +662,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     }
 
     // Register a callback to receive GAP events.
-    err = esp_ble_gap_register_callback(HandleGAPEvent);
+    err = MapBLEError(esp_ble_gap_register_callback(HandleGAPEvent));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gap_register_callback() failed: %s", ErrorStr(err));
@@ -653,7 +670,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     }
 
     // Set the maximum supported MTU size.
-    err = esp_ble_gatt_set_local_mtu(ESP_GATT_MAX_MTU_SIZE);
+    err = MapBLEError(esp_ble_gatt_set_local_mtu(ESP_GATT_MAX_MTU_SIZE));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatt_set_local_mtu() failed: %s", ErrorStr(err));
@@ -684,7 +701,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     }
 
     // Configure the BLE device name.
-    err = esp_ble_gap_set_device_name(mDeviceName);
+    err = MapBLEError(esp_ble_gap_set_device_name(mDeviceName));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %s", ErrorStr(err));
@@ -713,7 +730,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     index = static_cast<uint8_t>(index + sizeof(deviceIdInfo));
 
     // Construct the Chip BLE Service Data to be sent in the scan response packet.
-    err = esp_ble_gap_config_adv_data_raw(advData, sizeof(advData));
+    err = MapBLEError(esp_ble_gap_config_adv_data_raw(advData, sizeof(advData)));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %s", ErrorStr(err));
@@ -767,7 +784,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     ChipLogProgress(DeviceLayer, "Configuring CHIPoBLE advertising (interval %" PRIu32 " ms, %sconnectable, device name %s)",
                     (((uint32_t) advertParams.adv_int_min) * 10) / 16, (connectable) ? "" : "non-", mDeviceName);
 
-    err = esp_ble_gap_start_advertising(&advertParams);
+    err = MapBLEError(esp_ble_gap_start_advertising(&advertParams));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gap_start_advertising() failed: %s", ErrorStr(err));
@@ -1024,7 +1041,7 @@ void BLEManagerImpl::HandleTXCharRead(esp_ble_gatts_cb_param_t * param)
     // Send a zero-length response.
     memset(&rsp, 0, sizeof(esp_gatt_rsp_t));
     rsp.attr_value.handle = param->read.handle;
-    err                   = esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id, ESP_GATT_OK, &rsp);
+    err = MapBLEError(esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id, ESP_GATT_OK, &rsp));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
@@ -1050,8 +1067,8 @@ void BLEManagerImpl::HandleTXCharCCCDRead(esp_ble_gatts_cb_param_t * param)
         rsp.attr_value.len      = 2;
         rsp.attr_value.value[0] = conState->Subscribed ? 1 : 0;
     }
-    err = esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id,
-                                      (conState != NULL) ? ESP_GATT_OK : ESP_GATT_INTERNAL_ERROR, &rsp);
+    err = MapBLEError(esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id,
+                                                  (conState != NULL) ? ESP_GATT_OK : ESP_GATT_INTERNAL_ERROR, &rsp));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -350,7 +350,7 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     ChipLogProgress(DeviceLayer, "Closing BLE GATT connection (con %u)", conId);
 
     // Signal the ESP BLE layer to close the conneecction.
-    err = ble_gap_terminate(conId, BLE_ERR_REM_USER_CONN_TERM);
+    err = MapBLEError(ble_gap_terminate(conId, BLE_ERR_REM_USER_CONN_TERM));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ble_gap_terminate() failed: %s", ErrorStr(err));
@@ -387,7 +387,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
         ExitNow();
     }
 
-    err = ble_gattc_notify_custom(conId, mTXCharCCCDAttrHandle, om);
+    err = MapBLEError(ble_gattc_notify_custom(conId, mTXCharCCCDAttrHandle, om));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ble_gattc_notify_custom() failed: %s", ErrorStr(err));
@@ -426,9 +426,37 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}
 
+CHIP_ERROR BLEManagerImpl::MapBLEError(int bleErr)
+{
+    switch (bleErr)
+    {
+    case ESP_OK:
+        return CHIP_NO_ERROR;
+    case BLE_HS_EMSGSIZE:
+        return CHIP_ERROR_INVALID_MESSAGE_LENGTH;
+    case BLE_HS_ENOMEM:
+    case ESP_ERR_NO_MEM:
+        return CHIP_ERROR_NO_MEMORY;
+    case BLE_HS_ENOTCONN:
+        return CHIP_ERROR_NOT_CONNECTED;
+    case BLE_HS_ENOTSUP:
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    case BLE_HS_EAPP:
+        return CHIP_ERROR_READ_FAILED;
+    case BLE_HS_EBADDATA:
+        return CHIP_ERROR_DATA_NOT_ALIGNED;
+    case BLE_HS_ETIMEOUT:
+        return CHIP_ERROR_TIMEOUT;
+    case BLE_HS_ENOADDR:
+        return CHIP_ERROR_INVALID_ADDRESS;
+    case ESP_ERR_INVALID_ARG:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    default:
+        return CHIP_DEVICE_CONFIG_ESP32_BLE_ERROR_MIN + (CHIP_ERROR) bleErr;
+    }
+}
 void BLEManagerImpl::DriveBLEState(void)
 {
-    int ret;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Perform any initialization actions that must occur after the Chip task is running.
@@ -518,10 +546,9 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         if (mFlags.Has(Flags::kAdvertising))
         {
-            ret = ble_gap_adv_stop();
-            if (ret != 0)
+            err = MapBLEError(ble_gap_adv_stop());
+            if (err != CHIP_NO_ERROR)
             {
-                err = CHIP_ERROR_INTERNAL;
                 ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %s", ErrorStr(err));
                 ExitNow();
             }
@@ -599,7 +626,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         mSubscribedConIds[i] = BLE_CONNECTION_UNINITIALIZED;
     }
 
-    err = esp_nimble_hci_and_controller_init();
+    err = MapBLEError(esp_nimble_hci_and_controller_init());
     SuccessOrExit(err);
 
     nimble_port_init();
@@ -618,14 +645,14 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         ble_svc_gap_init();
         ble_svc_gatt_init();
 
-        err = ble_gatts_count_cfg(CHIPoBLEGATTAttrs);
+        err = MapBLEError(ble_gatts_count_cfg(CHIPoBLEGATTAttrs));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "ble_gatts_count_cfg failed: %s", ErrorStr(err));
             ExitNow();
         }
 
-        err = ble_gatts_add_svcs(CHIPoBLEGATTAttrs);
+        err = MapBLEError(ble_gatts_add_svcs(CHIPoBLEGATTAttrs));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(DeviceLayer, "ble_gatts_add_svcs failed: %s", ErrorStr(err));
@@ -657,7 +684,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     }
 
     // Configure the BLE device name.
-    err = ble_svc_gap_device_name_set(mDeviceName);
+    err = MapBLEError(ble_svc_gap_device_name_set(mDeviceName));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ble_svc_gap_device_name_set() failed: %s", ErrorStr(err));
@@ -686,7 +713,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     index = static_cast<uint8_t>(index + sizeof(deviceIdInfo));
 
     // Construct the Chip BLE Service Data to be sent in the scan response packet.
-    err = ble_gap_adv_set_data(advData, sizeof(advData));
+    err = MapBLEError(ble_gap_adv_set_data(advData, sizeof(advData)));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "ble_gap_adv_set_data failed: %s %d", ErrorStr(err), discriminator);
@@ -1051,8 +1078,7 @@ int BLEManagerImpl::gatt_svr_chr_access(uint16_t conn_handle, uint16_t attr_hand
 
 CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 {
-    int ret;
-
+    CHIP_ERROR err;
     ble_gap_adv_params adv_params;
     memset(&adv_params, 0, sizeof(adv_params));
     uint8_t own_addr_type = BLE_OWN_ADDR_RANDOM;
@@ -1094,32 +1120,31 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         {
             /* Advertising is already active. Stop and restart with the new parameters */
             ChipLogProgress(DeviceLayer, "Device already advertising, stop active advertisement and restart");
-            ret = ble_gap_adv_stop();
-            if (ret != 0)
+            err = MapBLEError(ble_gap_adv_stop());
+            if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %d, cannot restart", ret);
-                return CHIP_ERROR_INTERNAL;
+                ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %d, cannot restart", ErrorStr(err));
+                return err;
             }
         }
         else
         {
-            ret = ble_hs_pvcy_rpa_config(NIMBLE_HOST_ENABLE_RPA);
-            if (ret != 0)
+            err = MapBLEError(ble_hs_pvcy_rpa_config(NIMBLE_HOST_ENABLE_RPA));
+            if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "RPA not set: %d", ret);
-                return CHIP_ERROR_INTERNAL;
+                ChipLogError(DeviceLayer, "RPA not set: %d", ErrorStr(err));
+                return err;
             }
         }
-        ret = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &adv_params, ble_svr_gap_event, NULL);
-
-        if (ret == 0)
+        err = MapBLEError(ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER, &adv_params, ble_svr_gap_event, NULL));
+        if (err == CHIP_NO_ERROR)
         {
             return CHIP_NO_ERROR;
         }
         else
         {
-            ChipLogError(DeviceLayer, "ble_gap_adv_start() failed: %d", ret);
-            return CHIP_ERROR_INTERNAL;
+            ChipLogError(DeviceLayer, "ble_gap_adv_start() failed: %d", ErrorStr(err));
+            return err;
         }
     }
 }


### PR DESCRIPTION
 #### Problem

ESP32 APIs return the error codes specific to ESP32. When these API are called in the CHIP code, they should be mapped to corresponding CHIP error codes to be propagated forward so that the behavior is correct

 #### Summary of Changes

Added the function which maps ESP32 APIs return codes to CHIP error codes.

 Fixes #4256 