### PR TITLE
[Build] ChipTool iOS fails to build (again)

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 					"$(CHIP_ROOT)/src/darwin/Framework/CHIP/",
 					"$(CHIP_ROOT)/src/app/util",
 					"$(CHIP_ROOT)/third_party/nlio/repo/include",
+					"$(TEMP_DIR)/out/gen/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -667,6 +668,7 @@
 					"$(CHIP_ROOT)/config/ios",
 					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
 					.,
+					"$(TEMP_DIR)/out/gen/include",
 				);
 				INFOPLIST_FILE = CHIP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -33,18 +33,22 @@
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX
 #include <CoreFoundation/CoreFoundation.h>
 
 #include <IOKit/IOKitLib.h>
 #include <IOKit/network/IOEthernetController.h>
 #include <IOKit/network/IOEthernetInterface.h>
 #include <IOKit/network/IONetworkInterface.h>
+#endif // TARGET_OS_OSX
 
 namespace chip {
 namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
 
+#if TARGET_OS_OSX
 CHIP_ERROR FindInterfaces(io_iterator_t * primaryInterfaceIterator)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -122,6 +126,7 @@ exit:
 
     return err;
 }
+#endif // TARGET_OS_OSX
 
 /** Singleton instance of the ConfigurationManager implementation object.
  */
@@ -141,6 +146,7 @@ exit:
 
 CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
+#if TARGET_OS_OSX
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     io_iterator_t primaryInterfaceIterator;
@@ -151,6 +157,9 @@ CHIP_ERROR ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress(uint8_t * buf)
     IOObjectRelease(primaryInterfaceIterator);
 
     return err;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // TARGET_OS_OSX
 }
 
 bool ConfigurationManagerImpl::_CanFactoryReset()


### PR DESCRIPTION
 #### Problem

ChipTool iOS build are broken again. One of the cause is #5811, and the other reason in the recent PR related to CASE.

The fix for the issue related to #5811 is just to ignore the code using `IOKit` on iOS since it is only useful for debugging purpose on desktop. For the issue related with the CASE code, the fix is to include `out/gen/include` in the search path.

 #### Summary of Changes
 * Fix the build.