### PR TITLE
Followup for #5711 and ChipTool iOS. Some SetupPayload flags needs to…

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -28,10 +28,10 @@
 
 - (RendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value
 {
-    if (value.Has(chip::RendezvousInformationFlag::kBle)) {
+    if (value.Has(chip::RendezvousInformationFlag::kBLE)) {
         return kRendezvousInformationBLE;
     } else if (value.Has(chip::RendezvousInformationFlag::kSoftAP)) {
-        return kRendezvousInformationWiFi;
+        return kRendezvousInformationSoftAP;
     } else if (value.Has(chip::RendezvousInformationFlag::kOnNetwork)) {
         return kRendezvousInformationOnNetwork;
     } else {


### PR DESCRIPTION
… be renamed in order to compile properly

 #### Problem

Seems like #5711 forgot to rename some flags in `src/darwin`. Does not compile anymore.
