### PR TITLE
Remove `exit: return` idiom from src/inet and src/transport

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2019 Google LLC.
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
@@ -573,26 +573,23 @@ InterfaceId InterfaceIterator::GetInterfaceId(void)
  */
 INET_ERROR InterfaceIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
-    INET_ERROR err = INET_ERROR_NOT_IMPLEMENTED;
-
-    VerifyOrExit(HasCurrent(), err = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(HasCurrent(), INET_ERROR_INCORRECT_STATE);
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-    VerifyOrExit(strlen(mIntfArray[mCurIntf].if_name) < nameBufSize, err = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(strlen(mIntfArray[mCurIntf].if_name) < nameBufSize, INET_ERROR_NO_MEMORY);
     strncpy(nameBuf, mIntfArray[mCurIntf].if_name, nameBufSize);
-    err = INET_NO_ERROR;
+    return INET_NO_ERROR;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    err = ::chip::Inet::GetInterfaceName(mCurrentId, nameBuf, nameBufSize);
+    return ::chip::Inet::GetInterfaceName(mCurrentId, nameBuf, nameBufSize);
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-    err = ::chip::Inet::GetInterfaceName(mCurNetif, nameBuf, nameBufSize);
+    return ::chip::Inet::GetInterfaceName(mCurNetif, nameBuf, nameBufSize);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-exit:
-    return err;
+    return INET_ERROR_NOT_IMPLEMENTED;
 }
 
 /**
@@ -1005,22 +1002,19 @@ InterfaceId InterfaceAddressIterator::GetInterfaceId()
  */
 INET_ERROR InterfaceAddressIterator::GetInterfaceName(char * nameBuf, size_t nameBufSize)
 {
-    INET_ERROR err = INET_ERROR_NOT_IMPLEMENTED;
-
-    VerifyOrExit(HasCurrent(), err = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(HasCurrent(), INET_ERROR_INCORRECT_STATE);
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
-    VerifyOrExit(strlen(mCurAddr->ifa_name) < nameBufSize, err = INET_ERROR_NO_MEMORY);
+    VerifyOrReturnError(strlen(mCurAddr->ifa_name) < nameBufSize, INET_ERROR_NO_MEMORY);
     strncpy(nameBuf, mCurAddr->ifa_name, nameBufSize);
-    err = INET_NO_ERROR;
+    return INET_NO_ERROR;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    err = mIntfIter.GetInterfaceName(nameBuf, nameBufSize);
+    return mIntfIter.GetInterfaceName(nameBuf, nameBufSize);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP || CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
-exit:
-    return err;
+    return INET_ERROR_NOT_IMPLEMENTED;
 }
 
 /**

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -445,91 +445,70 @@ bool InetLayer::IsIdleTimerRunning()
  */
 INET_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
 {
-    INET_ERROR err = INET_NO_ERROR;
+    VerifyOrReturnError(llAddr != nullptr, INET_ERROR_BAD_ARGS);
+
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #if !LWIP_IPV6
-    err = INET_ERROR_NOT_IMPLEMENTED;
-    goto exit;
+    return INET_ERROR_NOT_IMPLEMENTED;
 #endif //! LWIP_IPV6
-#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-    if (llAddr == nullptr)
-    {
-        err = INET_ERROR_BAD_ARGS;
-        goto exit;
-    }
-
-#if CHIP_SYSTEM_CONFIG_USE_LWIP
     for (struct netif * intf = netif_list; intf != NULL; intf = intf->next)
     {
         if ((link != NULL) && (link != intf))
             continue;
-        int j;
-        for (j = 0; j < LWIP_IPV6_NUM_ADDRESSES; ++j)
+        for (int j = 0; j < LWIP_IPV6_NUM_ADDRESSES; ++j)
         {
             if (ip6_addr_isvalid(netif_ip6_addr_state(intf, j)) && ip6_addr_islinklocal(netif_ip6_addr(intf, j)))
             {
                 (*llAddr) = IPAddress::FromIPv6(*netif_ip6_addr(intf, j));
-                goto exit;
+                return INET_NO_ERROR;
             }
         }
         if (link != NULL)
         {
-            err = INET_ERROR_ADDRESS_NOT_FOUND;
-            break;
+            return INET_ERROR_ADDRESS_NOT_FOUND;
         }
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
     struct ifaddrs * ifaddr;
-    int rv;
-    rv = getifaddrs(&ifaddr);
-    if (rv != -1)
+    const int rv = getifaddrs(&ifaddr);
+    if (rv == -1)
     {
-        struct ifaddrs * ifaddr_iter = ifaddr;
-        while (ifaddr_iter != nullptr)
-        {
+        return INET_ERROR_ADDRESS_NOT_FOUND;
+    }
 
-            if (ifaddr_iter->ifa_addr != nullptr)
+    for (struct ifaddrs * ifaddr_iter = ifaddr; ifaddr_iter != nullptr; ifaddr_iter = ifaddr_iter->ifa_next)
+    {
+        if (ifaddr_iter->ifa_addr != nullptr)
+        {
+            if ((ifaddr_iter->ifa_addr->sa_family == AF_INET6) &&
+                ((link == INET_NULL_INTERFACEID) || (if_nametoindex(ifaddr_iter->ifa_name) == link)))
             {
-                if ((ifaddr_iter->ifa_addr->sa_family == AF_INET6) &&
-                    ((link == INET_NULL_INTERFACEID) || (if_nametoindex(ifaddr_iter->ifa_name) == link)))
+                struct in6_addr * sin6_addr = &(reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr;
+                if (sin6_addr->s6_addr[0] == 0xfe && (sin6_addr->s6_addr[1] & 0xc0) == 0x80) // Link Local Address
                 {
-                    struct in6_addr * sin6_addr = &(reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr;
-                    if (sin6_addr->s6_addr[0] == 0xfe && (sin6_addr->s6_addr[1] & 0xc0) == 0x80) // Link Local Address
-                    {
-                        (*llAddr) =
-                            IPAddress::FromIPv6((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
-                        break;
-                    }
+                    (*llAddr) = IPAddress::FromIPv6((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
+                    break;
                 }
             }
-            ifaddr_iter = ifaddr_iter->ifa_next;
         }
-        freeifaddrs(ifaddr);
     }
-    else
-    {
-        err = INET_ERROR_ADDRESS_NOT_FOUND;
-    }
+    freeifaddrs(ifaddr);
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    net_if * iface;
-    in6_addr * ip6_addr;
+    const net_if * const iface = (link == INET_NULL_INTERFACEID) ? net_if_get_default() : net_if_get_by_index(link);
+    VerifyOrReturnError(iface != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
-    iface = (link == INET_NULL_INTERFACEID) ? net_if_get_default() : net_if_get_by_index(link);
-    VerifyOrExit(iface != nullptr, err = INET_ERROR_ADDRESS_NOT_FOUND);
-
-    ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
-    VerifyOrExit(ip6_addr != nullptr, err = INET_ERROR_ADDRESS_NOT_FOUND);
+    const in6_addr * const ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
+    VerifyOrReturnError(ip6_addr != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
     *llAddr = IPAddress::FromIPv6(*ip6_addr);
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
-exit:
-    return err;
+    return INET_NO_ERROR;
 }
 
 #if INET_CONFIG_ENABLE_RAW_ENDPOINT
@@ -556,25 +535,21 @@ exit:
  */
 INET_ERROR InetLayer::NewRawEndPoint(IPVersion ipVer, IPProtocol ipProto, RawEndPoint ** retEndPoint)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = nullptr;
+    *retEndPoint = nullptr;
 
-    VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(State == kState_Initialized, INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = RawEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != nullptr)
-    {
-        (*retEndPoint)->Inet::RawEndPoint::Init(this, ipVer, ipProto);
-        SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumRawEps);
-    }
-    else
+    if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "Raw");
-        err = INET_ERROR_NO_ENDPOINTS;
+        return INET_ERROR_NO_ENDPOINTS;
     }
 
-exit:
-    return err;
+    (*retEndPoint)->Inet::RawEndPoint::Init(this, ipVer, ipProto);
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumRawEps);
+
+    return INET_NO_ERROR;
 }
 #endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
 
@@ -598,25 +573,21 @@ exit:
  */
 INET_ERROR InetLayer::NewTCPEndPoint(TCPEndPoint ** retEndPoint)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = nullptr;
+    *retEndPoint = nullptr;
 
-    VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(State == kState_Initialized, INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = TCPEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != nullptr)
-    {
-        (*retEndPoint)->Init(this);
-        SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumTCPEps);
-    }
-    else
+    if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "TCP");
-        err = INET_ERROR_NO_ENDPOINTS;
+        return INET_ERROR_NO_ENDPOINTS;
     }
 
-exit:
-    return err;
+    (*retEndPoint)->Init(this);
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumTCPEps);
+
+    return INET_NO_ERROR;
 }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
@@ -640,25 +611,21 @@ exit:
  */
 INET_ERROR InetLayer::NewUDPEndPoint(UDPEndPoint ** retEndPoint)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    *retEndPoint   = nullptr;
+    *retEndPoint = nullptr;
 
-    VerifyOrExit(State == kState_Initialized, err = INET_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(State == kState_Initialized, INET_ERROR_INCORRECT_STATE);
 
     *retEndPoint = UDPEndPoint::sPool.TryCreate(*mSystemLayer);
-    if (*retEndPoint != nullptr)
-    {
-        (*retEndPoint)->Init(this);
-        SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumUDPEps);
-    }
-    else
+    if (*retEndPoint == nullptr)
     {
         ChipLogError(Inet, "%s endpoint pool FULL", "UDP");
-        err = INET_ERROR_NO_ENDPOINTS;
+        return INET_ERROR_NO_ENDPOINTS;
     }
 
-exit:
-    return err;
+    (*retEndPoint)->Init(this);
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kInetLayer_NumUDPEps);
+
+    return INET_NO_ERROR;
 }
 #endif // INET_CONFIG_ENABLE_UDP_ENDPOINT
 
@@ -1049,10 +1016,7 @@ void InetLayer::HandleTCPInactivityTimer(chip::System::Layer * aSystemLayer, voi
 chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarget, chip::System::EventType aEventType,
                                                     uintptr_t aArgument)
 {
-    chip::System::Error lReturn = CHIP_SYSTEM_NO_ERROR;
-    InetLayerBasis & lBasis     = static_cast<InetLayerBasis &>(aTarget);
-
-    VerifyOrExit(INET_IsInetEvent(aEventType), lReturn = CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT);
+    VerifyOrReturnError(INET_IsInetEvent(aEventType), CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT);
 
     // Dispatch the event according to its type.
     switch (aEventType)
@@ -1101,20 +1065,19 @@ chip::System::Error InetLayer::HandleInetLayerEvent(chip::System::Object & aTarg
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 
     default:
-        lReturn = CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT;
-        ExitNow();
+        return CHIP_SYSTEM_ERROR_UNEXPECTED_EVENT;
     }
 
     // If the event was droppable, record the fact that it has been dequeued.
     if (IsDroppableEvent(aEventType))
     {
-        InetLayer & lInetLayer = lBasis.Layer();
+        InetLayerBasis & lBasis = static_cast<InetLayerBasis &>(aTarget);
+        InetLayer & lInetLayer  = lBasis.Layer();
 
         lInetLayer.DroppableEventDequeued();
     }
 
-exit:
-    return lReturn;
+    return CHIP_SYSTEM_NO_ERROR;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/inet/InetLayer.cpp
+++ b/src/inet/InetLayer.cpp
@@ -499,10 +499,10 @@ INET_ERROR InetLayer::GetLinkLocalAddr(InterfaceId link, IPAddress * llAddr)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS
 
 #if CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
-    const net_if * const iface = (link == INET_NULL_INTERFACEID) ? net_if_get_default() : net_if_get_by_index(link);
+    net_if * const iface = (link == INET_NULL_INTERFACEID) ? net_if_get_default() : net_if_get_by_index(link);
     VerifyOrReturnError(iface != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
-    const in6_addr * const ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
+    in6_addr * const ip6_addr = net_if_ipv6_get_ll(iface, NET_ADDR_PREFERRED);
     VerifyOrReturnError(ip6_addr != nullptr, INET_ERROR_ADDRESS_NOT_FOUND);
 
     *llAddr = IPAddress::FromIPv6(*ip6_addr);

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -152,18 +152,14 @@ static INET_ERROR LwIPBindInterface(struct raw_pcb * aRaw, InterfaceId intfId)
  */
 INET_ERROR RawEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, InterfaceId intfId)
 {
-    INET_ERROR res = INET_NO_ERROR;
-
     if (mState != kState_Ready && mState != kState_Bound)
     {
-        res = INET_ERROR_INCORRECT_STATE;
-        goto exit;
+        return INET_ERROR_INCORRECT_STATE;
     }
 
     if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
     {
-        res = INET_ERROR_WRONG_ADDRESS_TYPE;
-        goto exit;
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -172,7 +168,7 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, Int
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    res = GetPCB(addrType);
+    INET_ERROR res = GetPCB(addrType);
 
     // Bind the PCB to the specified address.
     if (res == INET_NO_ERROR)
@@ -210,28 +206,21 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, Int
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(res);
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Make sure we have the appropriate type of socket.
-    res = GetSocket(addrType);
-    SuccessOrExit(res);
-
-    res = IPEndPointBasis::Bind(addrType, addr, 0, intfId);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(GetSocket(addrType));
+    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, 0, intfId));
 
     mBoundIntfId = intfId;
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    if (res == INET_NO_ERROR)
-    {
-        mState = kState_Bound;
-    }
+    mState = kState_Bound;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 /**
@@ -376,22 +365,14 @@ ret:
  */
 INET_ERROR RawEndPoint::Listen()
 {
-    INET_ERROR res = INET_NO_ERROR;
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    chip::System::Layer & lSystemLayer = SystemLayer();
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
     if (mState == kState_Listening)
     {
-        res = INET_NO_ERROR;
-        goto exit;
+        return INET_NO_ERROR;
     }
 
     if (mState != kState_Bound)
     {
-        res = INET_ERROR_INCORRECT_STATE;
-        goto exit;
+        return INET_ERROR_INCORRECT_STATE;
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -414,19 +395,13 @@ INET_ERROR RawEndPoint::Listen()
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
     // Wake the thread calling select so that it starts selecting on the new socket.
-    lSystemLayer.WakeSelect();
-
+    SystemLayer().WakeSelect();
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    if (res == INET_NO_ERROR)
-    {
-        mState = kState_Listening;
-    }
+    mState = kState_Listening;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 /**
@@ -683,21 +658,16 @@ exit:
  */
 INET_ERROR RawEndPoint::SetICMPFilter(uint8_t numICMPTypes, const uint8_t * aICMPTypes)
 {
-    INET_ERROR err;
-
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 #if !(HAVE_NETINET_ICMP6_H && HAVE_ICMP6_FILTER)
-    err = INET_ERROR_NOT_IMPLEMENTED;
-    ExitNow();
+    return INET_ERROR_NOT_IMPLEMENTED;
 #endif //!(HAVE_NETINET_ICMP6_H && HAVE_ICMP6_FILTER)
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    VerifyOrExit(IPVer == kIPVersion_6, err = INET_ERROR_WRONG_ADDRESS_TYPE);
-    VerifyOrExit(IPProto == kIPProtocol_ICMPv6, err = INET_ERROR_WRONG_PROTOCOL_TYPE);
-    VerifyOrExit((numICMPTypes == 0 && aICMPTypes == nullptr) || (numICMPTypes != 0 && aICMPTypes != nullptr),
-                 err = INET_ERROR_BAD_ARGS);
-
-    err = INET_NO_ERROR;
+    VerifyOrReturnError(IPVer == kIPVersion_6, INET_ERROR_WRONG_ADDRESS_TYPE);
+    VerifyOrReturnError(IPProto == kIPProtocol_ICMPv6, INET_ERROR_WRONG_PROTOCOL_TYPE);
+    VerifyOrReturnError((numICMPTypes == 0 && aICMPTypes == nullptr) || (numICMPTypes != 0 && aICMPTypes != nullptr),
+                        INET_ERROR_BAD_ARGS);
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_TCPIP_CORE();
@@ -723,13 +693,12 @@ INET_ERROR RawEndPoint::SetICMPFilter(uint8_t numICMPTypes, const uint8_t * aICM
     }
     if (setsockopt(mSocket, IPPROTO_ICMPV6, ICMP6_FILTER, &filter, sizeof(filter)) == -1)
     {
-        err = chip::System::MapErrorPOSIX(errno);
+        return chip::System::MapErrorPOSIX(errno);
     }
 #endif // HAVE_NETINET_ICMP6_H && HAVE_ICMP6_FILTER
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-exit:
-    return err;
+    return INET_NO_ERROR;
 }
 
 /**
@@ -756,46 +725,41 @@ exit:
  */
 INET_ERROR RawEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
 {
-    INET_ERROR err = INET_NO_ERROR;
-
     // A lock is required because the LwIP thread may be referring to intf_filter,
     // while this code running in the Inet application is potentially modifying it.
     // NOTE: this only supports LwIP interfaces whose number is no bigger than 9.
 
     if (mState != kState_Ready && mState != kState_Bound)
+    {
         return INET_ERROR_INCORRECT_STATE;
+    }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    err = GetPCB(addrType);
-    SuccessOrExit(err);
+    INET_ERROR err = GetPCB(addrType);
 
-    err = LwIPBindInterface(mRaw, intfId);
+    if (err == INET_NO_ERROR)
+    {
+        err = LwIPBindInterface(mRaw, intfId);
+    }
 
     UNLOCK_TCPIP_CORE();
 
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(err);
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Make sure we have the appropriate type of socket.
-    err = GetSocket(addrType);
-    SuccessOrExit(err);
-
-    err = IPEndPointBasis::BindInterface(addrType, intfId);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(GetSocket(addrType));
+    ReturnErrorOnFailure(IPEndPointBasis::BindInterface(addrType, intfId));
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
-    if (err == INET_NO_ERROR)
-    {
-        mState = kState_Bound;
-    }
+    mState = kState_Bound;
 
-exit:
-    return err;
+    return INET_NO_ERROR;
 }
 
 void RawEndPoint::Init(InetLayer * inetLayer, IPVersion ipVer, IPProtocol ipProto)
@@ -835,12 +799,10 @@ void RawEndPoint::HandleDataReceived(System::PacketBufferHandle && msg)
 
 INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-
     // IMPORTANT: This method MUST be called with the LwIP stack LOCKED!
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-    if (mRaw == NULL)
+    if (mRaw == nullptr)
     {
         switch (addrType)
         {
@@ -852,20 +814,16 @@ INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
             break;
 
         default:
-            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-            goto exit;
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
 
         if (mRaw == NULL)
         {
             ChipLogError(Inet, "raw_new_ip_type failed");
-            lRetval = INET_ERROR_NO_MEMORY;
-            goto exit;
+            return INET_ERROR_NO_MEMORY;
         }
-        else
-        {
-            mLwIPEndPointType = kLwIPEndPointType_Raw;
-        }
+
+        mLwIPEndPointType = kLwIPEndPointType_Raw;
     }
     else
     {
@@ -874,12 +832,12 @@ INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
         switch (lLwIPAddrType)
         {
         case IPADDR_TYPE_V6:
-            VerifyOrExit(addrType == kIPAddressType_IPv6, lRetval = INET_ERROR_WRONG_ADDRESS_TYPE);
+            VerifyOrReturnError(addrType == kIPAddressType_IPv6, INET_ERROR_WRONG_ADDRESS_TYPE);
             break;
 
 #if INET_CONFIG_ENABLE_IPV4
         case IPADDR_TYPE_V4:
-            VerifyOrExit(addrType == kIPAddressType_IPv4, lRetval = INET_ERROR_WRONG_ADDRESS_TYPE);
+            VerifyOrReturnError(addrType == kIPAddressType_IPv4, INET_ERROR_WRONG_ADDRESS_TYPE);
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -904,20 +862,16 @@ INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
 #endif // INET_CONFIG_ENABLE_IPV4
         else
         {
-            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-            goto exit;
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
 
         if (mRaw == NULL)
         {
             ChipLogError(Inet, "raw_new failed");
-            lRetval = INET_ERROR_NO_MEMORY;
-            goto exit;
+            return INET_ERROR_NO_MEMORY;
         }
-        else
-        {
-            mLwIPEndPointType = kLwIPEndPointType_Raw;
-        }
+
+        mLwIPEndPointType = kLwIPEndPointType_Raw;
     }
     else
     {
@@ -929,14 +883,12 @@ INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
 
         if (addrType != pcbType)
         {
-            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-            goto exit;
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
     }
 #endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
-exit:
-    return (lRetval);
+    return INET_NO_ERROR;
 }
 
 /* This function is executed when a raw_pcb is listening and an IP datagram (v4 or v6) is received.
@@ -1021,8 +973,7 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void * arg, struct raw_pcb * pcb, struct
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 INET_ERROR RawEndPoint::GetSocket(IPAddressType aAddressType)
 {
-    INET_ERROR lRetval = INET_NO_ERROR;
-    const int lType    = (SOCK_RAW | SOCK_FLAGS);
+    constexpr int lType = (SOCK_RAW | SOCK_FLAGS);
     int lProtocol;
 
     switch (aAddressType)
@@ -1038,15 +989,10 @@ INET_ERROR RawEndPoint::GetSocket(IPAddressType aAddressType)
 #endif // INET_CONFIG_ENABLE_IPV4
 
     default:
-        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
-        goto exit;
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
-    lRetval = IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
-    SuccessOrExit(lRetval);
-
-exit:
-    return (lRetval);
+    return IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
 }
 
 SocketEvents RawEndPoint::PrepareIO()

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -155,25 +155,14 @@ static INET_ERROR LwIPBindInterface(struct udp_pcb * aUDP, InterfaceId intfId)
  */
 INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uint16_t port, InterfaceId intfId)
 {
-    INET_ERROR res = INET_NO_ERROR;
-
-#if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
-    nw_parameters_configure_protocol_block_t configure_tls;
-    nw_parameters_t parameters;
-
-#endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-
     if (mState != kState_Ready && mState != kState_Bound)
     {
-        res = INET_ERROR_INCORRECT_STATE;
-        goto exit;
+        return INET_ERROR_INCORRECT_STATE;
     }
 
     if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
     {
-        res = INET_ERROR_WRONG_ADDRESS_TYPE;
-        goto exit;
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -182,7 +171,7 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    res = GetPCB(addrType);
+    INET_ERROR res = GetPCB(addrType);
 
     // Bind the PCB to the specified address/port.
     if (res == INET_NO_ERROR)
@@ -220,18 +209,15 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(res);
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
     // Make sure we have the appropriate type of socket.
-    res = GetSocket(addrType);
-    SuccessOrExit(res);
-
-    res = IPEndPointBasis::Bind(addrType, addr, port, intfId);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(GetSocket(addrType));
+    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, intfId));
 
     mBoundPort   = port;
     mBoundIntfId = intfId;
@@ -264,29 +250,26 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, const IPAddress & addr, uin
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
+    nw_parameters_configure_protocol_block_t configure_tls;
+    nw_parameters_t parameters;
+
     if (intfId != INET_NULL_INTERFACEID)
     {
-        res = INET_ERROR_NOT_IMPLEMENTED;
-        goto exit;
+        return INET_ERROR_NOT_IMPLEMENTED;
     }
 
     configure_tls = NW_PARAMETERS_DISABLE_PROTOCOL;
     parameters    = nw_parameters_create_secure_udp(configure_tls, NW_PARAMETERS_DEFAULT_CONFIGURATION);
 
-    res = IPEndPointBasis::Bind(addrType, addr, port, parameters);
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(IPEndPointBasis::Bind(addrType, addr, port, parameters));
 
     mParameters = parameters;
 
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    if (res == INET_NO_ERROR)
-    {
-        mState = kState_Bound;
-    }
+    mState = kState_Bound;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 /**
@@ -306,22 +289,14 @@ exit:
  */
 INET_ERROR UDPEndPoint::Listen()
 {
-    INET_ERROR res = INET_NO_ERROR;
-
-#if CHIP_SYSTEM_CONFIG_USE_SOCKETS
-    chip::System::Layer & lSystemLayer = SystemLayer();
-#endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
-
     if (mState == kState_Listening)
     {
-        res = INET_NO_ERROR;
-        goto exit;
+        return INET_NO_ERROR;
     }
 
     if (mState != kState_Bound)
     {
-        res = INET_ERROR_INCORRECT_STATE;
-        goto exit;
+        return INET_ERROR_INCORRECT_STATE;
     }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -344,6 +319,7 @@ INET_ERROR UDPEndPoint::Listen()
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
+    chip::System::Layer & lSystemLayer = SystemLayer();
 
     // Wake the thread calling select so that it starts selecting on the new socket.
     lSystemLayer.WakeSelect();
@@ -352,18 +328,13 @@ INET_ERROR UDPEndPoint::Listen()
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    res = StartListener();
-    SuccessOrExit(res);
+    ReturnErrorOnFailure(StartListener());
 
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    if (res == INET_NO_ERROR)
-    {
-        mState = kState_Listening;
-    }
+    mState = kState_Listening;
 
-exit:
-    return res;
+    return INET_NO_ERROR;
 }
 
 /**
@@ -693,10 +664,10 @@ exit:
  */
 INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
 {
-    INET_ERROR err = INET_NO_ERROR;
-
     if (mState != kState_Ready && mState != kState_Bound)
+    {
         return INET_ERROR_INCORRECT_STATE;
+    }
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
@@ -706,37 +677,32 @@ INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    err = GetPCB(addrType);
-    SuccessOrExit(err);
+    INET_ERROR err = GetPCB(addrType);
 
-    err = LwIPBindInterface(mUDP, intfId);
+    if (err == INET_NO_ERROR)
+    {
+        err = LwIPBindInterface(mUDP, intfId);
+    }
 
     UNLOCK_TCPIP_CORE();
 
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(err);
 
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // Make sure we have the appropriate type of socket.
-    err = GetSocket(addrType);
-    SuccessOrExit(err);
-
-    err = IPEndPointBasis::BindInterface(addrType, intfId);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(GetSocket(addrType));
+    ReturnErrorOnFailure(IPEndPointBasis::BindInterface(addrType, intfId));
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS
 
 #if CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
-    err = INET_ERROR_UNKNOWN_INTERFACE;
-    SuccessOrExit(err);
+    return INET_ERROR_UNKNOWN_INTERFACE;
 #endif // CHIP_SYSTEM_CONFIG_USE_NETWORK_FRAMEWORK
 
-    if (err == INET_NO_ERROR)
-    {
-        mState = kState_Bound;
-    }
-exit:
-    return err;
+    mState = kState_Bound;
+
+    return INET_NO_ERROR;
 }
 
 void UDPEndPoint::Init(InetLayer * inetLayer)
@@ -793,8 +759,6 @@ void UDPEndPoint::HandleDataReceived(System::PacketBufferHandle && msg)
 
 INET_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
 {
-    INET_ERROR err = INET_NO_ERROR;
-
     // IMPORTANT: This method MUST be called with the LwIP stack LOCKED!
 
     // If a PCB hasn't been allocated yet...
@@ -821,14 +785,14 @@ INET_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
 #endif // INET_CONFIG_ENABLE_IPV4
         else
         {
-            ExitNow(err = INET_ERROR_WRONG_ADDRESS_TYPE);
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
 
         // Fail if the system has run out of PCBs.
         if (mUDP == NULL)
         {
             ChipLogError(Inet, "Unable to allocate UDP PCB");
-            ExitNow(err = INET_ERROR_NO_MEMORY);
+            return INET_ERROR_NO_MEMORY;
         }
 
         // Allow multiple bindings to the same port.
@@ -853,7 +817,7 @@ INET_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
             break;
 #endif // INET_CONFIG_ENABLE_IPV4
         default:
-            ExitNow(err = INET_ERROR_WRONG_ADDRESS_TYPE);
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
         }
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 #if INET_CONFIG_ENABLE_IPV4
@@ -864,11 +828,10 @@ INET_ERROR UDPEndPoint::GetPCB(IPAddressType addrType)
 #endif // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 
         // Fail if the existing PCB is not the correct type.
-        VerifyOrExit(addrType == pcbAddrType, err = INET_ERROR_WRONG_ADDRESS_TYPE);
+        VerifyOrReturnError(addrType == pcbAddrType, INET_ERROR_WRONG_ADDRESS_TYPE);
     }
 
-exit:
-    return err;
+    return INET_NO_ERROR;
 }
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
@@ -916,15 +879,10 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void * arg, struct udp_pcb * pcb, struct
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
 INET_ERROR UDPEndPoint::GetSocket(IPAddressType aAddressType)
 {
-    INET_ERROR lRetval  = INET_NO_ERROR;
-    const int lType     = (SOCK_DGRAM | SOCK_FLAGS);
-    const int lProtocol = 0;
+    constexpr int lType     = (SOCK_DGRAM | SOCK_FLAGS);
+    constexpr int lProtocol = 0;
 
-    lRetval = IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
-    SuccessOrExit(lRetval);
-
-exit:
-    return (lRetval);
+    return IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
 }
 
 SocketEvents UDPEndPoint::PrepareIO()

--- a/src/transport/NetworkProvisioning.cpp
+++ b/src/transport/NetworkProvisioning.cpp
@@ -141,38 +141,32 @@ size_t NetworkProvisioning::EncodedStringSize(const char * str)
 
 CHIP_ERROR NetworkProvisioning::EncodeString(const char * str, Encoding::LittleEndian::BufferWriter & bbuf)
 {
-    CHIP_ERROR err  = CHIP_NO_ERROR;
-    size_t length   = strlen(str);
-    uint16_t u16len = static_cast<uint16_t>(length);
-    VerifyOrExit(CanCastTo<uint16_t>(length), err = CHIP_ERROR_INVALID_ARGUMENT);
+    const size_t length   = strlen(str);
+    const uint16_t u16len = static_cast<uint16_t>(length);
+    VerifyOrReturnError(CanCastTo<uint16_t>(length), CHIP_ERROR_INVALID_ARGUMENT);
 
     bbuf.Put16(u16len);
     bbuf.Put(str);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR NetworkProvisioning::DecodeString(const uint8_t * input, size_t input_len, Encoding::LittleEndian::BufferWriter & bbuf,
                                              size_t & consumed)
 {
-    CHIP_ERROR err  = CHIP_NO_ERROR;
-    uint16_t length = 0;
+    VerifyOrReturnError(input_len >= sizeof(uint16_t), CHIP_ERROR_BUFFER_TOO_SMALL);
+    const uint16_t length = chip::Encoding::LittleEndian::Get16(input);
+    consumed              = sizeof(uint16_t);
 
-    VerifyOrExit(input_len >= sizeof(uint16_t), err = CHIP_ERROR_BUFFER_TOO_SMALL);
-    length   = chip::Encoding::LittleEndian::Get16(input);
-    consumed = sizeof(uint16_t);
-
-    VerifyOrExit(input_len - consumed >= length, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(input_len - consumed >= length, CHIP_ERROR_BUFFER_TOO_SMALL);
     bbuf.Put(&input[consumed], length);
 
     consumed += bbuf.Needed();
     bbuf.Put(static_cast<uint8_t>('\0'));
 
-    VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-exit:
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR NetworkProvisioning::SendIPAddress(const Inet::IPAddress & addr)
@@ -371,7 +365,7 @@ void NetworkProvisioning::ConnectivityHandler(const DeviceLayer::ChipDeviceEvent
 {
     NetworkProvisioning * session = reinterpret_cast<NetworkProvisioning *>(arg);
 
-    VerifyOrExit(session != nullptr, /**/);
+    VerifyOrReturn(session != nullptr);
 
     if (event->Type == DeviceLayer::DeviceEventType::kInternetConnectivityChange &&
         event->InternetConnectivityChange.IPv4 == DeviceLayer::kConnectivity_Established)
@@ -385,13 +379,10 @@ void NetworkProvisioning::ConnectivityHandler(const DeviceLayer::ChipDeviceEvent
     if (event->Type == DeviceLayer::DeviceEventType::kThreadStateChange && event->ThreadStateChange.AddressChanged)
     {
         Inet::IPAddress addr;
-        SuccessOrExit(DeviceLayer::ThreadStackMgr().GetExternalIPv6Address(addr));
+        ReturnOnFailure(DeviceLayer::ThreadStackMgr().GetExternalIPv6Address(addr));
         (void) session->SendIPAddress(addr);
     }
 #endif
-
-exit:
-    return;
 }
 #endif
 

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2021 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -62,13 +62,8 @@ public:
     template <typename... Args>
     CHIP_ERROR Init(Args &&... transportInitArgs)
     {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        err = mTransport.Init(this, std::forward<Args>(transportInitArgs)...);
-        SuccessOrExit(err);
-        err = TransportMgrBase::Init(&mTransport);
-    exit:
-        return err;
+        ReturnErrorOnFailure(mTransport.Init(this, std::forward<Args>(transportInitArgs)...));
+        return TransportMgrBase::Init(&mTransport);
     }
 
     template <typename... Args>


### PR DESCRIPTION
#### Problem

The `Exit` group of error-handling macros inhibit scoping, and
are unnecessary when there is no cleanup at the `exit:` label.

#### Summary of Changes

- Remove `exit: return` idiom from src/inet and src/transport,
  replacing `Exit` macros with corresponding `Return` macros.
- Incidentally fixed a bug in `RawEndPoint::BindInterface` and
  `UDPEndPoint::BindInterface` that could leave the LwIP lock held
  by invoking `SuccessOrExit()` within a locked section.
