### PR TITLE
Fix decoding random encrypted bytes as packet header

### DIFF
--- a/src/messaging/MessageCounterSync.cpp
+++ b/src/messaging/MessageCounterSync.cpp
@@ -198,8 +198,9 @@ void MessageCounterSyncMgr::ProcessPendingGroupMsgs(NodeId peerNodeId)
         if (!entry.msgBuf.IsNull())
         {
             PacketHeader packetHeader;
+            uint16_t headerSize = 0;
 
-            if (packetHeader.DecodeAndConsume(entry.msgBuf) != CHIP_NO_ERROR)
+            if (packetHeader.Decode((entry.msgBuf)->Start(), (entry.msgBuf)->DataLength(), &headerSize) != CHIP_NO_ERROR)
             {
                 ChipLogError(ExchangeManager, "ProcessPendingGroupMsgs::Failed to decode PacketHeader");
                 break;
@@ -207,6 +208,8 @@ void MessageCounterSyncMgr::ProcessPendingGroupMsgs(NodeId peerNodeId)
 
             if (packetHeader.GetSourceNodeId().HasValue() && packetHeader.GetSourceNodeId().Value() == peerNodeId)
             {
+                (entry.msgBuf)->ConsumeHead(headerSize);
+
                 // Reprocess message.
                 mExchangeMgr->GetSessionMgr()->HandleGroupMessageReceived(packetHeader, std::move(entry.msgBuf));
 

--- a/src/messaging/MessageCounterSync.cpp
+++ b/src/messaging/MessageCounterSync.cpp
@@ -198,10 +198,10 @@ void MessageCounterSyncMgr::ProcessPendingGroupMsgs(NodeId peerNodeId)
         if (!entry.msgBuf.IsNull())
         {
             PacketHeader packetHeader;
-            uint16_t headerSize = 0;
 
-            if (packetHeader.Decode((entry.msgBuf)->Start(), (entry.msgBuf)->DataLength(), &headerSize) != CHIP_NO_ERROR)
+            if (packetHeader.DecodeAndConsume(entry.msgBuf) != CHIP_NO_ERROR)
             {
+                ChipLogError(ExchangeManager, "ProcessPendingGroupMsgs::Failed to decode PacketHeader");
                 break;
             }
 

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -342,7 +342,15 @@ void CheckReceiveMessage(nlTestSuite * inSuite, void * inContext)
     // Should be able to send a message to itself by just calling send.
     callback.ReceiveHandlerCallCount = 0;
 
-    err = secureSessionMgr.SendMessage(localToRemoteSession, std::move(buffer));
+    PayloadHeader payloadHeader;
+
+    // Set the exchange ID for this header.
+    payloadHeader.SetExchangeID(0);
+
+    // Set the protocol ID and message type for this header.
+    payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
+
+    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, std::move(buffer));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
@@ -362,7 +370,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test MessageCounterSyncMgr::SendMsgCounterSyncReq", CheckSendMsgCounterSyncReq),
     NL_TEST_DEF("Test MessageCounterSyncMgr::AddToRetransTable", CheckAddRetransTable),
     NL_TEST_DEF("Test MessageCounterSyncMgr::AddToReceiveTable", CheckAddToReceiveTable),
-    NL_TEST_DEF("Test MessageCounterSyncMgr::CheckReceiveMessage", CheckReceiveMessage),
+    NL_TEST_DEF("Test MessageCounterSyncMgr::ReceiveMessage", CheckReceiveMessage),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -24,6 +24,7 @@
 #include "TestMessagingLayer.h"
 
 #include <core/CHIPCore.h>
+#include <core/CHIPKeyIds.h>
 #include <messaging/ReliableMessageContext.h>
 #include <messaging/ReliableMessageMgr.h>
 #include <protocols/Protocols.h>
@@ -97,6 +98,50 @@ public:
 
     nlTestSuite * mSuite        = nullptr;
     int ReceiveHandlerCallCount = 0;
+};
+
+class TestSessMgrCallback : public SecureSessionMgrDelegate
+{
+public:
+    void OnMessageReceived(const PacketHeader & header, const PayloadHeader & payloadHeader, SecureSessionHandle session,
+                           System::PacketBufferHandle msgBuf, SecureSessionMgr * mgr) override
+    {}
+
+    void OnNewConnection(SecureSessionHandle session, SecureSessionMgr * mgr) override
+    {
+        if (NewConnectionHandlerCallCount == 0)
+        {
+            mRemoteToLocalSession = session;
+        }
+
+        if (NewConnectionHandlerCallCount == 1)
+        {
+            mLocalToRemoteSession = session;
+        }
+        NewConnectionHandlerCallCount++;
+    }
+
+    void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override {}
+
+    CHIP_ERROR QueueReceivedMessageAndSync(Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf) override
+    {
+        PacketHeader packetHeader;
+        uint16_t headerSize = 0;
+
+        CHIP_ERROR err = packetHeader.Decode(msgBuf->Start(), msgBuf->DataLength(), &headerSize);
+        NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(mSuite, ChipKeyId::IsAppGroupKey(packetHeader.GetEncryptionKeyID()) == true);
+
+        ReceiveHandlerCallCount++;
+
+        return CHIP_NO_ERROR;
+    }
+
+    nlTestSuite * mSuite = nullptr;
+    SecureSessionHandle mRemoteToLocalSession;
+    SecureSessionHandle mLocalToRemoteSession;
+    int ReceiveHandlerCallCount       = 0;
+    int NewConnectionHandlerCallCount = 0;
 };
 
 class MockAppDelegate : public ExchangeDelegate
@@ -243,6 +288,68 @@ void CheckAddToReceiveTable(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
+TestSessMgrCallback callback;
+
+void CheckReceiveMessage(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    uint16_t payload_len = sizeof(PAYLOAD);
+
+    ctx.GetInetLayer().SystemLayer()->Init(nullptr);
+
+    chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
+    NL_TEST_ASSERT(inSuite, !buffer.IsNull());
+
+    IPAddress addr;
+    IPAddress::FromString("127.0.0.1", addr);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    TransportMgr<LoopbackTransport> transportMgr;
+    SecureSessionMgr secureSessionMgr;
+
+    err = transportMgr.Init("LOOPBACK");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    Transport::AdminPairingTable admins;
+    err = secureSessionMgr.Init(kSourceNodeId, ctx.GetInetLayer().SystemLayer(), &transportMgr, &admins);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    callback.mSuite = inSuite;
+
+    secureSessionMgr.SetDelegate(&callback);
+
+    Optional<Transport::PeerAddress> peer(Transport::PeerAddress::UDP(addr, CHIP_PORT));
+
+    Transport::AdminPairingInfo * admin = admins.AssignAdminId(0, kSourceNodeId);
+    NL_TEST_ASSERT(inSuite, admin != nullptr);
+
+    admin = admins.AssignAdminId(1, kDestinationNodeId);
+    NL_TEST_ASSERT(inSuite, admin != nullptr);
+
+    SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
+
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairingPeerToLocal, SecureSessionMgr::PairingDirection::kInitiator, 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer, SecureSessionMgr::PairingDirection::kResponder,
+                                      0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
+
+    // Should be able to send a message to itself by just calling send.
+    callback.ReceiveHandlerCallCount = 0;
+
+    err = secureSessionMgr.SendMessage(localToRemoteSession, std::move(buffer));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+}
+
 // Test Suite
 
 /**
@@ -255,6 +362,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("Test MessageCounterSyncMgr::SendMsgCounterSyncReq", CheckSendMsgCounterSyncReq),
     NL_TEST_DEF("Test MessageCounterSyncMgr::AddToRetransTable", CheckAddRetransTable),
     NL_TEST_DEF("Test MessageCounterSyncMgr::AddToReceiveTable", CheckAddToReceiveTable),
+    NL_TEST_DEF("Test MessageCounterSyncMgr::CheckReceiveMessage", CheckReceiveMessage),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -367,7 +367,7 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         {
             // We should encode the packetHeader into the buffer before storing the buffer into the queue.
             // The encoded packetHeader needs to be peeled off during re-processing after the peer message
-            // couter is synced.
+            // counter is synced.
             ReturnOnFailure(packetHeader.EncodeBeforeData(msg));
             err = mCB->QueueReceivedMessageAndSync(state, std::move(msg));
             VerifyOrReturn(err == CHIP_NO_ERROR);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -365,6 +365,10 @@ void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, cons
         // Queue the message as needed for sync with destination node.
         if (mCB != nullptr)
         {
+            // We should encode the packetHeader into the buffer before storing the buffer into the queue.
+            // The encoded packetHeader needs to be peeled off during re-processing after the peer message
+            // couter is synced.
+            ReturnOnFailure(packetHeader.EncodeBeforeData(msg));
             err = mCB->QueueReceivedMessageAndSync(state, std::move(msg));
             VerifyOrReturn(err == CHIP_NO_ERROR);
         }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
#5848 introduced regression:

1. SecureSessionMgr::OnMessageReceived as called from lower layers has the packet buffer pointing to the start of the encrypted payload, since the PacketHeader has been parsed out already.

2. When we detect a group message with unsynced message counter, we call QueueReceivedMessageAndSync and hand over the packetbuffer. We do not adjust its start position to point to the packet header (either manually or by re-encoding the packet header into it).

3. In MessageCounterSyncMgr::ProcessPendingGroupMsgs we then decode a PacketHeader from whatever the buffer's start position happens to be. Which, recall, is the start of the encrypted payload. 

4. We then pass that packet header, and the buffer (still pointing to the encrypted payload) into HandleGroupMessageReceived. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Add unit test that will demonstrate the code is broken as it stands.
2. When we go to queue the message, we should EncodeBeforedata the PacketHeader into the buffer. .
3. When we go to dequeue the message, we should DecodeAndConsume the PacketHeader from the buffer instead of the manual thing with ->Start() that the code does right now.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5903

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
