### PR TITLE
Clean up examples build files a bit

### DIFF
--- a/config/nrfconnect/chip-gn/lib/pw_rpc/BUILD.gn
+++ b/config/nrfconnect/chip-gn/lib/pw_rpc/BUILD.gn
@@ -19,8 +19,8 @@ import("$dir_pw_build/target_types.gni")
 static_library("pw_rpc") {
   output_name = "libPwRpc"
 
-  public_configs = [ "${dir_pigweed}/pw_hdlc:default_config" ]
   sources = [ "${dir_pigweed}/pw_hdlc/rpc_example/hdlc_rpc_server.cc" ]
+
   deps = [
     "$dir_pw_rpc:server",
     "$dir_pw_rpc/nanopb:echo_service",
@@ -31,6 +31,8 @@ static_library("pw_rpc") {
     dir_pw_hdlc,
     dir_pw_log,
   ]
+
+  public_configs = [ "${dir_pigweed}/pw_hdlc:default_config" ]
 
   output_dir = "${root_out_dir}/lib"
 

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -15,28 +15,15 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-import("${chip_root}/build/chip/tools.gni")
-
-assert(chip_build_tools)
-
-config("includes") {
-  include_dirs = [
-    ".",
-    "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-  ]
-}
-
 executable("chip-all-clusters-app") {
   sources = [ "main.cpp" ]
-
-  public_configs = [ ":includes" ]
 
   deps = [
     "${chip_root}/examples/all-clusters-app/all-clusters-common",
     "${chip_root}/src/lib",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/bridge-app/linux/BUILD.gn
+++ b/examples/bridge-app/linux/BUILD.gn
@@ -18,15 +18,6 @@ import("${chip_root}/build/chip/tools.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
-  include_dirs = [
-    ".",
-    "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-  ]
-}
-
 executable("chip-bridge-app") {
   sources = [
     "LightingManager.cpp",
@@ -35,12 +26,14 @@ executable("chip-bridge-app") {
     "main.cpp",
   ]
 
-  public_configs = [ ":includes" ]
-
   deps = [
     "${chip_root}/examples/bridge-app/bridge-common",
     "${chip_root}/src/lib",
   ]
+
+  cflags = [ "-Wconversion" ]
+
+  include_dirs = [ "include" ]
 
   output_dir = root_out_dir
 }

--- a/examples/build_overrides/openthread.gni
+++ b/examples/build_overrides/openthread.gni
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 declare_args() {
+  # Root directory for openthread.
   openthread_root = "//third_party/connectedhomeip/third_party/openthread/repo"
 }

--- a/examples/build_overrides/ot_br_posix.gni
+++ b/examples/build_overrides/ot_br_posix.gni
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 declare_args() {
+  # Root directory for ot-br-posix.
   ot_br_posix_root = "//third_party/connectedhomeip/third_party/ot-br-posix"
 }

--- a/examples/chip-tool-darwin/BUILD.gn
+++ b/examples/chip-tool-darwin/BUILD.gn
@@ -19,19 +19,10 @@ import("${chip_root}/build/chip/tools.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
-  include_dirs = [ "." ]
-}
-
 executable("chip-tool-darwin") {
   sources = [ "main.m" ]
 
-  cflags = [
-    "-Wconversion",
-    "-fobjc-arc",
-  ]
-
-  public_deps = [
+  deps = [
     "${chip_root}/src/app/server",
     "${chip_root}/src/darwin/Framework/CHIP",
     "${chip_root}/src/lib",
@@ -39,7 +30,10 @@ executable("chip-tool-darwin") {
     "${chip_root}/third_party/inipp",
   ]
 
-  public_configs = [ ":includes" ]
+  cflags = [
+    "-Wconversion",
+    "-fobjc-arc",
+  ]
 
   output_dir = root_out_dir
 }

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -20,10 +20,6 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
-  include_dirs = [ "." ]
-}
-
 chip_data_model("data_model") {
   cluster_sources = [ "media-playback-client" ]
 
@@ -45,9 +41,7 @@ executable("chip-tool") {
     "main.cpp",
   ]
 
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
+  deps = [
     ":data_model",
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib",
@@ -55,7 +49,7 @@ executable("chip-tool") {
     "${chip_root}/third_party/inipp",
   ]
 
-  public_configs = [ ":includes" ]
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/common/QRCode/BUILD.gn
+++ b/examples/common/QRCode/BUILD.gn
@@ -21,9 +21,9 @@ config("qrcode-common_config") {
 static_library("QRCode") {
   output_name = "libqrcode-common"
 
-  output_dir = "${root_out_dir}/lib"
-
   sources = [ "repo/c/qrcodegen.c" ]
 
   public_configs = [ ":qrcode-common_config" ]
+
+  output_dir = "${root_out_dir}/lib"
 }

--- a/examples/common/pigweed/BUILD.gn
+++ b/examples/common/pigweed/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/pigweed.gni")
+
 import("$dir_pw_build/target_types.gni")
 
 config("default_config") {
@@ -20,6 +21,8 @@ config("default_config") {
 }
 
 pw_source_set("system_rpc_server") {
+  sources = [ "system_rpc_server.cc" ]
+
   deps = [
     "$dir_pw_hdlc:pw_rpc",
     "$dir_pw_hdlc:rpc_channel_output",
@@ -27,6 +30,8 @@ pw_source_set("system_rpc_server") {
     "$dir_pw_stream:sys_io_stream",
     dir_pw_log,
   ]
-  sources = [ "system_rpc_server.cc" ]
+
+  cflags = [ "-Wconversion" ]
+
   public_configs = [ ":default_config" ]
 }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -18,10 +18,9 @@ import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
+import("${chip_root}/examples/lighting-app/lighting-common/lighting.gni")
 import("${efr32_sdk_build_root}/efr32_executable.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
-
-import("${chip_root}/examples/lighting-app/lighting-common/lighting.gni")
 
 assert(current_os == "freertos")
 
@@ -31,7 +30,11 @@ examples_plat_dir = "${chip_root}/examples/platform/efr32"
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
+
+  # PIN code for PASE session establishment.
   setupPinCode = 73141520
+
+  # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 }
 
@@ -43,16 +46,16 @@ if (efr32_board == "BRD4166A") {
 }
 
 efr32_sdk("sdk") {
+  sources = [
+    "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    "${efr32_project_dir}/include/FreeRTOSConfig.h",
+  ]
+
   include_dirs = [
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
-
-  sources = [
-    "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
   defines = [
@@ -65,36 +68,14 @@ efr32_sdk("sdk") {
     sources +=
         [ "${efr32_sdk_root}/hardware/kit/common/drivers/retargetserial.c" ]
     defines += [
-      "HAL_VCOM_ENABLE = 1",
+      "HAL_VCOM_ENABLE=1",
       "PW_RPC_ENABLED",
     ]
   }
 }
 
 efr32_executable("lighting_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-efr32-lighting-example.out"
-
-  public_deps = [
-    ":sdk",
-    "${chip_root}/examples/common/QRCode",
-    "${chip_root}/examples/lighting-app/lighting-common",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
-    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
-  ]
-
-  include_dirs += [
-    "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-    "${examples_plat_dir}",
-    "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
 
   sources = [
     "${examples_plat_dir}/LEDWidget.cpp",
@@ -108,16 +89,39 @@ efr32_executable("lighting_app") {
     "src/main.cpp",
   ]
 
+  deps = [
+    ":sdk",
+    "${chip_root}/examples/common/QRCode",
+    "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
+    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
+    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+  ]
+
+  include_dirs = [ "include" ]
+
+  defines = []
+
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
-
     defines += [ "DISPLAY_ENABLED" ]
   }
 
   if (enable_pw_rpc) {
-    public_deps += [
+    sources += [
+      "${chip_root}/examples/common/pigweed/RpcService.cpp",
+      "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
+      "${examples_plat_dir}/PigweedLogger.cpp",
+      "src/Rpc.cpp",
+    ]
+
+    deps += [
       "$dir_pw_assert",
       "$dir_pw_checksum",
+      "$dir_pw_hdlc:rpc_channel_output",
       "$dir_pw_stream",
       "$dir_pw_sys_io",
       "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
@@ -129,20 +133,11 @@ efr32_executable("lighting_app") {
       "${chip_root}/examples/common",
       "${chip_root}/examples/common/pigweed/efr32",
     ]
-
-    sources += [
-      "${chip_root}/examples/common/pigweed/RpcService.cpp",
-      "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-      "${examples_plat_dir}/PigweedLogger.cpp",
-      "src/Rpc.cpp",
-    ]
   }
 
-  output_dir = root_out_dir
-
   if (enable_heap_monitoring) {
-    defines += [ "HEAP_MONITORING" ]
     sources += [ "${examples_plat_dir}/MemMonitoring.cpp" ]
+    defines += [ "HEAP_MONITORING" ]
   }
 
   if (efr32_family == "efr32mg12") {
@@ -159,6 +154,8 @@ efr32_executable("lighting_app") {
       "-fstack-usage",
     ]
   }
+
+  output_dir = root_out_dir
 }
 
 group("efr32") {

--- a/examples/lighting-app/k32w/BUILD.gn
+++ b/examples/lighting-app/k32w/BUILD.gn
@@ -24,6 +24,16 @@ assert(current_os == "freertos")
 k32w_platform_dir = "${chip_root}/examples/platform/k32w"
 
 k32w_sdk("sdk") {
+  sources = [
+    "${k32w_platform_dir}/app/project_include/CHIPProjectConfig.h",
+    "${k32w_platform_dir}/app/project_include/FreeRTOSConfig.h",
+    "${k32w_platform_dir}/app/project_include/OpenThreadConfig.h",
+    "main/include/app_config.h",
+  ]
+
+  public_deps =
+      [ "${chip_root}/third_party/openthread/platforms:libopenthread-platform" ]
+
   include_dirs = [
     "main/include",
     "main",
@@ -34,16 +44,6 @@ k32w_sdk("sdk") {
     "${chip_root}/src/app/server",
     "${k32w_platform_dir}/util/include",
   ]
-
-  sources = [
-    "${k32w_platform_dir}/app/project_include/CHIPProjectConfig.h",
-    "${k32w_platform_dir}/app/project_include/FreeRTOSConfig.h",
-    "${k32w_platform_dir}/app/project_include/OpenThreadConfig.h",
-    "main/include/app_config.h",
-  ]
-
-  public_deps =
-      [ "${chip_root}/third_party/openthread/platforms:libopenthread-platform" ]
 
   defines = []
   if (is_debug) {
@@ -79,11 +79,13 @@ k32w_executable("light_app") {
     "${openthread_root}:libopenthread-ftd",
   ]
 
-  output_dir = root_out_dir
+  cflags = [ "-Wconversion" ]
 
   ldscript = "${k32w_platform_dir}/app/ldscripts/chip-k32w061-linker.ld"
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  output_dir = root_out_dir
 }
 
 group("k32w") {

--- a/examples/lighting-app/lighting-common/BUILD.gn
+++ b/examples/lighting-app/lighting-common/BUILD.gn
@@ -13,24 +13,14 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+
 import("${chip_root}/examples/lighting-app/lighting-common/lighting.gni")
 import("${chip_root}/src/app/chip_data_model.gni")
-import("${chip_root}/src/app/common_flags.gni")
-import("${chip_root}/src/lib/core/core.gni")
 
 if (enable_pw_rpc) {
   import("//build_overrides/pigweed.gni")
   import("$dir_pw_protobuf_compiler/proto.gni")
-}
 
-config("includes") {
-  include_dirs = [
-    ".",
-    "include",
-  ]
-}
-
-if (enable_pw_rpc) {
   pw_proto_library("lighting_service") {
     sources = [ "lighting_service/pigweed_lighting.proto" ]
     inputs = [ "lighting_service/pigweed_lighting.options" ]

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -19,13 +19,6 @@ import("${chip_root}/src/app/common_flags.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
-  include_dirs = [
-    ".",
-    "include",
-  ]
-}
-
 executable("chip-lighting-app") {
   sources = [
     "LightingManager.cpp",
@@ -34,12 +27,14 @@ executable("chip-lighting-app") {
     "main.cpp",
   ]
 
-  public_configs = [ ":includes" ]
-
   deps = [
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
   ]
+
+  include_dirs = [ "include" ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/lighting-app/qpg6100/BUILD.gn
+++ b/examples/lighting-app/qpg6100/BUILD.gn
@@ -27,25 +27,29 @@ qpg6100_project_dir = "${chip_root}/examples/lighting-app/qpg6100"
 examples_plat_dir = "${chip_root}/examples/platform/qpg6100"
 
 qpg6100_sdk("sdk") {
-  include_dirs = [
-    "${chip_root}/src/platform/qpg6100",
-    "${examples_plat_dir}/project_include",
-  ]
-
   sources = [
     "${examples_plat_dir}/app/include/Service.h",
     "${examples_plat_dir}/project_include/CHIPProjectConfig.h",
   ]
 
-  defines = []
+  include_dirs = [
+    "${chip_root}/src/platform/qpg6100",
+    "${examples_plat_dir}/project_include",
+  ]
 }
 
 qpg6100_executable("lighting_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-qpg6100-lighting-example.out"
 
-  public_deps = [
+  sources = [
+    "${examples_plat_dir}/app/Service.cpp",
+    "${examples_plat_dir}/app/main.cpp",
+    "src/AppTask.cpp",
+    "src/LightingManager.cpp",
+    "src/ZclCallbacks.cpp",
+  ]
+
+  deps = [
     ":sdk",
     "${chip_root}/examples/lighting-app/lighting-common/",
     "${chip_root}/src/lib",
@@ -56,27 +60,19 @@ qpg6100_executable("lighting_app") {
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
   ]
 
-  include_dirs += [
+  cflags = [ "-Wconversion" ]
+
+  include_dirs = [
     "${qpg6100_project_dir}/include/",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
     "${examples_plat_dir}",
     "${examples_plat_dir}/app/include",
   ]
 
-  sources = [
-    "${examples_plat_dir}/app/Service.cpp",
-    "${examples_plat_dir}/app/main.cpp",
-    "src/AppTask.cpp",
-    "src/LightingManager.cpp",
-    "src/ZclCallbacks.cpp",
-  ]
-
-  output_dir = root_out_dir
-
   ldscript = "${qpg6100_sdk_root}/qpg6100/ldscripts/chip-qpg6100-example.ld"
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  output_dir = root_out_dir
 }
 
 group("qpg6100") {

--- a/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
@@ -39,6 +39,7 @@ ti_simplelink_sdk("sdk") {
 
 ti_sysconfig("sysconfig") {
   sources = [ "${project_dir}/chip.syscfg" ]
+
   outputs = [
     "ti_devices_config.c",
     "ti_radio_config.c",
@@ -62,6 +63,7 @@ ti_sysconfig("sysconfig") {
     #"ti_ble_app_config.opt",
     #"ti_build_config.opt",
   ]
+
   public_configs = [ ":sdk_dmm_config" ]
 
   cflags = [
@@ -74,23 +76,7 @@ ti_sysconfig("sysconfig") {
 }
 
 ti_simplelink_executable("lock_app") {
-  include_dirs = [
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-    "${project_dir}",
-    "${project_dir}/main",
-    "${project_dir}/main/include",
-  ]
-  defines = []
   output_name = "chip-${ti_simplelink_board}-lock-example.out"
-
-  public_deps = [
-    ":sdk",
-    ":sysconfig",
-    "${chip_root}/examples/lock-app/lock-common",
-    "${chip_root}/src/lib",
-    "${openthread_root}:libopenthread-cli-ftd",
-  ]
 
   sources = [
     "${project_dir}/main/AppTask.cpp",
@@ -99,12 +85,24 @@ ti_simplelink_executable("lock_app") {
     "${project_dir}/main/main.cpp",
   ]
 
+  deps = [
+    ":sdk",
+    ":sysconfig",
+    "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/src/lib",
+    "${openthread_root}:libopenthread-cli-ftd",
+  ]
+
+  include_dirs = [
+    "${project_dir}",
+    "${project_dir}/main",
+  ]
+
   cflags = [
     "-Wno-implicit-fallthrough",
     "-Wno-sign-compare",
+    "-Wconversion",
   ]
-
-  output_dir = root_out_dir
 
   ldscript = "${ti_simplelink_sdk_root}/source/ti/dmm/apps/common/freertos/cc13x2x7_cc26x2x7.lds"
 
@@ -114,6 +112,8 @@ ti_simplelink_executable("lock_app") {
                 root_build_dir),
     "-T" + rebase_path(ldscript, root_build_dir),
   ]
+
+  output_dir = root_out_dir
 }
 
 group("cc13x2x7_26x2x7") {

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -28,7 +28,11 @@ examples_plat_dir = "${chip_root}/examples/platform/efr32"
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
+
+  # PIN code for PASE session establishment.
   setupPinCode = 73141520
+
+  # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 }
 
@@ -40,16 +44,16 @@ if (efr32_board == "BRD4166A") {
 }
 
 efr32_sdk("sdk") {
+  sources = [
+    "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    "${efr32_project_dir}/include/FreeRTOSConfig.h",
+  ]
+
   include_dirs = [
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
-
-  sources = [
-    "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
   defines = [
@@ -60,29 +64,7 @@ efr32_sdk("sdk") {
 }
 
 efr32_executable("lock_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-efr32-lock-example.out"
-
-  public_deps = [
-    ":sdk",
-    "${chip_root}/examples/common/QRCode",
-    "${chip_root}/examples/lock-app/lock-common",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
-    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
-  ]
-
-  include_dirs += [
-    "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-    "${examples_plat_dir}",
-    "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
 
   sources = [
     "${examples_plat_dir}/LEDWidget.cpp",
@@ -96,12 +78,27 @@ efr32_executable("lock_app") {
     "src/main.cpp",
   ]
 
+  deps = [
+    ":sdk",
+    "${chip_root}/examples/common/QRCode",
+    "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
+    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
+    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+  ]
+
+  include_dirs = [ "include" ]
+
+  defines = []
+
   if (show_qr_code) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
 
     defines += [ "DISPLAY_ENABLED" ]
   }
-  output_dir = root_out_dir
 
   if (enable_heap_monitoring) {
     defines += [ "HEAP_MONITORING" ]
@@ -122,6 +119,8 @@ efr32_executable("lock_app") {
       "-fstack-usage",
     ]
   }
+
+  output_dir = root_out_dir
 }
 
 group("efr32") {

--- a/examples/lock-app/k32w/BUILD.gn
+++ b/examples/lock-app/k32w/BUILD.gn
@@ -24,17 +24,6 @@ assert(current_os == "freertos")
 k32w_platform_dir = "${chip_root}/examples/platform/k32w"
 
 k32w_sdk("sdk") {
-  include_dirs = [
-    "main/include",
-    "main",
-    "${k32w_platform_dir}/app/project_include",
-    "${k32w_platform_dir}/app/support",
-    "${chip_root}/examples/lock-app/lock-common",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-    "${k32w_platform_dir}/util/include",
-  ]
-
   sources = [
     "${k32w_platform_dir}/app/project_include/CHIPProjectConfig.h",
     "${k32w_platform_dir}/app/project_include/FreeRTOSConfig.h",
@@ -44,6 +33,14 @@ k32w_sdk("sdk") {
 
   public_deps =
       [ "${chip_root}/third_party/openthread/platforms:libopenthread-platform" ]
+
+  include_dirs = [
+    "main/include",
+    "main",
+    "${k32w_platform_dir}/app/project_include",
+    "${k32w_platform_dir}/app/support",
+    "${k32w_platform_dir}/util/include",
+  ]
 
   defines = []
   if (is_debug) {
@@ -78,6 +75,8 @@ k32w_executable("lock_app") {
     "${openthread_root}:libopenthread-cli-ftd",
     "${openthread_root}:libopenthread-ftd",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 

--- a/examples/lock-app/qpg6100/BUILD.gn
+++ b/examples/lock-app/qpg6100/BUILD.gn
@@ -27,23 +27,29 @@ qpg6100_project_dir = "${chip_root}/examples/lock-app/qpg6100"
 examples_plat_dir = "${chip_root}/examples/platform/qpg6100"
 
 qpg6100_sdk("sdk") {
-  include_dirs = [
-    "${chip_root}/src/platform/qpg6100",
-    "${examples_plat_dir}/project_include",
-  ]
-
   sources = [
     "${examples_plat_dir}/app/include/Service.h",
     "${examples_plat_dir}/project_include/CHIPProjectConfig.h",
   ]
+
+  include_dirs = [
+    "${chip_root}/src/platform/qpg6100",
+    "${examples_plat_dir}/project_include",
+  ]
 }
 
 qpg6100_executable("lock_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-qpg6100-lock-example.out"
 
-  public_deps = [
+  sources = [
+    "${examples_plat_dir}/app/Service.cpp",
+    "${examples_plat_dir}/app/main.cpp",
+    "src/AppTask.cpp",
+    "src/BoltLockManager.cpp",
+    "src/ZclCallbacks.cpp",
+  ]
+
+  deps = [
     ":sdk",
     "${chip_root}/examples/lock-app/lock-common",
     "${chip_root}/src/lib",
@@ -54,27 +60,19 @@ qpg6100_executable("lock_app") {
     "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
   ]
 
-  include_dirs += [
-    "${qpg6100_project_dir}/include/",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
+  include_dirs = [
+    "${qpg6100_project_dir}/include",
     "${examples_plat_dir}",
     "${examples_plat_dir}/app/include",
   ]
 
-  sources = [
-    "${examples_plat_dir}/app/Service.cpp",
-    "${examples_plat_dir}/app/main.cpp",
-    "src/AppTask.cpp",
-    "src/BoltLockManager.cpp",
-    "src/ZclCallbacks.cpp",
-  ]
-
-  output_dir = root_out_dir
+  cflags = [ "-Wconversion" ]
 
   ldscript = "${qpg6100_sdk_root}/qpg6100/ldscripts/chip-qpg6100-example.ld"
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  output_dir = root_out_dir
 }
 
 group("qpg6100") {

--- a/examples/minimal-mdns/BUILD.gn
+++ b/examples/minimal-mdns/BUILD.gn
@@ -24,6 +24,8 @@ static_library("minimal-mdns-example-common") {
     "PacketReporter.h",
   ]
 
+  cflags = [ "-Wconversion" ]
+
   public_deps = [
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/mdns/minimal",
@@ -33,13 +35,13 @@ static_library("minimal-mdns-example-common") {
 executable("minimal-mdns-client") {
   sources = [ "client.cpp" ]
 
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
+  deps = [
     ":minimal-mdns-example-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/mdns/minimal",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }
@@ -47,14 +49,14 @@ executable("minimal-mdns-client") {
 executable("minimal-mdns-server") {
   sources = [ "server.cpp" ]
 
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
+  deps = [
     ":minimal-mdns-example-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/mdns/minimal",
     "${chip_root}/src/lib/mdns/minimal/responders",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }
@@ -62,13 +64,13 @@ executable("minimal-mdns-server") {
 executable("mdns-advertiser") {
   sources = [ "advertiser.cpp" ]
 
-  cflags = [ "-Wconversion" ]
-
-  public_deps = [
+  deps = [
     ":minimal-mdns-example-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/mdns",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/persistent-storage/KeyValueStorageTest.cpp
+++ b/examples/persistent-storage/KeyValueStorageTest.cpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <platform/KeyValueStoreManager.h>
+#include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
 #include <support/logging/CHIPLogging.h>
 

--- a/examples/persistent-storage/efr32/BUILD.gn
+++ b/examples/persistent-storage/efr32/BUILD.gn
@@ -28,17 +28,17 @@ efr32_project_dir = "${chip_root}/examples/persistent-storage/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/efr32"
 
 efr32_sdk("sdk") {
+  sources = [
+    "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    "${efr32_project_dir}/include/FreeRTOSConfig.h",
+  ]
+
   include_dirs = [
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${efr32_project_dir}/src",
     "${examples_plat_dir}",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
-
-  sources = [
-    "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
   defines = [
@@ -48,23 +48,7 @@ efr32_sdk("sdk") {
 }
 
 efr32_executable("persistent_storage") {
-  include_dirs = [ "${efr32_project_dir}/.." ]
-  defines = []
   output_name = "chip-efr32-persistent_storage-example.out"
-
-  deps = [ "$dir_pw_kvs:crc16" ]
-  public_deps = [
-    ":sdk",
-    "$dir_pw_assert",
-    "${chip_root}/src/lib",
-  ]
-
-  include_dirs += [
-    "${efr32_project_dir}/include",
-    "${chip_root}/src/app/util",
-    "${examples_plat_dir}",
-    "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
 
   sources = [
     "${efr32_project_dir}/../KeyValueStorageTest.cpp",
@@ -73,7 +57,17 @@ efr32_executable("persistent_storage") {
     "main.cpp",
   ]
 
-  output_dir = root_out_dir
+  deps = [
+    ":sdk",
+    "$dir_pw_assert",
+    "$dir_pw_kvs:crc16",
+    "${chip_root}/src/lib",
+  ]
+
+  include_dirs = [
+    "${efr32_project_dir}/..",
+    "${efr32_project_dir}/include",
+  ]
 
   if (efr32_family == "efr32mg12") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG12P.ld"
@@ -82,6 +76,8 @@ efr32_executable("persistent_storage") {
   }
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  output_dir = root_out_dir
 }
 
 group("efr32") {

--- a/examples/persistent-storage/linux/BUILD.gn
+++ b/examples/persistent-storage/linux/BUILD.gn
@@ -14,19 +14,17 @@
 
 import("//build_overrides/chip.gni")
 
-config("includes") {
-  include_dirs = [ "${chip_root}/examples/persistent-storage" ]
-}
-
 executable("persistent_storage") {
   sources = [
     "${chip_root}/examples/persistent-storage/KeyValueStorageTest.cpp",
     "main.cpp",
   ]
 
-  public_configs = [ ":includes" ]
-
   deps = [ "${chip_root}/src/lib" ]
+
+  cflags = [ "-Wconversion" ]
+
+  include_dirs = [ "${chip_root}/examples/persistent-storage" ]
 
   output_dir = root_out_dir
 }

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -16,8 +16,8 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/pigweed.gni")
-import("${build_root}/config/defaults.gni")
 
+import("${build_root}/config/defaults.gni")
 import("${chip_root}/config/efr32/lib/pw_rpc/pw_rpc.gni")
 import("${efr32_sdk_build_root}/efr32_executable.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
@@ -28,16 +28,16 @@ efr32_project_dir = "${chip_root}/examples/pigweed-app/efr32"
 examples_plat_dir = "${chip_root}/examples/platform/efr32"
 
 efr32_sdk("sdk") {
+  sources = [
+    "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    "${efr32_project_dir}/include/FreeRTOSConfig.h",
+  ]
+
   include_dirs = [
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
-
-  sources = [
-    "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
   defines = [
@@ -50,21 +50,7 @@ efr32_sdk("sdk") {
 }
 
 efr32_executable("pigweed_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-efr32-pigweed-example.out"
-
-  public_deps = [
-    ":sdk",
-    "$dir_pw_assert",
-    "$dir_pw_checksum",
-    "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
-    "${chip_root}/examples/common/pigweed:system_rpc_server",
-    "${chip_root}/src/lib",
-    "${examples_plat_dir}/pw_sys_io:pw_sys_io_efr32",
-  ]
-
-  include_dirs += [ "${chip_root}/examples/common/pigweed/efr32" ]
 
   sources = [
     "${chip_root}/examples/common/pigweed/RpcService.cpp",
@@ -76,7 +62,17 @@ efr32_executable("pigweed_app") {
     "src/main.cpp",
   ]
 
-  output_dir = root_out_dir
+  deps = [
+    ":sdk",
+    "$dir_pw_assert",
+    "$dir_pw_checksum",
+    "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+    "${chip_root}/examples/common/pigweed:system_rpc_server",
+    "${chip_root}/src/lib",
+    "${examples_plat_dir}/pw_sys_io:pw_sys_io_efr32",
+  ]
+
+  include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
 
   if (efr32_family == "efr32mg12") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG12P.ld"
@@ -85,6 +81,8 @@ efr32_executable("pigweed_app") {
   }
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+
+  output_dir = root_out_dir
 }
 
 group("efr32") {

--- a/examples/platform/efr32/BUILD.gn
+++ b/examples/platform/efr32/BUILD.gn
@@ -23,9 +23,11 @@ config("chip_examples_project_config") {
 
 source_set("openthread_core_config_efr32_chip_examples") {
   sources = [ "project_include/OpenThreadConfig.h" ]
+
   public_deps = [
     "${chip_root}/third_party/openthread/platforms/efr32:openthread_core_config_efr32",
     "${efr32_sdk_build_root}:efr32_sdk",
   ]
+
   public_configs = [ ":chip_examples_project_config" ]
 }

--- a/examples/platform/efr32/pw_sys_io/BUILD.gn
+++ b/examples/platform/efr32/pw_sys_io/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
+
 import("$dir_pw_build/target_types.gni")
 
 examples_plat_dir = "${chip_root}/examples/platform/efr32"
@@ -23,15 +24,16 @@ config("default_config") {
 }
 
 pw_source_set("pw_sys_io_efr32") {
-  public_configs = [ ":default_config" ]
-
-  public_deps = []
+  sources = [ "sys_io_efr32.cc" ]
 
   deps = [
     "$dir_pw_sys_io:default_putget_bytes",
     "$dir_pw_sys_io:facade",
   ]
 
+  cflags = [ "-Wconversion" ]
+
+  public_configs = [ ":default_config" ]
+
   include_dirs = [ "${examples_plat_dir}" ]
-  sources = [ "sys_io_efr32.cc" ]
 }

--- a/examples/platform/esp32/pw_sys_io/BUILD.gn
+++ b/examples/platform/esp32/pw_sys_io/BUILD.gn
@@ -15,15 +15,20 @@
 import("//build_overrides/pigweed.gni")
 
 import("$dir_pw_build/target_types.gni")
+
 config("default_config") {
   include_dirs = [ "public" ]
 }
 
 pw_source_set("pw_sys_io_esp32") {
-  public_configs = [ ":default_config" ]
+  sources = [ "sys_io_esp32.cc" ]
+
   deps = [
     "$dir_pw_sys_io:default_putget_bytes",
     "$dir_pw_sys_io:facade",
   ]
-  sources = [ "sys_io_esp32.cc" ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_configs = [ ":default_config" ]
 }

--- a/examples/platform/k32w/BUILD.gn
+++ b/examples/platform/k32w/BUILD.gn
@@ -23,6 +23,8 @@ config("chip_examples_project_config") {
 
 source_set("openthread_core_config_k32w_chip_examples") {
   sources = [ "app/project_include/OpenThreadConfig.h" ]
+
   public_deps = [ "${chip_root}/third_party/openthread/platforms/k32w:openthread_core_config_k32w" ]
+
   public_configs = [ ":chip_examples_project_config" ]
 }

--- a/examples/platform/k32w/app/BUILD.gn
+++ b/examples/platform/k32w/app/BUILD.gn
@@ -20,6 +20,8 @@ config("chip_examples_project_config") {
 
 source_set("openthread_core_config_k32w_chip_examples") {
   sources = [ "app/project_include/OpenThreadConfig.h" ]
+
   public_deps = [ "${chip_root}/third_party/openthread/platforms/k32w:openthread_core_config_k32w" ]
+
   public_configs = [ ":chip_examples_project_config" ]
 }

--- a/examples/platform/k32w/app/support/BUILD.gn
+++ b/examples/platform/k32w/app/support/BUILD.gn
@@ -28,5 +28,7 @@ source_set("freertos_mbedtls_utils") {
   #TODO: not sure this is required, maybe we should make this dependant on mbedtls
   public_deps = [ "${k32w_sdk_build_root}:k32w_sdk" ]
 
+  cflags = [ "-Wconversion" ]
+
   public_configs = [ ":support_config" ]
 }

--- a/examples/platform/nrfconnect/pw_sys_io/BUILD.gn
+++ b/examples/platform/nrfconnect/pw_sys_io/BUILD.gn
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# gn-format disable
 import("//build_overrides/pigweed.gni")
 
 import("$dir_pw_build/target_types.gni")
+
 config("default_config") {
   include_dirs = [ "public" ]
 }
 
 pw_source_set("pw_sys_io_nrfconnect") {
-  public_configs = [ ":default_config" ]
+  sources = [ "sys_io_nrfconnect.cc" ]
+
   deps = [
     "$dir_pw_sys_io:default_putget_bytes",
     "$dir_pw_sys_io:facade",
   ]
-  sources = [ "sys_io_nrfconnect.cc" ]
+
+  public_configs = [ ":default_config" ]
 }

--- a/examples/platform/qpg6100/BUILD.gn
+++ b/examples/platform/qpg6100/BUILD.gn
@@ -28,5 +28,6 @@ source_set("openthread_core_config_qpg6100_chip_examples") {
     "${chip_root}/third_party/openthread/platforms/qpg6100:openthread_core_config_qpg6100",
     "${qpg6100_sdk_build_root}:qpg6100_sdk",
   ]
+
   public_configs = [ ":chip_examples_project_config" ]
 }

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -14,12 +14,13 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/openthread.gni")
+
 import("${chip_root}/src/platform/device.gni")
 
 config("shell_common_config") {
   include_dirs = [
     ".",
-    "./include",
+    "include",
     "${chip_root}/src/lib/shell",
   ]
 

--- a/examples/shell/standalone/BUILD.gn
+++ b/examples/shell/standalone/BUILD.gn
@@ -25,11 +25,13 @@ project_dir = "./.."
 executable("chip-shell") {
   sources = [ "main.cpp" ]
 
-  public_deps = [
+  deps = [
     "${chip_root}/src/lib/shell",
     "${chip_root}/src/platform",
     "${project_dir}/shell_common:shell_common",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/tv-app/linux/BUILD.gn
+++ b/examples/tv-app/linux/BUILD.gn
@@ -19,22 +19,15 @@ import("${build_root}/chip/tools.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
-  include_dirs = [
-    ".",
-    "include",
-  ]
-}
-
 executable("chip-tv-app") {
   sources = [ "main.cpp" ]
-
-  public_configs = [ ":includes" ]
 
   deps = [
     "${chip_root}/examples/tv-app/tv-common",
     "${chip_root}/src/lib",
   ]
+
+  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -29,7 +29,11 @@ examples_plat_dir = "${chip_root}/examples/platform/efr32"
 declare_args() {
   # Dump memory usage at link time.
   chip_print_memory_usage = false
+
+  # PIN code for PASE session establishment.
   setupPinCode = 73141520
+
+  # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 }
 
@@ -41,16 +45,16 @@ if (efr32_board == "BRD4166A") {
 }
 
 efr32_sdk("sdk") {
+  sources = [
+    "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    "${efr32_project_dir}/include/FreeRTOSConfig.h",
+  ]
+
   include_dirs = [
     "${chip_root}/src/platform/EFR32",
     "${efr32_project_dir}/include",
     "${examples_plat_dir}",
     "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
-
-  sources = [
-    "${efr32_project_dir}/include/CHIPProjectConfig.h",
-    "${efr32_project_dir}/include/FreeRTOSConfig.h",
   ]
 
   defines = [
@@ -61,29 +65,8 @@ efr32_sdk("sdk") {
 }
 
 efr32_executable("window_app") {
-  include_dirs = []
-  defines = []
   output_name = "chip-efr32-window-example.out"
-
-  public_deps = [
-    ":sdk",
-    "${chip_root}/examples/common/QRCode",
-    "${chip_root}/examples/window-app/common:window-common",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/setup_payload",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
-    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
-    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
-  ]
-
-  include_dirs += [
-    "include",
-    "${chip_root}/src/app/util",
-    "${chip_root}/src/app/server",
-    "${examples_plat_dir}",
-    "${examples_plat_dir}/${efr32_family}/${efr32_board}",
-  ]
+  output_dir = root_out_dir
 
   sources = [
     "${examples_plat_dir}/LEDWidget.cpp",
@@ -99,6 +82,22 @@ efr32_executable("window_app") {
     "src/main.cpp",
   ]
 
+  deps = [
+    ":sdk",
+    "${chip_root}/examples/common/QRCode",
+    "${chip_root}/examples/window-app/common:window-common",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
+    "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
+    "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
+    "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
+  ]
+
+  include_dirs = [ "include" ]
+
+  defines = []
+
   if (show_qr_code) {
     sources += [
       "${examples_plat_dir}/display/lcd.c",
@@ -108,10 +107,9 @@ efr32_executable("window_app") {
     defines += [ "DISPLAY_ENABLED" ]
   }
 
-  output_dir = root_out_dir
-
   if (enable_heap_monitoring) {
     defines += [ "HEAP_MONITORING" ]
+
     sources += [ "${examples_plat_dir}/MemMonitoring.cpp" ]
   }
 

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -25,7 +25,7 @@ executable("chip-im-initiator") {
     "common.cpp",
   ]
 
-  public_deps = [
+  deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
@@ -43,7 +43,7 @@ executable("chip-im-responder") {
     "common.cpp",
   ]
 
-  public_deps = [
+  deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/app",
     "${chip_root}/src/lib/core",


### PR DESCRIPTION
- Normalize whitespace
- Remove unnecessary include_dirs, config targets, etc
- Document arguments in declare_args()
- Add some -Wconversion
- Reorder assignments to roughly the same order: sources, deps, etc
- public_deps isn't needed on executables, just use deps
- Remove assert(chip_build_tools) in "app" examples