### PR TITLE
Fix the doxygen workflow

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -15,7 +15,8 @@
 name: Doxygen
 
 on:
-    tag:
+    push:
+    pull_request:
 
 jobs:
     doxygen:
@@ -37,7 +38,7 @@ jobs:
               run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
               id: extract_branch
             - name: Deploy if master
-              if: steps.extract_branch.outputs.branch == 'master'
+              if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
               uses: peaceiris/actions-gh-pages@v3
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As of 8556f75e ("Disable doxygen generation on every push (#5694)") this
workflow is generating errors since "tag" is not a valid trigger.

Now that the graphs are disabled, add back the usual triggers, but turn
off deployment for forks so that it stops deleting the QR code page
at https://dhrishi.github.io/connectedhomeip/qrcode.html