### PR TITLE
actions: Remove some unused environment variables

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,6 @@ jobs:
                 type: [gcc_debug, gcc_release, clang, mbedtls, clang_experimental]
         env:
             BUILD_TYPE: ${{ matrix.type }}
-            BUILD_IMAGE: chip-build-openssl
-            BUILD_ORG: connectedhomeip
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -24,8 +24,6 @@ jobs:
 
         env:
             BUILD_TYPE: gn_linux
-            BUILD_IMAGE: chip-build
-            BUILD_ORG: connectedhomeip
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -28,8 +28,6 @@ jobs:
                 type: [main, clang, mbedtls]
         env:
             BUILD_TYPE: ${{ matrix.type }}
-            BUILD_IMAGE: chip-build-openssl
-            BUILD_ORG: connectedhomeip
 
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Remove BUILD_IMAGE, BUILD_ORG. It seems these were for parameterizing
the docker container selection but we never got it working, and
"chip-build-openssl" container no longer exists.