### PR TITLE
Optimize memory usage by encoding state into packet buffer

### DIFF
--- a/src/messaging/MessageCounterSync.h
+++ b/src/messaging/MessageCounterSync.h
@@ -60,10 +60,6 @@ public:
      *  Add a CHIP message into the cache table to queue the outging messages that trigger message counter synchronization protocol
      *  for retransmission.
      *
-     *  @param[in]    protocolId       The protocol identifier of the CHIP message to be sent.
-     *
-     *  @param[in]    msgType          The message type of the corresponding protocol.
-     *
      *  @param[in]    sendFlags        Flags set by the application for the CHIP message being sent.
      *
      *  @param[in]    msgBuf           A handle to the packet buffer holding the CHIP message.
@@ -73,8 +69,8 @@ public:
      *  @retval  #CHIP_ERROR_NO_MEMORY If there is no empty slot left in the table for addition.
      *  @retval  #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR AddToRetransmissionTable(Protocols::Id protocolId, uint8_t msgType, const SendFlags & sendFlags,
-                                        System::PacketBufferHandle msgBuf, Messaging::ExchangeContext * exchangeContext);
+    CHIP_ERROR AddToRetransmissionTable(const SendFlags & sendFlags, System::PacketBufferHandle msgBuf,
+                                        Messaging::ExchangeContext * exchangeContext);
 
     /**
      *  Add a CHIP message into the cache table to queue the incoming messages that trigger message counter synchronization
@@ -100,13 +96,11 @@ private:
      */
     struct RetransTableEntry
     {
-        RetransTableEntry() : protocolId(Protocols::NotSpecified) {}
+        RetransTableEntry() : exchangeContext(nullptr) {}
         ExchangeContext * exchangeContext; /**< The ExchangeContext for the stored CHIP message.
                                                 Non-null if and only if this entry is in use. */
         System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the CHIP message. */
         SendFlags sendFlags;               /**< Flags set by the application for the CHIP message being sent. */
-        Protocols::Id protocolId;          /**< The protocol identifier of the CHIP message to be sent. */
-        uint8_t msgType;                   /**< The message type of the CHIP message to be sent. */
     };
 
     /**


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
MessageCounterSyncMgr::RetransTableEntry has these members:

        ExchangeContext * exchangeContext; /**< The ExchangeContext for the stored CHIP message.
                                                Non-null if and only if this entry is in use. */
        System::PacketBufferHandle msgBuf; /**< A handle to the PacketBuffer object holding the CHIP message. */
        SendFlags sendFlags;               /**< Flags set by the application for the CHIP message being sent. */
        Protocols::Id protocolId;          /**< The protocol identifier of the CHIP message to be sent. */
        uint8_t msgType;                   /**< The message type of the CHIP message to be sent. */

We could store the protocolId and msgType inside the packetbuffer by endoding a PayloadHeader in there, so we don't need this out-of-band storage. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Move state out of the entry into the packetbuffer.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5771

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
