### PR TITLE
Optimize memory usage by refactoring ExchangeContext

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -283,6 +283,7 @@ void ExchangeContext::Free()
 
     DoClose(false);
     mExchangeMgr = nullptr;
+    mAppState    = nullptr;
 
     em->DecrementContextsInUse();
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -150,8 +150,8 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
         }
     }
 
-    err = dispatch->SendMessage(mSecureSession, mExchangeId, IsInitiator(), mReliableMessageContext, reliableTransmissionRequested,
-                                protocolId, msgType, std::move(msgBuf));
+    err = dispatch->SendMessage(mSecureSession, mExchangeId, IsInitiator(), GetReliableMessageContext(),
+                                reliableTransmissionRequested, protocolId, msgType, std::move(msgBuf));
 
 exit:
     if (err != CHIP_NO_ERROR && IsResponseExpected())
@@ -382,7 +382,8 @@ CHIP_ERROR ExchangeContext::HandleMessage(const PacketHeader & packetHeader, con
         dispatch = &defaultDispatch;
     }
 
-    CHIP_ERROR err = dispatch->OnMessageReceived(payloadHeader, packetHeader.GetMessageId(), peerAddress, mReliableMessageContext);
+    CHIP_ERROR err =
+        dispatch->OnMessageReceived(payloadHeader, packetHeader.GetMessageId(), peerAddress, GetReliableMessageContext());
     SuccessOrExit(err);
 
     // The SecureChannel::StandaloneAck message type is only used for CRMP; do not pass such messages to the application layer.

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -58,17 +58,17 @@ static void DefaultOnMessageReceived(ExchangeContext * ec, const PacketHeader & 
 
 bool ExchangeContext::IsInitiator() const
 {
-    return mFlags.Has(ExFlagValues::kFlagInitiator);
+    return mFlags.Has(Flags::kFlagInitiator);
 }
 
 bool ExchangeContext::IsResponseExpected() const
 {
-    return mFlags.Has(ExFlagValues::kFlagResponseExpected);
+    return mFlags.Has(Flags::kFlagResponseExpected);
 }
 
 void ExchangeContext::SetResponseExpected(bool inResponseExpected)
 {
-    mFlags.Set(ExFlagValues::kFlagResponseExpected, inResponseExpected);
+    mFlags.Set(Flags::kFlagResponseExpected, inResponseExpected);
 }
 
 void ExchangeContext::SetResponseTimeout(Timeout timeout)
@@ -183,13 +183,13 @@ void ExchangeContext::DoClose(bool clearRetransTable)
     // it is done with the exchange context and the message layer sets all callbacks to NULL and does not send anything
     // received on the exchange context up to higher layers.  At this point, the message layer needs to handle the
     // remaining work to be done on that exchange, (e.g. send all pending acks) before truly cleaning it up.
-    mReliableMessageContext.FlushAcks();
+    FlushAcks();
 
     // In case the protocol wants a harder release of the EC right away, such as calling Abort(), exchange
     // needs to clear the CRMP retransmission table immediately.
     if (clearRetransTable)
     {
-        mExchangeMgr->GetReliableMessageMgr()->ClearRetransTable(&mReliableMessageContext);
+        mExchangeMgr->GetReliableMessageMgr()->ClearRetransTable(static_cast<ReliableMessageContext *>(this));
     }
 
     // Cancel the response timer.
@@ -258,10 +258,10 @@ ExchangeContext * ExchangeContext::Alloc(ExchangeManager * em, uint16_t Exchange
     em->IncrementContextsInUse();
     mExchangeId    = ExchangeId;
     mSecureSession = session;
-    mFlags.Set(ExFlagValues::kFlagInitiator, Initiator);
+    mFlags.Set(Flags::kFlagInitiator, Initiator);
     mDelegate = delegate;
 
-    mReliableMessageContext.Init(em->GetReliableMessageMgr(), this);
+    Init(em->GetReliableMessageMgr());
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
     ChipLogProgress(ExchangeManager, "ec++ id: %d, inUse: %d, addr: 0x%x", (this - em->ContextPool + 1), em->GetContextsInUse(),

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -261,7 +261,11 @@ ExchangeContext * ExchangeContext::Alloc(ExchangeManager * em, uint16_t Exchange
     mFlags.Set(Flags::kFlagInitiator, Initiator);
     mDelegate = delegate;
 
-    Init(em->GetReliableMessageMgr());
+    SetDropAckDebug(false);
+    SetAckPending(false);
+    SetPeerRequestedAck(false);
+    SetMsgRcvdFromPeer(false);
+    SetAutoRequestAck(true);
 
 #if defined(CHIP_EXCHANGE_CONTEXT_DETAIL_LOGGING)
     ChipLogProgress(ExchangeManager, "ec++ id: %d, inUse: %d, addr: 0x%x", (this - em->ContextPool + 1), em->GetContextsInUse(),

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -36,8 +36,6 @@
 
 namespace chip {
 
-constexpr uint16_t kMsgCounterChallengeSize = 8; // The size of the message counter synchronization request message.
-
 namespace Messaging {
 
 class ExchangeManager;
@@ -170,9 +168,9 @@ public:
 
     uint16_t GetExchangeId() const { return mExchangeId; }
 
-    void SetChallenge(const uint8_t * value) { memcpy(&mChallenge[0], value, kMsgCounterChallengeSize); }
+    void SetAppState(void * state) { mAppState = state; }
 
-    const uint8_t * GetChallenge() const { return mChallenge; }
+    void * GetAppState() const { return mAppState; }
 
     SecureSessionHandle GetSecureSessionHandle() const { return mSecureSession; }
 
@@ -196,13 +194,10 @@ private:
     ExchangeDelegateBase * mDelegate = nullptr;
     ExchangeManager * mExchangeMgr   = nullptr;
     ExchangeACL * mExchangeACL       = nullptr;
+    void * mAppState               = nullptr;
 
     SecureSessionHandle mSecureSession; // The connection state
     uint16_t mExchangeId;               // Assigned exchange ID.
-
-    // [TODO: #4711]: this field need to be moved to appState object which implement 'exchange-specific' contextual
-    // actions with a delegate pattern.
-    uint8_t mChallenge[kMsgCounterChallengeSize]; // Challenge number to identify the sychronization request cryptographically.
 
     /**
      *  Search for an existing exchange that the message applies to.

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -194,7 +194,7 @@ private:
     ExchangeDelegateBase * mDelegate = nullptr;
     ExchangeManager * mExchangeMgr   = nullptr;
     ExchangeACL * mExchangeACL       = nullptr;
-    void * mAppState               = nullptr;
+    void * mAppState                 = nullptr;
 
     SecureSessionHandle mSecureSession; // The connection state
     uint16_t mExchangeId;               // Assigned exchange ID.

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -44,7 +44,7 @@ public:
     }
 
     CHIP_ERROR SendMessage(SecureSessionHandle session, uint16_t exchangeId, bool isInitiator,
-                           ReliableMessageContext & reliableMessageContext, bool isReliableTransmission, Protocols::Id protocol,
+                           ReliableMessageContext * reliableMessageContext, bool isReliableTransmission, Protocols::Id protocol,
                            uint8_t type, System::PacketBufferHandle message);
 
     virtual CHIP_ERROR ResendMessage(SecureSessionHandle session, EncryptedPacketBufferHandle message,
@@ -55,7 +55,7 @@ public:
 
     virtual CHIP_ERROR OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
                                          const Transport::PeerAddress & peerAddress,
-                                         ReliableMessageContext & reliableMessageContext);
+                                         ReliableMessageContext * reliableMessageContext);
 
 protected:
     virtual bool MessagePermitted(uint16_t protocol, uint8_t type) = 0;

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -225,9 +225,9 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         {
             // Found a matching exchange. Set flag for correct subsequent CRMP
             // retransmission timeout selection.
-            if (!ec.mReliableMessageContext.HasRcvdMsgFromPeer())
+            if (!ec.HasRcvdMsgFromPeer())
             {
-                ec.mReliableMessageContext.SetMsgRcvdFromPeer(true);
+                ec.SetMsgRcvdFromPeer(true);
             }
 
             // Matched ExchangeContext; send to message handler.

--- a/src/messaging/MessageCounterSync.cpp
+++ b/src/messaging/MessageCounterSync.cpp
@@ -84,7 +84,11 @@ void MessageCounterSyncMgr::OnResponseTimeout(Messaging::ExchangeContext * excha
 
     // Close the exchange if MsgCounterSyncRsp is not received before kMsgCounterSyncTimeout.
     if (exchangeContext != nullptr)
+    {
+        chip::Platform::MemoryFree(exchangeContext->GetAppState());
+        exchangeContext->SetAppState(nullptr);
         exchangeContext->Close();
+    }
 }
 
 CHIP_ERROR MessageCounterSyncMgr::AddToRetransmissionTable(Protocols::Id protocolId, uint8_t msgType, const SendFlags & sendFlags,
@@ -242,7 +246,8 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncReq(SecureSessionHandle sess
     Transport::PeerConnectionState * state       = nullptr;
     System::PacketBufferHandle msgBuf;
     Messaging::SendFlags sendFlags;
-    uint8_t challenge[kMsgCounterChallengeSize];
+    void * challenge = chip::Platform::MemoryAlloc(kMsgCounterChallengeSize);
+    VerifyOrExit(challenge != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(session);
     VerifyOrExit(state != nullptr, err = CHIP_ERROR_NOT_CONNECTED);
@@ -256,14 +261,14 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncReq(SecureSessionHandle sess
     VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 
     // Generate a 64-bit random number to uniquely identify the request.
-    err = DRBG_get_bytes(challenge, kMsgCounterChallengeSize);
+    err = DRBG_get_bytes(static_cast<uint8_t *>(challenge), kMsgCounterChallengeSize);
     SuccessOrExit(err);
 
     // Store generated Challenge value to ExchangeContext to resolve synchronization response.
-    exchangeContext->SetChallenge(challenge);
-
+    exchangeContext->SetAppState(challenge);
     memcpy(msgBuf->Start(), challenge, kMsgCounterChallengeSize);
     msgBuf->SetDataLength(kMsgCounterChallengeSize);
+    challenge = nullptr;
 
     sendFlags.Set(Messaging::SendMessageFlags::kNoAutoRequestAck, true).Set(Messaging::SendMessageFlags::kExpectResponse, true);
 
@@ -281,6 +286,7 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncReq(SecureSessionHandle sess
 exit:
     if (err != CHIP_NO_ERROR)
     {
+        chip::Platform::MemoryFree(challenge);
         ChipLogError(ExchangeManager, "Failed to send message counter synchronization request with error:%s", ErrorStr(err));
     }
 
@@ -311,7 +317,7 @@ CHIP_ERROR MessageCounterSyncMgr::SendMsgCounterSyncResp(Messaging::ExchangeCont
         bbuf.Put32(state->GetSendMessageIndex());
 
         // Fill in the random value
-        bbuf.Put(exchangeContext->GetChallenge(), kMsgCounterChallengeSize);
+        bbuf.Put(exchangeContext->GetAppState(), kMsgCounterChallengeSize);
 
         VerifyOrExit(bbuf.Fit(), err = CHIP_ERROR_NO_MEMORY);
     }
@@ -338,8 +344,9 @@ void MessageCounterSyncMgr::HandleMsgCounterSyncReq(Messaging::ExchangeContext *
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    const uint8_t * req = msgBuf->Start();
-    size_t reqlen       = msgBuf->DataLength();
+    void * challenge = nullptr;
+    uint8_t * req    = msgBuf->Start();
+    size_t reqlen    = msgBuf->DataLength();
 
     ChipLogDetail(ExchangeManager, "Received MsgCounterSyncReq request");
 
@@ -348,8 +355,12 @@ void MessageCounterSyncMgr::HandleMsgCounterSyncReq(Messaging::ExchangeContext *
     VerifyOrExit(req != nullptr, err = CHIP_ERROR_MESSAGE_INCOMPLETE);
     VerifyOrExit(reqlen == kMsgCounterChallengeSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
+    challenge = chip::Platform::MemoryAlloc(kMsgCounterChallengeSize);
+    VerifyOrExit(challenge != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    memcpy(challenge, req, kMsgCounterChallengeSize);
+
     // Store the 64-bit value sent in the Challenge filed of the MsgCounterSyncReq.
-    exchangeContext->SetChallenge(req);
+    exchangeContext->SetAppState(challenge);
 
     // Respond with MsgCounterSyncResp
     err = SendMsgCounterSyncResp(exchangeContext, { packetHeader.GetSourceNodeId().Value(), packetHeader.GetEncryptionKeyID(), 0 });
@@ -361,7 +372,11 @@ exit:
     }
 
     if (exchangeContext != nullptr)
+    {
+        chip::Platform::MemoryFree(exchangeContext->GetAppState());
+        exchangeContext->SetAppState(nullptr);
         exchangeContext->Close();
+    }
 
     return;
 }
@@ -400,7 +415,7 @@ void MessageCounterSyncMgr::HandleMsgCounterSyncResp(Messaging::ExchangeContext 
     memcpy(challenge, resp, kMsgCounterChallengeSize);
 
     // Verify that the response field matches the expected Challenge field for the exchange.
-    VerifyOrExit(memcmp(exchangeContext->GetChallenge(), challenge, kMsgCounterChallengeSize) == 0,
+    VerifyOrExit(memcmp(exchangeContext->GetAppState(), challenge, kMsgCounterChallengeSize) == 0,
                  err = CHIP_ERROR_INVALID_SIGNATURE);
 
     VerifyOrExit(packetHeader.GetSourceNodeId().HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -417,7 +432,11 @@ exit:
     }
 
     if (exchangeContext != nullptr)
+    {
+        chip::Platform::MemoryFree(exchangeContext->GetAppState());
+        exchangeContext->SetAppState(nullptr);
         exchangeContext->Close();
+    }
 
     return;
 }

--- a/src/messaging/MessageCounterSync.h
+++ b/src/messaging/MessageCounterSync.h
@@ -28,6 +28,7 @@
 namespace chip {
 namespace Messaging {
 
+constexpr uint16_t kMsgCounterChallengeSize   = 8;   // The size of the message counter synchronization request message.
 constexpr uint16_t kMsgCounterSyncRespMsgSize = 12;  // The size of the message counter synchronization response message.
 constexpr uint32_t kMsgCounterSyncTimeout     = 500; // The amount of time(in milliseconds) which a peer is given to respond
                                                      // to a message counter synchronization request.

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -39,7 +39,7 @@ namespace chip {
 namespace Messaging {
 
 ReliableMessageContext::ReliableMessageContext() :
-    mPendingPeerAckId(0), mConfig(gDefaultReliableMessageProtocolConfig), mNextAckTimeTick(0)
+    mConfig(gDefaultReliableMessageProtocolConfig), mNextAckTimeTick(0), mPendingPeerAckId(0)
 {}
 
 void ReliableMessageContext::RetainContext()

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -245,7 +245,7 @@ CHIP_ERROR ReliableMessageContext::HandleNeedsAck(uint32_t MessageId, BitFlags<M
         // Replace the Pending ack id.
         mPendingPeerAckId = MessageId;
         mNextAckTimeTick =
-            static_cast<uint16_t>(mConfig.mAckPiggybackTimeoutTick +
+            static_cast<uint16_t>(CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK +
                                   GetReliableMessageMgr()->GetTickCounterFromTimeDelta(System::Timer::GetCurrentEpoch()));
         SetAckPending(true);
     }

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -44,24 +44,13 @@ enum class MessageFlagValues : uint32_t;
 class ReliableMessageContext;
 class ReliableMessageMgr;
 
-class ReliableMessageDelegate
-{
-public:
-    virtual ~ReliableMessageDelegate() {}
-
-    /* Application callbacks */
-    virtual void OnSendError(CHIP_ERROR err) = 0; /**< Application callback for error while sending. */
-    virtual void OnAckRcvd()                 = 0; /**< Application callback for received acknowledgment. */
-};
-
 class ReliableMessageContext
 {
 public:
     ReliableMessageContext();
 
-    void Init(ReliableMessageMgr * manager, ExchangeContext * exchange);
+    void Init(ReliableMessageMgr * manager);
     void SetConfig(ReliableMessageProtocolConfig config) { mConfig = config; }
-    void SetDelegate(ReliableMessageDelegate * delegate) { mDelegate = delegate; }
 
     /**
      * Flush the pending Ack for current exchange.
@@ -186,17 +175,41 @@ public:
      */
     void SetMsgRcvdFromPeer(bool inMsgRcvdFromPeer);
 
-private:
+    /**
+     *  Determine whether there is already an acknowledgment pending to be sent to the peer on this exchange.
+     *
+     *  @return Returns 'true' if there is already an acknowledgment pending  on this exchange, else 'false'.
+     */
+    bool IsOccupied() const;
+
+    /**
+     *  Set if an acknowledgment needs to be sent back to the peer on this exchange.
+     *
+     *  @param[in]  inAckPending A Boolean indicating whether (true) or not
+     *                          (false) an acknowledgment should be sent back
+     *                          in response to a received message.
+     */
+    void SetOccupied(bool inOccupied);
+
+protected:
+    uint32_t mPendingPeerAckId;
+
     enum class Flags : uint16_t
     {
+        /// When set, signifies that this context is the initiator of the exchange.
+        kFlagInitiator = 0x0001,
+
+        /// When set, signifies that a response is expected for a message that is being sent.
+        kFlagResponseExpected = 0x0002,
+
         /// When set, automatically request an acknowledgment whenever a message is sent via UDP.
         kFlagAutoRequestAck = 0x0004,
 
         /// Internal and debug only: when set, the exchange layer does not send an acknowledgment.
         kFlagDropAckDebug = 0x0008,
 
-        /// If a response is expected for a message that is being sent.
-        kFlagResponseExpected = 0x0010,
+        /// When set, signifies current reliable message context is in usage.
+        kFlagOccupied = 0x0010,
 
         /// When set, signifies that there is an acknowledgment pending to be sent back.
         kFlagAckPending = 0x0020,
@@ -212,8 +225,9 @@ private:
 
     BitFlags<Flags> mFlags; // Internal state flags
 
-    void Retain();
-    void Release();
+private:
+    void RetainContext();
+    void ReleaseContext();
     CHIP_ERROR HandleRcvdAck(uint32_t AckMsgId);
     CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> Flags);
 
@@ -223,11 +237,8 @@ private:
     friend class ExchangeMessageDispatch;
 
     ReliableMessageMgr * mManager;
-    ExchangeContext * mExchange;
-    ReliableMessageDelegate * mDelegate;
     ReliableMessageProtocolConfig mConfig;
     uint16_t mNextAckTimeTick; // Next time for triggering Solo Ack
-    uint32_t mPendingPeerAckId;
 };
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -49,7 +49,6 @@ class ReliableMessageContext
 public:
     ReliableMessageContext();
 
-    void Init(ReliableMessageMgr * manager);
     void SetConfig(ReliableMessageProtocolConfig config) { mConfig = config; }
 
     /**
@@ -230,13 +229,14 @@ private:
     void ReleaseContext();
     CHIP_ERROR HandleRcvdAck(uint32_t AckMsgId);
     CHIP_ERROR HandleNeedsAck(uint32_t MessageId, BitFlags<MessageFlagValues> Flags);
+    ExchangeContext * GetExchangeContext();
+    ReliableMessageMgr * GetReliableMessageMgr();
 
 private:
     friend class ReliableMessageMgr;
     friend class ExchangeContext;
     friend class ExchangeMessageDispatch;
 
-    ReliableMessageMgr * mManager;
     ReliableMessageProtocolConfig mConfig;
     uint16_t mNextAckTimeTick; // Next time for triggering Solo Ack
 };

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -57,6 +57,8 @@ public:
      */
     CHIP_ERROR FlushAcks();
 
+    uint32_t GetPendingPeerAckId() { return mPendingPeerAckId; }
+
     /**
      *  Get the initial retransmission interval. It would be the time to wait before
      *  retransmission after first failure.
@@ -191,8 +193,6 @@ public:
     void SetOccupied(bool inOccupied);
 
 protected:
-    uint32_t mPendingPeerAckId;
-
     enum class Flags : uint16_t
     {
         /// When set, signifies that this context is the initiator of the exchange.
@@ -239,6 +239,7 @@ private:
 
     ReliableMessageProtocolConfig mConfig;
     uint16_t mNextAckTimeTick; // Next time for triggering Solo Ack
+    uint32_t mPendingPeerAckId;
 };
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -344,10 +344,11 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     VerifyOrReturnError(rc != nullptr, err);
 
-    const ExchangeMessageDispatch * transport = rc->mExchange->GetMessageDispatch();
+    const ExchangeMessageDispatch * transport = rc->GetExchangeContext()->GetMessageDispatch();
     VerifyOrExit(transport != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    err = transport->ResendMessage(rc->mExchange->GetSecureSession(), std::move(entry->retainedBuf), &entry->retainedBuf);
+    err =
+        transport->ResendMessage(rc->GetExchangeContext()->GetSecureSession(), std::move(entry->retainedBuf), &entry->retainedBuf);
     SuccessOrExit(err);
 
     // Update the counters

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -135,12 +135,12 @@ void ReliableMessageMgr::ExecuteActions()
 
         uint8_t sendCount = entry.sendCount;
 
-        if (sendCount == rc->mConfig.mMaxRetrans)
+        if (sendCount == CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS)
         {
             err = CHIP_ERROR_MESSAGE_NOT_ACKNOWLEDGED;
 
             ChipLogError(ExchangeManager, "Failed to Send CHIP MsgId:%08" PRIX32 " sendCount: %" PRIu8 " max retries: %" PRIu8,
-                         entry.retainedBuf.GetMsgId(), sendCount, rc->mConfig.mMaxRetrans);
+                         entry.retainedBuf.GetMsgId(), sendCount, CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS);
 
             // Remove from Table
             ClearRetransTable(entry);

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -118,14 +118,11 @@ struct ReliableMessageProtocolConfig
 {
     uint32_t mInitialRetransTimeoutTick; /**< Configurable timeout in msec for retransmission of the first sent message. */
     uint32_t mActiveRetransTimeoutTick;  /**< Configurable timeout in msec for retransmission of all subsequent messages. */
-    uint16_t mAckPiggybackTimeoutTick;   /**< Configurable timeout in msec for transmission of a solitary Ack message. */
-    uint8_t mMaxRetrans;                 /**< Configurable max value for retransmissions in the ExchangeContext. */
 };
 
 const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = {
     CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
-    CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
-    CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK, CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS
+    CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT
 };
 
 // clang-format on

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -105,18 +105,6 @@ void test_os_sleep_ms(uint64_t millisecs)
     nanosleep(&sleep_time, nullptr);
 }
 
-class ReliableMessageDelegateObject : public ReliableMessageDelegate
-{
-public:
-    ~ReliableMessageDelegateObject() override {}
-
-    /* Application callbacks */
-    void OnSendError(CHIP_ERROR err) override { SendErrorCalled = true; }
-    void OnAckRcvd() override {}
-
-    bool SendErrorCalled = false;
-};
-
 void CheckAddClearRetrans(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
@@ -154,14 +142,10 @@ void CheckFailRetrans(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, rc != nullptr);
 
     ReliableMessageMgr::RetransTableEntry * entry;
-    ReliableMessageDelegateObject delegate;
-    rc->SetDelegate(&delegate);
     rm->AddToRetransTable(rc, &entry);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
-    NL_TEST_ASSERT(inSuite, !delegate.SendErrorCalled);
     rm->FailRetransTableEntries(rc, CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
-    NL_TEST_ASSERT(inSuite, delegate.SendErrorCalled);
 }
 
 void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
@@ -226,9 +210,6 @@ void CheckSendStandaloneAckMessage(nlTestSuite * inSuite, void * inContext)
     ReliableMessageContext * rc = exchange->GetReliableMessageContext();
     NL_TEST_ASSERT(inSuite, rm != nullptr);
     NL_TEST_ASSERT(inSuite, rc != nullptr);
-
-    ReliableMessageDelegateObject delegate;
-    rc->SetDelegate(&delegate);
 
     NL_TEST_ASSERT(inSuite, rc->SendStandaloneAckMessage() == CHIP_NO_ERROR);
 }

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -175,8 +175,6 @@ void CheckResendMessage(nlTestSuite * inSuite, void * inContext)
     rc->SetConfig({
         1, // CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL
         1, // CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL
-        1, // CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK
-        3, // CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS
     });
 
     gSendMessageCount = 0;

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::SendMessageImpl(SecureSessionHa
 
 CHIP_ERROR SessionEstablishmentExchangeDispatch::OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
                                                                    const Transport::PeerAddress & peerAddress,
-                                                                   ReliableMessageContext & reliableMessageContext)
+                                                                   ReliableMessageContext * reliableMessageContext)
 {
     ReturnErrorOnFailure(ExchangeMessageDispatch::OnMessageReceived(payloadHeader, messageId, peerAddress, reliableMessageContext));
     mPeerAddress = peerAddress;

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -49,7 +49,7 @@ public:
 
     CHIP_ERROR OnMessageReceived(const PayloadHeader & payloadHeader, uint32_t messageId,
                                  const Transport::PeerAddress & peerAddress,
-                                 Messaging::ReliableMessageContext & reliableMessageContext) override;
+                                 Messaging::ReliableMessageContext * reliableMessageContext) override;
 
     const Transport::PeerAddress & GetPeerAddress() const { return mPeerAddress; }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
ExchangeContext is 120 bytes on 64-bit, 88 bytes on 32-bit. We have 8 of them in a pool, so this is ~1KB of RAM.

The following is the break down on 64-bit:
4 bytes refcount
4 bytes mResponseTimeout
52 bytes ReliableMessageContext (36 bytes on 32-bit)
4 bytes padding (64-bit only)
24 bytes pointers to delegate, exchange mgr, exchange acl (12 bytes on 32-bit)
16 bytes SecureSessionHandle
2 bytes exchange id
8 bytes challenge
2 bytes mFlags
4 bytes padding to get to 8-byte alignment (even on 32-bit!)

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Inherit ExchangeContext from ReliableMessageContext
2. Reuse mFlags from ReliableMessageContext in ExchangeContext
3. Remove mChallenge from ExchangeContext
4. Remove mExchange from ReliableMessageContext since this pointer can be derived
5. Remove delegate from ReliableMessageContext since CRMP is not visible to app
6. Remove mReliableMessageMgr from ReliableMessageContext
7. Remove shared configuration fields from ReliableMessageProtocolConfig, those configuration are same for all exchanges on the same node.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #5875, #5876, #4711  

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
