### PR TITLE
[IM] Encode error status code during command dispatch.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace BarrierControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_BARRIER_CONTROL_GO_TO_PERCENT_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -56,18 +56,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool percentOpenExists      = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (percentOpenExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(percentOpen);
+                    TLVUnpackError = aDataTlv.Get(percentOpen);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         percentOpenExists = true;
@@ -82,7 +82,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -103,10 +103,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfBarrierControlClusterBarrierControlGoToPercentCallback(percentOpen);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -118,8 +121,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_BARRIER_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_BARRIER_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -130,15 +134,16 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Basic {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_BASIC_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_BASIC_CLUSTER_ID);
             break;
         }
         }
@@ -149,10 +154,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Binding {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_BIND_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -170,18 +175,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool clusterIdExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (nodeIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(nodeId);
+                    TLVUnpackError = aDataTlv.Get(nodeId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         nodeIdExists = true;
@@ -191,11 +196,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -205,11 +210,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (endpointIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endpointId);
+                    TLVUnpackError = aDataTlv.Get(endpointId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endpointIdExists = true;
@@ -219,11 +224,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (clusterIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(clusterId);
+                    TLVUnpackError = aDataTlv.Get(clusterId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         clusterIdExists = true;
@@ -238,7 +243,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -259,10 +264,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfBindingClusterBindCallback(nodeId, groupId, endpointId, clusterId);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -282,18 +290,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool clusterIdExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (nodeIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(nodeId);
+                    TLVUnpackError = aDataTlv.Get(nodeId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         nodeIdExists = true;
@@ -303,11 +311,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -317,11 +325,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (endpointIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endpointId);
+                    TLVUnpackError = aDataTlv.Get(endpointId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endpointIdExists = true;
@@ -331,11 +339,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (clusterIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(clusterId);
+                    TLVUnpackError = aDataTlv.Get(clusterId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         clusterIdExists = true;
@@ -350,7 +358,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -371,17 +379,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfBindingClusterUnbindCallback(nodeId, groupId, endpointId, clusterId);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_BINDING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_BINDING_CLUSTER_ID);
             break;
         }
         }
@@ -392,10 +404,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace ColorControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_MOVE_COLOR_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -413,18 +425,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (rateXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rateX);
+                    TLVUnpackError = aDataTlv.Get(rateX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateXExists = true;
@@ -434,11 +446,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rateY);
+                    TLVUnpackError = aDataTlv.Get(rateY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateYExists = true;
@@ -448,11 +460,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -462,11 +474,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -481,7 +493,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -502,10 +514,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveColorCallback(rateX, rateY, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -529,18 +544,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -550,11 +565,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -564,11 +579,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (colorTemperatureMinimumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMinimum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMinimum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMinimumExists = true;
@@ -578,11 +593,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (colorTemperatureMaximumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMaximum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMaximum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMaximumExists = true;
@@ -592,11 +607,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -606,11 +621,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -625,7 +640,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -647,10 +662,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveColorTemperatureCallback(moveMode, rate, colorTemperatureMinimum,
                                                                        colorTemperatureMaximum, optionsMask, optionsOverride);
             }
-            else if (6 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 6,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    6, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -670,18 +688,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -691,11 +709,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -705,11 +723,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -719,11 +737,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -738,7 +756,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -759,10 +777,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveHueCallback(moveMode, rate, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -782,18 +803,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -803,11 +824,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -817,11 +838,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -831,11 +852,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -850,7 +871,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -871,10 +892,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveSaturationCallback(moveMode, rate, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -896,18 +920,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (colorXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorX);
+                    TLVUnpackError = aDataTlv.Get(colorX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorXExists = true;
@@ -917,11 +941,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (colorYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorY);
+                    TLVUnpackError = aDataTlv.Get(colorY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorYExists = true;
@@ -931,11 +955,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -945,11 +969,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -959,11 +983,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -978,7 +1002,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -999,10 +1023,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToColorCallback(colorX, colorY, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1022,18 +1049,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (colorTemperatureExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperature);
+                    TLVUnpackError = aDataTlv.Get(colorTemperature);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureExists = true;
@@ -1043,11 +1070,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1057,11 +1084,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1071,11 +1098,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1090,7 +1117,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1112,10 +1139,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveToColorTemperatureCallback(colorTemperature, transitionTime, optionsMask,
                                                                          optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1137,18 +1167,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (hueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(hue);
+                    TLVUnpackError = aDataTlv.Get(hue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         hueExists = true;
@@ -1158,11 +1188,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (directionExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(direction);
+                    TLVUnpackError = aDataTlv.Get(direction);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         directionExists = true;
@@ -1172,11 +1202,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1186,11 +1216,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1200,11 +1230,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1219,7 +1249,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1240,10 +1270,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToHueCallback(hue, direction, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1265,18 +1298,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (hueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(hue);
+                    TLVUnpackError = aDataTlv.Get(hue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         hueExists = true;
@@ -1286,11 +1319,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (saturationExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(saturation);
+                    TLVUnpackError = aDataTlv.Get(saturation);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         saturationExists = true;
@@ -1300,11 +1333,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1314,11 +1347,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1328,11 +1361,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1347,7 +1380,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1369,10 +1402,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveToHueAndSaturationCallback(hue, saturation, transitionTime, optionsMask,
                                                                          optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1392,18 +1428,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (saturationExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(saturation);
+                    TLVUnpackError = aDataTlv.Get(saturation);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         saturationExists = true;
@@ -1413,11 +1449,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1427,11 +1463,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1441,11 +1477,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1460,7 +1496,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1481,10 +1517,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToSaturationCallback(saturation, transitionTime, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1506,18 +1545,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepX);
+                    TLVUnpackError = aDataTlv.Get(stepX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepXExists = true;
@@ -1527,11 +1566,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepY);
+                    TLVUnpackError = aDataTlv.Get(stepY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepYExists = true;
@@ -1541,11 +1580,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1555,11 +1594,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1569,11 +1608,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1588,7 +1627,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1609,10 +1648,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepColorCallback(stepX, stepY, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1638,18 +1680,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1659,11 +1701,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1673,11 +1715,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1687,11 +1729,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (colorTemperatureMinimumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMinimum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMinimum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMinimumExists = true;
@@ -1701,11 +1743,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (colorTemperatureMaximumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMaximum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMaximum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMaximumExists = true;
@@ -1715,11 +1757,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1729,11 +1771,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1748,7 +1790,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1770,10 +1812,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterStepColorTemperatureCallback(stepMode, stepSize, transitionTime, colorTemperatureMinimum,
                                                                        colorTemperatureMaximum, optionsMask, optionsOverride);
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1795,18 +1840,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1816,11 +1861,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1830,11 +1875,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1844,11 +1889,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1858,11 +1903,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1877,7 +1922,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1898,10 +1943,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepHueCallback(stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1923,18 +1971,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1944,11 +1992,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1958,11 +2006,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1972,11 +2020,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1986,11 +2034,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -2005,7 +2053,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2026,10 +2074,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepSaturationCallback(stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2045,18 +2096,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -2066,11 +2117,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -2085,7 +2136,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2106,17 +2157,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStopMoveStepCallback(optionsMask, optionsOverride);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_COLOR_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_COLOR_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -2127,10 +2182,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace DoorLock {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_CLEAR_ALL_PINS_COMMAND_ID: {
 
@@ -2154,18 +2209,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool scheduleIdExists       = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2180,7 +2235,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2201,10 +2256,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearHolidayScheduleCallback(scheduleId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2218,18 +2276,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2244,7 +2302,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2265,10 +2323,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearPinCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2282,18 +2343,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2308,7 +2369,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2329,10 +2390,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearRfidCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2348,18 +2412,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2369,11 +2433,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2388,7 +2452,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2409,10 +2473,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearWeekdayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2428,18 +2495,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2449,11 +2516,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2468,7 +2535,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2489,10 +2556,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearYeardayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2506,18 +2576,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool scheduleIdExists       = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2532,7 +2602,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2553,10 +2623,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetHolidayScheduleCallback(scheduleId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2570,18 +2643,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool logIndexExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (logIndexExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(logIndex);
+                    TLVUnpackError = aDataTlv.Get(logIndex);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         logIndexExists = true;
@@ -2596,7 +2669,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2617,10 +2690,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetLogRecordCallback(logIndex);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2634,18 +2710,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2660,7 +2736,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2681,10 +2757,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetPinCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2698,18 +2777,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2724,7 +2803,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2745,10 +2824,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetRfidCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2762,18 +2844,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2788,7 +2870,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2809,10 +2891,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetUserTypeCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2828,18 +2913,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2849,11 +2934,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2868,7 +2953,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2889,10 +2974,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetWeekdayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2908,18 +2996,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2929,11 +3017,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2948,7 +3036,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2969,10 +3057,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetYeardayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2986,19 +3077,19 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool PINExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (PINExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         PINExists = true;
@@ -3013,7 +3104,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3034,10 +3125,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorCallback(const_cast<uint8_t *>(PIN));
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3057,18 +3151,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool operatingModeDuringHolidayExists = false;
             uint32_t validArgumentCount           = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -3078,11 +3172,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -3092,11 +3186,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -3106,11 +3200,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (operatingModeDuringHolidayExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(operatingModeDuringHoliday);
+                    TLVUnpackError = aDataTlv.Get(operatingModeDuringHoliday);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         operatingModeDuringHolidayExists = true;
@@ -3125,7 +3219,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3147,10 +3241,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterSetHolidayScheduleCallback(scheduleId, localStartTime, localEndTime,
                                                                  operatingModeDuringHoliday);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3170,18 +3267,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3191,11 +3288,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -3205,11 +3302,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3219,12 +3316,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -3239,7 +3336,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3260,10 +3357,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetPinCallback(userId, userStatus, userType, const_cast<uint8_t *>(pin));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3283,18 +3383,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool idExists               = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3304,11 +3404,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -3318,11 +3418,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3332,12 +3432,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (idExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.GetDataPtr(id);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         idExists = true;
@@ -3352,7 +3452,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3373,10 +3473,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetRfidCallback(userId, userStatus, userType, const_cast<uint8_t *>(id));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3392,18 +3495,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userTypeExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3413,11 +3516,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3432,7 +3535,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3453,10 +3556,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetUserTypeCallback(userId, userType);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3482,18 +3588,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool endMinuteExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -3503,11 +3609,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3517,11 +3623,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (daysMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(daysMask);
+                    TLVUnpackError = aDataTlv.Get(daysMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         daysMaskExists = true;
@@ -3531,11 +3637,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (startHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startHour);
+                    TLVUnpackError = aDataTlv.Get(startHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startHourExists = true;
@@ -3545,11 +3651,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (startMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startMinute);
+                    TLVUnpackError = aDataTlv.Get(startMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startMinuteExists = true;
@@ -3559,11 +3665,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (endHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endHour);
+                    TLVUnpackError = aDataTlv.Get(endHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endHourExists = true;
@@ -3573,11 +3679,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (endMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endMinute);
+                    TLVUnpackError = aDataTlv.Get(endMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endMinuteExists = true;
@@ -3592,7 +3698,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3614,10 +3720,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterSetWeekdayScheduleCallback(scheduleId, userId, daysMask, startHour, startMinute, endHour,
                                                                  endMinute);
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3637,18 +3746,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool localEndTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -3658,11 +3767,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3672,11 +3781,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -3686,11 +3795,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -3705,7 +3814,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3726,10 +3835,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetYeardayScheduleCallback(scheduleId, userId, localStartTime, localEndTime);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3743,19 +3855,19 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool PINExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (PINExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         PINExists = true;
@@ -3770,7 +3882,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3791,10 +3903,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorCallback(const_cast<uint8_t *>(PIN));
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3810,18 +3925,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutInSecondsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutInSeconds);
+                    TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutInSecondsExists = true;
@@ -3831,12 +3946,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -3851,7 +3966,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3872,17 +3987,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockWithTimeoutCallback(timeoutInSeconds, const_cast<uint8_t *>(pin));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -3893,10 +4012,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace GeneralCommissioning {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ARM_FAIL_SAFE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -3912,18 +4031,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (expiryLengthSecondsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(expiryLengthSeconds);
+                    TLVUnpackError = aDataTlv.Get(expiryLengthSeconds);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         expiryLengthSecondsExists = true;
@@ -3933,11 +4052,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -3947,11 +4066,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -3966,7 +4085,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3987,10 +4106,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterArmFailSafeCallback(expiryLengthSeconds, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4016,21 +4138,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (fabricIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        fabricId             = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        fabricId             = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -4041,14 +4163,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (fabricSecretExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        fabricSecret         = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        fabricSecret         = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -4059,11 +4181,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -4073,11 +4195,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -4092,7 +4214,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4113,17 +4235,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterSetFabricCallback(fabricId, fabricSecret, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -4134,10 +4260,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Groups {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_GROUP_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4151,18 +4277,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4172,12 +4298,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -4192,7 +4318,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4213,10 +4339,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupCallback(groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4232,18 +4361,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4253,12 +4382,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -4273,7 +4402,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4294,10 +4423,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupIfIdentifyingCallback(groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4313,18 +4445,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupCount);
+                    TLVUnpackError = aDataTlv.Get(groupCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupCountExists = true;
@@ -4334,12 +4466,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupListExists = true;
@@ -4354,7 +4486,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4375,10 +4507,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterGetGroupMembershipCallback(groupCount, groupList);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4398,18 +4533,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4424,7 +4559,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4445,10 +4580,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterRemoveGroupCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4462,18 +4600,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4488,7 +4626,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4509,17 +4647,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterViewGroupCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GROUPS_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GROUPS_CLUSTER_ID);
             break;
         }
         }
@@ -4530,10 +4672,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace IasZone {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ZONE_ENROLL_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4547,18 +4689,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool zoneIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (enrollResponseCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(enrollResponseCode);
+                    TLVUnpackError = aDataTlv.Get(enrollResponseCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         enrollResponseCodeExists = true;
@@ -4568,11 +4710,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (zoneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(zoneId);
+                    TLVUnpackError = aDataTlv.Get(zoneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         zoneIdExists = true;
@@ -4587,7 +4729,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4608,17 +4750,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIasZoneClusterZoneEnrollResponseCallback(enrollResponseCode, zoneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IAS_ZONE_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IAS_ZONE_CLUSTER_ID);
             break;
         }
         }
@@ -4629,10 +4775,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Identify {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_IDENTIFY_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4644,18 +4790,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool identifyTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (identifyTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(identifyTime);
+                    TLVUnpackError = aDataTlv.Get(identifyTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         identifyTimeExists = true;
@@ -4670,7 +4816,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4691,10 +4837,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIdentifyClusterIdentifyCallback(identifyTime);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4706,8 +4855,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IDENTIFY_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IDENTIFY_CLUSTER_ID);
             break;
         }
         }
@@ -4718,10 +4868,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_MOVE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4739,18 +4889,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -4760,11 +4910,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -4774,11 +4924,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -4788,11 +4938,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -4807,7 +4957,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4828,10 +4978,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveCallback(moveMode, rate, optionMask, optionOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4851,18 +5004,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (levelExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(level);
+                    TLVUnpackError = aDataTlv.Get(level);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         levelExists = true;
@@ -4872,11 +5025,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4886,11 +5039,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -4900,11 +5053,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -4919,7 +5072,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4940,10 +5093,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveToLevelCallback(level, transitionTime, optionMask, optionOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4959,18 +5115,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (levelExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(level);
+                    TLVUnpackError = aDataTlv.Get(level);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         levelExists = true;
@@ -4980,11 +5136,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4999,7 +5155,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5020,10 +5176,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveToLevelWithOnOffCallback(level, transitionTime);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5039,18 +5198,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool rateExists             = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -5060,11 +5219,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -5079,7 +5238,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5100,10 +5259,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveWithOnOffCallback(moveMode, rate);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5125,18 +5287,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -5146,11 +5308,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -5160,11 +5322,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -5174,11 +5336,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -5188,11 +5350,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -5207,7 +5369,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5228,10 +5390,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStepCallback(stepMode, stepSize, transitionTime, optionMask, optionOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5249,18 +5414,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -5270,11 +5435,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -5284,11 +5449,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -5303,7 +5468,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5324,10 +5489,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStepWithOnOffCallback(stepMode, stepSize, transitionTime);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5343,18 +5511,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -5364,11 +5532,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -5383,7 +5551,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5404,10 +5572,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStopCallback(optionMask, optionOverride);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5419,8 +5590,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_LEVEL_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_LEVEL_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -5431,10 +5603,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace LowPower {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_SLEEP_COMMAND_ID: {
 
@@ -5444,8 +5616,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_LOW_POWER_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_LOW_POWER_CLUSTER_ID);
             break;
         }
         }
@@ -5456,10 +5629,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_THREAD_NETWORK_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -5475,21 +5648,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5500,11 +5673,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5514,11 +5687,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5533,7 +5706,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5554,10 +5727,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5577,21 +5753,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5602,14 +5778,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5620,11 +5796,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5634,11 +5810,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5653,7 +5829,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5674,10 +5850,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5695,21 +5874,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5720,11 +5899,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5734,11 +5913,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5753,7 +5932,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5774,10 +5953,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterDisableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5795,21 +5977,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5820,11 +6002,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5834,11 +6016,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5853,7 +6035,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5874,10 +6056,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterEnableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5891,18 +6076,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5917,7 +6102,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5938,10 +6123,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(timeoutMs);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5959,21 +6147,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool TimeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (NetworkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        NetworkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        NetworkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5984,11 +6172,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (BreadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(Breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(Breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         BreadcrumbExists = true;
@@ -5998,11 +6186,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (TimeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(TimeoutMs);
+                    TLVUnpackError = aDataTlv.Get(TimeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         TimeoutMsExists = true;
@@ -6017,7 +6205,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6038,10 +6226,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterRemoveNetworkCallback(NetworkID, Breadcrumb, TimeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6059,21 +6250,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -6084,11 +6275,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -6098,11 +6289,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -6117,7 +6308,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6138,10 +6329,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterScanNetworksCallback(ssid, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6159,21 +6353,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -6184,11 +6378,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -6198,11 +6392,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -6217,7 +6411,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6238,10 +6432,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6261,21 +6458,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -6286,14 +6483,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -6304,11 +6501,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -6318,11 +6515,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -6337,7 +6534,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6358,17 +6555,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -6379,10 +6580,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_OFF_COMMAND_ID: {
 
@@ -6404,8 +6605,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_ON_OFF_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_ON_OFF_CLUSTER_ID);
             break;
         }
         }
@@ -6416,10 +6618,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Scenes {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_SCENE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -6439,18 +6641,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool extensionFieldSetsExists = false;
             uint32_t validArgumentCount   = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6460,11 +6662,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6474,11 +6676,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -6488,12 +6690,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sceneNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneNameExists = true;
@@ -6503,12 +6705,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (extensionFieldSetsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         extensionFieldSetsExists = true;
@@ -6523,7 +6725,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6545,10 +6747,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfScenesClusterAddSceneCallback(groupId, sceneId, transitionTime, const_cast<uint8_t *>(sceneName),
                                                      extensionFieldSets);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6562,18 +6767,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6588,7 +6793,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6609,10 +6814,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterGetSceneMembershipCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6630,18 +6838,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6651,11 +6859,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6665,11 +6873,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -6684,7 +6892,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6705,10 +6913,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRecallSceneCallback(groupId, sceneId, transitionTime);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6722,18 +6933,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6748,7 +6959,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6769,10 +6980,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveAllScenesCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6788,18 +7002,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6809,11 +7023,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6828,7 +7042,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6849,10 +7063,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6868,18 +7085,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6889,11 +7106,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6908,7 +7125,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6929,10 +7146,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterStoreSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6948,18 +7168,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6969,11 +7189,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6988,7 +7208,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -7009,17 +7229,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterViewSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_SCENES_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_SCENES_CLUSTER_ID);
             break;
         }
         }
@@ -7082,7 +7306,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         break;
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -468,8 +468,8 @@
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(0) },   /* Descriptor (server): device list */              \
             { 0x0001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(254) }, /* Descriptor (server): server list */              \
             { 0x0002, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(508) }, /* Descriptor (server): client list */              \
-            { 0x0003, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(762) }, /* Descriptor (server): parts list */               \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* Descriptor (server): cluster revision */         \
+            { 0x0003, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(762) }, /* Descriptor (server): parts list */               \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                          \
               ZAP_SIMPLE_DEFAULT(3) }, /* Basic (server): cluster revision */                                                      \
             { 0x0000, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                          \

--- a/examples/chip-tool/gen/IMClusterCommandHandler.cpp
+++ b/examples/chip-tool/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace DoorLock {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -56,18 +56,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -82,7 +82,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -103,10 +103,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllPinsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -120,18 +123,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -146,7 +149,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -167,10 +170,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllRfidsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -184,18 +190,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -210,7 +216,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -231,10 +237,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -248,18 +257,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -274,7 +283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -295,10 +304,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -312,18 +324,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -338,7 +350,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -359,10 +371,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -376,18 +391,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -402,7 +417,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -423,10 +438,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -440,18 +458,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -466,7 +484,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -487,10 +505,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -512,18 +533,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool operatingModeDuringHolidayExists = false;
             uint32_t validArgumentCount           = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -533,11 +554,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -547,11 +568,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -561,11 +582,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -575,11 +596,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (operatingModeDuringHolidayExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(operatingModeDuringHoliday);
+                    TLVUnpackError = aDataTlv.Get(operatingModeDuringHoliday);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         operatingModeDuringHolidayExists = true;
@@ -594,7 +615,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -616,10 +637,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetHolidayScheduleResponseCallback(scheduleId, status, localStartTime, localEndTime,
                                                                          operatingModeDuringHoliday);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -645,18 +669,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (logEntryIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(logEntryId);
+                    TLVUnpackError = aDataTlv.Get(logEntryId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         logEntryIdExists = true;
@@ -666,11 +690,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (timestampExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timestamp);
+                    TLVUnpackError = aDataTlv.Get(timestamp);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timestampExists = true;
@@ -680,11 +704,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (eventTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventType);
+                    TLVUnpackError = aDataTlv.Get(eventType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventTypeExists = true;
@@ -694,11 +718,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sourceExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(source);
+                    TLVUnpackError = aDataTlv.Get(source);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sourceExists = true;
@@ -708,11 +732,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (eventIdOrAlarmCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventIdOrAlarmCode);
+                    TLVUnpackError = aDataTlv.Get(eventIdOrAlarmCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventIdOrAlarmCodeExists = true;
@@ -722,11 +746,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -736,12 +760,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -756,7 +780,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -778,10 +802,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetLogRecordResponseCallback(logEntryId, timestamp, eventType, source, eventIdOrAlarmCode,
                                                                    userId, const_cast<uint8_t *>(pin));
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -801,18 +828,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -822,11 +849,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -836,11 +863,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -850,12 +877,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -870,7 +897,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -891,10 +918,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetPinResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(pin));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -914,18 +944,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool rfidExists             = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -935,11 +965,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -949,11 +979,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -963,12 +993,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (rfidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(rfid);
+                    TLVUnpackError = aDataTlv.GetDataPtr(rfid);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rfidExists = true;
@@ -983,7 +1013,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1004,10 +1034,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetRfidResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(rfid));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1023,18 +1056,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool userTypeExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1044,11 +1077,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -1063,7 +1096,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1084,10 +1117,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetUserTypeResponseCallback(userId, userType);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1115,18 +1151,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool endMinuteExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1136,11 +1172,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1150,11 +1186,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1164,11 +1200,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (daysMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(daysMask);
+                    TLVUnpackError = aDataTlv.Get(daysMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         daysMaskExists = true;
@@ -1178,11 +1214,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (startHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startHour);
+                    TLVUnpackError = aDataTlv.Get(startHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startHourExists = true;
@@ -1192,11 +1228,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (startMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startMinute);
+                    TLVUnpackError = aDataTlv.Get(startMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startMinuteExists = true;
@@ -1206,11 +1242,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (endHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endHour);
+                    TLVUnpackError = aDataTlv.Get(endHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endHourExists = true;
@@ -1220,11 +1256,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 7:
                     if (endMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endMinute);
+                    TLVUnpackError = aDataTlv.Get(endMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endMinuteExists = true;
@@ -1239,7 +1275,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1261,10 +1297,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(scheduleId, userId, status, daysMask, startHour,
                                                                          startMinute, endHour, endMinute);
             }
-            else if (8 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 8,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    8, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1286,18 +1325,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool localEndTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1307,11 +1346,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1321,11 +1360,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1335,11 +1374,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -1349,11 +1388,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -1368,7 +1407,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1389,10 +1428,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetYeardayScheduleResponseCallback(scheduleId, userId, status, localStartTime, localEndTime);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1406,18 +1448,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1432,7 +1474,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1453,10 +1495,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1470,18 +1515,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1496,7 +1541,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1517,10 +1562,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1534,18 +1582,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1560,7 +1608,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1581,10 +1629,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1598,18 +1649,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1624,7 +1675,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1645,10 +1696,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1662,18 +1716,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1688,7 +1742,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1709,10 +1763,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetUserTypeResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1726,18 +1783,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1752,7 +1809,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1773,10 +1830,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1790,18 +1850,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1816,7 +1876,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1837,10 +1897,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1854,18 +1917,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1880,7 +1943,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1901,10 +1964,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1918,18 +1984,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1944,7 +2010,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1965,17 +2031,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -1986,10 +2056,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace GeneralCommissioning {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ARM_FAIL_SAFE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2003,18 +2073,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2024,12 +2094,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2044,7 +2114,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2065,10 +2135,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2084,18 +2157,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2105,12 +2178,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2125,7 +2198,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2147,10 +2220,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(errorCode,
                                                                                         const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2166,18 +2242,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2187,12 +2263,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2207,7 +2283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2228,17 +2304,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterSetFabricResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -2249,10 +2329,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Groups {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_GROUP_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2266,18 +2346,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2287,11 +2367,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2306,7 +2386,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2327,10 +2407,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2348,18 +2431,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -2369,11 +2452,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupCount);
+                    TLVUnpackError = aDataTlv.Get(groupCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupCountExists = true;
@@ -2383,12 +2466,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupListExists = true;
@@ -2403,7 +2486,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2424,10 +2507,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterGetGroupMembershipResponseCallback(capacity, groupCount, groupList);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2443,18 +2529,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2464,11 +2550,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2483,7 +2569,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2504,10 +2590,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterRemoveGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2525,18 +2614,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2546,11 +2635,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2560,12 +2649,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -2580,7 +2669,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2601,17 +2690,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterViewGroupResponseCallback(status, groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GROUPS_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GROUPS_CLUSTER_ID);
             break;
         }
         }
@@ -2622,10 +2715,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Identify {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2637,18 +2730,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeout);
+                    TLVUnpackError = aDataTlv.Get(timeout);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutExists = true;
@@ -2663,7 +2756,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2684,17 +2777,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIdentifyClusterIdentifyQueryResponseCallback(timeout);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IDENTIFY_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IDENTIFY_CLUSTER_ID);
             break;
         }
         }
@@ -2705,10 +2802,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace NetworkCommissioning {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_THREAD_NETWORK_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2722,18 +2819,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2743,12 +2840,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2763,7 +2860,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2784,10 +2881,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2803,18 +2903,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2824,12 +2924,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2844,7 +2944,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2865,10 +2965,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2884,18 +2987,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2905,12 +3008,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2925,7 +3028,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2946,10 +3049,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2965,18 +3071,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2986,12 +3092,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3006,7 +3112,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3027,10 +3133,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3046,18 +3155,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3067,12 +3176,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3087,7 +3196,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3108,10 +3217,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3131,18 +3243,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool threadScanResultsExists = false;
             uint32_t validArgumentCount  = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3152,12 +3264,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3167,12 +3279,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (wifiScanResultsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(wifiScanResults));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(wifiScanResults));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         wifiScanResultsExists = true;
@@ -3182,12 +3294,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (threadScanResultsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(threadScanResults));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(threadScanResults));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         threadScanResultsExists = true;
@@ -3202,7 +3314,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3224,10 +3336,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfNetworkCommissioningClusterScanNetworksResponseCallback(errorCode, const_cast<uint8_t *>(debugText),
                                                                                wifiScanResults, threadScanResults);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3243,18 +3358,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3264,12 +3379,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3284,7 +3399,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3305,10 +3420,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3324,18 +3442,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3345,12 +3463,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3365,7 +3483,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3386,17 +3504,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -3407,10 +3529,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Scenes {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_SCENE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -3426,18 +3548,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3447,11 +3569,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3461,11 +3583,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3480,7 +3602,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3501,10 +3623,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterAddSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3526,18 +3651,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3547,11 +3672,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -3561,11 +3686,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3575,11 +3700,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sceneCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneCount);
+                    TLVUnpackError = aDataTlv.Get(sceneCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneCountExists = true;
@@ -3589,12 +3714,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneListExists = true;
@@ -3609,7 +3734,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3630,10 +3755,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterGetSceneMembershipResponseCallback(status, capacity, groupId, sceneCount, sceneList);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3649,18 +3777,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3670,11 +3798,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3689,7 +3817,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3710,10 +3838,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveAllScenesResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3731,18 +3862,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3752,11 +3883,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3766,11 +3897,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3785,7 +3916,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3806,10 +3937,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3827,18 +3961,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3848,11 +3982,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3862,11 +3996,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3881,7 +4015,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3902,10 +4036,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterStoreSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3929,18 +4066,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool extensionFieldSetsExists = false;
             uint32_t validArgumentCount   = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3950,11 +4087,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3964,11 +4101,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3978,11 +4115,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -3992,12 +4129,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneNameExists = true;
@@ -4007,12 +4144,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (extensionFieldSetsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         extensionFieldSetsExists = true;
@@ -4027,7 +4164,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4049,17 +4186,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfScenesClusterViewSceneResponseCallback(status, groupId, sceneId, transitionTime,
                                                               const_cast<uint8_t *>(sceneName), extensionFieldSets);
             }
-            else if (6 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 6,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    6, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_SCENES_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_SCENES_CLUSTER_ID);
             break;
         }
         }
@@ -4080,7 +4221,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     {
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_THREAD_NETWORK_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -60,21 +60,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -85,11 +85,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -99,11 +99,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -118,7 +118,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -139,10 +139,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -162,21 +165,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -187,14 +190,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -205,11 +208,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -219,11 +222,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -238,7 +241,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -259,10 +262,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -280,21 +286,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -305,11 +311,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -319,11 +325,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -338,7 +344,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -359,10 +365,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterDisableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -380,21 +389,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -405,11 +414,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -419,11 +428,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -438,7 +447,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -459,10 +468,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterEnableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -476,18 +488,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -502,7 +514,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -523,10 +535,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(timeoutMs);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -544,21 +559,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool TimeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (NetworkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        NetworkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        NetworkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -569,11 +584,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (BreadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(Breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(Breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         BreadcrumbExists = true;
@@ -583,11 +598,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (TimeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(TimeoutMs);
+                    TLVUnpackError = aDataTlv.Get(TimeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         TimeoutMsExists = true;
@@ -602,7 +617,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -623,10 +638,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterRemoveNetworkCallback(NetworkID, Breadcrumb, TimeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -644,21 +662,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -669,11 +687,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -683,11 +701,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -702,7 +720,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -723,10 +741,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterScanNetworksCallback(ssid, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -744,21 +765,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -769,11 +790,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -783,11 +804,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -802,7 +823,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -823,10 +844,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -846,21 +870,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -871,14 +895,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -889,11 +913,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -903,11 +927,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -922,7 +946,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -943,17 +967,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -977,7 +1005,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         break;
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
+++ b/examples/tv-app/tv-common/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace BarrierControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_BARRIER_CONTROL_GO_TO_PERCENT_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -56,18 +56,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool percentOpenExists      = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (percentOpenExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(percentOpen);
+                    TLVUnpackError = aDataTlv.Get(percentOpen);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         percentOpenExists = true;
@@ -82,7 +82,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -103,10 +103,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfBarrierControlClusterBarrierControlGoToPercentCallback(percentOpen);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -118,8 +121,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_BARRIER_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_BARRIER_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -130,10 +134,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace ColorControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_MOVE_COLOR_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -151,18 +155,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (rateXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rateX);
+                    TLVUnpackError = aDataTlv.Get(rateX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateXExists = true;
@@ -172,11 +176,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rateY);
+                    TLVUnpackError = aDataTlv.Get(rateY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateYExists = true;
@@ -186,11 +190,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -200,11 +204,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -219,7 +223,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -240,10 +244,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveColorCallback(rateX, rateY, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -267,18 +274,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -288,11 +295,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -302,11 +309,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (colorTemperatureMinimumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMinimum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMinimum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMinimumExists = true;
@@ -316,11 +323,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (colorTemperatureMaximumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMaximum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMaximum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMaximumExists = true;
@@ -330,11 +337,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -344,11 +351,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -363,7 +370,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -385,10 +392,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveColorTemperatureCallback(moveMode, rate, colorTemperatureMinimum,
                                                                        colorTemperatureMaximum, optionsMask, optionsOverride);
             }
-            else if (6 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 6,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    6, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -408,18 +418,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -429,11 +439,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -443,11 +453,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -457,11 +467,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -476,7 +486,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -497,10 +507,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveHueCallback(moveMode, rate, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -520,18 +533,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -541,11 +554,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -555,11 +568,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -569,11 +582,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -588,7 +601,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -609,10 +622,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveSaturationCallback(moveMode, rate, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -634,18 +650,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (colorXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorX);
+                    TLVUnpackError = aDataTlv.Get(colorX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorXExists = true;
@@ -655,11 +671,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (colorYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorY);
+                    TLVUnpackError = aDataTlv.Get(colorY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorYExists = true;
@@ -669,11 +685,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -683,11 +699,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -697,11 +713,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -716,7 +732,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -737,10 +753,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToColorCallback(colorX, colorY, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -760,18 +779,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (colorTemperatureExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperature);
+                    TLVUnpackError = aDataTlv.Get(colorTemperature);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureExists = true;
@@ -781,11 +800,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -795,11 +814,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -809,11 +828,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -828,7 +847,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -850,10 +869,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveToColorTemperatureCallback(colorTemperature, transitionTime, optionsMask,
                                                                          optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -875,18 +897,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (hueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(hue);
+                    TLVUnpackError = aDataTlv.Get(hue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         hueExists = true;
@@ -896,11 +918,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (directionExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(direction);
+                    TLVUnpackError = aDataTlv.Get(direction);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         directionExists = true;
@@ -910,11 +932,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -924,11 +946,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -938,11 +960,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -957,7 +979,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -978,10 +1000,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToHueCallback(hue, direction, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1003,18 +1028,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (hueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(hue);
+                    TLVUnpackError = aDataTlv.Get(hue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         hueExists = true;
@@ -1024,11 +1049,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (saturationExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(saturation);
+                    TLVUnpackError = aDataTlv.Get(saturation);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         saturationExists = true;
@@ -1038,11 +1063,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1052,11 +1077,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1066,11 +1091,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1085,7 +1110,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1107,10 +1132,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterMoveToHueAndSaturationCallback(hue, saturation, transitionTime, optionsMask,
                                                                          optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1130,18 +1158,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (saturationExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(saturation);
+                    TLVUnpackError = aDataTlv.Get(saturation);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         saturationExists = true;
@@ -1151,11 +1179,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1165,11 +1193,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1179,11 +1207,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1198,7 +1226,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1219,10 +1247,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterMoveToSaturationCallback(saturation, transitionTime, optionsMask, optionsOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1244,18 +1275,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepXExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepX);
+                    TLVUnpackError = aDataTlv.Get(stepX);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepXExists = true;
@@ -1265,11 +1296,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepYExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepY);
+                    TLVUnpackError = aDataTlv.Get(stepY);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepYExists = true;
@@ -1279,11 +1310,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1293,11 +1324,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1307,11 +1338,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1326,7 +1357,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1347,10 +1378,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepColorCallback(stepX, stepY, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1376,18 +1410,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1397,11 +1431,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1411,11 +1445,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1425,11 +1459,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (colorTemperatureMinimumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMinimum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMinimum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMinimumExists = true;
@@ -1439,11 +1473,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (colorTemperatureMaximumExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(colorTemperatureMaximum);
+                    TLVUnpackError = aDataTlv.Get(colorTemperatureMaximum);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         colorTemperatureMaximumExists = true;
@@ -1453,11 +1487,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1467,11 +1501,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1486,7 +1520,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1508,10 +1542,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfColorControlClusterStepColorTemperatureCallback(stepMode, stepSize, transitionTime, colorTemperatureMinimum,
                                                                        colorTemperatureMaximum, optionsMask, optionsOverride);
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1533,18 +1570,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1554,11 +1591,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1568,11 +1605,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1582,11 +1619,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1596,11 +1633,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1615,7 +1652,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1636,10 +1673,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepHueCallback(stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1661,18 +1701,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -1682,11 +1722,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -1696,11 +1736,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -1710,11 +1750,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1724,11 +1764,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1743,7 +1783,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1764,10 +1804,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStepSaturationCallback(stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1783,18 +1826,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionsOverrideExists  = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (optionsMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsMask);
+                    TLVUnpackError = aDataTlv.Get(optionsMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsMaskExists = true;
@@ -1804,11 +1847,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (optionsOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionsOverride);
+                    TLVUnpackError = aDataTlv.Get(optionsOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionsOverrideExists = true;
@@ -1823,7 +1866,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1844,17 +1887,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfColorControlClusterStopMoveStepCallback(optionsMask, optionsOverride);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_COLOR_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_COLOR_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -1865,10 +1912,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace DoorLock {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_LOCK_DOOR_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -1880,18 +1927,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1906,7 +1953,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1927,10 +1974,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1944,18 +1994,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1970,7 +2020,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1991,17 +2041,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -2012,10 +2066,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace DoorLock {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_CLEAR_ALL_PINS_COMMAND_ID: {
 
@@ -2039,18 +2093,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool scheduleIdExists       = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2065,7 +2119,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2086,10 +2140,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearHolidayScheduleCallback(scheduleId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2103,18 +2160,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2129,7 +2186,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2150,10 +2207,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearPinCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2167,18 +2227,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2193,7 +2253,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2214,10 +2274,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearRfidCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2233,18 +2296,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2254,11 +2317,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2273,7 +2336,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2294,10 +2357,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearWeekdayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2313,18 +2379,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2334,11 +2400,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2353,7 +2419,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2374,10 +2440,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearYeardayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2391,18 +2460,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool scheduleIdExists       = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2417,7 +2486,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2438,10 +2507,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetHolidayScheduleCallback(scheduleId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2455,18 +2527,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool logIndexExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (logIndexExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(logIndex);
+                    TLVUnpackError = aDataTlv.Get(logIndex);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         logIndexExists = true;
@@ -2481,7 +2553,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2502,10 +2574,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetLogRecordCallback(logIndex);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2519,18 +2594,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2545,7 +2620,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2566,10 +2641,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetPinCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2583,18 +2661,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2609,7 +2687,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2630,10 +2708,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetRfidCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2647,18 +2728,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2673,7 +2754,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2694,10 +2775,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetUserTypeCallback(userId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2713,18 +2797,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2734,11 +2818,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2753,7 +2837,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2774,10 +2858,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetWeekdayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2793,18 +2880,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2814,11 +2901,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -2833,7 +2920,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2854,10 +2941,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetYeardayScheduleCallback(scheduleId, userId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2871,19 +2961,19 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool PINExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (PINExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         PINExists = true;
@@ -2898,7 +2988,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2919,10 +3009,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorCallback(const_cast<uint8_t *>(PIN));
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2942,18 +3035,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool operatingModeDuringHolidayExists = false;
             uint32_t validArgumentCount           = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -2963,11 +3056,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -2977,11 +3070,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -2991,11 +3084,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (operatingModeDuringHolidayExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(operatingModeDuringHoliday);
+                    TLVUnpackError = aDataTlv.Get(operatingModeDuringHoliday);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         operatingModeDuringHolidayExists = true;
@@ -3010,7 +3103,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3032,10 +3125,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterSetHolidayScheduleCallback(scheduleId, localStartTime, localEndTime,
                                                                  operatingModeDuringHoliday);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3055,18 +3151,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3076,11 +3172,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -3090,11 +3186,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3104,12 +3200,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -3124,7 +3220,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3145,10 +3241,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetPinCallback(userId, userStatus, userType, const_cast<uint8_t *>(pin));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3168,18 +3267,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool idExists               = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3189,11 +3288,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -3203,11 +3302,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3217,12 +3316,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (idExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(id);
+                    TLVUnpackError = aDataTlv.GetDataPtr(id);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         idExists = true;
@@ -3237,7 +3336,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3258,10 +3357,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetRfidCallback(userId, userStatus, userType, const_cast<uint8_t *>(id));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3277,18 +3379,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool userTypeExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3298,11 +3400,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -3317,7 +3419,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3338,10 +3440,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetUserTypeCallback(userId, userType);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3367,18 +3472,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool endMinuteExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -3388,11 +3493,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3402,11 +3507,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (daysMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(daysMask);
+                    TLVUnpackError = aDataTlv.Get(daysMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         daysMaskExists = true;
@@ -3416,11 +3521,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (startHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startHour);
+                    TLVUnpackError = aDataTlv.Get(startHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startHourExists = true;
@@ -3430,11 +3535,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (startMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startMinute);
+                    TLVUnpackError = aDataTlv.Get(startMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startMinuteExists = true;
@@ -3444,11 +3549,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (endHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endHour);
+                    TLVUnpackError = aDataTlv.Get(endHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endHourExists = true;
@@ -3458,11 +3563,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (endMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endMinute);
+                    TLVUnpackError = aDataTlv.Get(endMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endMinuteExists = true;
@@ -3477,7 +3582,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3499,10 +3604,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterSetWeekdayScheduleCallback(scheduleId, userId, daysMask, startHour, startMinute, endHour,
                                                                  endMinute);
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3522,18 +3630,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool localEndTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -3543,11 +3651,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -3557,11 +3665,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -3571,11 +3679,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -3590,7 +3698,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3611,10 +3719,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetYeardayScheduleCallback(scheduleId, userId, localStartTime, localEndTime);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3628,19 +3739,19 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool PINExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (PINExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(PIN);
+                    TLVUnpackError = aDataTlv.GetDataPtr(PIN);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         PINExists = true;
@@ -3655,7 +3766,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3676,10 +3787,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorCallback(const_cast<uint8_t *>(PIN));
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3695,18 +3809,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutInSecondsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutInSeconds);
+                    TLVUnpackError = aDataTlv.Get(timeoutInSeconds);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutInSecondsExists = true;
@@ -3716,12 +3830,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -3736,7 +3850,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3757,17 +3871,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockWithTimeoutCallback(timeoutInSeconds, const_cast<uint8_t *>(pin));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -3778,10 +3896,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Groups {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_GROUP_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -3795,18 +3913,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3816,12 +3934,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -3836,7 +3954,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3857,10 +3975,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupCallback(groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3876,18 +3997,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3897,12 +4018,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -3917,7 +4038,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3938,10 +4059,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupIfIdentifyingCallback(groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3957,18 +4081,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupCount);
+                    TLVUnpackError = aDataTlv.Get(groupCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupCountExists = true;
@@ -3978,12 +4102,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupListExists = true;
@@ -3998,7 +4122,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4019,10 +4143,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterGetGroupMembershipCallback(groupCount, groupList);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4042,18 +4169,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4068,7 +4195,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4089,10 +4216,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterRemoveGroupCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4106,18 +4236,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -4132,7 +4262,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4153,17 +4283,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterViewGroupCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GROUPS_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GROUPS_CLUSTER_ID);
             break;
         }
         }
@@ -4174,10 +4308,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace IasZone {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ZONE_ENROLL_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4191,18 +4325,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool zoneIdExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (enrollResponseCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(enrollResponseCode);
+                    TLVUnpackError = aDataTlv.Get(enrollResponseCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         enrollResponseCodeExists = true;
@@ -4212,11 +4346,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (zoneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(zoneId);
+                    TLVUnpackError = aDataTlv.Get(zoneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         zoneIdExists = true;
@@ -4231,7 +4365,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4252,17 +4386,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIasZoneClusterZoneEnrollResponseCallback(enrollResponseCode, zoneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IAS_ZONE_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IAS_ZONE_CLUSTER_ID);
             break;
         }
         }
@@ -4273,10 +4411,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Identify {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_IDENTIFY_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4288,18 +4426,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool identifyTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (identifyTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(identifyTime);
+                    TLVUnpackError = aDataTlv.Get(identifyTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         identifyTimeExists = true;
@@ -4314,7 +4452,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4335,10 +4473,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIdentifyClusterIdentifyCallback(identifyTime);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4350,8 +4491,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IDENTIFY_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IDENTIFY_CLUSTER_ID);
             break;
         }
         }
@@ -4362,10 +4504,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace LevelControl {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_MOVE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -4383,18 +4525,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -4404,11 +4546,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -4418,11 +4560,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -4432,11 +4574,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -4451,7 +4593,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4472,10 +4614,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveCallback(moveMode, rate, optionMask, optionOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4495,18 +4640,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (levelExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(level);
+                    TLVUnpackError = aDataTlv.Get(level);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         levelExists = true;
@@ -4516,11 +4661,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4530,11 +4675,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -4544,11 +4689,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -4563,7 +4708,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4584,10 +4729,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveToLevelCallback(level, transitionTime, optionMask, optionOverride);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4603,18 +4751,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (levelExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(level);
+                    TLVUnpackError = aDataTlv.Get(level);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         levelExists = true;
@@ -4624,11 +4772,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4643,7 +4791,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4664,10 +4812,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveToLevelWithOnOffCallback(level, transitionTime);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4683,18 +4834,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool rateExists             = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (moveModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(moveMode);
+                    TLVUnpackError = aDataTlv.Get(moveMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         moveModeExists = true;
@@ -4704,11 +4855,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (rateExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(rate);
+                    TLVUnpackError = aDataTlv.Get(rate);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rateExists = true;
@@ -4723,7 +4874,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4744,10 +4895,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterMoveWithOnOffCallback(moveMode, rate);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4769,18 +4923,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -4790,11 +4944,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -4804,11 +4958,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4818,11 +4972,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -4832,11 +4986,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -4851,7 +5005,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4872,10 +5026,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStepCallback(stepMode, stepSize, transitionTime, optionMask, optionOverride);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4893,18 +5050,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (stepModeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepMode);
+                    TLVUnpackError = aDataTlv.Get(stepMode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepModeExists = true;
@@ -4914,11 +5071,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (stepSizeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(stepSize);
+                    TLVUnpackError = aDataTlv.Get(stepSize);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         stepSizeExists = true;
@@ -4928,11 +5085,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -4947,7 +5104,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4968,10 +5125,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStepWithOnOffCallback(stepMode, stepSize, transitionTime);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -4987,18 +5147,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool optionOverrideExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (optionMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionMask);
+                    TLVUnpackError = aDataTlv.Get(optionMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionMaskExists = true;
@@ -5008,11 +5168,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (optionOverrideExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(optionOverride);
+                    TLVUnpackError = aDataTlv.Get(optionOverride);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         optionOverrideExists = true;
@@ -5027,7 +5187,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5048,10 +5208,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfLevelControlClusterStopCallback(optionMask, optionOverride);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5063,8 +5226,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_LEVEL_CONTROL_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_LEVEL_CONTROL_CLUSTER_ID);
             break;
         }
         }
@@ -5075,10 +5239,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace LowPower {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_SLEEP_COMMAND_ID: {
 
@@ -5088,8 +5252,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_LOW_POWER_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_LOW_POWER_CLUSTER_ID);
             break;
         }
         }
@@ -5100,10 +5265,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace NetworkCommissioning {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_THREAD_NETWORK_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -5119,21 +5284,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5144,11 +5309,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5158,11 +5323,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5177,7 +5342,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5198,10 +5363,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5221,21 +5389,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5246,14 +5414,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5264,11 +5432,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5278,11 +5446,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5297,7 +5465,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5318,10 +5486,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5339,21 +5510,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5364,11 +5535,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5378,11 +5549,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5397,7 +5568,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5418,10 +5589,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterDisableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5439,21 +5613,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (networkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        networkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        networkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5464,11 +5638,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5478,11 +5652,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5497,7 +5671,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5518,10 +5692,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterEnableNetworkCallback(networkID, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5535,18 +5712,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5561,7 +5738,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5582,10 +5759,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(timeoutMs);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5603,21 +5783,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool TimeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (NetworkIDExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        NetworkID            = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        NetworkID            = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5628,11 +5808,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (BreadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(Breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(Breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         BreadcrumbExists = true;
@@ -5642,11 +5822,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (TimeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(TimeoutMs);
+                    TLVUnpackError = aDataTlv.Get(TimeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         TimeoutMsExists = true;
@@ -5661,7 +5841,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5682,10 +5862,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterRemoveNetworkCallback(NetworkID, Breadcrumb, TimeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5703,21 +5886,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5728,11 +5911,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5742,11 +5925,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5761,7 +5944,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5782,10 +5965,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterScanNetworksCallback(ssid, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5803,21 +5989,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (operationalDatasetExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        operationalDataset   = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        operationalDataset   = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5828,11 +6014,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5842,11 +6028,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5861,7 +6047,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -5882,10 +6068,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(operationalDataset, breadcrumb, timeoutMs);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -5905,21 +6094,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutMsExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (ssidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        ssid                 = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        ssid                 = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5930,14 +6119,14 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (credentialsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     {
                         const uint8_t * data = nullptr;
-                        TLVUnpackError       = dataTlv.GetDataPtr(data);
-                        credentials          = chip::ByteSpan(data, dataTlv.GetLength());
+                        TLVUnpackError       = aDataTlv.GetDataPtr(data);
+                        credentials          = chip::ByteSpan(data, aDataTlv.GetLength());
                     }
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
@@ -5948,11 +6137,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (breadcrumbExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(breadcrumb);
+                    TLVUnpackError = aDataTlv.Get(breadcrumb);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         breadcrumbExists = true;
@@ -5962,11 +6151,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (timeoutMsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeoutMs);
+                    TLVUnpackError = aDataTlv.Get(timeoutMs);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutMsExists = true;
@@ -5981,7 +6170,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6002,17 +6191,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(ssid, credentials, breadcrumb, timeoutMs);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -6023,10 +6216,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace OnOff {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_OFF_COMMAND_ID: {
 
@@ -6048,8 +6241,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_ON_OFF_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_ON_OFF_CLUSTER_ID);
             break;
         }
         }
@@ -6060,10 +6254,10 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Scenes {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_SCENE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -6083,18 +6277,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool extensionFieldSetsExists = false;
             uint32_t validArgumentCount   = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6104,11 +6298,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6118,11 +6312,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -6132,12 +6326,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sceneNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneNameExists = true;
@@ -6147,12 +6341,12 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (extensionFieldSetsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         extensionFieldSetsExists = true;
@@ -6167,7 +6361,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6189,10 +6383,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfScenesClusterAddSceneCallback(groupId, sceneId, transitionTime, const_cast<uint8_t *>(sceneName),
                                                      extensionFieldSets);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6206,18 +6403,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6232,7 +6429,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6253,10 +6450,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterGetSceneMembershipCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6274,18 +6474,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool transitionTimeExists   = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6295,11 +6495,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6309,11 +6509,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -6328,7 +6528,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6349,10 +6549,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRecallSceneCallback(groupId, sceneId, transitionTime);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6366,18 +6569,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6392,7 +6595,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6413,10 +6616,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveAllScenesCallback(groupId);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6432,18 +6638,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6453,11 +6659,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6472,7 +6678,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6493,10 +6699,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6512,18 +6721,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6533,11 +6742,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6552,7 +6761,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6573,10 +6782,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterStoreSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -6592,18 +6804,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -6613,11 +6825,11 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -6632,7 +6844,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -6653,17 +6865,21 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterViewSceneCallback(groupId, sceneId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_SCENES_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_SCENES_CLUSTER_ID);
             break;
         }
         }
@@ -6717,7 +6933,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         break;
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/examples/window-app/common/gen/IMClusterCommandHandler.cpp
+++ b/examples/window-app/common/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace WindowCovering {
 
-void DispatchServerCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchServerCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_WINDOW_COVERING_DOWN_CLOSE_COMMAND_ID: {
 
@@ -62,18 +62,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool percentageLiftValueExists = false;
             uint32_t validArgumentCount    = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (percentageLiftValueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(percentageLiftValue);
+                    TLVUnpackError = aDataTlv.Get(percentageLiftValue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         percentageLiftValueExists = true;
@@ -88,7 +88,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -109,10 +109,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfWindowCoveringClusterWindowCoveringGoToLiftPercentageCallback(percentageLiftValue);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -126,18 +129,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool liftValueExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (liftValueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(liftValue);
+                    TLVUnpackError = aDataTlv.Get(liftValue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         liftValueExists = true;
@@ -152,7 +155,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -173,10 +176,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfWindowCoveringClusterWindowCoveringGoToLiftValueCallback(liftValue);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -190,18 +196,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool percentageTiltValueExists = false;
             uint32_t validArgumentCount    = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (percentageTiltValueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(percentageTiltValue);
+                    TLVUnpackError = aDataTlv.Get(percentageTiltValue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         percentageTiltValueExists = true;
@@ -216,7 +222,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -237,10 +243,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfWindowCoveringClusterWindowCoveringGoToTiltPercentageCallback(percentageTiltValue);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -254,18 +263,18 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
             bool tiltValueExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (tiltValueExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(tiltValue);
+                    TLVUnpackError = aDataTlv.Get(tiltValue);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         tiltValueExists = true;
@@ -280,7 +289,7 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -301,10 +310,13 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfWindowCoveringClusterWindowCoveringGoToTiltValueCallback(tiltValue);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -322,8 +334,9 @@ void DispatchServerCommand(app::Command * command, CommandId commandId, Endpoint
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_WINDOW_COVERING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_WINDOW_COVERING_CLUSTER_ID);
             break;
         }
         }
@@ -347,7 +360,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         break;
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
+++ b/src/app/zap-templates/partials/im_command_handler_cluster_commands.zapt
@@ -16,32 +16,32 @@ bool {{asSymbol label}}Exists = false;
 {{/zcl_command_arguments}}
 uint32_t validArgumentCount = 0;
 
-while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
 {
-  switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+  switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
   {
 {{#zcl_command_arguments}}
     case {{index}}:
       if ({{asSymbol label}}Exists)
       {
-            ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+            ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
             TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
             break;
       }
 {{#if (isOctetString type)}}
     {
         const uint8_t * data = nullptr;
-        TLVUnpackError = dataTlv.GetDataPtr(data);
-        {{asSymbol label}} = chip::ByteSpan(data, dataTlv.GetLength());
+        TLVUnpackError = aDataTlv.GetDataPtr(data);
+        {{asSymbol label}} = chip::ByteSpan(data, aDataTlv.GetLength());
     }
 {{else if (isString type)}}
       // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-      TLVUnpackError = dataTlv.GetDataPtr({{asSymbol label}});
+      TLVUnpackError = aDataTlv.GetDataPtr({{asSymbol label}});
 {{else if isArray}}
       // Just for compatibility, we will add array type support in IM later.
-      TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>({{asSymbol label}}));
+      TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>({{asSymbol label}}));
 {{else}}
-      TLVUnpackError = dataTlv.Get({{asSymbol label}});
+      TLVUnpackError = aDataTlv.Get({{asSymbol label}});
 {{/if}}
       if (CHIP_NO_ERROR == TLVUnpackError)
       {
@@ -57,7 +57,7 @@ while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
   }
   if (TLVUnpackError != CHIP_NO_ERROR)
   {
-    ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32, TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+    ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32, TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
     break;
   }
 }
@@ -82,8 +82,10 @@ if (CHIP_NO_ERROR == TLVError && CHIP_NO_ERROR == TLVUnpackError && {{zcl_comman
 emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback({{#zcl_command_arguments}}{{#if (isCharString type)}}const_cast<uint8_t*>({{asSymbol label}}){{else}}{{asSymbol label}}{{/if}}{{#unless (isLastElement index count)}}, {{/unless}}{{/zcl_command_arguments}});
 {{#if (zcl_command_arguments_count this.id)}}
 }
-else if ({{zcl_command_arguments_count this.id}} != validArgumentCount)
+else
 {
-      ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, {{zcl_command_arguments_count this.id}}, validArgumentCount);
+      apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest, Protocols::SecureChannel::Id,
+                      Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+      ChipLogProgress(Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32, {{zcl_command_arguments_count this.id}}, validArgumentCount, TLVError, TLVUnpackError);
 }
 {{/if}}

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -26,13 +26,13 @@ namespace clusters {
 {{#if (user_cluster_has_enabled_command name side)}}
 namespace {{asCamelCased name false}} {
 
-void Dispatch{{asCamelCased side false}}Command(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void Dispatch{{asCamelCased side false}}Command(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {{#if (user_cluster_has_enabled_manufacturer_command name side)}}
     {{else}}
     {{/if}}
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         {{#all_user_cluster_commands}}
         {{#unless mfgCode}}
@@ -48,8 +48,9 @@ void Dispatch{{asCamelCased side false}}Command(app::Command * command, CommandI
         {{/all_user_cluster_commands}}
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_{{asDelimitedMacro define}}_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                            Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_{{asDelimitedMacro define}}_ID);
             break;
         }
         }
@@ -82,7 +83,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     {{/all_user_clusters}}
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                            Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/src/controller/python/gen/IMClusterCommandHandler.cpp
+++ b/src/controller/python/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace DoorLock {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -56,18 +56,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -82,7 +82,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -103,10 +103,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllPinsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -120,18 +123,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -146,7 +149,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -167,10 +170,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllRfidsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -184,18 +190,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -210,7 +216,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -231,10 +237,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -248,18 +257,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -274,7 +283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -295,10 +304,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -312,18 +324,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -338,7 +350,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -359,10 +371,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -376,18 +391,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -402,7 +417,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -423,10 +438,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -440,18 +458,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -466,7 +484,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -487,10 +505,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -512,18 +533,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool operatingModeDuringHolidayExists = false;
             uint32_t validArgumentCount           = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -533,11 +554,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -547,11 +568,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -561,11 +582,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -575,11 +596,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (operatingModeDuringHolidayExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(operatingModeDuringHoliday);
+                    TLVUnpackError = aDataTlv.Get(operatingModeDuringHoliday);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         operatingModeDuringHolidayExists = true;
@@ -594,7 +615,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -616,10 +637,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetHolidayScheduleResponseCallback(scheduleId, status, localStartTime, localEndTime,
                                                                          operatingModeDuringHoliday);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -645,18 +669,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (logEntryIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(logEntryId);
+                    TLVUnpackError = aDataTlv.Get(logEntryId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         logEntryIdExists = true;
@@ -666,11 +690,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (timestampExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timestamp);
+                    TLVUnpackError = aDataTlv.Get(timestamp);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timestampExists = true;
@@ -680,11 +704,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (eventTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventType);
+                    TLVUnpackError = aDataTlv.Get(eventType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventTypeExists = true;
@@ -694,11 +718,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sourceExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(source);
+                    TLVUnpackError = aDataTlv.Get(source);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sourceExists = true;
@@ -708,11 +732,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (eventIdOrAlarmCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventIdOrAlarmCode);
+                    TLVUnpackError = aDataTlv.Get(eventIdOrAlarmCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventIdOrAlarmCodeExists = true;
@@ -722,11 +746,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -736,12 +760,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -756,7 +780,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -778,10 +802,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetLogRecordResponseCallback(logEntryId, timestamp, eventType, source, eventIdOrAlarmCode,
                                                                    userId, const_cast<uint8_t *>(pin));
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -801,18 +828,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -822,11 +849,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -836,11 +863,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -850,12 +877,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -870,7 +897,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -891,10 +918,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetPinResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(pin));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -914,18 +944,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool rfidExists             = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -935,11 +965,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -949,11 +979,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -963,12 +993,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (rfidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(rfid);
+                    TLVUnpackError = aDataTlv.GetDataPtr(rfid);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rfidExists = true;
@@ -983,7 +1013,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1004,10 +1034,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetRfidResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(rfid));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1023,18 +1056,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool userTypeExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1044,11 +1077,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -1063,7 +1096,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1084,10 +1117,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetUserTypeResponseCallback(userId, userType);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1115,18 +1151,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool endMinuteExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1136,11 +1172,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1150,11 +1186,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1164,11 +1200,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (daysMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(daysMask);
+                    TLVUnpackError = aDataTlv.Get(daysMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         daysMaskExists = true;
@@ -1178,11 +1214,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (startHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startHour);
+                    TLVUnpackError = aDataTlv.Get(startHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startHourExists = true;
@@ -1192,11 +1228,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (startMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startMinute);
+                    TLVUnpackError = aDataTlv.Get(startMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startMinuteExists = true;
@@ -1206,11 +1242,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (endHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endHour);
+                    TLVUnpackError = aDataTlv.Get(endHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endHourExists = true;
@@ -1220,11 +1256,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 7:
                     if (endMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endMinute);
+                    TLVUnpackError = aDataTlv.Get(endMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endMinuteExists = true;
@@ -1239,7 +1275,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1261,10 +1297,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(scheduleId, userId, status, daysMask, startHour,
                                                                          startMinute, endHour, endMinute);
             }
-            else if (8 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 8,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    8, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1286,18 +1325,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool localEndTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1307,11 +1346,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1321,11 +1360,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1335,11 +1374,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -1349,11 +1388,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -1368,7 +1407,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1389,10 +1428,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetYeardayScheduleResponseCallback(scheduleId, userId, status, localStartTime, localEndTime);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1406,18 +1448,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1432,7 +1474,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1453,10 +1495,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1470,18 +1515,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1496,7 +1541,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1517,10 +1562,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1534,18 +1582,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1560,7 +1608,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1581,10 +1629,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1598,18 +1649,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1624,7 +1675,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1645,10 +1696,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1662,18 +1716,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1688,7 +1742,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1709,10 +1763,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetUserTypeResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1726,18 +1783,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1752,7 +1809,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1773,10 +1830,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1790,18 +1850,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1816,7 +1876,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1837,10 +1897,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1854,18 +1917,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1880,7 +1943,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1901,10 +1964,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1918,18 +1984,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1944,7 +2010,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1965,17 +2031,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -1986,10 +2056,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace GeneralCommissioning {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ARM_FAIL_SAFE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2003,18 +2073,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2024,12 +2094,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2044,7 +2114,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2065,10 +2135,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2084,18 +2157,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2105,12 +2178,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2125,7 +2198,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2147,10 +2220,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(errorCode,
                                                                                         const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2166,18 +2242,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2187,12 +2263,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2207,7 +2283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2228,17 +2304,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterSetFabricResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -2249,10 +2329,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Groups {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_GROUP_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2266,18 +2346,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2287,11 +2367,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2306,7 +2386,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2327,10 +2407,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2348,18 +2431,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -2369,11 +2452,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupCount);
+                    TLVUnpackError = aDataTlv.Get(groupCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupCountExists = true;
@@ -2383,12 +2466,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupListExists = true;
@@ -2403,7 +2486,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2424,10 +2507,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterGetGroupMembershipResponseCallback(capacity, groupCount, groupList);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2443,18 +2529,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2464,11 +2550,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2483,7 +2569,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2504,10 +2590,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterRemoveGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2525,18 +2614,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2546,11 +2635,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2560,12 +2649,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -2580,7 +2669,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2601,17 +2690,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterViewGroupResponseCallback(status, groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GROUPS_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GROUPS_CLUSTER_ID);
             break;
         }
         }
@@ -2622,10 +2715,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Identify {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2637,18 +2730,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeout);
+                    TLVUnpackError = aDataTlv.Get(timeout);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutExists = true;
@@ -2663,7 +2756,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2684,17 +2777,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIdentifyClusterIdentifyQueryResponseCallback(timeout);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IDENTIFY_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IDENTIFY_CLUSTER_ID);
             break;
         }
         }
@@ -2705,10 +2802,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Scenes {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_SCENE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2724,18 +2821,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2745,11 +2842,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2759,11 +2856,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -2778,7 +2875,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2799,10 +2896,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterAddSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2824,18 +2924,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2845,11 +2945,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -2859,11 +2959,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2873,11 +2973,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sceneCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneCount);
+                    TLVUnpackError = aDataTlv.Get(sceneCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneCountExists = true;
@@ -2887,12 +2987,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneListExists = true;
@@ -2907,7 +3007,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2928,10 +3028,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterGetSceneMembershipResponseCallback(status, capacity, groupId, sceneCount, sceneList);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2947,18 +3050,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2968,11 +3071,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2987,7 +3090,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3008,10 +3111,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveAllScenesResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3029,18 +3135,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3050,11 +3156,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3064,11 +3170,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3083,7 +3189,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3104,10 +3210,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3125,18 +3234,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3146,11 +3255,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3160,11 +3269,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3179,7 +3288,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3200,10 +3309,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterStoreSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3227,18 +3339,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool extensionFieldSetsExists = false;
             uint32_t validArgumentCount   = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3248,11 +3360,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3262,11 +3374,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3276,11 +3388,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -3290,12 +3402,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneNameExists = true;
@@ -3305,12 +3417,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (extensionFieldSetsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         extensionFieldSetsExists = true;
@@ -3325,7 +3437,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3347,17 +3459,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfScenesClusterViewSceneResponseCallback(status, groupId, sceneId, transitionTime,
                                                               const_cast<uint8_t *>(sceneName), extensionFieldSets);
             }
-            else if (6 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 6,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    6, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_SCENES_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_SCENES_CLUSTER_ID);
             break;
         }
         }
@@ -3378,7 +3494,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     {
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }

--- a/src/darwin/Framework/CHIP/gen/IMClusterCommandHandler.cpp
+++ b/src/darwin/Framework/CHIP/gen/IMClusterCommandHandler.cpp
@@ -41,10 +41,10 @@ namespace clusters {
 
 namespace DoorLock {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_CLEAR_ALL_PINS_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -56,18 +56,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -82,7 +82,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -103,10 +103,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllPinsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -120,18 +123,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -146,7 +149,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -167,10 +170,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearAllRfidsResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -184,18 +190,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -210,7 +216,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -231,10 +237,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -248,18 +257,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -274,7 +283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -295,10 +304,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -312,18 +324,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -338,7 +350,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -359,10 +371,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -376,18 +391,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -402,7 +417,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -423,10 +438,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -440,18 +458,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -466,7 +484,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -487,10 +505,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterClearYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -512,18 +533,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool operatingModeDuringHolidayExists = false;
             uint32_t validArgumentCount           = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -533,11 +554,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -547,11 +568,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -561,11 +582,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -575,11 +596,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (operatingModeDuringHolidayExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(operatingModeDuringHoliday);
+                    TLVUnpackError = aDataTlv.Get(operatingModeDuringHoliday);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         operatingModeDuringHolidayExists = true;
@@ -594,7 +615,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -616,10 +637,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetHolidayScheduleResponseCallback(scheduleId, status, localStartTime, localEndTime,
                                                                          operatingModeDuringHoliday);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -645,18 +669,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (logEntryIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(logEntryId);
+                    TLVUnpackError = aDataTlv.Get(logEntryId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         logEntryIdExists = true;
@@ -666,11 +690,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (timestampExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timestamp);
+                    TLVUnpackError = aDataTlv.Get(timestamp);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timestampExists = true;
@@ -680,11 +704,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (eventTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventType);
+                    TLVUnpackError = aDataTlv.Get(eventType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventTypeExists = true;
@@ -694,11 +718,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sourceExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(source);
+                    TLVUnpackError = aDataTlv.Get(source);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sourceExists = true;
@@ -708,11 +732,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (eventIdOrAlarmCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(eventIdOrAlarmCode);
+                    TLVUnpackError = aDataTlv.Get(eventIdOrAlarmCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         eventIdOrAlarmCodeExists = true;
@@ -722,11 +746,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -736,12 +760,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -756,7 +780,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -778,10 +802,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetLogRecordResponseCallback(logEntryId, timestamp, eventType, source, eventIdOrAlarmCode,
                                                                    userId, const_cast<uint8_t *>(pin));
             }
-            else if (7 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 7,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    7, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -801,18 +828,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool pinExists              = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -822,11 +849,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -836,11 +863,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -850,12 +877,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (pinExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(pin);
+                    TLVUnpackError = aDataTlv.GetDataPtr(pin);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         pinExists = true;
@@ -870,7 +897,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -891,10 +918,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetPinResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(pin));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -914,18 +944,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool rfidExists             = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -935,11 +965,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userStatusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userStatus);
+                    TLVUnpackError = aDataTlv.Get(userStatus);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userStatusExists = true;
@@ -949,11 +979,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -963,12 +993,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (rfidExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(rfid);
+                    TLVUnpackError = aDataTlv.GetDataPtr(rfid);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         rfidExists = true;
@@ -983,7 +1013,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1004,10 +1034,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetRfidResponseCallback(userId, userStatus, userType, const_cast<uint8_t *>(rfid));
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1023,18 +1056,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool userTypeExists         = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1044,11 +1077,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userTypeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userType);
+                    TLVUnpackError = aDataTlv.Get(userType);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userTypeExists = true;
@@ -1063,7 +1096,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1084,10 +1117,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetUserTypeResponseCallback(userId, userType);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1115,18 +1151,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool endMinuteExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1136,11 +1172,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1150,11 +1186,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1164,11 +1200,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (daysMaskExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(daysMask);
+                    TLVUnpackError = aDataTlv.Get(daysMask);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         daysMaskExists = true;
@@ -1178,11 +1214,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (startHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startHour);
+                    TLVUnpackError = aDataTlv.Get(startHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startHourExists = true;
@@ -1192,11 +1228,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (startMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(startMinute);
+                    TLVUnpackError = aDataTlv.Get(startMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         startMinuteExists = true;
@@ -1206,11 +1242,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 6:
                     if (endHourExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endHour);
+                    TLVUnpackError = aDataTlv.Get(endHour);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endHourExists = true;
@@ -1220,11 +1256,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 7:
                     if (endMinuteExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(endMinute);
+                    TLVUnpackError = aDataTlv.Get(endMinute);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         endMinuteExists = true;
@@ -1239,7 +1275,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1261,10 +1297,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(scheduleId, userId, status, daysMask, startHour,
                                                                          startMinute, endHour, endMinute);
             }
-            else if (8 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 8,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    8, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1286,18 +1325,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool localEndTimeExists     = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (scheduleIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(scheduleId);
+                    TLVUnpackError = aDataTlv.Get(scheduleId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         scheduleIdExists = true;
@@ -1307,11 +1346,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (userIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(userId);
+                    TLVUnpackError = aDataTlv.Get(userId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         userIdExists = true;
@@ -1321,11 +1360,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1335,11 +1374,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (localStartTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localStartTime);
+                    TLVUnpackError = aDataTlv.Get(localStartTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localStartTimeExists = true;
@@ -1349,11 +1388,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (localEndTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(localEndTime);
+                    TLVUnpackError = aDataTlv.Get(localEndTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         localEndTimeExists = true;
@@ -1368,7 +1407,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1389,10 +1428,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterGetYeardayScheduleResponseCallback(scheduleId, userId, status, localStartTime, localEndTime);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1406,18 +1448,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1432,7 +1474,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1453,10 +1495,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterLockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1470,18 +1515,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1496,7 +1541,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1517,10 +1562,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetHolidayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1534,18 +1582,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1560,7 +1608,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1581,10 +1629,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetPinResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1598,18 +1649,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1624,7 +1675,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1645,10 +1696,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetRfidResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1662,18 +1716,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1688,7 +1742,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1709,10 +1763,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetUserTypeResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1726,18 +1783,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1752,7 +1809,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1773,10 +1830,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1790,18 +1850,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1816,7 +1876,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1837,10 +1897,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterSetYeardayScheduleResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1854,18 +1917,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1880,7 +1943,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1901,10 +1964,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockDoorResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -1918,18 +1984,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool statusExists           = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -1944,7 +2010,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -1965,17 +2031,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(status);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_DOOR_LOCK_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_DOOR_LOCK_CLUSTER_ID);
             break;
         }
         }
@@ -1986,10 +2056,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace GeneralCommissioning {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ARM_FAIL_SAFE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2003,18 +2073,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2024,12 +2094,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2044,7 +2114,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2065,10 +2135,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2084,18 +2157,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2105,12 +2178,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2125,7 +2198,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2147,10 +2220,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(errorCode,
                                                                                         const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2166,18 +2242,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2187,12 +2263,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2207,7 +2283,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2228,17 +2304,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGeneralCommissioningClusterSetFabricResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GENERAL_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -2249,10 +2329,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Groups {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_GROUP_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2266,18 +2346,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2287,11 +2367,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2306,7 +2386,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2327,10 +2407,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterAddGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2348,18 +2431,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -2369,11 +2452,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupCount);
+                    TLVUnpackError = aDataTlv.Get(groupCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupCountExists = true;
@@ -2383,12 +2466,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(groupList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupListExists = true;
@@ -2403,7 +2486,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2424,10 +2507,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterGetGroupMembershipResponseCallback(capacity, groupCount, groupList);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2443,18 +2529,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2464,11 +2550,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2483,7 +2569,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2504,10 +2590,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterRemoveGroupResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2525,18 +2614,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupNameExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -2546,11 +2635,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -2560,12 +2649,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(groupName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(groupName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupNameExists = true;
@@ -2580,7 +2669,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2601,17 +2690,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfGroupsClusterViewGroupResponseCallback(status, groupId, const_cast<uint8_t *>(groupName));
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_GROUPS_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_GROUPS_CLUSTER_ID);
             break;
         }
         }
@@ -2622,10 +2715,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Identify {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_IDENTIFY_QUERY_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2637,18 +2730,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool timeoutExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (timeoutExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(timeout);
+                    TLVUnpackError = aDataTlv.Get(timeout);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         timeoutExists = true;
@@ -2663,7 +2756,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2684,17 +2777,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfIdentifyClusterIdentifyQueryResponseCallback(timeout);
             }
-            else if (1 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 1,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    1, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_IDENTIFY_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_IDENTIFY_CLUSTER_ID);
             break;
         }
         }
@@ -2705,10 +2802,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace NetworkCommissioning {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_THREAD_NETWORK_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -2722,18 +2819,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2743,12 +2840,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2763,7 +2860,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2784,10 +2881,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2803,18 +2903,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2824,12 +2924,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2844,7 +2944,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2865,10 +2965,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2884,18 +2987,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2905,12 +3008,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -2925,7 +3028,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -2946,10 +3049,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -2965,18 +3071,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -2986,12 +3092,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3006,7 +3112,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3027,10 +3133,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3046,18 +3155,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3067,12 +3176,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3087,7 +3196,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3108,10 +3217,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3131,18 +3243,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool threadScanResultsExists = false;
             uint32_t validArgumentCount  = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3152,12 +3264,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3167,12 +3279,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (wifiScanResultsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(wifiScanResults));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(wifiScanResults));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         wifiScanResultsExists = true;
@@ -3182,12 +3294,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (threadScanResultsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(threadScanResults));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(threadScanResults));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         threadScanResultsExists = true;
@@ -3202,7 +3314,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3224,10 +3336,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfNetworkCommissioningClusterScanNetworksResponseCallback(errorCode, const_cast<uint8_t *>(debugText),
                                                                                wifiScanResults, threadScanResults);
             }
-            else if (4 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 4,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    4, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3243,18 +3358,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3264,12 +3379,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3284,7 +3399,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3305,10 +3420,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3324,18 +3442,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool debugTextExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (errorCodeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(errorCode);
+                    TLVUnpackError = aDataTlv.Get(errorCode);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         errorCodeExists = true;
@@ -3345,12 +3463,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (debugTextExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(debugText);
+                    TLVUnpackError = aDataTlv.GetDataPtr(debugText);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         debugTextExists = true;
@@ -3365,7 +3483,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3386,17 +3504,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(errorCode, const_cast<uint8_t *>(debugText));
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID);
             break;
         }
         }
@@ -3407,10 +3529,10 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
 
 namespace Scenes {
 
-void DispatchClientCommand(app::Command * command, CommandId commandId, EndpointId endpointId, TLV::TLVReader & dataTlv)
+void DispatchClientCommand(app::Command * apCommandObj, CommandId aCommandId, EndpointId aEndpointId, TLV::TLVReader & aDataTlv)
 {
     {
-        switch (commandId)
+        switch (aCommandId)
         {
         case ZCL_ADD_SCENE_RESPONSE_COMMAND_ID: {
             // We are using TLVUnpackError and TLVError here since both of them can be CHIP_END_OF_TLV
@@ -3426,18 +3548,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3447,11 +3569,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3461,11 +3583,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3480,7 +3602,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3501,10 +3623,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterAddSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3526,18 +3651,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneListExists        = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3547,11 +3672,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (capacityExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(capacity);
+                    TLVUnpackError = aDataTlv.Get(capacity);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         capacityExists = true;
@@ -3561,11 +3686,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3575,11 +3700,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (sceneCountExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneCount);
+                    TLVUnpackError = aDataTlv.Get(sceneCount);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneCountExists = true;
@@ -3589,12 +3714,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneListExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(sceneList));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneListExists = true;
@@ -3609,7 +3734,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3630,10 +3755,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterGetSceneMembershipResponseCallback(status, capacity, groupId, sceneCount, sceneList);
             }
-            else if (5 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 5,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    5, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3649,18 +3777,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool groupIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3670,11 +3798,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3689,7 +3817,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3710,10 +3838,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveAllScenesResponseCallback(status, groupId);
             }
-            else if (2 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 2,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    2, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3731,18 +3862,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3752,11 +3883,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3766,11 +3897,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3785,7 +3916,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3806,10 +3937,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterRemoveSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3827,18 +3961,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool sceneIdExists          = false;
             uint32_t validArgumentCount = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3848,11 +3982,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3862,11 +3996,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3881,7 +4015,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -3902,10 +4036,13 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 // TODO(#5098) We should pass the Command Object and EndpointId to the cluster callbacks.
                 emberAfScenesClusterStoreSceneResponseCallback(status, groupId, sceneId);
             }
-            else if (3 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 3,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    3, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
@@ -3929,18 +4066,18 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
             bool extensionFieldSetsExists = false;
             uint32_t validArgumentCount   = 0;
 
-            while ((TLVError = dataTlv.Next()) == CHIP_NO_ERROR)
+            while ((TLVError = aDataTlv.Next()) == CHIP_NO_ERROR)
             {
-                switch (TLV::TagNumFromTag(dataTlv.GetTag()))
+                switch (TLV::TagNumFromTag(aDataTlv.GetTag()))
                 {
                 case 0:
                     if (statusExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(status);
+                    TLVUnpackError = aDataTlv.Get(status);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         statusExists = true;
@@ -3950,11 +4087,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 1:
                     if (groupIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(groupId);
+                    TLVUnpackError = aDataTlv.Get(groupId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         groupIdExists = true;
@@ -3964,11 +4101,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 2:
                     if (sceneIdExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(sceneId);
+                    TLVUnpackError = aDataTlv.Get(sceneId);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneIdExists = true;
@@ -3978,11 +4115,11 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 3:
                     if (transitionTimeExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
-                    TLVUnpackError = dataTlv.Get(transitionTime);
+                    TLVUnpackError = aDataTlv.Get(transitionTime);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         transitionTimeExists = true;
@@ -3992,12 +4129,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 4:
                     if (sceneNameExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // TODO(#5542): The cluster handlers should accept a ByteSpan for all string types.
-                    TLVUnpackError = dataTlv.GetDataPtr(sceneName);
+                    TLVUnpackError = aDataTlv.GetDataPtr(sceneName);
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         sceneNameExists = true;
@@ -4007,12 +4144,12 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 case 5:
                     if (extensionFieldSetsExists)
                     {
-                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(dataTlv.GetTag()));
+                        ChipLogProgress(Zcl, "Duplicate TLV tag %" PRIx32, TLV::TagNumFromTag(aDataTlv.GetTag()));
                         TLVUnpackError = CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_ELEMENT;
                         break;
                     }
                     // Just for compatibility, we will add array type support in IM later.
-                    TLVUnpackError = dataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
+                    TLVUnpackError = aDataTlv.GetDataPtr(const_cast<const uint8_t *&>(extensionFieldSets));
                     if (CHIP_NO_ERROR == TLVUnpackError)
                     {
                         extensionFieldSetsExists = true;
@@ -4027,7 +4164,7 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 if (TLVUnpackError != CHIP_NO_ERROR)
                 {
                     ChipLogProgress(Zcl, "Failed to decode TLV data with tag %" PRIx32 ": %" PRId32,
-                                    TLV::TagNumFromTag(dataTlv.GetTag()), TLVUnpackError);
+                                    TLV::TagNumFromTag(aDataTlv.GetTag()), TLVUnpackError);
                     break;
                 }
             }
@@ -4049,17 +4186,21 @@ void DispatchClientCommand(app::Command * command, CommandId commandId, Endpoint
                 emberAfScenesClusterViewSceneResponseCallback(status, groupId, sceneId, transitionTime,
                                                               const_cast<uint8_t *>(sceneName), extensionFieldSets);
             }
-            else if (6 != validArgumentCount)
+            else
             {
-                ChipLogProgress(Zcl, "Missing command arguments in TLV data, command requires %d, given %" PRIu32, 6,
-                                validArgumentCount);
+                apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kBadRequest,
+                                            Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+                ChipLogProgress(
+                    Zcl, "Failed to dispatch command, %d/%" PRIu32 " arguments parsed, TLVError=%" PRIu32 ", UnpackError=%" PRIu32,
+                    6, validArgumentCount, TLVError, TLVUnpackError);
             }
             break;
         }
         default: {
             // Unrecognized command ID, error status will apply.
-            // TODO: Encode response for command not found
-            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, commandId, ZCL_SCENES_CLUSTER_ID);
+            apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound,
+                                        Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeGeneralFailure);
+            ChipLogError(Zcl, "Unknown command %" PRIx16 " for cluster %" PRIx16, aCommandId, ZCL_SCENES_CLUSTER_ID);
             break;
         }
         }
@@ -4080,7 +4221,8 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     {
     default:
         // Unrecognized cluster ID, error status will apply.
-        // TODO: Encode response for Cluster not found
+        apCommandObj->AddStatusCode(nullptr, Protocols::SecureChannel::GeneralStatusCode::kNotFound, Protocols::SecureChannel::Id,
+                                    Protocols::SecureChannel::kProtocolCodeGeneralFailure);
         ChipLogError(Zcl, "Unknown cluster %" PRIx16, aClusterId);
         break;
     }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

We does not encode error code during dispatching commands.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

Add code for encoding command responses.

The second commit is generated by

```
./scripts/tools/zap_regen_all.py && for x in $(gd --name-only | grep -ve '(.zap$)|(.py$)|(.gn$)'); do clang-format -i $x; done && git add examples/ src/ && gc -m "Run codegen"
```

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
