### PR TITLE
[linux] Remove known devices before running BLE scan

### DIFF
--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -250,7 +250,7 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 * device)
     }
 
     const auto devicePath = g_dbus_proxy_get_object_path(G_DBUS_PROXY(device));
-    GError * error = nullptr;
+    GError * error        = nullptr;
 
     if (!bluez_adapter1_call_remove_device_sync(mAdapter, devicePath, nullptr, &error))
     {

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -86,6 +86,10 @@ private:
     /// Check if a given device is a CHIP device and if yes, report it as discovered
     void ReportDevice(BluezDevice1 * device);
 
+    /// Check if a given device is a CHIP device and if yes, remove it from the adapter
+    /// so that it can be re-discovered if it's still advertising.
+    void RemoveDevice(BluezDevice1 * device);
+
     GDBusObjectManager * mManager         = nullptr;
     BluezAdapter1 * mAdapter              = nullptr;
     GCancellable * mCancellable           = nullptr;


### PR DESCRIPTION
 #### Problem
Linux BLE layer tries to connect to known devices, cached by Bluez daemon before running the active scan. It may cause
an issue when trying to connect to a device which is no longer advertising or it has changed its BLE address which can be especially painful after enabling features like BLE address randomization.

 #### Summary of Changes
Remove known devices before running an active BLE scan.
