### PR TITLE
ESP32: Fixes in temperature-measurement-app and lock-app

### DIFF
--- a/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
@@ -51,7 +51,8 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
     CHIP_ERROR err;
-    mCB = cb RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
+    mCB                              = cb;
+    RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -54,13 +54,13 @@ void CHIPDeviceManager::CommonDeviceEventHandler(const ChipDeviceEvent * event, 
 CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
 {
     CHIP_ERROR err;
-    mCB = cb;
+    mCB                              = cb;
+    RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
 
     // Initialize the CHIP stack.
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
-    RendezvousInformationFlags flags = RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE);
     if (flags.Has(RendezvousInformationFlag::kBLE))
     {
         ConnectivityMgr().SetBLEAdvertisingEnabled(true);


### PR DESCRIPTION
 #### Problem
The `temperature-measurement-app` and `lock-app` fail to build successfully.

 #### Summary of Changes
 Added the needed fix in `main/CHIPDeviceManager.cpp` under each example.

 Fixes #5948 