### PR TITLE
Use ErrorStr in the ExchangeMgr instead of raw error code

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -306,7 +306,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %d", err);
+        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(err));
     }
 }
 
@@ -331,7 +331,8 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(ExchangeManager,
-                     "Message counter synchronization for received message, failed to send synchronization request, err = %d", err);
+                     "Message counter synchronization for received message, failed to send synchronization request, err = %s",
+                     ErrorStr(err));
     }
 
     return err;


### PR DESCRIPTION
 #### Problem

The `ExchangeMgr` logs raw error code when something wrong happens. That's not very convenient when you encounter an error and try to figure out what it is. 

 #### Summary of Changes
 * Use `ErrorStr` instead of raw error code