### PR TITLE
Mdns device controller update device

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -37,6 +37,7 @@ executable("chip-tool") {
     "commands/clusters/ModelCommand.cpp",
     "commands/common/Command.cpp",
     "commands/common/Commands.cpp",
+    "commands/discover/DiscoverCommand.cpp",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",

--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -18,38 +18,23 @@
 
 #pragma once
 
-#include "Command.h"
+#include "DiscoverCommand.h"
+#include <controller/DeviceAddressUpdater.h>
 #include <mdns/Resolver.h>
 
-class Discover : public Command, public chip::Mdns::ResolverDelegate
+class Resolve : public DiscoverCommand, public chip::Mdns::ResolverDelegate
 {
 public:
-    Discover() : Command("resolve-node-id")
-    {
-        AddArgument("nodeid", 0, UINT64_MAX, &mNodeId);
-        AddArgument("fabricid", 0, UINT64_MAX, &mFabricId);
-    }
+    Resolve() : DiscoverCommand("resolve") {}
 
-    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override
+    /////////// DiscoverCommand Interface /////////
+    CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
-        ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
-        ReturnErrorOnFailure(mCommissioner.Init(localId, &storage));
-        ReturnErrorOnFailure(mCommissioner.ServiceEvents());
-
         ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(this));
-        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().ResolveNodeId(mNodeId, mFabricId, chip::Inet::kIPAddressType_Any));
-
-        UpdateWaitForResponse(true);
-        WaitForResponse(mWaitDurationInSeconds);
-
-        mCommissioner.ServiceEventSignal();
-        mCommissioner.Shutdown();
-
-        VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
-
-        return CHIP_NO_ERROR;
+        return chip::Mdns::Resolver::Instance().ResolveNodeId(remoteId, fabricId, chip::Inet::kIPAddressType_Any);
     }
 
+    /////////// ResolverDelegate Interface /////////
     void OnNodeIdResolved(NodeId nodeId, const chip::Mdns::ResolvedNodeData & nodeData) override
     {
         char addrBuffer[chip::Transport::PeerAddress::kMaxToStringSize];
@@ -63,12 +48,34 @@ public:
         ChipLogProgress(chipTool, "NodeId Resolution: failed!");
         SetCommandExitStatus(false);
     };
+};
+
+class Update : public DiscoverCommand, public chip::Controller::DeviceAddressUpdateDelegate
+{
+public:
+    Update() : DiscoverCommand("update") {}
+
+    /////////// DiscoverCommand Interface /////////
+    CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
+    {
+        ReturnErrorOnFailure(mAddressUpdater.Init(&mCommissioner, this));
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(&mAddressUpdater));
+        return chip::Mdns::Resolver::Instance().ResolveNodeId(remoteId, fabricId, chip::Inet::kIPAddressType_Any);
+    }
+
+    /////////// DeviceAddressUpdateDelegate Interface /////////
+    void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override
+    {
+        if (CHIP_NO_ERROR != error)
+        {
+            ChipLogError(chipTool, "Failed to update the device address: %s", chip::ErrorStr(error));
+        }
+
+        SetCommandExitStatus(CHIP_NO_ERROR == error);
+    }
 
 private:
-    uint16_t mWaitDurationInSeconds = 30;
-    ChipDeviceCommissioner mCommissioner;
-    chip::NodeId mNodeId;
-    uint64_t mFabricId;
+    chip::Controller::DeviceAddressUpdater mAddressUpdater;
 };
 
 void registerCommandsDiscover(Commands & commands)
@@ -76,7 +83,8 @@ void registerCommandsDiscover(Commands & commands)
     const char * clusterName = "Discover";
 
     commands_list clusterCommands = {
-        make_unique<Discover>(),
+        make_unique<Resolve>(),
+        make_unique<Update>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -22,8 +22,13 @@ constexpr uint16_t kWaitDurationInSeconds = 30;
 
 CHIP_ERROR DiscoverCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
 {
+    chip::Controller::ControllerInitParams params{
+        .storageDelegate              = &storage,
+        .mDeviceAddressUpdateDelegate = this,
+    };
+
     ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
-    ReturnErrorOnFailure(mCommissioner.Init(localId, &storage));
+    ReturnErrorOnFailure(mCommissioner.Init(localId, params));
     ReturnErrorOnFailure(mCommissioner.ServiceEvents());
 
     ReturnErrorOnFailure(RunCommand(mNodeId, mFabricId));

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -1,0 +1,40 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "DiscoverCommand.h"
+
+constexpr uint16_t kWaitDurationInSeconds = 30;
+
+CHIP_ERROR DiscoverCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
+{
+    ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
+    ReturnErrorOnFailure(mCommissioner.Init(localId, &storage));
+    ReturnErrorOnFailure(mCommissioner.ServiceEvents());
+
+    ReturnErrorOnFailure(RunCommand(mNodeId, mFabricId));
+
+    UpdateWaitForResponse(true);
+    WaitForResponse(kWaitDurationInSeconds);
+
+    mCommissioner.ServiceEventSignal();
+    mCommissioner.Shutdown();
+
+    VerifyOrReturnError(GetCommandExitStatus(), CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -21,7 +21,7 @@
 #include "../../config/PersistentStorage.h"
 #include "../common/Command.h"
 
-class DiscoverCommand : public Command
+class DiscoverCommand : public Command, public chip::Controller::DeviceAddressUpdateDelegate
 {
 public:
     DiscoverCommand(const char * commandName) : Command(commandName)
@@ -29,6 +29,9 @@ public:
         AddArgument("nodeid", 0, UINT64_MAX, &mNodeId);
         AddArgument("fabricid", 0, UINT64_MAX, &mFabricId);
     }
+
+    /////////// DeviceAddressUpdateDelegate Interface /////////
+    void OnAddressUpdateComplete(NodeId nodeId, CHIP_ERROR error) override{};
 
     /////////// Command Interface /////////
     CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../../config/PersistentStorage.h"
+#include "../common/Command.h"
+
+class DiscoverCommand : public Command
+{
+public:
+    DiscoverCommand(const char * commandName) : Command(commandName)
+    {
+        AddArgument("nodeid", 0, UINT64_MAX, &mNodeId);
+        AddArgument("fabricid", 0, UINT64_MAX, &mFabricId);
+    }
+
+    /////////// Command Interface /////////
+    CHIP_ERROR Run(PersistentStorage & storage, NodeId localId, NodeId remoteId) override;
+
+    virtual CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) = 0;
+
+protected:
+    ChipDeviceCommissioner mCommissioner;
+
+private:
+    chip::NodeId mNodeId;
+    uint64_t mFabricId;
+};

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -44,6 +44,10 @@
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+#include <controller/DeviceAddressUpdater.h>
+#endif
+
 namespace chip {
 
 namespace Controller {
@@ -58,6 +62,9 @@ struct ControllerInitParams
     Inet::InetLayer * inetLayer                 = nullptr;
 #if CHIP_ENABLE_INTERACTION_MODEL
     app::InteractionModelDelegate * imDelegate = nullptr;
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
 #endif
 };
 
@@ -121,6 +128,9 @@ public:
 class DLL_EXPORT DeviceController : public Messaging::ExchangeDelegate,
                                     public Messaging::ExchangeMgrDelegate,
                                     public PersistentStorageResultDelegate,
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+                                    public Mdns::ResolverDelegate,
+#endif
                                     public app::InteractionModelDelegate
 {
 public:
@@ -165,6 +175,18 @@ public:
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
      */
     CHIP_ERROR GetDevice(NodeId deviceId, Device ** device);
+
+    /**
+     * @brief
+     *   This function update the device informations asynchronously using mdns.
+     *   If new device informations has been found, it will be persisted.
+     *
+     * @param[in] device    The input device object to update
+     * @param[in] fabricId  The fabricId used for mdns resolution
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, or corresponding error code.
+     */
+    CHIP_ERROR UpdateDevice(Device * device, uint64_t fabricId);
 
     void PersistDevice(Device * device);
 
@@ -211,6 +233,9 @@ protected:
     SecureSessionMgr * mSessionMgr;
     Messaging::ExchangeManager * mExchangeMgr;
     PersistentStorageDelegate * mStorageDelegate;
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    DeviceAddressUpdateDelegate * mDeviceAddressUpdateDelegate = nullptr;
+#endif
     Inet::InetLayer * mInetLayer;
     System::Layer * mSystemLayer;
 
@@ -239,6 +264,12 @@ private:
 
     //////////// PersistentStorageResultDelegate Implementation ///////////////
     void OnPersistentStorageStatus(const char * key, Operation op, CHIP_ERROR err) override;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
+    //////////// ResolverDelegate Implementation ///////////////
+    void OnNodeIdResolved(NodeId nodeId, const chip::Mdns::ResolvedNodeData & nodeData) override;
+    void OnNodeIdResolutionFailed(NodeId nodeId, CHIP_ERROR error) override;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
     void ReleaseAllDevices();
 };


### PR DESCRIPTION
 #### Problem

When the device IP change, the pairing information needs to be updated. This PR adds `DeviceController::UpdateDevice` to the `DeviceController` in order to look over `Mdns` for the latest device information.

For the moment, the signature is `UpdateDevice(Device * device, uint64_t fabricId)` since the fabric is not stored anywhere but it is needed in order to properly do the Mdns mapping. At some point the `fabricId` will likely be retrieved from the controller or something similar.

This PR also add a `update` method to `chip-tool` in order to update the pairing information if needed.

 #### Summary of Changes
 * Add `DeviceController::UpdateDevice(Device * device, uint64_t fabricId);`
 * Add a `update` method to the `Discover` module of `chip-tool`