### PR TITLE
Zap update

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/bridge-app/bridge-common/gen/attribute-size.cpp
+++ b/examples/bridge-app/bridge-common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/chip-tool/gen/attribute-size.cpp
+++ b/examples/chip-tool/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/lighting-app/lighting-common/gen/attribute-size.cpp
+++ b/examples/lighting-app/lighting-common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/lock-app/lock-common/gen/attribute-size.cpp
+++ b/examples/lock-app/lock-common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/examples/window-app/common/gen/attribute-size.cpp
+++ b/examples/window-app/common/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;

--- a/src/darwin/Framework/CHIP/gen/attribute-size.cpp
+++ b/src/darwin/Framework/CHIP/gen/attribute-size.cpp
@@ -57,12 +57,12 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
     {
         if (write)
         {
-            // src is a pointer to native-endian uint16_t, dst is pointer to buffer that should hold little-endian value
+            // src is a pointer to native-endian uint16_t, dest is pointer to buffer that should hold little-endian value
             emberAfCopyInt16u(dest, 0, *reinterpret_cast<uint16_t *>(src));
         }
         else
         {
-            // src is pointer to buffer holding little-endian value, dst is a pointer to native-endian uint16_t
+            // src is pointer to buffer holding little-endian value, dest is a pointer to native-endian uint16_t
             *reinterpret_cast<uint16_t *>(dest) = emberAfGetInt16u(src, 0, kSizeLengthInBytes);
         }
         return kSizeLengthInBytes;


### PR DESCRIPTION
 #### Problem
 The current ZAP version that is checked out as a submodule is broken if someone tries to open a `zap` config file via the menu `Electron -> Open File`. It throws somewhere in `menu.js` because of an undefined `httpPort`.

It has been fixed upstream. 

 #### Summary of Changes
 * Update ZAP submodule
 * Rerun `./scripts/tools/zap_regen_all.py`