### PR TITLE
doxygen: Remove deployment

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -37,9 +37,3 @@ jobs:
               shell: bash
               run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
               id: extract_branch
-            - name: Deploy if master
-              if: steps.extract_branch.outputs.branch == 'master' && github.repository == 'project-chip/connectedhomeip'
-              uses: peaceiris/actions-gh-pages@v3
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: ./docs/html


### PR DESCRIPTION
Despite reducing the size of a docs build to 500M to 50M, this is still
growing the repository at a prodigious rate. There are still some
images, and it it appears the results are not at all reproducible so
after ~10 commits we're already at 500M again.

It seems hosting doxygen from a git branch of the main repository will
have unacceptable costs, so remove the deployment step. We still want
the build coverage, however.