### PR TITLE
happy: Fix static analysis deprecation warning

### DIFF
--- a/third_party/happy/BUILD.gn
+++ b/third_party/happy/BUILD.gn
@@ -17,5 +17,5 @@ import("$dir_pw_build/python.gni")
 
 pw_python_package("happy") {
   setup = [ "repo/setup.py" ]
-  lint = false
+  static_analysis = []
 }


### PR DESCRIPTION
This fixes the following warning:

WARNING: The 'lint' option for pw_python_package is deprecated. Instead, use 'static_analysis = []' to disable linting.