### PR TITLE
Fix CRMP retransmission does not occur as expected issue.

### DIFF
--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -135,9 +135,14 @@ CHIP_ERROR ReliableMessageContext::FlushAcks()
     return err;
 }
 
-uint64_t ReliableMessageContext::GetCurrentRetransmitTimeoutTick()
+uint64_t ReliableMessageContext::GetInitialRetransmitTimeoutTick()
 {
-    return (HasRcvdMsgFromPeer() ? mConfig.mActiveRetransTimeoutTick : mConfig.mInitialRetransTimeoutTick);
+    return mConfig.mInitialRetransTimeoutTick;
+}
+
+uint64_t ReliableMessageContext::GetActiveRetransmitTimeoutTick()
+{
+    return mConfig.mActiveRetransTimeoutTick;
 }
 
 /**

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -70,13 +70,20 @@ public:
     CHIP_ERROR FlushAcks();
 
     /**
-     *  Get the current retransmit timeout. It would be either the initial or
-     *  the active retransmit timeout based on whether the ExchangeContext has
-     *  an active message exchange going with its peer.
+     *  Get the initial retransmission interval. It would be the time to wait before
+     *  retransmission after first failure.
      *
-     *  @return the current retransmit time.
+     *  @return the initial retransmission interval.
      */
-    uint64_t GetCurrentRetransmitTimeoutTick();
+    uint64_t GetInitialRetransmitTimeoutTick();
+
+    /**
+     *  Get the active retransmit interval. It would be the time to wait before
+     *  retransmission after subsequent failures.
+     *
+     *  @return the active retransmission interval.
+     */
+    uint64_t GetActiveRetransmitTimeoutTick();
 
     /**
      *  Send a SecureChannel::StandaloneAck message.

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -152,7 +152,7 @@ void ReliableMessageMgr::ExecuteActions()
         if (err == CHIP_NO_ERROR)
         {
             // If the retransmission was successful, update the passive timer
-            entry.nextRetransTimeTick = static_cast<uint16_t>(rc->GetCurrentRetransmitTimeoutTick());
+            entry.nextRetransTimeTick = static_cast<uint16_t>(rc->GetActiveRetransmitTimeoutTick());
 #if !defined(NDEBUG)
             ChipLogProgress(ExchangeManager, "Retransmit MsgId:%08" PRIX32 " Send Cnt %d", entry.retainedBuf.GetMsgId(),
                             entry.sendCount);
@@ -288,7 +288,7 @@ void ReliableMessageMgr::StartRetransmision(RetransTableEntry * entry)
 {
     VerifyOrDie(entry != nullptr && entry->rc != nullptr);
 
-    entry->nextRetransTimeTick = static_cast<uint16_t>(entry->rc->GetCurrentRetransmitTimeoutTick() +
+    entry->nextRetransTimeTick = static_cast<uint16_t>(entry->rc->GetInitialRetransmitTimeoutTick() +
                                                        GetTickCounterFromTimeDelta(System::Timer::GetCurrentEpoch()));
 
     // Check if the timer needs to be started and start it.

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -122,10 +122,11 @@ struct ReliableMessageProtocolConfig
     uint8_t mMaxRetrans;                 /**< Configurable max value for retransmissions in the ExchangeContext. */
 };
 
-const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = { CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL,
-                                                                              CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL,
-                                                                              CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK,
-                                                                              CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS };
+const ReliableMessageProtocolConfig gDefaultReliableMessageProtocolConfig = {
+    CHIP_CONFIG_RMP_DEFAULT_INITIAL_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+    CHIP_CONFIG_RMP_DEFAULT_ACTIVE_RETRY_INTERVAL >> CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT,
+    CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT_TICK, CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS
+};
 
 // clang-format on
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, CRMP retransmission does not behave as expected. Spec the initial retransmission occurs after 5000ms and subsequent retransmission occurs after 300ms.

1. The initial re-transmission actually occurs after 320000ms,  this seems a regression introduced by #5841, which use time interval value as ticks 

2. Initial retransmission interval is used after both first failure and subsequent failures.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Does not return initial and active interval based on if there is a response, since re-transmission occurs only in no response cases.
2. Convert wait interval period from ms to ticks.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
