### PR TITLE
Change error return to allow default values to be used

### DIFF
--- a/src/platform/qpg6100/qpg6100Config.cpp
+++ b/src/platform/qpg6100/qpg6100Config.cpp
@@ -268,7 +268,7 @@ CHIP_ERROR QPG6100Config::MapNVMError(qvStatus_t aStatus)
     case QV_STATUS_KEY_LEN_TOO_SMALL:
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     case QV_STATUS_INVALID_DATA:
-        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
     default:
         break;
     }


### PR DESCRIPTION
 #### Problem
* Incorrect error mapping causes problems with default values

 #### Summary of Changes
* Switched to a more conventional one