### PR TITLE
Add offset_of and owner_of

### DIFF
--- a/src/lib/support/OwnerOf.h
+++ b/src/lib/support/OwnerOf.h
@@ -18,14 +18,15 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 namespace chip {
 
-template<class ClassType, class MemberType>
-constexpr ClassType* OwnerOf(MemberType *ptr, const MemberType ClassType::*member) {
-    return reinterpret_cast<ClassType*>(reinterpret_cast<uintptr_t>(ptr) - offsetof(ClassType, member));
+template <class ClassType, class MemberType>
+constexpr ClassType * OwnerOf(MemberType * ptr, const MemberType ClassType::*member)
+{
+    return reinterpret_cast<ClassType *>(reinterpret_cast<uintptr_t>(ptr) - offsetof(ClassType, member));
 }
 
-}
+} // namespace chip

--- a/src/lib/support/OwnerOf.h
+++ b/src/lib/support/OwnerOf.h
@@ -1,0 +1,31 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace chip {
+
+template<class ClassType, class MemberType>
+constexpr ClassType* OwnerOf(MemberType *ptr, const MemberType ClassType::*member) {
+    return reinterpret_cast<ClassType*>(reinterpret_cast<uintptr_t>(ptr) - offsetof(ClassType, member));
+}
+
+}

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -29,6 +29,7 @@ chip_test_suite("tests") {
     "TestCHIPCounter.cpp",
     "TestCHIPMem.cpp",
     "TestErrorStr.cpp",
+    "TestOwnerOf.cpp",
     "TestPool.cpp",
     "TestPrivateHeap.cpp",
     "TestSafeInt.cpp",

--- a/src/lib/support/tests/TestOwnerOf.cpp
+++ b/src/lib/support/tests/TestOwnerOf.cpp
@@ -23,10 +23,12 @@
 
 using namespace chip;
 
-class Member {
+class Member
+{
 };
 
-class Base {
+class Base
+{
 public:
     uint32_t Offset0;
     uint32_t Offset4;
@@ -45,10 +47,7 @@ static void TestMemberOwner(nlTestSuite * inSuite, void * inContext)
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = {
-    NL_TEST_DEF_FN(TestMemberOwner),
-    NL_TEST_SENTINEL()
-};
+static const nlTest sTests[] = { NL_TEST_DEF_FN(TestMemberOwner), NL_TEST_SENTINEL() };
 
 int TestOwnerOf(void)
 {

--- a/src/lib/support/tests/TestOwnerOf.cpp
+++ b/src/lib/support/tests/TestOwnerOf.cpp
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <support/OwnerOf.h>
+#include <support/UnitTestRegistration.h>
+
+#include <nlunit-test.h>
+
+using namespace chip;
+
+class Member {
+};
+
+class Base {
+public:
+    uint32_t Offset0;
+    uint32_t Offset4;
+    Member member;
+};
+
+static void TestMemberOwner(nlTestSuite * inSuite, void * inContext)
+{
+    Base base;
+    Member * member = &base.member;
+    NL_TEST_ASSERT(inSuite, OwnerOf(member, &Base::member) == &base);
+    NL_TEST_ASSERT(inSuite, &OwnerOf(member, &Base::member)->member == member);
+}
+
+#define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+static const nlTest sTests[] = {
+    NL_TEST_DEF_FN(TestMemberOwner),
+    NL_TEST_SENTINEL()
+};
+
+int TestOwnerOf(void)
+{
+    nlTestSuite theSuite = { "CHIP OwnerOf tests", &sTests[0], nullptr, nullptr };
+
+    // Run test suit againt one context.
+    nlTestRunner(&theSuite, nullptr);
+    return nlTestRunnerStats(&theSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestOwnerOf)
+

--- a/src/lib/support/tests/TestOwnerOf.cpp
+++ b/src/lib/support/tests/TestOwnerOf.cpp
@@ -60,4 +60,3 @@ int TestOwnerOf(void)
 }
 
 CHIP_REGISTER_TEST_SUITE(TestOwnerOf)
-


### PR DESCRIPTION
`owner_of` function is able to eliminate several pointer in order to save memory.