### PR TITLE
[Hotfix]Move cirque to manual only

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -15,8 +15,7 @@
 name: Cirque
 
 on:
-    push:
-    pull_request:
+  workflow_dispatch:
 
 jobs:
     cirque:


### PR DESCRIPTION
Problems:
See the crash in cirque IM test

Summary of changes:
Move cirque to manual trigger on demand temporarily
