### PR TITLE
Add CHIP stack module.

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -87,6 +87,19 @@
 #endif // CHIP_CONFIG_ERROR_TYPE
 
 /**
+ *  @def CHIP_CONFIG_CHIP_IS_SINGLETON
+ *
+ *  @brief
+ *    This defines whether chip is singleton. If chip is singleton, all
+ *    pointers to chip components like SecureSessionMgr, ExchangeManager, etc
+ *    can be omitted, which saves memory on small platforms. For some situation
+ *    where there can be multiple chip instances, define this to 0.
+ */
+#ifndef CHIP_CONFIG_CHIP_IS_SINGLETON
+#define CHIP_CONFIG_CHIP_IS_SINGLETON 1
+#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
+
+/**
  *  @def CHIP_CONFIG_NO_ERROR
  *
  *  @brief

--- a/src/stack/BUILD.gn
+++ b/src/stack/BUILD.gn
@@ -1,0 +1,57 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/common_flags.gni")
+
+static_library("stack") {
+  sources = [
+    "ChipRef.h",
+    "Stack.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}
+
+static_library("stack_impl") {
+  sources = [ "StackImpl.h" ]
+
+  public_deps = [
+    "${chip_root}/src/lib/mdns",
+    "${chip_root}/src/messaging",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/src/stack",
+    "${chip_root}/src/transport",
+  ]
+}
+
+static_library("stack_controller") {
+  sources = [ "ControllerStack.h" ]
+
+  public_deps = [ "${chip_root}/src/stack" ]
+}
+
+static_library("stack_controller_impl") {
+  sources = [ "ControllerStackImpl.h" ]
+
+  public_deps = [
+    "${chip_root}/src/controller",
+    "${chip_root}/src/stack:stack_controller",
+    "${chip_root}/src/stack:stack_impl",
+  ]
+}

--- a/src/stack/ChipRef.h
+++ b/src/stack/ChipRef.h
@@ -1,0 +1,56 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <stack/Stack.h>
+
+namespace chip {
+
+/*
+ * @brief
+ *   Base class for any objects which is holding a reference to chip stack.
+ *
+ *   When CHIP_CONFIG_CHIP_IS_SINGLETON is true, this class has no overhead.
+ *
+ *   This class should be used as a member since size of empty class is not zero, unless [[no_unique_address]] (C++20)
+ *   is used. This class should be used as a base class because it is opt-out by empty base optimization.
+ */
+class ChipRef
+{
+public:
+    Init(ChipRef & ref)
+    {
+#if !CHIP_CONFIG_CHIP_IS_SINGLETON
+        mChip = ref.mChip;
+#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
+    }
+
+#if CHIP_CONFIG_CHIP_IS_SINGLETON
+    // When chip is singleton, the application must implement this function to return a chip stack.
+    static Stack & GetChipStack();
+#else
+    Stack & GetChipStack() { return mChip; }
+#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
+
+private:
+#if !CHIP_CONFIG_CHIP_IS_SINGLETON
+    Stack * mChip;
+#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
+}
+
+} // namespace chip

--- a/src/stack/ControllerStack.h
+++ b/src/stack/ControllerStack.h
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <ble/BleLayer.h>
+#include <stack/Stack.h>
+
+namespace chip {
+
+// Forward declare all CHIP components, so that all components are able to contain a pointer to the CHIP stack.
+namespace Controller {
+class DeviceCommissioner;
+}
+
+class ControllerStack : public virtual Stack
+{
+public:
+    virtual ~ControllerStack() {}
+
+    virtual CHIP_ERROR InitController(PersistentStorageDelegate * storageDelegate,
+                                      Controller::DevicePairingDelegate * pairingDelegate) = 0;
+    virtual CHIP_ERROR Shutdown()                                                          = 0;
+
+    virtual Controller::DeviceCommissioner & GetDeviceCommissioner() = 0;
+};
+
+} // namespace chip

--- a/src/stack/ControllerStackImpl.h
+++ b/src/stack/ControllerStackImpl.h
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <ble/BleLayer.h>
+#include <stack/ControllerStack.h>
+#include <stack/StackImpl.h>
+
+namespace chip {
+
+/* ========================== ControllerStackImpl ========================== */
+template <typename... Configurations>
+class ControllerStackImpl : public ControllerStack, public StackImpl<Configurations...>
+{
+public:
+    ControllerStackImpl(NodeId localDeviceId) : StackImpl<Configurations...>(localDeviceId) {}
+    ~ControllerStackImpl() override {}
+
+    CHIP_ERROR InitController(PersistentStorageDelegate * storageDelegate,
+                              Controller::DevicePairingDelegate * pairingDelegate) override
+    {
+        ReturnErrorOnFailure(StackImpl<Configurations...>::Init());
+        ReturnErrorOnFailure(mDeviceCommissioner.Init(this, storageDelegate, pairingDelegate));
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Shutdown() override
+    {
+        ReturnErrorOnFailure(mDeviceCommissioner.Shutdown());
+        ReturnErrorOnFailure(StackImpl<Configurations...>::Shutdown());
+        return CHIP_NO_ERROR;
+    }
+
+    Controller::DeviceCommissioner & GetDeviceCommissioner() override { return mDeviceCommissioner; }
+
+private:
+    Controller::DeviceCommissioner mDeviceCommissioner;
+};
+
+} // namespace chip

--- a/src/stack/Stack.h
+++ b/src/stack/Stack.h
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+
+namespace chip {
+
+// Forward declare all CHIP components, so that all components are able to contain a pointer to the CHIP stack.
+namespace Ble {
+class BleLayer;
+}
+class TransportMgrBase;
+class SecureSessionMgr;
+namespace Transport {
+class AdminPairingTable;
+}
+namespace Messaging {
+class ExchangeManager;
+}
+namespace app {
+class InteractionModelEngine;
+}
+
+class Stack
+{
+public:
+    virtual ~Stack() {}
+
+    virtual CHIP_ERROR Init()     = 0;
+    virtual CHIP_ERROR Shutdown() = 0;
+
+    virtual NodeId GetLocalNodeId()          = 0;
+    virtual System::Layer & GetSystemLayer() = 0;
+    virtual Inet::InetLayer & GetInetLayer() = 0;
+    virtual Ble::BleLayer * GetBleLayer()    = 0;
+
+    virtual TransportMgrBase & GetTransportManager()          = 0;
+    virtual CHIP_ERROR ResetTransport()                       = 0;
+    virtual SecureSessionMgr & GetSecureSessionManager()      = 0;
+    virtual Transport::AdminPairingTable & GetAdmins()        = 0;
+    virtual Messaging::ExchangeManager & GetExchangeManager() = 0;
+#ifdef CHIP_ENABLE_INTERACTION_MODEL
+    virtual app::InteractionModelEngine & GetInteractionModelEngine() = 0;
+#endif
+};
+
+} // namespace chip

--- a/src/stack/StackImpl.h
+++ b/src/stack/StackImpl.h
@@ -1,0 +1,243 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <stack/Stack.h>
+#include <stack/Traits.h>
+
+#include <app/InteractionModelEngine.h>
+#include <messaging/ExchangeMgr.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/UDP.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
+#endif
+
+namespace chip {
+
+/* ========================== SystemLayer Configuration ========================== */
+struct SystemLayerConfiguration
+{
+};
+template <typename T>
+struct IsSystemLayerConfiguration : std::is_base_of<SystemLayerConfiguration, T>
+{
+};
+
+#if CONFIG_DEVICE_LAYER
+class DefaultSystemLayer : SystemLayerConfiguration
+{
+public:
+    CHIP_ERROR Init() { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    System::Layer & Get() { return DeviceLayer::SystemLayer; }
+};
+#else
+class DefaultSystemLayer : SystemLayerConfiguration
+{
+public:
+    CHIP_ERROR Init() { return mSystemLayer.Init(nullptr); }
+
+    CHIP_ERROR Shutdown() { return mSystemLayer.Shutdown(); }
+
+    System::Layer & Get() { return mSystemLayer; }
+
+private:
+    System::Layer mSystemLayer;
+};
+#endif // CONFIG_DEVICE_LAYER
+
+/* ========================== InetLayer Configuration ========================== */
+struct InetLayerConfiguration
+{
+};
+template <typename T>
+struct IsInetLayerConfiguration : std::is_base_of<InetLayerConfiguration, T>
+{
+};
+
+#if CONFIG_DEVICE_LAYER
+class DefaultInetLayer : InetLayerConfiguration
+{
+public:
+    CHIP_ERROR Init(System::Layer & aSystemLayer) { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    Inet::InetLayer & Get() { return DeviceLayer::InetLayer; }
+};
+#else
+class DefaultInetLayer : InetLayerConfiguration
+{
+public:
+    CHIP_ERROR Init(System::Layer & aSystemLayer) { return mInetLayer.Init(aSystemLayer, nullptr); }
+
+    CHIP_ERROR Shutdown() { return mInetLayer.Shutdown(); }
+
+    Inet::InetLayer & Get() { return mInetLayer; }
+
+private:
+    Inet::InetLayer mInetLayer;
+};
+#endif // CONFIG_DEVICE_LAYER
+
+/* ========================== BleLayer Configuration ========================== */
+struct BleLayerConfiguration
+{
+};
+template <typename T>
+struct IsBleLayerConfiguration : std::is_base_of<BleLayerConfiguration, T>
+{
+};
+
+class DefaultBleLayer : BleLayerConfiguration
+{
+public:
+    template <typename T>
+    CHIP_ERROR Init(T * stack)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    Ble::BleLayer * Get() { return nullptr; }
+};
+
+/* ========================== Transport Configuration ========================== */
+struct TransportConfiguration
+{
+};
+template <typename T>
+struct IsTransportConfiguration : std::is_base_of<TransportConfiguration, T>
+{
+};
+
+class DefaultTransport : TransportConfiguration
+{
+public:
+    using transport = TransportMgr<Transport::UDP
+#if INET_CONFIG_ENABLE_IPV4
+                                   ,
+                                   Transport::UDP /* IPv4 */
+#endif
+                                   >;
+
+    CHIP_ERROR Init(Inet::InetLayer & inetLayer)
+    {
+        return mTransportManager.Init(
+            Transport::UdpListenParameters(&inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(mPort)
+#if INET_CONFIG_ENABLE_IPV4
+                ,
+            Transport::UdpListenParameters(&inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(mPort)
+#endif
+        );
+    }
+
+    TransportMgrBase & Get() { return mTransportManager; }
+    void SetListenPort(uint16_t port) { mPort = port; }
+
+private:
+    transport mTransportManager;
+    uint16_t mPort = CHIP_PORT;
+};
+
+/* ========================== StackImpl ========================== */
+template <typename... Configurations>
+class StackImpl : public virtual Stack
+{
+private:
+    using SystemLayerConfig =
+        typename first_if_any_or_default<IsSystemLayerConfiguration, DefaultSystemLayer, Configurations...>::type;
+    using InetLayerConfig = typename first_if_any_or_default<IsInetLayerConfiguration, DefaultInetLayer, Configurations...>::type;
+    using BleLayerConfig  = typename first_if_any_or_default<IsBleLayerConfiguration, DefaultBleLayer, Configurations...>::type;
+    using TransportConfig = typename first_if_any_or_default<IsTransportConfiguration, DefaultTransport, Configurations...>::type;
+
+public:
+    StackImpl(NodeId localDeviceId) : mLocalDeviceId(localDeviceId) {}
+    virtual ~StackImpl() override {}
+
+    CHIP_ERROR Init() override
+    {
+#if CONFIG_DEVICE_LAYER
+        // Initialize the CHIP stack.
+        ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgr().InitChipStack());
+#endif
+        ReturnErrorOnFailure(mSystemLayer.Init());
+        ReturnErrorOnFailure(mInetLayer.Init(mSystemLayer.Get()));
+        ReturnErrorOnFailure(mTransport.Init(mInetLayer.Get()));
+        ReturnErrorOnFailure(mBleLayer.Init(this));
+        ReturnErrorOnFailure(mSessionManager.Init(mLocalDeviceId, &GetSystemLayer(), &GetTransportManager(), &mAdmins));
+        ReturnErrorOnFailure(mExchangeManager.Init(&mSessionManager));
+#ifdef CHIP_ENABLE_INTERACTION_MODEL
+        ReturnErrorOnFailure(mInteractionModelEngine.Init(&mExchangeManager, nullptr));
+#endif
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Shutdown() override
+    {
+        mExchangeManager.Shutdown();
+        mSessionManager.Shutdown();
+
+        Ble::BleLayer * ble = GetBleLayer();
+        if (ble != nullptr)
+            ble->Shutdown();
+        mInetLayer.Shutdown();
+        mSystemLayer.Shutdown();
+#if CONFIG_DEVICE_LAYER
+        ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
+#endif // CONFIG_DEVICE_LAYER
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ResetTransport() override { return mTransport.Init(mInetLayer.Get()); }
+
+    TransportConfig & GetTransportConfig() { return mTransport; }
+
+    NodeId GetLocalNodeId() override { return mLocalDeviceId; }
+    System::Layer & GetSystemLayer() override { return mSystemLayer.Get(); }
+    Inet::InetLayer & GetInetLayer() override { return mInetLayer.Get(); }
+    BleLayerConfig & GetBleLayerConfig() { return mBleLayer; }
+    Ble::BleLayer * GetBleLayer() override { return mBleLayer.Get(); }
+    TransportMgrBase & GetTransportManager() override { return mTransport.Get(); }
+    SecureSessionMgr & GetSecureSessionManager() override { return mSessionManager; }
+    Transport::AdminPairingTable & GetAdmins() override { return mAdmins; }
+    Messaging::ExchangeManager & GetExchangeManager() override { return mExchangeManager; }
+#ifdef CHIP_ENABLE_INTERACTION_MODEL
+    app::InteractionModelEngine & GetInteractionModelEngine() override { return mInteractionModelEngine; }
+#endif
+private:
+    NodeId mLocalDeviceId;
+
+    SystemLayerConfig mSystemLayer;
+    InetLayerConfig mInetLayer;
+    BleLayerConfig mBleLayer;
+
+    Transport::AdminPairingTable mAdmins;
+
+    TransportConfig mTransport;
+    SecureSessionMgr mSessionManager;
+    Messaging::ExchangeManager mExchangeManager;
+#ifdef CHIP_ENABLE_INTERACTION_MODEL
+    app::InteractionModelEngine mInteractionModelEngine;
+#endif
+};
+
+} // namespace chip

--- a/src/stack/Traits.h
+++ b/src/stack/Traits.h
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace chip {
+
+template <template <typename> class Cond, typename Default, typename... Ts>
+struct first_if_any_or_default;
+
+template <template <typename> class Cond, typename Default>
+struct first_if_any_or_default<Cond, Default>
+{
+    using type                  = Default;
+    static constexpr bool found = false;
+};
+
+template <template <typename> class Cond, typename Default, typename T, typename... Ts>
+struct first_if_any_or_default<Cond, Default, T, Ts...>
+{
+private:
+    using next = first_if_any_or_default<Cond, Default, Ts...>;
+
+public:
+    using type                  = typename std::conditional<Cond<T>::value, T, typename next::type>::type;
+    static constexpr bool found = Cond<T>::value || next::found;
+};
+
+template <class, template <class, class...> class>
+struct is_instance : public std::false_type
+{
+};
+
+template <class... Ts, template <class, class...> class U>
+struct is_instance<U<Ts...>, U> : public std::true_type
+{
+};
+
+} // namespace chip


### PR DESCRIPTION
 #### Problem
Currently CHIP stack contains several components, and these components are allocated and initialized by all device applications and controller apps. CHIP stack will introduce a class in charge of the allocation and initialization and destruction of all CHIP components.