### PR TITLE
Aligned QR code alphabet to be up to date with the spec.

### DIFF
--- a/src/setup_payload/Base41.cpp
+++ b/src/setup_payload/Base41.cpp
@@ -35,7 +35,7 @@ namespace chip {
 
 static const char codes[]        = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
                               'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
-                              'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '*', '+', '-', '.' };
+                              'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', ' ', '+', '-', '.', '/' };
 static const int kBase41ChunkLen = 3;
 static const int kBytesChunkLen  = 2;
 static const int kRadix          = sizeof(codes) / sizeof(codes[0]);
@@ -127,12 +127,12 @@ static inline CHIP_ERROR decodeChar(char c, uint8_t & value)
         kBogus, // ''', =39
         kBogus, // '(', =40
         kBogus, // ')', =41
-        37,     // '*', =42
-        38,     // '+', =43
+        kBogus, // '*', =42
+        37,     // '+', =43
         kBogus, // ',', =44
-        39,     // '-', =45
-        40,     // '.', =46
-        kBogus, // '/', =47
+        38,     // '-', =45
+        39,     // '.', =46
+        40,     // '/', =47
         0,      // '0', =48
         1,      // '1', =49
         2,      // '2', =50

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -99,7 +99,7 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     input[2] = 0;
     NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL10");
     input[2] = 40;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL1.");
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL1/");
     input[2] = 41;
     NL_TEST_ASSERT(inSuite, base41Encode(input, 3) == "SL101");
     input[2] = 255;
@@ -117,17 +117,17 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     // largest optimizated encoding value
     input[0] = ((kRadix * kRadix) - 1) % 256;
     input[1] = ((kRadix * kRadix) - 1) / 256;
-    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "..");
+    NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "//");
     // can't optimize
     input[0] = ((kRadix * kRadix)) % 256;
     input[1] = ((kRadix * kRadix)) / 256;
     NL_TEST_ASSERT(inSuite, base41Encode(input, 2) == "001");
 
     // fun with strings
-    NL_TEST_ASSERT(inSuite, base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1) == "GHF.KGL+48-G5LGK35");
+    NL_TEST_ASSERT(inSuite, base41Encode((uint8_t *) "Hello World!", sizeof("Hello World!") - 1) == "GHF/KGL-48.G5LGK35");
 
     vector<uint8_t> decoded = vector<uint8_t>();
-    NL_TEST_ASSERT(inSuite, base41Decode("GHF.KGL+48-G5LGK35", decoded) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, base41Decode("GHF/KGL-48.G5LGK35", decoded) == CHIP_NO_ERROR);
 
     string hello_world;
     for (uint8_t b : decoded)
@@ -175,7 +175,7 @@ void TestBase41(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, decoded.size() == 1 && decoded[0] == 255);
     NL_TEST_ASSERT(inSuite, base41Decode("A6", decoded) == CHIP_NO_ERROR); // this is 256, needs 2 output bytes
     NL_TEST_ASSERT(inSuite, decoded.size() == 2 && decoded[0] + decoded[1] * 256 == 256);
-    NL_TEST_ASSERT(inSuite, base41Decode("..", decoded) == CHIP_NO_ERROR); // this is (41*41)-1, or 1680, needs 2 output bytes
+    NL_TEST_ASSERT(inSuite, base41Decode("//", decoded) == CHIP_NO_ERROR); // this is (41*41)-1, or 1680, needs 2 output bytes
     NL_TEST_ASSERT(inSuite, decoded.size() == 2 && decoded[0] + decoded[1] * 256 == (kRadix * kRadix) - 1);
 }
 


### PR DESCRIPTION
 #### Problem
Currently Base-41 alphabet used by QR code is 0-9A-Z *+-. while according to spec it should be 0-9A-Z +-./

 #### Summary of Changes
Aligned alphabet to the spec requirements.

 Fixes #5611 