### PR TITLE
Mark CHIPDeviceController::startup storageDelegate argument to be _Nu…

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param[in] queue The queue on which the storage callbacks will be delivered
  */
-- (BOOL)startup:(id<CHIPPersistentStorageDelegate>)storageDelegate queue:(dispatch_queue_t)queue;
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate queue:(_Nullable dispatch_queue_t)queue;
 
 /**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -122,7 +122,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     return YES;
 }
 
-- (BOOL)startup:(id<CHIPPersistentStorageDelegate>)storageDelegate queue:(nonnull dispatch_queue_t)queue
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate queue:(_Nullable dispatch_queue_t)queue
 {
     __block BOOL commissionerInitialized = NO;
     dispatch_sync(_chipWorkQueue, ^{

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -28,7 +28,7 @@ public:
     CHIPPersistentStorageDelegateBridge();
     ~CHIPPersistentStorageDelegateBridge();
 
-    void setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue);
+    void setFrameworkDelegate(_Nullable id<CHIPPersistentStorageDelegate> delegate, _Nullable dispatch_queue_t queue);
 
     void SetStorageDelegate(chip::PersistentStorageResultDelegate * delegate) override;
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -26,7 +26,8 @@ CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(void)
 
 CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}
 
-void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(id<CHIPPersistentStorageDelegate> delegate, dispatch_queue_t queue)
+void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(
+    _Nullable id<CHIPPersistentStorageDelegate> delegate, _Nullable dispatch_queue_t queue)
 {
     dispatch_async(mWorkQueue, ^{
         if (delegate && queue) {


### PR DESCRIPTION
…llable to allow calling into the default persistent storage implementation

 #### Problem
 Currently one can not pass `nil` to storage delegate to get the default implementation.

 #### Summary of changes
 * Add `_Nullable`