### PR TITLE
Fix printing of strings to not show garbage.

### DIFF
--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "af.h"
 #include "debug-printing.h"
 
 #include <platform/CHIPDeviceConfig.h>
@@ -85,5 +86,5 @@ void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, b
 
 void emberAfPrintString(int category, const uint8_t * string)
 {
-    emberAfPrint(category, "%s", string);
+    emberAfPrint(category, "%.*s", emberAfStringLength(string), string + 1);
 }


### PR DESCRIPTION
Strings have length embedded; they are not null-terminated.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
ZCL strings are not null-terminated, but we are printing them with raw %s.  This also treats their length as a char!

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Print the right thing.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
