### PR TITLE
Improve Command Add API in IM Command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,6 @@ jobs:
                      "gcc_release") GN_ARGS='is_debug=false';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
-                     "clang_experimental") GN_ARGS='is_clang=true chip_enable_interaction_model=true';;
                      *) ;;
                   esac
 

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -67,14 +67,14 @@ CHIP_ERROR Command::Reset()
     SuccessOrExit(err);
 
     commandListBuilder = mInvokeCommandBuilder.CreateCommandListBuilder();
-    SuccessOrExit(commandListBuilder.GetError());
+    err                = commandListBuilder.GetError();
+    SuccessOrExit(err);
     MoveToState(CommandState::Initialized);
 
     mCommandIndex = 0;
 
 exit:
     ChipLogFunctError(err);
-
     return err;
 }
 
@@ -123,6 +123,7 @@ CHIP_ERROR Command::ProcessCommandMessage(System::PacketBufferHandle && payload,
     }
 
 exit:
+    ChipLogFunctError(err);
     return err;
 }
 
@@ -136,86 +137,58 @@ void Command::Shutdown()
 
     mpExchangeMgr = nullptr;
     mpDelegate    = nullptr;
-    MoveToState(CommandState::Uninitialized);
+    ClearState();
 
     mCommandIndex = 0;
 exit:
     return;
 }
 
-chip::TLV::TLVWriter & Command::CreateCommandDataElementTLVWriter()
+CHIP_ERROR Command::PrepareCommand(const CommandParams * const apCommandParams)
 {
-    mCommandDataBuf = chip::System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
-    if (mCommandDataBuf.IsNull())
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    CommandDataElement::Builder commandDataElement =
+        mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
+    err = commandDataElement.GetError();
+    SuccessOrExit(err);
+
+    if (apCommandParams != nullptr)
     {
-        ChipLogDetail(DataManagement, "Unable to allocate packet buffer");
-    }
-
-    mCommandDataWriter.Init(mCommandDataBuf.Retain());
-
-    return mCommandDataWriter;
-}
-
-CHIP_ERROR Command::AddCommand(chip::EndpointId aEndpointId, chip::GroupId aGroupId, chip::ClusterId aClusterId,
-                               chip::CommandId aCommandId, BitFlags<CommandPathFlags> aFlags)
-{
-    CommandParams commandParams(aEndpointId, aGroupId, aClusterId, aCommandId, aFlags);
-
-    return AddCommand(commandParams);
-}
-
-CHIP_ERROR Command::AddCommand(CommandParams & aCommandParams)
-{
-    CHIP_ERROR err              = CHIP_NO_ERROR;
-    const uint8_t * commandData = nullptr;
-    uint32_t commandLen         = 0;
-
-    if (!mCommandDataBuf.IsNull())
-    {
-        commandData = mCommandDataBuf->Start();
-        commandLen  = mCommandDataBuf->DataLength();
-    }
-
-    if (commandLen > 0 && commandData != nullptr)
-    {
-        // Command argument list can be empty.
-        VerifyOrExit(commandLen >= 2, err = CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrExit(commandData[0] == chip::TLV::kTLVType_Structure, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-        commandData += 1;
-        commandLen -= 1;
-    }
-
-    {
-        CommandDataElement::Builder commandDataElement =
-            mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
-
-        err = Command::ConstructCommandPath(aCommandParams, commandDataElement);
-        SuccessOrExit(err);
-
-        if (commandLen > 0 && commandData != nullptr)
-        {
-            // Copy the application data into a new TLV structure field contained with the
-            // command structure.  NOTE: The TLV writer will take care of moving the app data
-            // to the correct location within the buffer.
-            err = mInvokeCommandBuilder.GetWriter()->PutPreEncodedContainer(chip::TLV::ContextTag(CommandDataElement::kCsTag_Data),
-                                                                            chip::TLV::kTLVType_Structure, commandData, commandLen);
-            SuccessOrExit(err);
-        }
-        commandDataElement.EndOfCommandDataElement();
-
-        err = commandDataElement.GetError();
+        err = ConstructCommandPath(*apCommandParams, commandDataElement);
         SuccessOrExit(err);
     }
-    MoveToState(CommandState::AddCommand);
 
+    err = commandDataElement.GetWriter()->StartContainer(TLV::ContextTag(CommandDataElement::kCsTag_Data), TLV::kTLVType_Structure,
+                                                         mDataElementContainerType);
 exit:
-    mCommandDataBuf = nullptr;
     ChipLogFunctError(err);
     return err;
 }
 
-CHIP_ERROR Command::ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder & aCommandDataElement)
+TLV::TLVWriter * Command::GetCommandDataElementTLVWriter()
+{
+    return mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder().GetWriter();
+}
+
+CHIP_ERROR Command::FinishCommand()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    CommandDataElement::Builder commandDataElement = mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder();
+    err                                            = commandDataElement.GetWriter()->EndContainer(mDataElementContainerType);
+    SuccessOrExit(err);
+    commandDataElement.EndOfCommandDataElement();
+    err = commandDataElement.GetError();
+    SuccessOrExit(err);
+    MoveToState(CommandState::AddCommand);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR Command::ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder aCommandDataElement)
 {
     CommandPath::Builder commandPath = aCommandDataElement.CreateCommandPathBuilder();
     if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
@@ -249,9 +222,11 @@ CHIP_ERROR Command::ClearExistingExchangeContext()
 CHIP_ERROR Command::FinalizeCommandsMessage()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-
-    CommandList::Builder commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();
-    SuccessOrExit(commandListBuilder.GetError());
+    CommandList::Builder commandListBuilder;
+    VerifyOrExit(mState == CommandState::AddCommand, err = CHIP_ERROR_INCORRECT_STATE);
+    commandListBuilder = mInvokeCommandBuilder.GetCommandListBuilder().EndOfCommandList();
+    err                = commandListBuilder.GetError();
+    SuccessOrExit(err);
 
     mInvokeCommandBuilder.EndOfInvokeCommand();
     err = mInvokeCommandBuilder.GetError();
@@ -259,10 +234,6 @@ CHIP_ERROR Command::FinalizeCommandsMessage()
 
     err = mCommandMessageWriter.Finalize(&mCommandMessageBuf);
     SuccessOrExit(err);
-
-    VerifyOrExit(mCommandMessageBuf->EnsureReservedSize(System::PacketBuffer::kDefaultHeaderReserve),
-                 err = CHIP_ERROR_BUFFER_TOO_SMALL);
-
 exit:
     ChipLogFunctError(err);
     return err;

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -120,25 +120,18 @@ CHIP_ERROR CommandHandler::AddStatusCode(const CommandParams * apCommandParams,
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Builder statusElementBuilder;
-    CommandDataElement::Builder commandDataElement =
-        mInvokeCommandBuilder.GetCommandListBuilder().CreateCommandDataElementBuilder();
 
-    if (apCommandParams != nullptr)
-    {
-        err = ConstructCommandPath(*apCommandParams, commandDataElement);
-        SuccessOrExit(err);
-    }
+    err = PrepareCommand(apCommandParams);
+    SuccessOrExit(err);
 
-    statusElementBuilder = commandDataElement.CreateStatusElementBuilder();
+    statusElementBuilder =
+        mInvokeCommandBuilder.GetCommandListBuilder().GetCommandDataElementBuilder().CreateStatusElementBuilder();
     statusElementBuilder.EncodeStatusElement(aGeneralCode, aProtocolId.ToFullyQualifiedSpecForm(), aProtocolCode)
         .EndOfStatusElement();
     err = statusElementBuilder.GetError();
     SuccessOrExit(err);
 
-    commandDataElement.EndOfCommandDataElement();
-    err = commandDataElement.GetError();
-    SuccessOrExit(err);
-    MoveToState(CommandState::AddCommand);
+    err = FinishCommand();
 
 exit:
     ChipLogFunctError(err);

--- a/src/app/MessageDef/CommandDataElement.cpp
+++ b/src/app/MessageDef/CommandDataElement.cpp
@@ -59,7 +59,7 @@ CommandDataElement::Parser::ParseData(chip::TLV::TLVReader & aReader, int aDepth
 
     if (aDepth == 0)
     {
-        PRETTY_PRINT("\tCommandDataElement = ");
+        PRETTY_PRINT("\tCommandData = ");
     }
     else
     {

--- a/src/app/MessageDef/CommandList.h
+++ b/src/app/MessageDef/CommandList.h
@@ -63,9 +63,14 @@ public:
     /**
      *  @brief Initialize a CommandDataElement::Builder for writing into the TLV stream
      *
-     *  @return A reference to AttributeDataList::Builder
+     *  @return A reference to CommandDataElement::Builder
      */
     CommandDataElement::Builder & CreateCommandDataElementBuilder();
+
+    /**
+     *  @return A reference to CommandDataElement::Builder
+     */
+    CommandDataElement::Builder & GetCommandDataElementBuilder() { return mCommandDataElementBuilder; };
 
     /**
      *  @brief Mark the end of this CommandList

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -146,21 +146,16 @@ void TestCommandInteraction::AddCommandDataElement(nlTestSuite * apSuite, void *
     }
     else
     {
-        chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
-        chip::TLV::TLVWriter writer  = apCommand->CreateCommandDataElementTLVWriter();
-        err                          = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+        err = apCommand->PrepareCommand(&commandParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-        err = writer.PutBoolean(chip::TLV::ContextTag(1), true);
+        chip::TLV::TLVWriter * writer = apCommand->GetCommandDataElementTLVWriter();
+
+        err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-        err = writer.EndContainer(dummyType);
+        err = apCommand->FinishCommand();
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        err = writer.Finalize();
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        apCommand->AddCommand(commandParams);
     }
 }
 
@@ -198,9 +193,12 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
-    err = commandHandler.AddCommand(commandParams);
+    err = commandHandler.PrepareCommand(&commandParams);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    err = commandHandler.FinishCommand();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = commandHandler.SendCommandResponse();
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_NOT_CONNECTED);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR SendCommandRequest(void)
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    chip::app::Command::CommandParams CommandParams = { kTestEndPointId, // Endpoint
+    chip::app::Command::CommandParams commandParams = { kTestEndPointId, // Endpoint
                                                         kTestGroupId,    // GroupId
                                                         kTestClusterId,  // ClusterId
                                                         kTestCommandId,  // CommandId
@@ -96,27 +96,19 @@ CHIP_ERROR SendCommandRequest(void)
 
     uint8_t effectIdentifier = 1; // Dying light
     uint8_t effectVariant    = 1;
+    chip::TLV::TLVWriter * writer;
 
-    chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
-
-    chip::TLV::TLVWriter writer = gpCommandSender->CreateCommandDataElementTLVWriter();
-
-    err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+    err = gpCommandSender->PrepareCommand(&commandParams);
     SuccessOrExit(err);
 
-    err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
+    writer = gpCommandSender->GetCommandDataElementTLVWriter();
+    err    = writer->Put(chip::TLV::ContextTag(1), effectIdentifier);
     SuccessOrExit(err);
 
-    err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
+    err = writer->Put(chip::TLV::ContextTag(2), effectVariant);
     SuccessOrExit(err);
 
-    err = writer.EndContainer(dummyType);
-    SuccessOrExit(err);
-
-    err = writer.Finalize();
-    SuccessOrExit(err);
-
-    err = gpCommandSender->AddCommand(CommandParams);
+    err = gpCommandSender->FinishCommand();
     SuccessOrExit(err);
 
     err = gpCommandSender->SendCommandRequest(chip::kTestDeviceNodeId, gAdminId);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -68,10 +68,6 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     uint8_t effectIdentifier = 1; // Dying light
     uint8_t effectVariant    = 1;
 
-    chip::TLV::TLVType dummyType = chip::TLV::kTLVType_NotSpecified;
-
-    chip::TLV::TLVWriter writer = apCommandObj->CreateCommandDataElementTLVWriter();
-
     if (statusCodeFlipper)
     {
         printf("responder constructing status code in command");
@@ -81,22 +77,20 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     else
     {
         printf("responder constructing command data in command");
-        err = writer.StartContainer(chip::TLV::AnonymousTag, chip::TLV::kTLVType_Structure, dummyType);
+
+        chip::TLV::TLVWriter * writer;
+
+        err = apCommandObj->PrepareCommand(&commandParams);
         SuccessOrExit(err);
 
-        err = writer.Put(chip::TLV::ContextTag(1), effectIdentifier);
+        writer = apCommandObj->GetCommandDataElementTLVWriter();
+        err    = writer->Put(chip::TLV::ContextTag(1), effectIdentifier);
         SuccessOrExit(err);
 
-        err = writer.Put(chip::TLV::ContextTag(2), effectVariant);
+        err = writer->Put(chip::TLV::ContextTag(2), effectVariant);
         SuccessOrExit(err);
 
-        err = writer.EndContainer(dummyType);
-        SuccessOrExit(err);
-
-        err = writer.Finalize();
-        SuccessOrExit(err);
-
-        err = apCommandObj->AddCommand(commandParams);
+        err = apCommandObj->FinishCommand();
         SuccessOrExit(err);
     }
     statusCodeFlipper = !statusCodeFlipper;


### PR DESCRIPTION
Summary of Changes:
-- Add PrepareCommand, GetCommandDataElementTLVWriter and FinishCommand
API to handle command add functionality, and remove old AddCommand which
create the redundant buffer to hold command data
-- Temporarily disable IM in experimental build since these API are used in ember, and we need to update ember in correspondence in separate PR and avoid large PR.