### PR TITLE
Set exchange delegate for app message send

### DIFF
--- a/src/app/util/chip-message-send.cpp
+++ b/src/app/util/chip-message-send.cpp
@@ -39,6 +39,16 @@ using namespace chip;
 //
 // https://github.com/project-chip/connectedhomeip/issues/2566 tracks that API.
 namespace chip {
+// TODO: This is a placeholder delegate for exchange context created in Device::SendMessage()
+//       Delete this class when Device::SendMessage() is obsoleted.
+class DeviceExchangeDelegate : public Messaging::ExchangeDelegate
+{
+    void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                           System::PacketBufferHandle payload) override
+    {}
+    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
+};
+
 extern SecureSessionMgr & SessionManager();
 extern Messaging::ExchangeManager & ExchangeManager();
 } // namespace chip
@@ -90,7 +100,8 @@ EmberStatus chipSendUnicast(NodeId destination, EmberApsFrame * apsFrame, uint16
     // handler to receive messages. We need to set flag kFromInitiator to allow receiver to deliver message to corresponding
     // unsolicited message handler, and we also need to set flag kNoAutoRequestAck since there is no persistent exchange to
     // receive the ack message. This logic needs to be deleted after we convert all legacy ZCL messages to IM messages.
-
+    DeviceExchangeDelegate delegate;
+    exchange->SetDelegate(&delegate);
     Messaging::SendFlags sendFlags;
 
     sendFlags.Set(Messaging::SendMessageFlags::kFromInitiator).Set(Messaging::SendMessageFlags::kNoAutoRequestAck);

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -125,8 +125,6 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
 
     bool reliableTransmissionRequested = !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck);
 
-    ChipLogProgress(ExchangeManager, "Trying to send message using dispatch %p", GetMessageDispatch());
-
     VerifyOrExit(GetMessageDispatch() != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     // If a response message is expected...


### PR DESCRIPTION
 #### Problem
The command's response from the device is not being sent.

 #### Summary of Changes
#5938 introduced concept of exchange message dispatch. During rework of the code, the default dispatch object was removed. The app-sender need to set the delegate explicitly to be able to send the message thru default dispatch.

Also, removed a log that got added as part of debugging.