### PR TITLE
Build failure when mDNS is disabled (#6038)

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -43,7 +43,9 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/StorablePeerConnection.h>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
 #include "Mdns.h"
+#endif
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -269,6 +271,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     void RendezvousComplete() const override
     {
         // Once rendezvous completed, assume we are operational
@@ -277,6 +280,7 @@ public:
             ChipLogError(Discovery, "Failed to start advertising operational state at rendezvous completion time.");
         }
     }
+#endif
 
     void SetDelegate(AppDelegate * delegate) { mDelegate = delegate; }
 
@@ -526,7 +530,9 @@ void InitServer(AppDelegate * delegate)
 
 // Starting mDNS server only for Thread devices due to problem reported in issue #5076.
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_DEVICE_CONFIG_ENABLE_MDNS
     app::Mdns::StartServer();
+#endif
 #endif
 
 exit:


### PR DESCRIPTION
 #### Problem
 When building a local application with mDNS disabled a build error occurs for unreferenced mDNS functions.

 #### Summary of Changes
Use of the build define CHIP_DEVICE_CONFIG_ENABLE_MDNS in Server.cpp.

 Fixes #6038
