### PR TITLE
The ExchangeContext is not closed once a message has been dispatched …

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -391,16 +391,20 @@ CHIP_ERROR DeviceController::ServiceEventSignal()
 void DeviceController::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
                                          const PayloadHeader & payloadHeader, System::PacketBufferHandle msgBuf)
 {
-    VerifyOrReturn(mState == State::Initialized, ChipLogError(Controller, "OnMessageReceived was called in incorrect state"));
+    uint16_t index;
 
-    VerifyOrReturn(packetHeader.GetSourceNodeId().HasValue(),
-                   ChipLogError(Controller, "OnMessageReceived was called for unknown source node"));
+    VerifyOrExit(mState == State::Initialized, ChipLogError(Controller, "OnMessageReceived was called in incorrect state"));
 
-    uint16_t index = FindDeviceIndex(packetHeader.GetSourceNodeId().Value());
-    VerifyOrReturn(index < kNumMaxActiveDevices,
-                   ChipLogError(Controller, "OnMessageReceived was called for unknown device object"));
+    VerifyOrExit(packetHeader.GetSourceNodeId().HasValue(),
+                 ChipLogError(Controller, "OnMessageReceived was called for unknown source node"));
+
+    index = FindDeviceIndex(packetHeader.GetSourceNodeId().Value());
+    VerifyOrExit(index < kNumMaxActiveDevices, ChipLogError(Controller, "OnMessageReceived was called for unknown device object"));
 
     mActiveDevices[index].OnMessageReceived(packetHeader, payloadHeader, std::move(msgBuf));
+
+exit:
+    ec->Close();
 }
 
 void DeviceController::OnResponseTimeout(Messaging::ExchangeContext * ec)


### PR DESCRIPTION
…via CHIPDeviceController to a CHIPDevice

 #### Problem
 When a message is received by `CHIPDeviceController` in order to be dispatched to a `CHIPDevice`, the `ExchangeContext` is never closed. As a result after `CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS` it starts to be an error message and no messages can be received anymore:
 ```
CHIP: [EM] Alloc ctxt FAILED
CHIP: [EM] OnMessageReceived failed, err = CHIP Error 4011 (0x00000FAB): No memory
```

 #### Summary of Changes
 * Close the `ExchangeContext` once the message has been dispatched.