### PR TITLE
[mdns] Added mdns remove service API and its SRP implementation.

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -90,6 +90,7 @@ public:
     CHIP_ERROR AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
                              size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
+    CHIP_ERROR RemoveAllSrpServices();
     CHIP_ERROR SetupSrpHost(const char * aHostName);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -240,6 +241,11 @@ inline CHIP_ERROR ThreadStackManager::AddSrpService(const char * aInstanceName, 
 inline CHIP_ERROR ThreadStackManager::RemoveSrpService(const char * aInstanceName, const char * aName)
 {
     return static_cast<ImplClass *>(this)->_RemoveSrpService(aInstanceName, aName);
+}
+
+inline CHIP_ERROR ThreadStackManager::RemoveAllSrpServices()
+{
+    return static_cast<ImplClass *>(this)->_RemoveAllSrpServices();
 }
 
 inline CHIP_ERROR ThreadStackManager::SetupSrpHost(const char * aHostName)

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -136,13 +136,25 @@ CHIP_ERROR ChipMdnsSetHostname(const char * hostname);
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service);
 
 /**
- * This function stops publishing service via mDNS.
+ * This function stops publishing all services via mDNS.
  *
  * @retval CHIP_NO_ERROR                The publish stops successfully.
  * @retval Error code                   Stopping the publish fails.
  *
  */
 CHIP_ERROR ChipMdnsStopPublish();
+
+/**
+ * This function stops publishing a specific service via mDNS.
+ *
+ * @param[in] service   The service entry.
+ *
+ * @retval CHIP_NO_ERROR                The service stop succeeds.
+ * @retval CHIP_ERROR_INVALID_ARGUMENT  The service is nullptr.
+ * @retval Error code                   The service stop fails.
+ *
+ */
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service);
 
 /**
  * This function browses the services published by mdns

--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -483,6 +483,11 @@ CHIP_ERROR ChipMdnsStopPublish()
     return MdnsContexts::GetInstance().Removes(ContextType::Register);
 }
 
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                           chip::Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
 {

--- a/src/platform/ESP32/MdnsImpl.cpp
+++ b/src/platform/ESP32/MdnsImpl.cpp
@@ -108,6 +108,11 @@ CHIP_ERROR ChipMdnsStopPublish()
     return mdns_service_remove_all() == ESP_OK ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL;
 }
 
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ChipMdnsBrowse(const char * /*type*/, MdnsServiceProtocol /*protocol*/, chip::Inet::IPAddressType addressType,
                           chip::Inet::InterfaceId /*interface*/, MdnsBrowseCallback /*callback*/, void * /*context*/)
 {

--- a/src/platform/Linux/MdnsImpl.cpp
+++ b/src/platform/Linux/MdnsImpl.cpp
@@ -757,6 +757,11 @@ CHIP_ERROR ChipMdnsStopPublish()
     return MdnsAvahi::GetInstance().StopPublish();
 }
 
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, chip::Inet::IPAddressType addressType,
                           chip::Inet::InterfaceId interface, MdnsBrowseCallback callback, void * context)
 {

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -827,7 +827,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPrimary80215
     const otExtAddress * extendedAddr = otLinkGetExtendedAddress(mOTInst);
     memcpy(buf, extendedAddr, sizeof(otExtAddress));
     return CHIP_NO_ERROR;
-};
+}
 
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetFactoryAssignedEUI64(uint8_t (&buf)[8])
@@ -836,7 +836,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetFactoryAssig
     otLinkGetFactoryAssignedIeeeEui64(mOTInst, &extendedAddr);
     memcpy(buf, extendedAddr.m8, sizeof(extendedAddr.m8));
     return CHIP_NO_ERROR;
-};
+}
 
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6Address(chip::Inet::IPAddress & addr)
@@ -873,7 +873,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPollPeriod(u
     buf = otLinkGetPollPeriod(mOTInst);
     Impl()->UnlockThreadStack();
     return CHIP_NO_ERROR;
-};
+}
 
 template <class ImplClass>
 CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstance * otInst)
@@ -1246,6 +1246,25 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveSrpServic
     VerifyOrExit(srpService, error = MapOpenThreadError(OT_ERROR_NOT_FOUND));
 
     error = MapOpenThreadError(otSrpClientRemoveService(mOTInst, &(srpService->mService)));
+
+exit:
+    Impl()->UnlockThreadStack();
+
+    return error;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveAllSrpServices()
+{
+    CHIP_ERROR error;
+
+    Impl()->LockThreadStack();
+    const otSrpClientService * services = otSrpClientGetServices(mOTInst);
+
+    // In case of empty list just return with no error
+    VerifyOrExit(services != nullptr, error = CHIP_NO_ERROR);
+
+    error = MapOpenThreadError(otSrpClientRemoveHostAndServices(mOTInst, false));
 
 exit:
     Impl()->UnlockThreadStack();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -99,6 +99,7 @@ protected:
     CHIP_ERROR _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
                               size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
+    CHIP_ERROR _RemoveAllSrpServices();
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 

--- a/src/platform/OpenThread/MdnsImpl.cpp
+++ b/src/platform/OpenThread/MdnsImpl.cpp
@@ -42,6 +42,9 @@ const char * GetProtocolString(MdnsServiceProtocol protocol)
 
 CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 {
+    if (service == nullptr)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+
     char serviceType[kMdnsTypeMaxSize + kMdnsProtocolTextMaxSize + 1];
     snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
 
@@ -51,7 +54,18 @@ CHIP_ERROR ChipMdnsPublishService(const MdnsService * service)
 
 CHIP_ERROR ChipMdnsStopPublish()
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return ThreadStackMgr().RemoveAllSrpServices();
+}
+
+CHIP_ERROR ChipMdnsStopPublishService(const MdnsService * service)
+{
+    if (service == nullptr)
+        return CHIP_ERROR_INVALID_ARGUMENT;
+
+    char serviceType[kMdnsTypeMaxSize + kMdnsProtocolTextMaxSize + 1];
+    snprintf(serviceType, sizeof(serviceType), "%s.%s", service->mType, GetProtocolString(service->mProtocol));
+
+    return ThreadStackMgr().RemoveSrpService(service->mName, serviceType);
 }
 
 CHIP_ERROR ChipMdnsBrowse(const char * type, MdnsServiceProtocol protocol, Inet::IPAddressType addressType,


### PR DESCRIPTION
 #### Problem
There is not mdns remove specific service API on the CHIP level, but only ChipMdnsStopPublish which seems to remove all services.

 #### Summary of Changes
* Added ChipMdnsRemoveService method API.
* Added ChipMdnsRemoveService implementation for OpenThread
platform (SRP) and left it not implemented for the others.
* Added ChipMdnsStopPublish implementation for OpenThread (SRP).

 Fixes #3469 
