### PR TITLE
Use default application dispatch if an application hasn't provided one

### DIFF
--- a/src/protocols/secure_channel/NetworkProvisioning.cpp
+++ b/src/protocols/secure_channel/NetworkProvisioning.cpp
@@ -69,7 +69,7 @@ void NetworkProvisioning::OnMessageReceived(Messaging::ExchangeContext * exchang
     // Currently, the only mechanism to get this callback is via unsolicited message handler.
     // That means that we now own the reference to exchange context. Let's free the reference since we no longer
     // need it.
-    exchangeContext->Release();
+    exchangeContext->Close();
 }
 
 CHIP_ERROR NetworkProvisioning::HandleNetworkProvisioningMessage(uint8_t msgType, const System::PacketBufferHandle & msgBuf)
@@ -196,7 +196,7 @@ CHIP_ERROR NetworkProvisioning::SendMessageUsingExchange(uint8_t msgType, System
     VerifyOrReturnError(exchangeContext != nullptr, CHIP_ERROR_INTERNAL);
     CHIP_ERROR err = exchangeContext->SendMessage(Protocols::NetworkProvisioning::Id, msgType, std::move(msgPayload),
                                                   Messaging::SendMessageFlags::kNoAutoRequestAck);
-    exchangeContext->Release();
+    exchangeContext->Close();
     return err;
 }
 


### PR DESCRIPTION
 #### Problem
Please see issue #6032 

 #### Summary of Changes
The exchange context now requires the application to select a message dispatch object that's used for sending the messages. This is done to differentiate between session establishment messages (which are unencrypted) and the application messages (which are encrypted).

Some of the test apps are not registering the delegate. This change adds a default dispatch (for encrypted traffic).

 Fixes #6032
