### PR TITLE
Add presubmit checks for RPCs

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -52,6 +52,11 @@ jobs:
               run:
                   scripts/examples/gn_efr32_example.sh
                   examples/lighting-app/efr32/ out/lighting_app_debug BRD4161A
+            - name: Build example EFR32 Lighting App for BRD4161A with RPCs
+              run:
+                  scripts/examples/gn_efr32_example.sh
+                  examples/lighting-app/efr32/ out/lighting_app_debug_rpc BRD4161A
+                  -args='import("//with_pw_rpc.gni")'
             - name: Build example EFR32 Window Covering for BRD4161A
               run:
                   scripts/examples/gn_efr32_example.sh examples/window-app/efr32/
@@ -72,6 +77,7 @@ jobs:
                   path: |
                       out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out
                       out/lighting_app_debug/BRD4161A/chip-efr32-lighting-example.out
+                      out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Remove SiliconLabs binaries for CodeQL Analysis

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -59,6 +59,10 @@ jobs:
               run:
                   scripts/examples/gn_build_example.sh examples/all-clusters-app/linux
                   out/all_clusters_debug chip_bypass_rendezvous=true
+            - name: Build example lighting app with RPCs
+              run:
+                  scripts/examples/gn_build_example.sh examples/lighting-app/linux
+                  out/lighting_app_debug_rpc 'import("//with_pw_rpc.gni")'
             - name: Build example Standalone Bridge
               run:
                   scripts/examples/gn_build_example.sh examples/bridge-app/linux out/bridge_debug
@@ -79,6 +83,7 @@ jobs:
                       out/all_clusters_debug/all-clusters-server
                       out/bridge_debug/bridge-app-server
                       out/chip_tool_debug/chip-tool
+                      out/lighting_app_debug_rpc/chip-lighting-app
                       out/shell_debug/chip-shell
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -52,6 +52,8 @@ jobs:
               run: scripts/examples/nrfconnect_example.sh lock-app nrf52840dk_nrf52840
             - name: Build example nRF Connect SDK Lighting App on nRF52840 DK
               run: scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840
+            - name: Build example nRF Connect SDK Lighting App on nRF52840 DK with RPC
+              run: scripts/examples/nrfconnect_example.sh lighting-app nrf52840dk_nrf52840 -DOVERLAY_CONFIG=rpc.overlay
             - name: Build example nRF Connect SDK Shell on nRF52840 DK
               run: scripts/examples/nrfconnect_example.sh shell nrf52840dk_nrf52840
             - name: Build example nRF Connect SDK Pigweed on nRF52840 DK

--- a/scripts/examples/gn_build_example.sh
+++ b/scripts/examples/gn_build_example.sh
@@ -38,6 +38,9 @@ for arg; do
         *=*)
             GN_ARGS+=("$arg")
             ;;
+        *import*)
+            GN_ARGS+=("$arg")
+            ;;
         *)
             echo >&2 "invalid argument: $arg"
             exit 2

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -31,7 +31,11 @@ if [ -z "$3" ]; then
     #print stats
     arm-none-eabi-size -A "$2"/"$EFR32_BOARD"/*.out
 else
-    gn gen --check --fail-on-unused-args --root="$1" --args="efr32_board=\"$3\"" "$2/$3"
+    if [ -z "$4" ]; then
+        gn gen --check --fail-on-unused-args --root="$1" --args="efr32_board=\"$3\"" "$2/$3"
+    else
+        gn gen --check --fail-on-unused-args --root="$1" --args="efr32_board=\"$3\"" "$2/$3" "$4"
+    fi
     ninja -v -C "$2/$3"
     #print stats
     arm-none-eabi-size -A "$2"/"$3"/*.out


### PR DESCRIPTION

 #### Problem
 RPC builds don't have presubmit checks.

 #### Summary of Changes
Add presubmit checks for the lighting-app RPC builds on: linux, efr32, and nrf32.
