### PR TITLE
Add pairDeviceWithoutSecurity and setListenPort methods to src/darwin…

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
      discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
+- (BOOL)pairDeviceWithoutSecurity:(uint64_t)deviceID
+                          address:(NSString *)address
+                             port:(uint16_t)port
+                            error:(NSError * __autoreleasing *)error;
+- (void)setListenPort:(uint16_t)port;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (void)sendWiFiCredentials:(NSString *)ssid password:(NSString *)password;


### PR DESCRIPTION
…/Framework/CHIP/CHIPDeviceController.h/m for debugging purposes


 #### Problem
 For debugging/day-to-day development this is sometimes useful to quickly bypass pairing (especially when debugging with a local server).
The code is already inside `ChipDeviceController` so it is not exposing anything new, just making it easier to use the feature. 

I suspect that I may be able to remove that in a few weeks, once the new pairing workflow is in place. But in the meantime I keep rebasing a variant of this change locally and maybe this could help others.

 #### Summary of Changes
 * Add `pairDeviceWithoutSecurity` to iOS `CHIPDeviceController`
 * Add `setListenPort` to iOS `CHIPDeviceController`