### PR TITLE
[Python dev ctrl] ChipStack is initialized twice on Darwin

### DIFF
--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -56,11 +56,13 @@ extern "C" void pychip_native_init()
     }
 #endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#ifndef CONFIG_DEVICE_LAYER
     err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
     }
+#endif
     int result   = pthread_create(&sPlatformMainThread, nullptr, PlatformMainLoop, nullptr);
     int tmpErrno = errno;
 


### PR DESCRIPTION
 #### Problem

The CHIP stack is initialised twice when the darwin backend is used since it is already initialised by `CHIPDeviceController`.

 #### Summary of Changes
 * Add `#ifndef CONFIG_DEVICE_LAYER` inside python `StackInit`.