### PR TITLE
src/controller/python/chip/native/StackInit.cpp:29:10: error: unused …

### DIFF
--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -26,7 +26,9 @@
 namespace {
 
 pthread_t sPlatformMainThread;
+#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 uint32_t sBluetoothAdapterId = 0;
+#endif
 
 void * PlatformMainLoop(void *)
 {


### PR DESCRIPTION
…variable 'sBluetoothAdapterId' [-Werror,-Wunused-variable]

 #### Problem

ToT does not build anymore for me. 

 #### Summary of Changes
 * Remove the unused var