### PR TITLE
Fix minimal-mdns examples with clang

### DIFF
--- a/examples/minimal-mdns/advertiser.cpp
+++ b/examples/minimal-mdns/advertiser.cpp
@@ -120,10 +120,18 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
         gOptions.pairingHint = Optional<uint8_t>::Value(static_cast<uint8_t>(atoi(aValue)));
         return true;
     case kOptionOperationalFabricId:
-        gOptions.fabricId = atoll(aValue);
+        if (sscanf(aValue, "%" SCNx64, &gOptions.fabricId) != 1)
+        {
+            PrintArgError("%s: Invalid fabric id: %s\n", aProgram, aValue);
+            return false;
+        }
         return true;
     case kOptionOperationalNodeId:
-        gOptions.nodeId = atoll(aValue);
+        if (sscanf(aValue, "%" SCNx64, &gOptions.nodeId) != 1)
+        {
+            PrintArgError("%s: Invalid node id: %s\n", aProgram, aValue);
+            return false;
+        }
         return true;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
@@ -146,7 +154,7 @@ OptionDef cmdLineOptionsDef[] = {
 
     { "fabrid-id", kArgumentRequired, kOptionOperationalFabricId },
     { "node-id", kArgumentRequired, kOptionOperationalNodeId },
-    nullptr,
+    {},
 };
 
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",

--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -17,6 +17,7 @@
 
 #include <cstdio>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <inet/InetInterface.h>
@@ -151,7 +152,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "query-port", kArgumentRequired, kOptionQueryPort },
     { "timeout-ms", kArgumentRequired, kOptionRuntimeMs },
     { "multicast-reply", kNoArgument, kOptionMulticastReplies },
-    nullptr,
+    {},
 };
 
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",

--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -86,7 +86,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "listen-port", kArgumentRequired, kOptionListenPort },
     { "enable-ip-v4", kNoArgument, kOptionEnableIpV4 },
     { "instance-name", kArgumentRequired, kOptionInstanceName },
-    nullptr,
+    {},
 };
 
 OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS",


### PR DESCRIPTION
This fixes some warnings when building with clang:

```
clang++ -MMD -MF obj/mdns-advertiser.advertiser.cpp.o.d -Wconversion -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Wextra -Wshadow -Wunreachable-code -Werror -Wimplicit-fallthrough -Wheader-hygiene -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-missing-field-initializers -Wno-unused-parameter -fdiagnostics-color -fno-strict-aliasing -D_REENTRANT -isystem../../third_party/connectedhomeip/third_party/ot-br-posix/repo/src -isystem../../third_party/connectedhomeip/third_party/ot-br-posix/repo/include -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=1 -DCHIP_HAVE_CONFIG_H=1 -DLWIP_IPV4=1 -DLWIP_IPV6=1 -DLWIP_API=1 -DLWIP_ETHERNET=1 -DLWIP_SLIP=0 -DLWIP_6LOWPAN=1 -DLWIP_PPP=1 -I../../third_party/connectedhomeip/src/app/util -I../../third_party/connectedhomeip/src/app -Igen/third_party/connectedhomeip/src/app/include -I../../third_party/connectedhomeip/src/include -I../../third_party/connectedhomeip/src -Igen/include -I../../third_party/connectedhomeip/src/lib -I../../third_party/connectedhomeip/config/standalone -I../../third_party/connectedhomeip/third_party/nlassert/repo/include -I../../third_party/connectedhomeip/third_party/nlio/repo/include -I../../third_party/connectedhomeip/src/lwip/standalone -I../../third_party/connectedhomeip/third_party/lwip/repo/lwip/src/include -I../../third_party/connectedhomeip/src/lwip/include -I../../third_party/connectedhomeip/src/setup_payload -Igen -Igen -I../../third_party/connectedhomeip/third_party/inipp/repo/inipp -I../../third_party/connectedhomeip/src/app/server -c ../../advertiser.cpp -o obj/mdns-advertiser.advertiser.cpp.o
This fixes the following warnings:
../../advertiser.cpp:123:29: error: implicit conversion changes signedness: 'long long' to 'uint64_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
        gOptions.fabricId = atoll(aValue);
                          ~ ^~~~~~~~~~~~~

clang++ -MMD -MF obj/minimal-mdns-server.server.cpp.o.d -Wconversion -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Wextra -Wshadow -Wunreachable-code -Werror -Wimplicit-fallthrough -Wheader-hygiene -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-missing-field-initializers -Wno-unused-parameter -fdiagnostics-color -fno-strict-aliasing -D_REENTRANT -isystem../../third_party/connectedhomeip/third_party/ot-br-posix/repo/src -isystem../../third_party/connectedhomeip/third_party/ot-br-posix/repo/include -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -std=gnu++14 -fno-rtti -Wnon-virtual-dtor -DCHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=1 -DCHIP_HAVE_CONFIG_H=1 -DLWIP_IPV4=1 -DLWIP_IPV6=1 -DLWIP_API=1 -DLWIP_ETHERNET=1 -DLWIP_SLIP=0 -DLWIP_6LOWPAN=1 -DLWIP_PPP=1 -I../../third_party/connectedhomeip/src/app/util -I../../third_party/connectedhomeip/src/app -Igen/third_party/connectedhomeip/src/app/include -I../../third_party/connectedhomeip/src/include -I../../third_party/connectedhomeip/src -Igen/include -I../../third_party/connectedhomeip/src/lib -I../../third_party/connectedhomeip/config/standalone -I../../third_party/connectedhomeip/third_party/nlassert/repo/include -I../../third_party/connectedhomeip/third_party/nlio/repo/include -I../../third_party/connectedhomeip/src/lwip/standalone -I../../third_party/connectedhomeip/third_party/lwip/repo/lwip/src/include -I../../third_party/connectedhomeip/src/lwip/include -I../../third_party/connectedhomeip/src/setup_payload -Igen -Igen -I../../third_party/connectedhomeip/third_party/inipp/repo/inipp -I../../third_party/connectedhomeip/src/app/server -c ../../server.cpp -o obj/minimal-mdns-server.server.cpp.o
../../server.cpp:89:5: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    nullptr,
    ^~~~~~~
    {      }
```