### PR TITLE
[esp32] use minimal mDNS by default

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -86,7 +86,7 @@ menu "CHIP Core"
 
         config USE_MINIMAL_MDNS
             bool "Use the minimal mDNS implementation shipped in the CHIP library"
-            default n
+            default y
             help
                 The CHIP library is shipped with a minimal mDNS implementation,
                 enable this config to use it rather than the mDNS library in IDF.


### PR DESCRIPTION

 #### Problem

The mDNS library in IDF currently doesn't support subtypes. Use minimal
mDNS instead for compilance with the spec.
