### PR TITLE
Move default -std level to an argument

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -210,15 +210,11 @@ config("symbols_default") {
   cflags = [ "-g${symbol_level}" ]
 }
 
-config("gnu14") {
-  cflags_c = [ "-std=gnu11" ]
-  cflags_objc = [ "-std=gnu11" ]
-  cflags_cc = [ "-std=gnu++14" ]
-  cflags_objcc = [ "-std=gnu++14" ]
-}
-
 config("std_default") {
-  configs = [ ":gnu14" ]
+  cflags_c = [ "-std=${c_standard}" ]
+  cflags_objc = [ "-std=${c_standard}" ]
+  cflags_cc = [ "-std=${cpp_standard}" ]
+  cflags_objcc = [ "-std=${cpp_standard}" ]
 }
 
 config("cosmetic_default") {

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -34,4 +34,10 @@ declare_args() {
 
   # Remove unwind tables from the binary to save space.
   exclude_unwind_tables = current_os != "android"
+
+  # C standard level (value for -std flag).
+  c_standard = "gnu11"
+
+  # C++ standard level (value for -std flag).
+  cpp_standard = "gnu++14"
 }

--- a/config/efr32/lib/pw_rpc/BUILD.gn
+++ b/config/efr32/lib/pw_rpc/BUILD.gn
@@ -16,17 +16,6 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("$dir_pw_build/target_types.gni")
 
-config("cpp17") {
-  cflags_cc = [ "-std=gnu++17" ]
-  cflags_c = [ "-std=gnu11" ]
-  cflags_objc = [ "-std=gnu11" ]
-  cflags_objcc = [ "-std=gnu++17" ]
-}
-
-config("std_cpp17") {
-  configs = [ ":cpp17" ]
-}
-
 static_library("pw_rpc") {
   output_name = "libPwRpc"
 

--- a/config/linux/lib/pw_rpc/BUILD.gn
+++ b/config/linux/lib/pw_rpc/BUILD.gn
@@ -16,17 +16,6 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("$dir_pw_build/target_types.gni")
 
-config("cpp17") {
-  cflags_cc = [ "-std=gnu++17" ]
-  cflags_c = [ "-std=gnu11" ]
-  cflags_objc = [ "-std=gnu11" ]
-  cflags_objcc = [ "-std=gnu++17" ]
-}
-
-config("std_cpp17") {
-  configs = [ ":cpp17" ]
-}
-
 static_library("pw_rpc") {
   output_name = "libPwRpc"
 

--- a/examples/lighting-app/efr32/with_pw_rpc.gni
+++ b/examples/lighting-app/efr32/with_pw_rpc.gni
@@ -23,4 +23,5 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_pw_rpc = true
 chip_enable_openthread = true
-default_configs_std = [ "${chip_root}/config/efr32/lib/pw_rpc:std_cpp17" ]
+
+cpp_standard = "gnu++17"

--- a/examples/lighting-app/linux/with_pw_rpc.gni
+++ b/examples/lighting-app/linux/with_pw_rpc.gni
@@ -21,7 +21,8 @@ import("${chip_root}/config/standalone/args.gni")
 
 import("//build_overrides/pigweed.gni")
 
-default_configs_std = [ "${chip_root}/config/linux/lib/pw_rpc:std_cpp17" ]
+cpp_standard = "gnu++17"
+
 pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"

--- a/examples/lock-app/efr32/with_pw_rpc.gni
+++ b/examples/lock-app/efr32/with_pw_rpc.gni
@@ -22,4 +22,4 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-default_configs_std = [ "${chip_root}/config/efr32/lib/pw_rpc:std_cpp17" ]
+cpp_standard = "gnu++17"

--- a/examples/persistent-storage/efr32/with_pw_rpc.gni
+++ b/examples/persistent-storage/efr32/with_pw_rpc.gni
@@ -22,4 +22,4 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-default_configs_std = [ "${chip_root}/config/efr32/lib/pw_rpc:std_cpp17" ]
+cpp_standard = "gnu++17"

--- a/examples/pigweed-app/efr32/args.gni
+++ b/examples/pigweed-app/efr32/args.gni
@@ -18,4 +18,4 @@ import("${chip_root}/src/platform/EFR32/args.gni")
 
 efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-default_configs_std = [ "${chip_root}/config/efr32/lib/pw_rpc:std_cpp17" ]
+cpp_standard = "gnu++17"


### PR DESCRIPTION
Currently applications that want to change the default standard level
are creating a new config target which causes some minor duplication.
Simplify this to just setting a new cpp_standard argument.