### PR TITLE
uint64_t support in emberAfFillExternalBuffer

### DIFF
--- a/src/app/util/client-api.cpp
+++ b/src/app/util/client-api.cpp
@@ -62,7 +62,7 @@ EmberApsFrame * emAfCommandApsFrame = NULL;
 static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameControl, uint16_t manufacturerCode,
                             CommandId commandId, const char * format, va_list argPointer)
 {
-    uint32_t value;
+    uint64_t value;
     uint8_t valueLen;
     uint8_t * data;
     uint16_t dataLen;
@@ -160,8 +160,8 @@ static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameC
         }
         else
         {
-            // u, v, x, and w are one-, two-, three-, or four-byte integers.  u and v
-            // must be extracted as an int while x and w come through as an uint32_t.
+            // u, v, x, w, and y are one-, two-, three-, four-byte or eight-byte integers.  u and v
+            // must be extracted as an int while x and w come through as an uint32_t, y as a uint64_t.
             // In all cases, the value is copied to the destination buffer in little-
             // endian format.
             dataLen = 0;
@@ -181,12 +181,27 @@ static uint16_t vFillBuffer(uint8_t * buffer, uint16_t bufferLen, uint8_t frameC
             {
                 valueLen = 4;
             }
+            else if (cmd == 'y')
+            {
+                valueLen = 8;
+            }
             else
             {
                 emberAfDebugPrintln("ERR: Unknown format '%c'", cmd);
                 return 0;
             }
-            value = valueLen <= 2 ? static_cast<uint32_t>(va_arg(argPointer, int)) : va_arg(argPointer, uint32_t);
+            if (valueLen <= 2)
+            {
+                value = static_cast<uint64_t>(va_arg(argPointer, int));
+            }
+            else if (valueLen <= 4)
+            {
+                value = static_cast<uint64_t>(va_arg(argPointer, uint32_t));
+            }
+            else
+            {
+                value = va_arg(argPointer, uint64_t);
+            }
         }
 
         // The destination buffer must be at least as large as the running total

--- a/src/app/util/client-api.h
+++ b/src/app/util/client-api.h
@@ -116,6 +116,8 @@ uint16_t emberAfFillExternalBuffer(uint8_t frameControl, chip::ClusterId cluster
  *            destination buffer.
  *     - 'w': uint32_t. The bytes are copied in little-endian format to the
  *            destination buffer.
+ *     - 'y': uint64_t. The bytes are copied in little-endian format to the
+ *            destination buffer.
  *     - 'l': Pointer to a buffer containing a ZigBee long string, with the
  *            first two bytes of the buffer specifying the length of the string
  *            data in little-endian format. The length bytes and the string


### PR DESCRIPTION
In the fabric cluster, I need to return a uint64_t fabricID so need emberAfFillExternalBuffer to support it