### PR TITLE
[server] Fix ExchangeContext leak

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -392,7 +392,8 @@ public:
             HandleDataModelMessage(packetHeader.GetSourceNodeId().Value(), std::move(buffer));
         }
 
-    exit:;
+    exit:
+        exchangeContext->Close();
     }
 
     void OnResponseTimeout(ExchangeContext * ec) override


### PR DESCRIPTION
 #### Problem
Similarly to #6045, `ExchangeContext` should be released on the accesory side once a message is processed not to leak the contexts. Otherwise, `[EM] Alloc ctxt FAILED` error is raised after a few messages received/sent.

 #### Summary of Changes
Release `ExchangeContext` object in `ServerCallback::OnMessageReceived`.