### PR TITLE
Fix CheckExchangeMessages crashes when malicious packet is sent

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -311,6 +311,14 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         // AND The message was received from the peer node associated with the exchange
         && (mSecureSession == session)
 
+        // AND The message must come with a source Node ID.
+        && (packetHeader.GetSourceNodeId().HasValue())
+
+        // AND The message's source Node ID matches the peer Node ID associated with the exchange, or the peer Node ID of the
+        // exchange is 'any'.
+        && ((mSecureSession.GetPeerNodeId() == kAnyNodeId) ||
+            (mSecureSession.GetPeerNodeId() == packetHeader.GetSourceNodeId().Value()))
+
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast
         //    case, the initiator is ill defined)

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -149,9 +149,9 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // send a malicious packet
-    // TODO: https://github.com/project-chip/connectedhomeip/issues/4635
-    // ec1->SendMessage(0x0001, 0x0002, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
-    //                 SendFlags(Messaging::SendMessageFlags::kNone));
+    ec1->SendMessage(Protocols::Id(VendorId::Common, 0x0001), 0x0002,
+                     System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                     SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
CheckExchangeMessages crashes when malicious packet is sent. 

CHIP: [IN] Secure message was encrypted: Msg ID 0
CHIP: [IN] Sending msg from 123654 to 111222333
CHIP: [IN] Sending secure msg on generic transport
CHIP: [EM] ec pos: 3, id: 16809, Delegate: 0x0
CHIP: [EM] Dropping unexpected message 00000001:2 41A9 MsgId:00000000
CHIP: [EM] Piggybacking Ack for MsgId:00000000 with msg
CHIP: [IN] Secure message was encrypted: Msg ID 0
CHIP: [IN] Sending msg from 123654 to 123654
CHIP: [IN] Sending secure msg on generic transport
CHIP: [IN] Data received on an unknown connection (2). Dropping it!!
CHIP: [EM] Accept FAILED, err = Error 4127 (0x0000101F)
CHIP: [IN] Secure msg send status 0
CHIP: [EM] Flushed pending ack for MsgId:00000000
CHIP: [IN] Secure msg send status 0
CHIP: [IN] Secure message was encrypted: Msg ID 1
CHIP: [IN] Sending msg from 123654 to 111222333
CHIP: [IN] Sending secure msg on generic transport
CHIP: [EM] ec pos: 3, id: 16809, Delegate: 0xe9d9c508
CHIP: [IN] Secure msg send status 0
Specifically, CHIP: [IN] Sending msg from 123654 to 123654, where the CRMP acknowledgement is sent from a node to itself. The message is dropped as the receiver does not identify the connection corresponding to the key ID.

If the connection tracking logic is fixed, the test starts crashing. The following are the test logs (which shows the src and dest node is correct for the ack message).

CHIP: [IN] Secure message was encrypted: Msg ID 0
CHIP: [IN] Sending msg from 123654 to 111222333
CHIP: [IN] Sending secure msg on generic transport
CHIP: [EM] ec pos: 3, id: 16809, Delegate: 0x0
CHIP: [EM] Dropping unexpected message 00000001:2 41A9 MsgId:00000000
CHIP: [EM] Piggybacking Ack for MsgId:00000000 with msg
CHIP: [IN] Secure message was encrypted: Msg ID 0
CHIP: [IN] Sending msg from 111222333 to 123654
CHIP: [IN] Sending secure msg on generic transport
CHIP: [EM] Rxd Ack; Removing MsgId:00000000 from Retrans Table
CHIP: [EM] Removed CHIP MsgId:00000000 from RetransTable
CHIP: [IN] Secure msg send status 0
CHIP: [EM] Flushed pending ack for MsgId:00000000
CHIP: [IN] Secure msg send status 0
Abort trap: 6
and, the following is the stack trace for the crash.

  * frame #0: 0x00007fff67cd733a libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fff67d93e60 libsystem_pthread.dylib`pthread_kill + 430
    frame #2: 0x00007fff67c5e808 libsystem_c.dylib`abort + 120
    frame #3: 0x000000010000f605 TestExchangeMgr`chip::Messaging::ReliableMessageMgr::StartRetransmision(this=0x0000000100059040, entry=0x0000000100059070) at ReliableMessageMgr.cpp:333:5
    frame #4: 0x000000010000be10 TestExchangeMgr`chip::Messaging::ExchangeContext::SendMessage(this=0x000000010005b6c0, protocolId=1, msgType='\x02', msgBuf=PacketBufferHandle @ 0x00007ffeefbff520, sendFlags=0x00007ffeefbff518, msgCtxt=0x0000000000000000) at ExchangeContext.cpp:160:52

The root cause of this crash is when the malicious packet is looped back from the the LoopbackTransport, ExchangeMgr treats it as a valid message sent from the a know exchange, and deliver to the exchange delegate which actual send the message.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
The exchangeMgr should only deliver the received message to the exchange delegate when the received message's source Node ID matches the peer Node ID associated with the exchange, or the peer Node ID of the exchange is 'any'

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #4635 

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
