### PR TITLE
[zcl] Log string attributes when parsing ZCL responses

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/endpoint_config.h
@@ -518,11 +518,11 @@
 #define GENERATED_ATTRIBUTE_COUNT 133
 #define GENERATED_ATTRIBUTES                                                                                                       \
     {                                                                                                                              \
-        { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },        /* Descriptor (server): cluster revision */         \
-            { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(0) },   /* Descriptor (server): device list */              \
+        { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(0) },       /* Descriptor (server): device list */              \
             { 0x0001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(254) }, /* Descriptor (server): server list */              \
             { 0x0002, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(508) }, /* Descriptor (server): client list */              \
             { 0x0003, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(762) }, /* Descriptor (server): parts list */               \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },    /* Descriptor (server): cluster revision */         \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                          \
               ZAP_SIMPLE_DEFAULT(3) }, /* Basic (server): cluster revision */                                                      \
             { 0x0000, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                          \
@@ -544,18 +544,18 @@
             { 0x0009, ZAP_TYPE(INT32U), 4, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                          \
               ZAP_LONG_DEFAULTS_INDEX(1192) }, /* Basic (server): SoftwareVersion */                                               \
             { 0x000A, ZAP_TYPE(CHAR_STRING), 64, ZAP_ATTRIBUTE_MASK(SINGLETON),                                                    \
-              ZAP_LONG_DEFAULTS_INDEX(1196) },                              /* Basic (server): SoftwareVersionString */            \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* General Commissioning (server): cluster revision */ \
+              ZAP_LONG_DEFAULTS_INDEX(1196) }, /* Basic (server): SoftwareVersionString */                                         \
             { 0x0000, ZAP_TYPE(OCTET_STRING), 8, 0,                                                                                \
               ZAP_LONG_DEFAULTS_INDEX(1260) }, /* General Commissioning (server): FabricId */                                      \
             { 0x0001, ZAP_TYPE(INT64U), 8, ZAP_ATTRIBUTE_MASK(WRITABLE),                                                           \
               ZAP_LONG_DEFAULTS_INDEX(1268) },                              /* General Commissioning (server): Breadcrumb */       \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* General Commissioning (server): cluster revision */ \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Network Commissioning (server): cluster revision */ \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Binding (server): cluster revision */               \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Group Key Management (server): cluster revision */  \
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1276) }, /* Group Key Management (server): groups */        \
             { 0x0001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1530) }, /* Group Key Management (server): group keys */    \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },          /* Identify (server): cluster revision */          \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Group Key Management (server): cluster revision */  \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(2) },      /* Identify (server): cluster revision */              \
             { 0x0000, ZAP_TYPE(INT16U), 2, ZAP_ATTRIBUTE_MASK(WRITABLE),                                                           \
               ZAP_SIMPLE_DEFAULT(0x0000) },                                     /* Identify (server): identify time */             \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(3) },          /* Groups (server): cluster revision */            \
@@ -570,11 +570,11 @@
             { 0x0000, ZAP_TYPE(BOOLEAN), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },      /* On/off (server): on/off */                      \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(3) },          /* Level Control (server): cluster revision */     \
             { 0x0000, ZAP_TYPE(INT8U), 1, 0, ZAP_SIMPLE_DEFAULT(0x00) },        /* Level Control (server): current level */        \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* Descriptor (server): cluster revision */        \
             { 0x0000, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(1784) }, /* Descriptor (server): device list */             \
             { 0x0001, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2038) }, /* Descriptor (server): server list */             \
             { 0x0002, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2292) }, /* Descriptor (server): client list */             \
             { 0x0003, ZAP_TYPE(ARRAY), 254, 0, ZAP_LONG_DEFAULTS_INDEX(2546) }, /* Descriptor (server): parts list */              \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },     /* Descriptor (server): cluster revision */        \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0,                                                                                      \
               ZAP_SIMPLE_DEFAULT(0x0001) }, /* OTA Software Update Server (server): cluster revision */                            \
             { 0xFFFD, ZAP_TYPE(INT16U), 2, 0,                                                                                      \
@@ -675,15 +675,15 @@
             { 0x0001, ZAP_TYPE(ENUM16), 2, 0, ZAP_EMPTY_DEFAULT() },          /* IAS Zone (server): zone type */                   \
             { 0x0002, ZAP_TYPE(BITMAP16), 2, 0, ZAP_SIMPLE_DEFAULT(0x0000) }, /* IAS Zone (server): zone status */                 \
             { 0x0010, ZAP_TYPE(IEEE_ADDRESS), 8, ZAP_ATTRIBUTE_MASK(WRITABLE),                                                     \
-              ZAP_LONG_DEFAULTS_INDEX(3054) },                              /* IAS Zone (server): IAS CIE address */               \
-            { 0x0011, ZAP_TYPE(INT8U), 1, 0, ZAP_SIMPLE_DEFAULT(0xff) },    /* IAS Zone (server): Zone ID */                       \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Low Power (server): cluster revision */             \
-            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Application Basic (server): cluster revision */     \
+              ZAP_LONG_DEFAULTS_INDEX(3054) },                                       /* IAS Zone (server): IAS CIE address */      \
+            { 0x0011, ZAP_TYPE(INT8U), 1, 0, ZAP_SIMPLE_DEFAULT(0xff) },             /* IAS Zone (server): Zone ID */              \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) },          /* Low Power (server): cluster revision */    \
             { 0x0000, ZAP_TYPE(CHAR_STRING), 32, 0, ZAP_LONG_DEFAULTS_INDEX(3062) }, /* Application Basic (server): vendor name */ \
             { 0x0001, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },                 /* Application Basic (server): vendor id */   \
             { 0x0002, ZAP_TYPE(CHAR_STRING), 32, 0,                                                                                \
-              ZAP_LONG_DEFAULTS_INDEX(3094) },                       /* Application Basic (server): application name */            \
-            { 0x0003, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() }, /* Application Basic (server): product id */                  \
+              ZAP_LONG_DEFAULTS_INDEX(3094) },                              /* Application Basic (server): application name */     \
+            { 0x0003, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },        /* Application Basic (server): product id */           \
+            { 0xFFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(0x0001) }, /* Application Basic (server): cluster revision */     \
             { 0x0005, ZAP_TYPE(CHAR_STRING), 32, 0,                                                                                \
               ZAP_LONG_DEFAULTS_INDEX(3126) },                             /* Application Basic (server): application id */        \
             { 0x0006, ZAP_TYPE(INT16U), 2, 0, ZAP_EMPTY_DEFAULT() },       /* Application Basic (server): catalog vendor id */     \

--- a/examples/chip-tool/gen/CHIPClientCallbacks.cpp
+++ b/examples/chip-tool/gen/CHIPClientCallbacks.cpp
@@ -199,6 +199,27 @@ void LogStatus(uint8_t status)
     }
 }
 
+void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+{
+    if (isAscii)
+    {
+        ChipLogProgress(Zcl, "  value: %.*s", length, string);
+        return;
+    }
+
+    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
+    char * bufferPos                              = buffer + strlen(buffer);
+    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
+
+    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    {
+        snprintf(bufferPos, bufferEnd - bufferPos, "%02X ", string[i]);
+    }
+
+    ChipLogProgress(Zcl, "%s", buffer);
+}
+
 // Singleton instance of the callbacks manager
 app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInstance();
 
@@ -290,7 +311,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Short Strings must contains at least one byte for the length
                 CHECK_MESSAGE_LENGTH(1);
                 uint8_t length = chip::Encoding::Read8(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFF)
@@ -299,6 +319,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x42);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));
@@ -311,7 +332,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Long Strings must contains at least two bytes for the length
                 CHECK_MESSAGE_LENGTH(2);
                 uint16_t length = chip::Encoding::LittleEndian::Read16(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFFFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFFFF)
@@ -320,6 +340,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x44);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -183,6 +183,27 @@ void LogStatus(uint8_t status)
     }
 }
 
+void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+{
+    if (isAscii)
+    {
+        ChipLogProgress(Zcl, "  value: %.*s", length, string);
+        return;
+    }
+
+    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
+    char * bufferPos                              = buffer + strlen(buffer);
+    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
+
+    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    {
+        snprintf(bufferPos, bufferEnd - bufferPos, "%02X ", string[i]);
+    }
+
+    ChipLogProgress(Zcl, "%s", buffer);
+}
+
 // Singleton instance of the callbacks manager
 app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInstance();
 
@@ -271,7 +292,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                     // Short Strings must contains at least one byte for the length
                     CHECK_MESSAGE_LENGTH(1);
                     uint8_t length = chip::Encoding::Read8(message);
-                    ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                     // When the length is set to 0xFF, it represents a non-value. In this case the data field is zero length.
                     if (length == 0xFF)
@@ -280,6 +300,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                     }
 
                     CHECK_MESSAGE_LENGTH(length);
+                    LogStringAttribute(message, length, attributeType == 0x42);
                     Callback::Callback<StringAttributeCallback> * cb = Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                     cb->mCall(cb->mContext, chip::ByteSpan(message, length));
                     break;
@@ -291,7 +312,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                     // Long Strings must contains at least two bytes for the length
                     CHECK_MESSAGE_LENGTH(2);
                     uint16_t length = chip::Encoding::LittleEndian::Read16(message);
-                    ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                     // When the length is set to 0xFFFF, it represents a non-value. In this case the data field is zero length.
                     if (length == 0xFFFF)
@@ -300,6 +320,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                     }
 
                     CHECK_MESSAGE_LENGTH(length);
+                    LogStringAttribute(message, length, attributeType == 0x44);
                     Callback::Callback<StringAttributeCallback> * cb = Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                     cb->mCall(cb->mContext, chip::ByteSpan(message, length));
                     break;

--- a/src/controller/python/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/python/gen/CHIPClientCallbacks.cpp
@@ -199,6 +199,27 @@ void LogStatus(uint8_t status)
     }
 }
 
+void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+{
+    if (isAscii)
+    {
+        ChipLogProgress(Zcl, "  value: %.*s", length, string);
+        return;
+    }
+
+    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
+    char * bufferPos                              = buffer + strlen(buffer);
+    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
+
+    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    {
+        snprintf(bufferPos, bufferEnd - bufferPos, "%02X ", string[i]);
+    }
+
+    ChipLogProgress(Zcl, "%s", buffer);
+}
+
 // Singleton instance of the callbacks manager
 app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInstance();
 
@@ -290,7 +311,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Short Strings must contains at least one byte for the length
                 CHECK_MESSAGE_LENGTH(1);
                 uint8_t length = chip::Encoding::Read8(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFF)
@@ -299,6 +319,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x42);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));
@@ -311,7 +332,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Long Strings must contains at least two bytes for the length
                 CHECK_MESSAGE_LENGTH(2);
                 uint16_t length = chip::Encoding::LittleEndian::Read16(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFFFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFFFF)
@@ -320,6 +340,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x44);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));

--- a/src/darwin/Framework/CHIP/gen/CHIPClientCallbacks.cpp
+++ b/src/darwin/Framework/CHIP/gen/CHIPClientCallbacks.cpp
@@ -199,6 +199,27 @@ void LogStatus(uint8_t status)
     }
 }
 
+void LogStringAttribute(const uint8_t * string, const uint16_t length, const bool isAscii)
+{
+    if (isAscii)
+    {
+        ChipLogProgress(Zcl, "  value: %.*s", length, string);
+        return;
+    }
+
+    constexpr size_t kByteInHexLength             = 3; // 2 hex digits + space
+    char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = "  value: ";
+    char * bufferPos                              = buffer + strlen(buffer);
+    char * const bufferEnd                        = buffer + CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE;
+
+    for (uint16_t i = 0; i < length && bufferPos + kByteInHexLength < bufferEnd; i++, bufferPos += kByteInHexLength)
+    {
+        snprintf(bufferPos, bufferEnd - bufferPos, "%02X ", string[i]);
+    }
+
+    ChipLogProgress(Zcl, "%s", buffer);
+}
+
 // Singleton instance of the callbacks manager
 app::CHIPDeviceCallbacksMgr & gCallbacks = app::CHIPDeviceCallbacksMgr::GetInstance();
 
@@ -290,7 +311,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Short Strings must contains at least one byte for the length
                 CHECK_MESSAGE_LENGTH(1);
                 uint8_t length = chip::Encoding::Read8(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFF)
@@ -299,6 +319,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x42);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));
@@ -311,7 +332,6 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 // Long Strings must contains at least two bytes for the length
                 CHECK_MESSAGE_LENGTH(2);
                 uint16_t length = chip::Encoding::LittleEndian::Read16(message);
-                ChipLogProgress(Zcl, "  length: 0x%02x", length);
 
                 // When the length is set to 0xFFFF, it represents a non-value. In this case the data field is zero length.
                 if (length == 0xFFFF)
@@ -320,6 +340,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                 }
 
                 CHECK_MESSAGE_LENGTH(length);
+                LogStringAttribute(message, length, attributeType == 0x44);
                 Callback::Callback<StringAttributeCallback> * cb =
                     Callback::Callback<StringAttributeCallback>::FromCancelable(onSuccessCallback);
                 cb->mCall(cb->mContext, chip::ByteSpan(message, length));


### PR DESCRIPTION
 #### Problem
ZCL client callbacks log only lengths of ZCL attributes of string types. As a result Python CHIP Controller's `zclread` command doesn't print the read string attributes in a human readable format.

 #### Summary of Changes
Add a function to log the entire value.

Related to #5604