### PR TITLE
ESP32: Advertisement stop error for slow advertisement timeout

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -546,13 +546,15 @@ void BLEManagerImpl::DriveBLEState(void)
     {
         if (mFlags.Has(Flags::kAdvertising))
         {
-            err = MapBLEError(ble_gap_adv_stop());
-            if (err != CHIP_NO_ERROR)
+            if (ble_gap_adv_active())
             {
-                ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %s", ErrorStr(err));
-                ExitNow();
+                err = MapBLEError(ble_gap_adv_stop());
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(DeviceLayer, "ble_gap_adv_stop() failed: %s", ErrorStr(err));
+                    ExitNow();
+                }
             }
-
             // mFlags.Clear(Flags::kAdvertisingRefreshNeeded);
 
             // Transition to the not Advertising state...


### PR DESCRIPTION
 #### Problem
 The RPA timeout collides with slow advertisement timeout after 15 minutes from advertisement start, hence NimBLE throws ble_gap_adv_stop() error for slow advertisement timeout.
Failed log
```
I (1787) all-clusters-app: Copy/paste the below URL in a browser to see the QR CODE:
	https://dhrishi.github.io/connectedhomeip/qrcode.html?data=CH%3AH34JG6Y00%200C9SS0
I (31697) chip[DL]: Configuring CHIPoBLE advertising (interval 500 ms, connectable, device name CHIP-3840)
I (31697) chip[DL]: Device already advertising, stop active advertisement and restart
GAP procedure initiated: stop advertising.
GAP procedure initiated: advertise; disc_mode=2 adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=800 adv_itvl_max=800
GAP procedure initiated: stop advertising.
GAP procedure initiated: stop advertising.
E (906697) chip[DL]: ble_gap_adv_stop() failed: Device Layer Error 11000002 (0x00A7D8C2): Not service provisioned
E (906697) chip[DL]: Disabling CHIPoBLE service due to error: Device Layer Error 11000002 (0x00A7D8C2): Not service provisioned
```

 #### Summary of Changes
Called `ble_gap_adv_stop()` only if advertisement is active.
Successful log

 ```
 I (1797) all-clusters-app: Copy/paste the below URL in a browser to see the QR CODE:
	https://dhrishi.github.io/connectedhomeip/qrcode.html?data=CH%3AH34JG6Y00%200C9SS0
I (36707) chip[DL]: Configuring CHIPoBLE advertising (interval 500 ms, connectable, device name CHIP-3840)
I (36707) chip[DL]: Device already advertising, stop active advertisement and restart
GAP procedure initiated: stop advertising.
GAP procedure initiated: advertise; disc_mode=2 adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=800 adv_itvl_max=800
GAP procedure initiated: stop advertising.
I (906707) chip[DL]: CHIPoBLE advertising stopped
```
 Fixes #6128 