### PR TITLE
chip-device-ctrl: add ability to configure reporting (subscribe)

### DIFF
--- a/src/app/zap-templates/templates/chip/python-CHIPClusters-cpp.zapt
+++ b/src/app/zap-templates/templates/chip/python-CHIPClusters-cpp.zapt
@@ -94,6 +94,16 @@ CHIP_ERROR chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCa
     cluster.Associate(device, ZCLendpointId);
     return cluster.ReadAttribute{{asCamelCased name false}}(g{{asCallbackAttributeType atomicTypeId}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel());
 }
+
+{{#if (isReportableAttribute)}}
+CHIP_ERROR chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, uint16_t minInterval, uint16_t maxInterval{{#unless (isDiscreteType)}}, {{chipType}} change{{/unless}})
+{
+    VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::Controller::{{asCamelCased parent.name false}}Cluster cluster;
+    cluster.Associate(device, ZCLendpointId);
+    return cluster.ConfigureAttribute{{asCamelCased name false}}(g{{asCallbackAttributeType atomicTypeId}}AttributeCallback.Cancel(), gDefaultFailureCallback.Cancel(), minInterval, maxInterval{{#unless (isDiscreteType)}}, change{{/unless}});
+}
+{{/if}}
 {{/unless}}
 {{/chip_server_cluster_attributes}}
 

--- a/src/app/zap-templates/templates/chip/python-CHIPClusters-py.zapt
+++ b/src/app/zap-templates/templates/chip/python-CHIPClusters-py.zapt
@@ -61,6 +61,13 @@ class ChipClusters:
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
         funcCaller(lambda: func(device, endpoint, groupid))
 
+    def ConfigureAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, minInterval: int, maxInterval: int, change: int, imEnabled):
+        func = getattr(self, "Cluster{}_ConfigureAttribute{}".format(cluster, attribute), None)
+        if not func:
+            raise UnknownAttribute(cluster, attribute)
+        funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
+        funcCaller(lambda: func(device, endpoint, minInterval, maxInterval, change))
+
     # Cluster commands
 
 {{#chip_server_clusters}}
@@ -84,6 +91,10 @@ class ChipClusters:
 {{#unless isList}}
     def Cluster{{asCamelCased parent.name false}}_ReadAttribute{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(device, ZCLendpoint, ZCLgroupid)
+{{#if (isReportableAttribute)}}
+    def Cluster{{asCamelCased parent.name false}}_ConfigureAttribute{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, minInterval: int, maxInterval: int, change: int):
+        return self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}(device, ZCLendpoint, minInterval, maxInterval, change)
+{{/if}}
 {{/unless}}
 {{/chip_server_cluster_attributes}}
 {{/chip_server_clusters}}
@@ -109,6 +120,11 @@ class ChipClusters:
         # Cluster {{asCamelCased parent.name false}} ReadAttribute {{asCamelCased name false}}
         self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+{{#if (isReportableAttribute)}}
+        # Cluster {{asCamelCased parent.name false}} ConfigureAttribute {{asCamelCased name false}}
+        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16{{#unless (isDiscreteType)}}, ctypes.{{asPythonCType chipType}}{{/unless}}]
+        self._chipLib.chip_ime_ConfigureAttribute_{{asCamelCased parent.name false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
+{{/if}}
 {{/unless}}
 {{/chip_server_cluster_attributes}}
 {{/chip_server_clusters}}

--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -144,7 +144,8 @@ class DeviceMgrCmd(Cmd):
 
         self.bleMgr = None
 
-        self.devCtrl = ChipDeviceCtrl.ChipDeviceController(controllerNodeId=controllerNodeId, bluetoothAdapter=bluetoothAdapter)
+        self.devCtrl = ChipDeviceCtrl.ChipDeviceController(
+            controllerNodeId=controllerNodeId, bluetoothAdapter=bluetoothAdapter)
 
         # If we are on Linux and user selects non-default bluetooth adapter.
         if sys.platform.startswith("linux") and (bluetoothAdapter is not None):
@@ -179,6 +180,7 @@ class DeviceMgrCmd(Cmd):
         "resolve",
         "zcl",
         "zclread",
+        "zclconfigure",
 
         "set-pairing-wifi-credential",
         "set-pairing-thread-credential",
@@ -410,14 +412,16 @@ class DeviceMgrCmd(Cmd):
             print("Device is assigned with nodeid = {}".format(nodeid))
 
             if args[0] == "-ip" and len(args) >= 3:
-                self.devCtrl.ConnectIP(args[1].encode("utf-8"), int(args[2]), nodeid)
+                self.devCtrl.ConnectIP(args[1].encode(
+                    "utf-8"), int(args[2]), nodeid)
             elif args[0] == "-ble" and len(args) >= 3:
                 self.devCtrl.ConnectBLE(int(args[1]), int(args[2]), nodeid)
             else:
                 print("Usage:")
                 self.do_help("connect SetupPinCode")
                 return
-            print("Device temporary node id (**this does not match spec**): {}".format(nodeid))
+            print(
+                "Device temporary node id (**this does not match spec**): {}".format(nodeid))
         except exceptions.ChipStackException as ex:
             print(str(ex))
             return
@@ -435,7 +439,8 @@ class DeviceMgrCmd(Cmd):
                 err = self.devCtrl.ResolveNode(int(args[0]), int(args[1]))
                 if err == 0:
                     address = self.devCtrl.GetAddressAndPort(int(args[1]))
-                    address = "{}:{}".format(*address) if address else "unknown"
+                    address = "{}:{}".format(
+                        *address) if address else "unknown"
                     print("Current address: " + address)
             else:
                 self.do_help("resolve")
@@ -514,11 +519,40 @@ class DeviceMgrCmd(Cmd):
             elif len(args) == 5:
                 if args[0] not in all_attrs:
                     raise exceptions.UnknownCluster(args[0])
-                self.devCtrl.ZCLReadAttribute(args[0], args[1], int(args[2]), int(args[3]), int(args[4]))
+                self.devCtrl.ZCLReadAttribute(args[0], args[1], int(
+                    args[2]), int(args[3]), int(args[4]))
             else:
                 self.do_help("zclread")
         except exceptions.ChipStackException as ex:
             print("An exception occurred during reading ZCL attribute:")
+            print(str(ex))
+        except Exception as ex:
+            print("An exception occurred during processing input:")
+            print(str(ex))
+
+    def do_zclconfigure(self, line):
+        """
+        To configure ZCL attribute reporting:
+        zclconfigure <cluster> <attribute> <nodeid> <endpoint> <minInterval> <maxInterval> <change>
+        """
+        try:
+            args = shlex.split(line)
+            all_attrs = self.devCtrl.ZCLAttributeList()
+            if len(args) == 1 and args[0] == '?':
+                print('\n'.join(all_attrs.keys()))
+            elif len(args) == 2 and args[0] == '?':
+                if args[1] not in all_attrs:
+                    raise exceptions.UnknownCluster(args[1])
+                print('\n'.join(all_attrs.get(args[1])))
+            elif len(args) == 7:
+                if args[0] not in all_attrs:
+                    raise exceptions.UnknownCluster(args[0])
+                self.devCtrl.ZCLConfigureAttribute(args[0], args[1], int(
+                    args[2]), int(args[3]), int(args[4]), int(args[5]), int(args[6]))
+            else:
+                self.do_help("zclconfigure")
+        except exceptions.ChipStackException as ex:
+            print("An exception occurred during configuring reporting of ZCL attribute:")
             print(str(ex))
         except Exception as ex:
             print("An exception occurred during processing input:")
@@ -550,7 +584,8 @@ class DeviceMgrCmd(Cmd):
         try:
             args = shlex.split(line)
             if len(args) == 3:
-                self.devCtrl.SetThreadCredential(int(args[0]), int(args[1], 16), args[2])
+                self.devCtrl.SetThreadCredential(
+                    int(args[0]), int(args[1], 16), args[2])
                 print("Thread credential set")
             else:
                 self.do_help("set-pairing-thread-credential")
@@ -635,16 +670,19 @@ def main():
     adapterId = None
     if sys.platform.startswith("linux"):
         if not options.bluetoothAdapter.startswith("hci"):
-            print("Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
+            print(
+                "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
             sys.exit(-1)
         else:
             try:
                 adapterId = int(options.bluetoothAdapter[3:])
             except:
-                print("Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
+                print(
+                    "Invalid bluetooth adapter: {}, adapter name looks like hci0, hci1 etc.")
                 sys.exit(-1)
 
-    devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr, controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
+    devMgrCmd = DeviceMgrCmd(rendezvousAddr=options.rendezvousAddr,
+                             controllerNodeId=options.controllerNodeId, bluetoothAdapter=adapterId)
     print("Chip Device Controller Shell")
     if options.rendezvousAddr:
         print("Rendezvous address set to %s" % options.rendezvousAddr)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -39,10 +39,13 @@ import enum
 __all__ = ["ChipDeviceController"]
 
 _DevicePairingDelegate_OnPairingCompleteFunct = CFUNCTYPE(None, c_uint32)
-_DeviceAddressUpdateDelegate_OnUpdateComplete = CFUNCTYPE(None, c_uint64, c_uint32)
+_DeviceAddressUpdateDelegate_OnUpdateComplete = CFUNCTYPE(
+    None, c_uint64, c_uint32)
 
 # This is a fix for WEAV-429. Jay Logue recommends revisiting this at a later
 # date to allow for truely multiple instances so this is temporary.
+
+
 def _singleton(cls):
     instance = [None]
 
@@ -61,6 +64,7 @@ class DCState(enum.IntEnum):
     RENDEZVOUS_ONGOING = 3
     RENDEZVOUS_CONNECTED = 4
 
+
 @_singleton
 class ChipDeviceController(object):
     def __init__(self, startNetworkThread=True, controllerNodeId=0, bluetoothAdapter=None):
@@ -74,7 +78,8 @@ class ChipDeviceController(object):
         self._InitLib()
 
         devCtrl = c_void_p(None)
-        res = self._dmLib.pychip_DeviceController_NewDeviceController(pointer(devCtrl), controllerNodeId)
+        res = self._dmLib.pychip_DeviceController_NewDeviceController(
+            pointer(devCtrl), controllerNodeId)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
@@ -87,7 +92,8 @@ class ChipDeviceController(object):
         def HandleKeyExchangeComplete(err):
             if err != 0:
                 print("Failed to establish secure session to device: {}".format(err))
-                self._ChipStack.callbackRes = self._ChipStack.ErrorToException(err)
+                self._ChipStack.callbackRes = self._ChipStack.ErrorToException(
+                    err)
             else:
                 print("Secure Session to Device Established")
                 self._ChipStack.callbackRes = True
@@ -105,22 +111,28 @@ class ChipDeviceController(object):
 
         im.InitIMDelegate()
 
-        self.cbHandleKeyExchangeCompleteFunct = _DevicePairingDelegate_OnPairingCompleteFunct(HandleKeyExchangeComplete)
-        self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(self.devCtrl, self.cbHandleKeyExchangeCompleteFunct)
+        self.cbHandleKeyExchangeCompleteFunct = _DevicePairingDelegate_OnPairingCompleteFunct(
+            HandleKeyExchangeComplete)
+        self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback(
+            self.devCtrl, self.cbHandleKeyExchangeCompleteFunct)
 
-        self.cbOnAddressUpdateComplete = _DeviceAddressUpdateDelegate_OnUpdateComplete(HandleAddressUpdateComplete)
-        self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(self.cbOnAddressUpdateComplete)
+        self.cbOnAddressUpdateComplete = _DeviceAddressUpdateDelegate_OnUpdateComplete(
+            HandleAddressUpdateComplete)
+        self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete(
+            self.cbOnAddressUpdateComplete)
 
         self.state = DCState.IDLE
 
     def __del__(self):
         if self.devCtrl != None:
-            self._dmLib.pychip_DeviceController_DeleteDeviceController(self.devCtrl)
+            self._dmLib.pychip_DeviceController_DeleteDeviceController(
+                self.devCtrl)
             self.devCtrl = None
 
     def IsConnected(self):
         return self._ChipStack.Call(
-            lambda: self._dmLib.pychip_DeviceController_IsConnected(self.devCtrl)
+            lambda: self._dmLib.pychip_DeviceController_IsConnected(
+                self.devCtrl)
         )
 
     def ConnectBle(self, bleConnection):
@@ -136,13 +148,15 @@ class ChipDeviceController(object):
     def ConnectBLE(self, discriminator, setupPinCode, nodeid):
         self.state = DCState.RENDEZVOUS_ONGOING
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_DeviceController_ConnectBLE(self.devCtrl, discriminator, setupPinCode, nodeid)
+            lambda: self._dmLib.pychip_DeviceController_ConnectBLE(
+                self.devCtrl, discriminator, setupPinCode, nodeid)
         )
 
     def ConnectIP(self, ipaddr, setupPinCode, nodeid):
         self.state = DCState.RENDEZVOUS_ONGOING
         return self._ChipStack.CallAsync(
-            lambda: self._dmLib.pychip_DeviceController_ConnectIP(self.devCtrl, ipaddr, setupPinCode, nodeid)
+            lambda: self._dmLib.pychip_DeviceController_ConnectIP(
+                self.devCtrl, ipaddr, setupPinCode, nodeid)
         )
 
     def ResolveNode(self, fabricid, nodeid):
@@ -155,20 +169,23 @@ class ChipDeviceController(object):
         port = c_uint16(0)
 
         error = self._ChipStack.Call(
-            lambda: self._dmLib.pychip_DeviceController_GetAddressAndPort(self.devCtrl, nodeid, address, 64, pointer(port))
+            lambda: self._dmLib.pychip_DeviceController_GetAddressAndPort(
+                self.devCtrl, nodeid, address, 64, pointer(port))
         )
 
         return (address.value.decode(), port.value) if error == 0 else None
 
     def ZCLSend(self, cluster, command, nodeid, endpoint, groupid, args, blocking=False):
         device = c_void_p(None)
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(self.devCtrl, nodeid, pointer(device)))
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
+            self.devCtrl, nodeid, pointer(device)))
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
         commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
         im.ClearCommandStatus(commandSenderHandle)
-        self._Cluster.SendCommand(device, cluster, command, endpoint, groupid, args, commandSenderHandle != 0)
+        self._Cluster.SendCommand(
+            device, cluster, command, endpoint, groupid, args, commandSenderHandle != 0)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(commandSenderHandle, 1)
@@ -176,13 +193,30 @@ class ChipDeviceController(object):
 
     def ZCLReadAttribute(self, cluster, attribute, nodeid, endpoint, groupid, blocking=True):
         device = c_void_p(None)
-        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(self.devCtrl, nodeid, pointer(device)))
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
+            self.devCtrl, nodeid, pointer(device)))
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
         commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
         im.ClearCommandStatus(commandSenderHandle)
-        res = self._Cluster.ReadAttribute(device, cluster, attribute, endpoint, groupid, commandSenderHandle != 0)
+        res = self._Cluster.ReadAttribute(
+            device, cluster, attribute, endpoint, groupid, commandSenderHandle != 0)
+        if blocking:
+            # We only send 1 command by this function, so index is always 0
+            return im.WaitCommandIndexStatus(commandSenderHandle, 1)
+
+    def ZCLConfigureAttribute(self, cluster, attribute, nodeid, endpoint, minInterval, maxInterval, change, blocking=True):
+        device = c_void_p(None)
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_GetDeviceByNodeId(
+            self.devCtrl, nodeid, pointer(device)))
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
+
+        commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
+        im.ClearCommandStatus(commandSenderHandle)
+        res = self._Cluster.ConfigureAttribute(
+            device, cluster, attribute, endpoint, minInterval, maxInterval, change, commandSenderHandle != 0)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(commandSenderHandle, 1)
@@ -210,12 +244,14 @@ class ChipDeviceController(object):
         self._ChipStack.blockingCB = blockingCB
 
     def SetWifiCredential(self, ssid, password):
-        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential(self.devCtrl, ssid.encode("utf-8") + b'\0', password.encode("utf-8") + b'\0')
+        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential(
+            self.devCtrl, ssid.encode("utf-8") + b'\0', password.encode("utf-8") + b'\0')
         if ret != 0:
             raise self._ChipStack.ErrorToException(res)
 
     def SetThreadCredential(self, channel, panid, masterKey):
-        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetThreadCredential(self.devCtrl, channel, panid, masterKey.encode("utf-8") + b'\0')
+        ret = self._dmLib.pychip_ScriptDevicePairingDelegate_SetThreadCredential(
+            self.devCtrl, channel, panid, masterKey.encode("utf-8") + b'\0')
         if ret != 0:
             raise self._ChipStack.ErrorToException(ret)
 
@@ -224,34 +260,44 @@ class ChipDeviceController(object):
         if self._dmLib is None:
             self._dmLib = CDLL(self._ChipStack.LocateChipDLL())
 
-            self._dmLib.pychip_DeviceController_NewDeviceController.argtypes = [POINTER(c_void_p), c_uint64]
+            self._dmLib.pychip_DeviceController_NewDeviceController.argtypes = [
+                POINTER(c_void_p), c_uint64]
             self._dmLib.pychip_DeviceController_NewDeviceController.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_DeleteDeviceController.argtypes = [c_void_p]
+            self._dmLib.pychip_DeviceController_DeleteDeviceController.argtypes = [
+                c_void_p]
             self._dmLib.pychip_DeviceController_DeleteDeviceController.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_ConnectBLE.argtypes = [c_void_p, c_uint16, c_uint32, c_uint64]
+            self._dmLib.pychip_DeviceController_ConnectBLE.argtypes = [
+                c_void_p, c_uint16, c_uint32, c_uint64]
             self._dmLib.pychip_DeviceController_ConnectBLE.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_ConnectIP.argtypes = [c_void_p, c_char_p, c_uint32, c_uint64]
+            self._dmLib.pychip_DeviceController_ConnectIP.argtypes = [
+                c_void_p, c_char_p, c_uint32, c_uint64]
             self._dmLib.pychip_DeviceController_ConnectIP.restype = c_uint32
 
-            self._dmLib.pychip_DeviceController_GetAddressAndPort.argtypes = [c_void_p, c_uint64, c_char_p, c_uint64, POINTER(c_uint16)]
+            self._dmLib.pychip_DeviceController_GetAddressAndPort.argtypes = [
+                c_void_p, c_uint64, c_char_p, c_uint64, POINTER(c_uint16)]
             self._dmLib.pychip_DeviceController_GetAddressAndPort.restype = c_uint32
 
-            self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential.argtypes = [c_void_p, c_char_p, c_char_p]
+            self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential.argtypes = [
+                c_void_p, c_char_p, c_char_p]
             self._dmLib.pychip_ScriptDevicePairingDelegate_SetWifiCredential.restype = c_uint32
 
-            self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback.argtypes = [c_void_p, _DevicePairingDelegate_OnPairingCompleteFunct]
+            self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback.argtypes = [
+                c_void_p, _DevicePairingDelegate_OnPairingCompleteFunct]
             self._dmLib.pychip_ScriptDevicePairingDelegate_SetKeyExchangeCallback.restype = c_uint32
 
-            self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete.argtypes = [_DeviceAddressUpdateDelegate_OnUpdateComplete]
+            self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete.argtypes = [
+                _DeviceAddressUpdateDelegate_OnUpdateComplete]
             self._dmLib.pychip_ScriptDeviceAddressUpdateDelegate_SetOnAddressUpdateComplete.restype = None
 
-            self._dmLib.pychip_Resolver_ResolveNode.argtypes = [c_uint64, c_uint64]
+            self._dmLib.pychip_Resolver_ResolveNode.argtypes = [
+                c_uint64, c_uint64]
             self._dmLib.pychip_Resolver_ResolveNode.restype = c_uint32
 
-            self._dmLib.pychip_GetDeviceByNodeId.argtypes = [c_void_p, c_uint64, POINTER(c_void_p)]
+            self._dmLib.pychip_GetDeviceByNodeId.argtypes = [
+                c_void_p, c_uint64, POINTER(c_void_p)]
             self._dmLib.pychip_GetDeviceByNodeId.restype = c_uint32
 
             self._dmLib.pychip_GetCommandSenderHandle.argtypes = [c_void_p]


### PR DESCRIPTION
Add ability to configure attribute reporting to chip-device-ctrl.

Currently aligned with SiLabs codebase, not the CHIP spec (8.5.2. Subscribe Request Action).

