### PR TITLE
Add IM CommandPathParams/AttributePathParams/EventPathParams

### DIFF
--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <support/BitFlags.h>
+
+namespace chip {
+namespace app {
+enum class AttributePathFlags : uint8_t
+{
+    kFieldIdValid   = 0x01,
+    kListIndexValid = 0x02,
+};
+
+struct AttributePathParams
+{
+    AttributePathParams(NodeId aNodeId, EndpointId aEndpointId, ClusterId aClusterId, FieldId aFieldId, ListIndex aListIndex,
+                        const BitFlags<AttributePathFlags> aFlags) :
+        mNodeId(aNodeId),
+        mEndpointId(aEndpointId), mClusterId(aClusterId), mFieldId(aFieldId), mListIndex(aListIndex), mFlags(aFlags)
+    {}
+    AttributePathParams(const AttributePathParams & aAttributePathParams)
+    {
+        mNodeId     = aAttributePathParams.mNodeId;
+        mEndpointId = aAttributePathParams.mEndpointId;
+        mClusterId  = aAttributePathParams.mClusterId;
+        mFieldId    = aAttributePathParams.mFieldId;
+        mListIndex  = aAttributePathParams.mListIndex;
+        mFlags      = aAttributePathParams.mFlags;
+    }
+    bool IsSamePath(const AttributePathParams & other) const
+    {
+        if (other.mNodeId != mNodeId || other.mEndpointId != mEndpointId || other.mClusterId != mClusterId)
+        {
+            return false;
+        }
+        if (mFlags != other.mFlags)
+        {
+            return false;
+        }
+        if (mFlags == AttributePathFlags::kFieldIdValid && other.mFieldId != mFieldId)
+        {
+            return false;
+        }
+        if (mFlags == AttributePathFlags::kListIndexValid && other.mListIndex != mListIndex)
+        {
+            return false;
+        }
+        return true;
+    }
+    chip::NodeId mNodeId         = 0;
+    chip::EndpointId mEndpointId = 0;
+    chip::ClusterId mClusterId   = 0;
+    chip::FieldId mFieldId       = 0;
+    chip::ListIndex mListIndex   = 0;
+    BitFlags<AttributePathFlags> mFlags;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/AttributePathParams.h>
+#include <app/util/basic-types.h>
+
+namespace chip {
+namespace app {
+struct ClusterInfo
+{
+    ClusterInfo(const AttributePathParams & aAttributePathParams, bool aDirty) :
+        mAttributePathParams(aAttributePathParams), mDirty(aDirty)
+    {}
+    bool IsDirty() { return mDirty; }
+    void SetDirty() { mDirty = true; }
+    void ClearDirty() { mDirty = false; }
+    bool IsSamePath(const ClusterInfo & other) const { return other.mAttributePathParams.IsSamePath(mAttributePathParams); }
+    AttributePathParams mAttributePathParams;
+    bool mDirty = false;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -144,7 +144,7 @@ exit:
     return;
 }
 
-CHIP_ERROR Command::PrepareCommand(const CommandParams * const apCommandParams)
+CHIP_ERROR Command::PrepareCommand(const CommandPathParams * const apCommandPathParams)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -153,9 +153,9 @@ CHIP_ERROR Command::PrepareCommand(const CommandParams * const apCommandParams)
     err = commandDataElement.GetError();
     SuccessOrExit(err);
 
-    if (apCommandParams != nullptr)
+    if (apCommandPathParams != nullptr)
     {
-        err = ConstructCommandPath(*apCommandParams, commandDataElement);
+        err = ConstructCommandPath(*apCommandPathParams, commandDataElement);
         SuccessOrExit(err);
     }
 
@@ -188,20 +188,21 @@ exit:
     return err;
 }
 
-CHIP_ERROR Command::ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder aCommandDataElement)
+CHIP_ERROR Command::ConstructCommandPath(const CommandPathParams & aCommandPathParams,
+                                         CommandDataElement::Builder aCommandDataElement)
 {
     CommandPath::Builder commandPath = aCommandDataElement.CreateCommandPathBuilder();
-    if (aCommandParams.Flags.Has(CommandPathFlags::kEndpointIdValid))
+    if (aCommandPathParams.mFlags.Has(CommandPathFlags::kEndpointIdValid))
     {
-        commandPath.EndpointId(aCommandParams.EndpointId);
+        commandPath.EndpointId(aCommandPathParams.mEndpointId);
     }
 
-    if (aCommandParams.Flags.Has(CommandPathFlags::kGroupIdValid))
+    if (aCommandPathParams.mFlags.Has(CommandPathFlags::kGroupIdValid))
     {
-        commandPath.GroupId(aCommandParams.GroupId);
+        commandPath.GroupId(aCommandPathParams.mGroupId);
     }
 
-    commandPath.ClusterId(aCommandParams.ClusterId).CommandId(aCommandParams.CommandId).EndOfCommandPath();
+    commandPath.ClusterId(aCommandPathParams.mClusterId).CommandId(aCommandPathParams.mCommandId).EndOfCommandPath();
 
     return commandPath.GetError();
 }

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -24,6 +24,11 @@
 
 #pragma once
 
+#include <app/CommandPathParams.h>
+#include <app/InteractionModelDelegate.h>
+#include <app/MessageDef/CommandDataElement.h>
+#include <app/MessageDef/CommandList.h>
+#include <app/MessageDef/InvokeCommand.h>
 #include <core/CHIPCore.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
@@ -35,11 +40,6 @@
 #include <support/logging/CHIPLogging.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
-
-#include <app/InteractionModelDelegate.h>
-#include <app/MessageDef/CommandDataElement.h>
-#include <app/MessageDef/CommandList.h>
-#include <app/MessageDef/InvokeCommand.h>
 
 namespace chip {
 namespace app {
@@ -59,31 +59,6 @@ public:
         Initialized,       //< The invoke command message has been initialized and is ready
         AddCommand,        //< The invoke command message has added Command
         Sending,           //< The invoke command message  has sent out the invoke command
-    };
-
-    enum class CommandPathFlags : uint8_t
-    {
-        kEndpointIdValid = 0x01, /**< Set when the EndpointId field is valid */
-        kGroupIdValid    = 0x02, /**< Set when the GroupId field is valid */
-    };
-
-    /**
-     * Encapsulates arguments to be passed into SendCommand().
-     *
-     */
-    struct CommandParams
-    {
-        CommandParams(chip::EndpointId endpointId, chip::GroupId groupId, chip::ClusterId clusterId, chip::CommandId commandId,
-                      const BitFlags<CommandPathFlags> & flags) :
-            EndpointId(endpointId),
-            GroupId(groupId), ClusterId(clusterId), CommandId(commandId), Flags(flags)
-        {}
-
-        chip::EndpointId EndpointId;
-        chip::GroupId GroupId;
-        chip::ClusterId ClusterId;
-        chip::CommandId CommandId;
-        BitFlags<CommandPathFlags> Flags;
     };
 
     /**
@@ -117,10 +92,10 @@ public:
      */
     CHIP_ERROR FinalizeCommandsMessage();
 
-    CHIP_ERROR PrepareCommand(const CommandParams * const apCommandParams);
+    CHIP_ERROR PrepareCommand(const CommandPathParams * const apCommandPathParams);
     TLV::TLVWriter * GetCommandDataElementTLVWriter();
     CHIP_ERROR FinishCommand();
-    virtual CHIP_ERROR AddStatusCode(const CommandParams * apCommandParams,
+    virtual CHIP_ERROR AddStatusCode(const CommandPathParams * apCommandPathParams,
                                      const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
                                      const Protocols::Id aProtocolId, const uint16_t aProtocolCode)
     {
@@ -147,7 +122,7 @@ protected:
     CHIP_ERROR ClearExistingExchangeContext();
     void MoveToState(const CommandState aTargetState);
     CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle && payload, CommandRoleId aCommandRoleId);
-    CHIP_ERROR ConstructCommandPath(const CommandParams & aCommandParams, CommandDataElement::Builder aCommandDataElement);
+    CHIP_ERROR ConstructCommandPath(const CommandPathParams & aCommandPathParams, CommandDataElement::Builder aCommandDataElement);
     void ClearState();
     const char * GetStateStr() const;
 

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -114,14 +114,14 @@ exit:
     return err;
 }
 
-CHIP_ERROR CommandHandler::AddStatusCode(const CommandParams * apCommandParams,
+CHIP_ERROR CommandHandler::AddStatusCode(const CommandPathParams * apCommandPathParams,
                                          const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
                                          const Protocols::Id aProtocolId, const uint16_t aProtocolCode)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     StatusElement::Builder statusElementBuilder;
 
-    err = PrepareCommand(apCommandParams);
+    err = PrepareCommand(apCommandPathParams);
     SuccessOrExit(err);
 
     statusElementBuilder =

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -44,8 +44,9 @@ class CommandHandler : public Command
 public:
     void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                            System::PacketBufferHandle payload);
-    CHIP_ERROR AddStatusCode(const CommandParams * apCommandParams, const Protocols::SecureChannel::GeneralStatusCode aGeneralCode,
-                             const Protocols::Id aProtocolId, const uint16_t aProtocolCode) override;
+    CHIP_ERROR AddStatusCode(const CommandPathParams * apCommandPathParams,
+                             const Protocols::SecureChannel::GeneralStatusCode aGeneralCode, const Protocols::Id aProtocolId,
+                             const uint16_t aProtocolCode) override;
 
 private:
     friend class TestCommandInteraction;

--- a/src/app/CommandPathParams.h
+++ b/src/app/CommandPathParams.h
@@ -1,0 +1,67 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <support/BitFlags.h>
+
+namespace chip {
+namespace app {
+
+enum class CommandPathFlags : uint8_t
+{
+    kEndpointIdValid = 0x01,
+    kGroupIdValid    = 0x02,
+};
+
+struct CommandPathParams
+{
+    CommandPathParams(EndpointId aEndpointId, GroupId aGroupId, ClusterId aClusterId, CommandId aCommandId,
+                      const BitFlags<CommandPathFlags> & aFlags) :
+        mEndpointId(aEndpointId),
+        mGroupId(aGroupId), mClusterId(aClusterId), mCommandId(aCommandId), mFlags(aFlags)
+    {}
+    bool IsSamePath(const CommandPathParams & other) const
+    {
+        if (other.mClusterId != mClusterId || other.mCommandId != mCommandId)
+        {
+            return false;
+        }
+        if (mFlags != other.mFlags)
+        {
+            return false;
+        }
+        if (mFlags == CommandPathFlags::kEndpointIdValid && other.mEndpointId != mEndpointId)
+        {
+            return false;
+        }
+        if (mFlags == CommandPathFlags::kGroupIdValid && other.mGroupId != mGroupId)
+        {
+            return false;
+        }
+        return true;
+    }
+    EndpointId mEndpointId = 0;
+    GroupId mGroupId       = 0;
+    ClusterId mClusterId   = 0;
+    CommandId mCommandId   = 0;
+    BitFlags<CommandPathFlags> mFlags;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/EventPathParams.h
+++ b/src/app/EventPathParams.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+
+namespace chip {
+namespace app {
+struct EventPathParams
+{
+    EventPathParams(NodeId aNodeId, EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId, bool aIsUrgent) :
+        mNodeId(aNodeId), mEndpointId(aEndpointId), mClusterId(aClusterId), mEventId(aEventId), mIsUrgent(aIsUrgent)
+    {}
+    bool IsSamePath(const EventPathParams & other) const
+    {
+        return other.mNodeId == mNodeId && other.mEndpointId == mEndpointId && other.mClusterId == mClusterId &&
+            other.mEventId == mEventId;
+    }
+    NodeId mNodeId         = 0;
+    EndpointId mEndpointId = 0;
+    ClusterId mClusterId   = 0;
+    EventId mEventId       = 0;
+    bool mIsUrgent         = false;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/InteractionModelDelegate.h
+++ b/src/app/InteractionModelDelegate.h
@@ -33,7 +33,6 @@ namespace chip {
 namespace app {
 class ReadClient;
 class CommandSender;
-struct EventPathParams;
 
 /**
  * @brief

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <app/AttributePathParams.h>
+#include <app/EventPathParams.h>
 #include <app/InteractionModelDelegate.h>
 #include <app/MessageDef/ReadRequest.h>
 #include <core/CHIPCore.h>

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -22,7 +22,11 @@ chip_test_suite("tests") {
   output_name = "libAppTests"
 
   test_sources = [
+    "TestAttributePathParams.cpp",
+    "TestClusterInfo.cpp",
     "TestCommandInteraction.cpp",
+    "TestCommandPathParams.cpp",
+    "TestEventPathParams.cpp",
     "TestMessageDef.cpp",
     "TestReadInteraction.cpp",
     "TestReportingEngine.cpp",

--- a/src/app/tests/TestAttributePathParams.cpp
+++ b/src/app/tests/TestAttributePathParams.cpp
@@ -1,0 +1,104 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CommandPathParams
+ *
+ */
+
+#include <app/AttributePathParams.h>
+#include <nlunit-test.h>
+#include <support/UnitTestRegistration.h>
+
+namespace chip {
+namespace app {
+namespace TestAttributePathParams {
+void TestSamePath(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    NL_TEST_ASSERT(apSuite, attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentNodeId(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(6, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentEndpointId(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 6, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentClusterId(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 2, 6, 4, 5, AttributePathFlags::kFieldIdValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentFieldId(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 2, 3, 6, 5, AttributePathFlags::kFieldIdValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentListIndex(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kListIndexValid);
+    AttributePathParams attributePathParams2(1, 2, 3, 4, 6, AttributePathFlags::kListIndexValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+
+void TestDifferentPathFlag(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 2, 3, 4, 5, AttributePathFlags::kListIndexValid);
+    NL_TEST_ASSERT(apSuite, !attributePathParams1.IsSamePath(attributePathParams2));
+}
+} // namespace TestAttributePathParams
+} // namespace app
+} // namespace chip
+
+namespace {
+const nlTest sTests[] = { NL_TEST_DEF("TestSamePath", chip::app::TestAttributePathParams::TestSamePath),
+                          NL_TEST_DEF("TestDifferentNodeId", chip::app::TestAttributePathParams::TestDifferentNodeId),
+                          NL_TEST_DEF("TestDifferentEndpointId", chip::app::TestAttributePathParams::TestDifferentEndpointId),
+                          NL_TEST_DEF("TestDifferentClusterId", chip::app::TestAttributePathParams::TestDifferentClusterId),
+                          NL_TEST_DEF("TestDifferentFieldId", chip::app::TestAttributePathParams::TestDifferentFieldId),
+                          NL_TEST_DEF("TestDifferentListIndex", chip::app::TestAttributePathParams::TestDifferentListIndex),
+                          NL_TEST_DEF("TestDifferentPathFlag", chip::app::TestAttributePathParams::TestDifferentPathFlag),
+                          NL_TEST_SENTINEL() };
+}
+
+int TestAttributePathParams()
+{
+    nlTestSuite theSuite = { "AttributePathParams", &sTests[0], nullptr, nullptr };
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestAttributePathParams)

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CommandPathParams
+ *
+ */
+
+#include <app/ClusterInfo.h>
+#include <nlunit-test.h>
+#include <support/UnitTestRegistration.h>
+
+namespace chip {
+namespace app {
+namespace TestClusterInfo {
+void TestSamePath(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    ClusterInfo clusterInfo1(attributePathParams1, false);
+    ClusterInfo clusterInfo2(attributePathParams2, false);
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsSamePath(clusterInfo2));
+}
+
+void TestDifferentPath(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    AttributePathParams attributePathParams2(6, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    ClusterInfo clusterInfo1(attributePathParams1, false);
+    ClusterInfo clusterInfo2(attributePathParams2, false);
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsSamePath(clusterInfo2));
+}
+
+void TestDirty(nlTestSuite * apSuite, void * apContext)
+{
+    AttributePathParams attributePathParams1(1, 2, 3, 4, 5, AttributePathFlags::kFieldIdValid);
+    ClusterInfo clusterInfo1(attributePathParams1, false);
+    clusterInfo1.SetDirty();
+    NL_TEST_ASSERT(apSuite, clusterInfo1.IsDirty());
+    clusterInfo1.ClearDirty();
+    NL_TEST_ASSERT(apSuite, !clusterInfo1.IsDirty());
+}
+} // namespace TestClusterInfo
+} // namespace app
+} // namespace chip
+
+namespace {
+const nlTest sTests[] = { NL_TEST_DEF("TestSamePath", chip::app::TestClusterInfo::TestSamePath),
+                          NL_TEST_DEF("TestDifferentPath", chip::app::TestClusterInfo::TestDifferentPath),
+                          NL_TEST_DEF("TestDirtiness", chip::app::TestClusterInfo::TestDirty), NL_TEST_SENTINEL() };
+}
+
+int TestClusterInfo()
+{
+    nlTestSuite theSuite = { "ClusterInfo", &sTests[0], nullptr, nullptr };
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestClusterInfo)

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -124,12 +124,12 @@ void TestCommandInteraction::GenerateReceivedCommand(nlTestSuite * apSuite, void
 void TestCommandInteraction::AddCommandDataElement(nlTestSuite * apSuite, void * apContext, Command * apCommand,
                                                    bool aNeedStatusCode, bool aIsEmptyResponse)
 {
-    CHIP_ERROR err                                  = CHIP_NO_ERROR;
-    chip::app::Command::CommandParams commandParams = { 1, // Endpoint
-                                                        2, // GroupId
-                                                        3, // ClusterId
-                                                        4, // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    chip::app::CommandPathParams commandPathParams = { 1, // Endpoint
+                                                       2, // GroupId
+                                                       3, // ClusterId
+                                                       4, // CommandId
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
 
     if (aNeedStatusCode)
     {
@@ -140,13 +140,13 @@ void TestCommandInteraction::AddCommandDataElement(nlTestSuite * apSuite, void *
         }
         else
         {
-            apCommand->AddStatusCode(&commandParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
+            apCommand->AddStatusCode(&commandPathParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
                                      Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeSuccess);
         }
     }
     else
     {
-        err = apCommand->PrepareCommand(&commandParams);
+        err = apCommand->PrepareCommand(&commandPathParams);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
         chip::TLV::TLVWriter * writer = apCommand->GetCommandDataElementTLVWriter();
@@ -181,12 +181,12 @@ void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSu
 
 void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite * apSuite, void * apContext)
 {
-    CHIP_ERROR err                                  = CHIP_NO_ERROR;
-    chip::app::Command::CommandParams commandParams = { 1, // Endpoint
-                                                        2, // GroupId
-                                                        3, // ClusterId
-                                                        4, // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    CHIP_ERROR err                                 = CHIP_NO_ERROR;
+    chip::app::CommandPathParams commandPathParams = { 1, // Endpoint
+                                                       2, // GroupId
+                                                       3, // ClusterId
+                                                       4, // CommandId
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
     app::CommandHandler commandHandler;
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
     err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
@@ -196,7 +196,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
 
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
-    err = commandHandler.PrepareCommand(&commandParams);
+    err = commandHandler.PrepareCommand(&commandPathParams);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = commandHandler.FinishCommand();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);

--- a/src/app/tests/TestCommandPathParams.cpp
+++ b/src/app/tests/TestCommandPathParams.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for AttributePathParams
+ *
+ */
+
+#include <app/CommandPathParams.h>
+#include <nlunit-test.h>
+#include <support/UnitTestRegistration.h>
+
+namespace chip {
+namespace app {
+namespace TestCommandPathParams {
+void TestSamePath(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    CommandPathParams commandPathParams2(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    NL_TEST_ASSERT(apSuite, commandPathParams1.IsSamePath(commandPathParams2));
+}
+
+void TestDifferentEndpointId(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    CommandPathParams commandPathParams2(6, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    NL_TEST_ASSERT(apSuite, !commandPathParams1.IsSamePath(commandPathParams2));
+}
+
+void TestDifferentGroupId(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kGroupIdValid);
+    CommandPathParams commandPathParams2(1, 6, 3, 4, CommandPathFlags::kGroupIdValid);
+    NL_TEST_ASSERT(apSuite, !commandPathParams1.IsSamePath(commandPathParams2));
+}
+
+void TestDifferentClusterId(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    CommandPathParams commandPathParams2(1, 2, 6, 4, CommandPathFlags::kEndpointIdValid);
+    NL_TEST_ASSERT(apSuite, !commandPathParams1.IsSamePath(commandPathParams2));
+}
+
+void TestDifferentCommandId(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    CommandPathParams commandPathParams2(1, 2, 3, 6, CommandPathFlags::kEndpointIdValid);
+    NL_TEST_ASSERT(apSuite, !commandPathParams1.IsSamePath(commandPathParams2));
+}
+
+void TestDifferentPathFlag(nlTestSuite * apSuite, void * apContext)
+{
+    CommandPathParams commandPathParams1(1, 2, 3, 4, CommandPathFlags::kEndpointIdValid);
+    CommandPathParams commandPathParams2(1, 2, 3, 4, CommandPathFlags::kGroupIdValid);
+    NL_TEST_ASSERT(apSuite, !commandPathParams1.IsSamePath(commandPathParams2));
+}
+} // namespace TestCommandPathParams
+} // namespace app
+} // namespace chip
+
+namespace {
+const nlTest sTests[] = { NL_TEST_DEF("TestSamePath", chip::app::TestCommandPathParams::TestSamePath),
+                          NL_TEST_DEF("TestDifferentEndpointId", chip::app::TestCommandPathParams::TestDifferentEndpointId),
+                          NL_TEST_DEF("TestDifferentGroupId", chip::app::TestCommandPathParams::TestDifferentGroupId),
+                          NL_TEST_DEF("TestDifferentClusterId", chip::app::TestCommandPathParams::TestDifferentClusterId),
+                          NL_TEST_DEF("TestDifferentCommandId", chip::app::TestCommandPathParams::TestDifferentCommandId),
+                          NL_TEST_DEF("TestDifferentPathFlag", chip::app::TestCommandPathParams::TestDifferentPathFlag),
+                          NL_TEST_SENTINEL() };
+}
+
+int TestCommandPathParams()
+{
+    nlTestSuite theSuite = { "CommandPathParams", &sTests[0], nullptr, nullptr };
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestCommandPathParams)

--- a/src/app/tests/TestEventPathParams.cpp
+++ b/src/app/tests/TestEventPathParams.cpp
@@ -1,0 +1,88 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for EventPathParams
+ *
+ */
+
+#include <app/EventPathParams.h>
+#include <nlunit-test.h>
+#include <support/UnitTestRegistration.h>
+
+namespace chip {
+namespace app {
+namespace TestEventPathParams {
+void TestSamePath(nlTestSuite * apSuite, void * apContext)
+{
+    EventPathParams eventPathParams1(1, 2, 3, 4, false);
+    EventPathParams eventPathParams2(1, 2, 3, 4, false);
+    NL_TEST_ASSERT(apSuite, eventPathParams1.IsSamePath(eventPathParams2));
+}
+
+void TestDifferentNodeId(nlTestSuite * apSuite, void * apContext)
+{
+    EventPathParams eventPathParams1(1, 2, 3, 4, false);
+    EventPathParams eventPathParams2(6, 2, 3, 4, false);
+    NL_TEST_ASSERT(apSuite, !eventPathParams1.IsSamePath(eventPathParams2));
+}
+
+void TestDifferentEndpointId(nlTestSuite * apSuite, void * apContext)
+{
+    EventPathParams eventPathParams1(1, 2, 3, 4, false);
+    EventPathParams eventPathParams2(1, 6, 3, 4, false);
+    NL_TEST_ASSERT(apSuite, !eventPathParams1.IsSamePath(eventPathParams2));
+}
+
+void TestDifferentClusterId(nlTestSuite * apSuite, void * apContext)
+{
+    EventPathParams eventPathParams1(1, 2, 3, 4, false);
+    EventPathParams eventPathParams2(1, 2, 6, 4, false);
+    NL_TEST_ASSERT(apSuite, !eventPathParams1.IsSamePath(eventPathParams2));
+}
+
+void TestDifferentEventId(nlTestSuite * apSuite, void * apContext)
+{
+    EventPathParams eventPathParams1(1, 2, 3, 4, false);
+    EventPathParams eventPathParams2(1, 2, 3, 6, false);
+    NL_TEST_ASSERT(apSuite, !eventPathParams1.IsSamePath(eventPathParams2));
+}
+} // namespace TestEventPathParams
+} // namespace app
+} // namespace chip
+
+namespace {
+const nlTest sTests[] = { NL_TEST_DEF("TestSamePath", chip::app::TestEventPathParams::TestSamePath),
+                          NL_TEST_DEF("TestDifferentNodeId", chip::app::TestEventPathParams::TestDifferentNodeId),
+                          NL_TEST_DEF("TestDifferentEndpointId", chip::app::TestEventPathParams::TestDifferentEndpointId),
+                          NL_TEST_DEF("TestDifferentClusterId", chip::app::TestEventPathParams::TestDifferentClusterId),
+                          NL_TEST_DEF("TestDifferentEventId", chip::app::TestEventPathParams::TestDifferentEventId),
+                          NL_TEST_SENTINEL() };
+}
+
+int TestEventPathParams()
+{
+    nlTestSuite theSuite = { "EventPathParams", &sTests[0], nullptr, nullptr };
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestEventPathParams)

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -86,11 +86,11 @@ CHIP_ERROR SendCommandRequest(void)
 
     printf("\nSend invoke command request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    chip::app::Command::CommandParams commandParams = { kTestEndPointId, // Endpoint
-                                                        kTestGroupId,    // GroupId
-                                                        kTestClusterId,  // ClusterId
-                                                        kTestCommandId,  // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    chip::app::CommandPathParams commandPathParams = { kTestEndPointId, // Endpoint
+                                                       kTestGroupId,    // GroupId
+                                                       kTestClusterId,  // ClusterId
+                                                       kTestCommandId,  // CommandId
+                                                       chip::app::CommandPathFlags::kEndpointIdValid };
 
     // Add command data here
 
@@ -98,7 +98,7 @@ CHIP_ERROR SendCommandRequest(void)
     uint8_t effectVariant    = 1;
     chip::TLV::TLVWriter * writer;
 
-    err = gpCommandSender->PrepareCommand(&commandParams);
+    err = gpCommandSender->PrepareCommand(&commandPathParams);
     SuccessOrExit(err);
 
     writer = gpCommandSender->GetCommandDataElementTLVWriter();
@@ -264,6 +264,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
     }
 }
+
 } // namespace app
 } // namespace chip
 

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -57,11 +57,11 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
         chip::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
     }
 
-    chip::app::Command::CommandParams commandParams = { kTestEndPointId, // Endpoint
-                                                        kTestGroupId,    // GroupId
-                                                        kTestClusterId,  // ClusterId
-                                                        kTestCommandId,  // CommandId
-                                                        (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    chip::app::CommandPathParams commandPathParams = { kTestEndPointId, // Endpoint
+                                                       kTestGroupId,    // GroupId
+                                                       kTestClusterId,  // ClusterId
+                                                       kTestCommandId,  // CommandId
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
 
     // Add command data here
 
@@ -71,7 +71,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
     if (statusCodeFlipper)
     {
         printf("responder constructing status code in command");
-        apCommandObj->AddStatusCode(&commandParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
+        apCommandObj->AddStatusCode(&commandPathParams, Protocols::SecureChannel::GeneralStatusCode::kSuccess,
                                     Protocols::SecureChannel::Id, Protocols::SecureChannel::kProtocolCodeSuccess);
     }
     else
@@ -80,7 +80,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 
         chip::TLV::TLVWriter * writer;
 
-        err = apCommandObj->PrepareCommand(&commandParams);
+        err = apCommandObj->PrepareCommand(&commandPathParams);
         SuccessOrExit(err);
 
         writer = apCommandObj->GetCommandDataElementTLVWriter();
@@ -98,6 +98,7 @@ void DispatchSingleClusterCommand(chip::ClusterId aClusterId, chip::CommandId aC
 exit:
     return;
 }
+
 } // namespace app
 } // namespace chip
 

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -66,11 +66,11 @@ bool IMEmberAfSendDefaultResponseWithCallback(EmberAfStatus status)
         return false;
     }
 
-    chip::app::Command::CommandParams returnStatusParam = { imCompatibilityEmberApsFrame.sourceEndpoint,
-                                                            0, // GroupId
-                                                            imCompatibilityEmberApsFrame.clusterId,
-                                                            imCompatibilityEmberAfCluster.commandId,
-                                                            (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    chip::app::CommandPathParams returnStatusParam = { imCompatibilityEmberApsFrame.sourceEndpoint,
+                                                       0, // GroupId
+                                                       imCompatibilityEmberApsFrame.clusterId,
+                                                       imCompatibilityEmberAfCluster.commandId,
+                                                       (chip::app::CommandPathFlags::kEndpointIdValid) };
 
     CHIP_ERROR err =
         currentCommandObject->AddStatusCode(&returnStatusParam, chip::Protocols::SecureChannel::GeneralStatusCode::kSuccess,

--- a/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/chip/CHIPClusters-src.zapt
@@ -24,8 +24,8 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, k{{asCamelCased name false}}CommandId,
-                                         (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, k{{asCamelCased name false}}CommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
     app::Command * ZCLcommand = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));

--- a/src/controller/CHIPClusters.cpp
+++ b/src/controller/CHIPClusters.cpp
@@ -112,9 +112,9 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -142,9 +142,9 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -216,9 +216,9 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -411,9 +411,9 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -448,9 +448,9 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -500,9 +500,9 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -538,9 +538,9 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -578,9 +578,9 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -614,9 +614,9 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -651,9 +651,9 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -690,9 +690,9 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -727,9 +727,9 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -766,9 +766,9 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -805,9 +805,9 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -842,9 +842,9 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -882,9 +882,9 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -926,9 +926,9 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -965,9 +965,9 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1003,9 +1003,9 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1686,9 +1686,9 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1711,9 +1711,9 @@ CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1737,9 +1737,9 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1766,9 +1766,9 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1795,9 +1795,9 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1824,9 +1824,9 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1856,9 +1856,9 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1888,9 +1888,9 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1917,9 +1917,9 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1946,9 +1946,9 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -1975,9 +1975,9 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2004,9 +2004,9 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2033,9 +2033,9 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2065,9 +2065,9 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2097,9 +2097,9 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2127,9 +2127,9 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2163,9 +2163,9 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2199,9 +2199,9 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2235,9 +2235,9 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2267,9 +2267,9 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2309,9 +2309,9 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2345,9 +2345,9 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2374,9 +2374,9 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2462,9 +2462,9 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2496,9 +2496,9 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2523,9 +2523,9 @@ CHIP_ERROR GeneralCommissioningCluster::SetFabric(Callback::Cancelable * onSucce
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2633,9 +2633,9 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2664,9 +2664,9 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2696,9 +2696,9 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2727,9 +2727,9 @@ CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2753,9 +2753,9 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2782,9 +2782,9 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2897,9 +2897,9 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2925,9 +2925,9 @@ CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -2983,9 +2983,9 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3019,9 +3019,9 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3056,9 +3056,9 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3088,9 +3088,9 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3120,9 +3120,9 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3158,9 +3158,9 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3192,9 +3192,9 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3222,9 +3222,9 @@ CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCa
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3287,9 +3287,9 @@ CHIP_ERROR LowPowerCluster::Sleep(Callback::Cancelable * onSuccessCallback, Call
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSleepCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSleepCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3330,9 +3330,9 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3365,9 +3365,9 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3402,9 +3402,9 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3437,9 +3437,9 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3472,9 +3472,9 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3503,9 +3503,9 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3538,9 +3538,9 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3574,9 +3574,9 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3609,9 +3609,9 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3661,9 +3661,9 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3686,9 +3686,9 @@ CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3711,9 +3711,9 @@ CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3774,9 +3774,9 @@ CHIP_ERROR OperationalCredentialsCluster::GetFabricId(Callback::Cancelable * onS
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetFabricIdCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetFabricIdCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3801,9 +3801,9 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3835,9 +3835,9 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3891,9 +3891,9 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3933,9 +3933,9 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3962,9 +3962,9 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -3996,9 +3996,9 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4025,9 +4025,9 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4056,9 +4056,9 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4087,9 +4087,9 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4231,9 +4231,9 @@ CHIP_ERROR ThermostatCluster::ClearWeeklySchedule(Callback::Cancelable * onSucce
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeeklyScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeeklyScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4256,9 +4256,9 @@ CHIP_ERROR ThermostatCluster::GetRelayStatusLog(Callback::Cancelable * onSuccess
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRelayStatusLogCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRelayStatusLogCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4282,9 +4282,9 @@ CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccess
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeeklyScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeeklyScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4315,9 +4315,9 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeeklyScheduleCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeeklyScheduleCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4351,9 +4351,9 @@ CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSucces
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetpointRaiseLowerCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetpointRaiseLowerCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4488,9 +4488,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringDownClose(Callback::Cancelable *
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringDownCloseCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringDownCloseCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4515,9 +4515,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftPercentage(Callback::Can
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftPercentageCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftPercentageCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4545,9 +4545,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftValue(Callback::Cancelab
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftValueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftValueCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4576,9 +4576,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltPercentage(Callback::Can
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltPercentageCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltPercentageCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4606,9 +4606,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltValue(Callback::Cancelab
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltValueCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltValueCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4636,9 +4636,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringStop(Callback::Cancelable * onSu
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringStopCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringStopCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 
@@ -4662,9 +4662,9 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringUpOpen(Callback::Cancelable * on
     (void) onSuccessCallback;
     (void) onFailureCallback;
 
-    app::Command::CommandParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringUpOpenCommandId,
-                                              (chip::app::Command::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand             = mDevice->GetCommandSender();
+    app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringUpOpenCommandId,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
     ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
 


### PR DESCRIPTION
-- Move/Rename CommandPathParams in IM utilities
-- Add AttributePathParams, EventPathParams, ClusterInfo to IM utilities header
so that other IM can directly include this and avoid forward
declarations and header include loop.