### PR TITLE
Build error when compiling with define BIGENDIAN_CPU set (#6143)

### DIFF
--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -695,7 +695,7 @@ int8_t emberAfCompareValues(uint8_t * val1, uint8_t * val2, uint8_t len, bool si
  */
 void emberAfGetEui64(EmberEUI64 returnEui64);
 
-#ifdef EZSP_HOST
+#if (BIGENDIAN_CPU) || defined(EZSP_HOST)
 // Normally this is provided by the stack code, but on the host
 // it is provided by the application code.
 void emberReverseMemCopy(uint8_t * dest, const uint8_t * src, uint16_t length);


### PR DESCRIPTION
 #### Problem
When compiling with the define BIGENDIAN_CPU set a build error occurs:
chipd/sources/chip-daemon/3rdparty/connectedhomeip/src/app/util/attribute-table.cpp:446:59: error: 'emberReverseMemCopy' was not declared in this scope emberReverseMemCopy(buffer + *bufIndex, data, size);

This function is declared in af.h, but this is within a define EZSP_HOST.

#### Summary of Changes
Made the function declaration available via the BIGENDIAN_CPU define.

 Fixes #6143
