### PR TITLE
Revert "Fix CheckExchangeMessages crashes when malicious packet is se…

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -316,14 +316,6 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         // AND The message was received from the peer node associated with the exchange
         && (mSecureSession == session)
 
-        // AND The message must come with a source Node ID.
-        && (packetHeader.GetSourceNodeId().HasValue())
-
-        // AND The message's source Node ID matches the peer Node ID associated with the exchange, or the peer Node ID of the
-        // exchange is 'any'.
-        && ((mSecureSession.GetPeerNodeId() == kAnyNodeId) ||
-            (mSecureSession.GetPeerNodeId() == packetHeader.GetSourceNodeId().Value()))
-
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast
         //    case, the initiator is ill defined)

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -149,9 +149,9 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // send a malicious packet
-    ec1->SendMessage(Protocols::Id(VendorId::Common, 0x0001), 0x0002,
-                     System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
-                     SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
+    // TODO: https://github.com/project-chip/connectedhomeip/issues/4635
+    // ec1->SendMessage(0x0001, 0x0002, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+    //                 SendFlags(Messaging::SendMessageFlags::kNone));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet


### PR DESCRIPTION
…nt (#6120)"

This reverts commit eeff872fde187e829685a662b8a97f673b924a84.

 #### Problem

This commits broke Pairing  over BLE on the esp32: `CHIP: [EM] OnMessageReceived failed, err = CHIP Error 4112 (0x00001010): Unsolicited msg with originator bit clear`.

 #### Summary of Changes
 * Revert eeff872fde187e829685a662b8a97f673b924a84