### PR TITLE
Use endpoint 0 instead of 1 in iOS ChipTool for Network Provisioning,…

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Info.plist
+++ b/src/darwin/CHIPTool/CHIPTool/Info.plist
@@ -20,16 +20,18 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Network usage is required for discovering accessories</string>
-	<key>NSBonjourServices</key>
-	<array><string>_chip._tcp</string></array>
 	<key>NFCReaderUsageDescription</key>
 	<string>To read a setup payload code via NFC code</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Used to connect to the peripheral</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_chip._tcp</string>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Used to scan QR code</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Network usage is required for discovering accessories</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -38,7 +38,7 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 
-    self.cluster = [[CHIPBinding alloc] initWithDevice:CHIPGetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
+    self.cluster = [[CHIPBinding alloc] initWithDevice:CHIPGetPairedDevice() endpoint:0 queue:dispatch_get_main_queue()];
 }
 
 - (void)dismissKeyboard

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Echo client/EchoViewController.m
@@ -45,7 +45,7 @@
     UITapGestureRecognizer * tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissKeyboard)];
     [self.view addGestureRecognizer:tap];
 
-    self.cluster = [[CHIPBasic alloc] initWithDevice:CHIPGetPairedDevice() endpoint:1 queue:dispatch_get_main_queue()];
+    self.cluster = [[CHIPBasic alloc] initWithDevice:CHIPGetPairedDevice() endpoint:0 queue:dispatch_get_main_queue()];
 }
 
 - (void)dismissKeyboard

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -519,7 +519,7 @@
 - (void)addWiFiNetwork:(NSString *)ssid password:(NSString *)password
 {
     self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:CHIPGetPairedDevice()
-                                                           endpoint:1
+                                                           endpoint:0
                                                               queue:dispatch_get_main_queue()];
     NSData * networkId = [ssid dataUsingEncoding:NSUTF8StringEncoding];
     NSData * credentials = [password dataUsingEncoding:NSUTF8StringEncoding];
@@ -539,7 +539,7 @@
 - (void)addThreadNetwork:(NSData *)threadDataSet
 {
     self.cluster = [[CHIPNetworkCommissioning alloc] initWithDevice:CHIPGetPairedDevice()
-                                                           endpoint:1
+                                                           endpoint:0
                                                               queue:dispatch_get_main_queue()];
     uint64_t breadcrumb = 0;
     uint32_t timeoutMs = 3000;


### PR DESCRIPTION
… Echo and Bindings

 #### Problem

After #6000, the endpoints from #5990 and echo/bindings should be 0 by default instead of 1.

 #### Summary of Changes
 * Replace `1` by `0`