### PR TITLE
Use spec defined max application message size

### DIFF
--- a/src/transport/SecureMessageCodec.cpp
+++ b/src/transport/SecureMessageCodec.cpp
@@ -29,13 +29,6 @@
 #include <support/SafeInt.h>
 #include <transport/SecureMessageCodec.h>
 
-// Maximum length of application data that can be encrypted as one block.
-// The limit is derived from IPv6 MTU (1280 bytes) - expected header overheads.
-// This limit would need additional reviews once we have formalized Secure Transport header.
-//
-// TODO: this should be checked within the transport message sending instead of the session management layer.
-static const size_t kMax_SecureSDU_Length = 1024;
-
 namespace chip {
 
 using System::PacketBuffer;
@@ -48,7 +41,7 @@ CHIP_ERROR Encode(NodeId localNodeId, Transport::PeerConnectionState * state, Pa
 {
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    VerifyOrReturnError(msgBuf->TotalLength() < kMax_SecureSDU_Length, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrReturnError(msgBuf->TotalLength() <= kMaxAppMessageLen, CHIP_ERROR_MESSAGE_TOO_LONG);
 
     uint32_t msgId = state->GetSendMessageIndex();
 

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -39,6 +39,8 @@ namespace chip {
 
 static constexpr size_t kMaxTagLen = 16;
 
+static constexpr size_t kMaxAppMessageLen = 1200;
+
 typedef int PacketHeaderFlags;
 
 namespace Header {

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -55,6 +55,8 @@ const char PAYLOAD[]                = "Hello!";
 constexpr NodeId kSourceNodeId      = 123654;
 constexpr NodeId kDestinationNodeId = 111222333;
 
+const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
+
 class LoopbackTransport : public Transport::Base
 {
 public:
@@ -102,8 +104,16 @@ public:
 
         size_t data_len = msgBuf->DataLength();
 
-        int compare = memcmp(msgBuf->Start(), PAYLOAD, data_len);
-        NL_TEST_ASSERT(mSuite, compare == 0);
+        if (LargeMessageSent)
+        {
+            int compare = memcmp(msgBuf->Start(), LARGE_PAYLOAD, data_len);
+            NL_TEST_ASSERT(mSuite, compare == 0);
+        }
+        else
+        {
+            int compare = memcmp(msgBuf->Start(), PAYLOAD, data_len);
+            NL_TEST_ASSERT(mSuite, compare == 0);
+        }
 
         ReceiveHandlerCallCount++;
     }
@@ -123,6 +133,8 @@ public:
     SecureSessionHandle mLocalToRemoteSession;
     int ReceiveHandlerCallCount       = 0;
     int NewConnectionHandlerCallCount = 0;
+
+    bool LargeMessageSent = false;
 };
 
 TestSessMgrCallback callback;
@@ -150,6 +162,8 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     uint16_t payload_len = sizeof(PAYLOAD);
+
+    callback.LargeMessageSent = false;
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
@@ -209,6 +223,30 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
 
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    // Let's send the max sized message and make sure it is received
+    chip::System::PacketBufferHandle large_buffer = chip::MessagePacketBuffer::NewWithData(LARGE_PAYLOAD, kMaxAppMessageLen);
+    NL_TEST_ASSERT(inSuite, !large_buffer.IsNull());
+
+    callback.LargeMessageSent = true;
+
+    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, std::move(large_buffer));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    ctx.DriveIOUntil(1000 /* ms */, []() { return callback.ReceiveHandlerCallCount != 0; });
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 2);
+
+    uint16_t large_payload_len = sizeof(LARGE_PAYLOAD);
+
+    // Let's send bigger message than supported and make sure it fails to send
+    chip::System::PacketBufferHandle extra_large_buffer = chip::MessagePacketBuffer::NewWithData(LARGE_PAYLOAD, large_payload_len);
+    NL_TEST_ASSERT(inSuite, !extra_large_buffer.IsNull());
+
+    callback.LargeMessageSent = true;
+
+    err = secureSessionMgr.SendMessage(localToRemoteSession, payloadHeader, std::move(extra_large_buffer));
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_MESSAGE_TOO_LONG);
 }
 
 void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
@@ -216,6 +254,8 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     uint16_t payload_len = sizeof(PAYLOAD);
+
+    callback.LargeMessageSent = false;
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 
@@ -290,6 +330,8 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
     uint16_t payload_len = sizeof(PAYLOAD);
+
+    callback.LargeMessageSent = false;
 
     ctx.GetInetLayer().SystemLayer()->Init(nullptr);
 


### PR DESCRIPTION
 #### Problem
Unable to send spec defined max application message using CHIP stack.

 #### Summary of Changes
Update the limits to match specifications. Also, add unit test to make sure the max sized message could be sent. And, message with size large than max is dropped, and an error is returned.

 Fixes #6146, #6147
