### PR TITLE
Reading 8- or 16-bit attributes from big-endian device returns 0 (#6166)

### DIFF
--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -97,27 +97,27 @@ typedef void (*EmberAfGenericClusterFunction)(void);
  */
 typedef struct
 {
-#if (BIGENDIAN_CPU)
+#if defined(BIGENDIAN_CPU) && (BIGENDIAN_CPU != 0)
+// Big endian
 #if (UINTPTR_MAX == UINT32_MAX)
     uint32_t align : 16;
-#elif (UINTPTR_MAX == UINT64_MAX)
-    uint64_t align : 48;
-#endif
-#endif
-
-    /**
-     * Actual value.
-     */
     uint16_t value;
-
-#if (!BIGENDIAN_CPU)
-#if (UINTPTR_MAX == UINT32_MAX)
-    uint32_t align : 16;
 #elif (UINTPTR_MAX == UINT64_MAX)
     uint64_t align : 48;
+    uint16_t value;
 #endif
+#else
+// Little endian
+#if (UINTPTR_MAX == UINT32_MAX)
+    uint16_t value;
+    uint32_t align : 16;
+#elif (UINTPTR_MAX == UINT64_MAX)
+    uint16_t value;
+    uint64_t align : 48;
 #endif
-} EmberAfAlignValue;
+
+#endif // defined(BIGENDIAN_CPU) && (BIGENDIAN_CPU != 0)
+} EmberAfAlignValue16;
 
 /**
  * @brief Type for default values.
@@ -137,7 +137,7 @@ typedef union
     /**
      * Actual default value if the attribute size is 2 bytes or less.
      */
-    EmberAfAlignValue defaultValue;
+    EmberAfAlignValue16 defaultValue;
 } EmberAfDefaultAttributeValue;
 
 /**
@@ -176,7 +176,7 @@ typedef union
     /**
      * Default value of the attribute.
      */
-    EmberAfAlignValue defaultValue;
+    EmberAfAlignValue16 defaultValue;
     /**
      * Points to the min max attribute value structure, if min/max is
      * supported for this attribute.

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -89,6 +89,37 @@ typedef void (*EmberAfGenericClusterFunction)(void);
 #define EMBER_AF_NULL_MANUFACTURER_CODE 0x0000
 
 /**
+ * @brief Type for align a 16 bits value.
+ *
+ * This structure has the same size as a pointer and is used to align
+ * a 16 bit value to the 16 least significant bits of a pointer.
+ * Note that this structure is aware of the endianess and the pointer size.
+ */
+typedef struct
+{
+#if (BIGENDIAN_CPU)
+#if (UINTPTR_MAX == UINT32_MAX)
+    uint32_t align : 16;
+#elif (UINTPTR_MAX == UINT64_MAX)
+    uint64_t align : 48;
+#endif
+#endif
+
+    /**
+     * Actual value.
+     */
+    uint16_t value;
+
+#if (!BIGENDIAN_CPU)
+#if (UINTPTR_MAX == UINT32_MAX)
+    uint32_t align : 16;
+#elif (UINTPTR_MAX == UINT64_MAX)
+    uint64_t align : 48;
+#endif
+#endif
+} EmberAfAlignValue;
+
+/**
  * @brief Type for default values.
  *
  * Default value is either a value itself, if it is 2 bytes or less,
@@ -106,7 +137,7 @@ typedef union
     /**
      * Actual default value if the attribute size is 2 bytes or less.
      */
-    uint16_t defaultValue;
+    EmberAfAlignValue defaultValue;
 } EmberAfDefaultAttributeValue;
 
 /**
@@ -143,9 +174,9 @@ typedef union
      */
     uint8_t * ptrToDefaultValue;
     /**
-     * Actual default value if the attribute size is 2 bytes or less.
+     * Default value of the attribute.
      */
-    uint16_t defaultValue;
+    EmberAfAlignValue defaultValue;
     /**
      * Points to the min max attribute value structure, if min/max is
      * supported for this attribute.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1088,7 +1088,7 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool writeTokens)
                     {
                         if (emberAfAttributeSize(am) <= 2)
                         {
-                            ptr = (uint8_t *) &(am->defaultValue.ptrToMinMaxValue->defaultValue.defaultValue);
+                            ptr = (uint8_t *) &(am->defaultValue.ptrToMinMaxValue->defaultValue.defaultValue.value);
                         }
                         else
                         {
@@ -1099,7 +1099,7 @@ void emAfLoadAttributeDefaults(EndpointId endpoint, bool writeTokens)
                     {
                         if (emberAfAttributeSize(am) <= 2)
                         {
-                            ptr = (uint8_t *) &(am->defaultValue.defaultValue);
+                            ptr = (uint8_t *) &(am->defaultValue.defaultValue.value);
                         }
                         else
                         {

--- a/src/app/util/attribute-table.cpp
+++ b/src/app/util/attribute-table.cpp
@@ -536,8 +536,8 @@ EmberAfStatus emAfWriteAttribute(EndpointId endpoint, ClusterId cluster, Attribu
         if (dataLen <= 2)
         {
             int8_t minR, maxR;
-            uint8_t * minI = (uint8_t *) &(minv.defaultValue);
-            uint8_t * maxI = (uint8_t *) &(maxv.defaultValue);
+            uint8_t * minI = (uint8_t *) &(minv.defaultValue.value);
+            uint8_t * maxI = (uint8_t *) &(maxv.defaultValue.value);
 // On big endian cpu with length 1 only the second byte counts
 #if (BIGENDIAN_CPU)
             if (dataLen == 1)


### PR DESCRIPTION
 #### Problem
When reading an 8- or 16-bit attribute from a big endian device the value is 0, despite that defaults other than 0 are defined.

The defaults of these attributes are defined in a zap-file and from that a header file is generated (endpoint_config.h).
This header file contains structures that are used by the software to read cluster information and the attributes of these clusters.
The value of these attributes are stored in a **union** that also contains 2 pointers:
`typedef union { uint8_t * ptrToDefaultValue; uint16_t defaultValue; EmberAfAttributeMinMaxValue * ptrToMinMaxValue; } EmberAfDefaultOrMinMaxAttributeValue;`

A generated default value is compiled into that union using an explicit type cast to a pointer.
**Example:**
`{ (uint8_t *) 3 } }`
In a 32-bit little-endian the memory layout will be:
03 00 00 00
The 16-bit defaultValue (the first 2 bytes) will have the value 3, which is correct.

In a 32-bit big-endian system the layout will be:
00 00 00 03
The 16-bit defaultValue (the first 2 bytes) will have the value 0, which is not correct.

 #### Summary of Changes
Use a structure for the defaultValue, and that structure has the same size as a pointer.
Then use alignment bits to always align the 16-bit defaultValue with the least-significant-bits of the pointer.

**NOTE:**
Tested it on:
32-bit little-endian (esp32)
64-bit little-endian (linux)
32-bit big-endian (openwrt)

 Fixes #6166
