### PR TITLE
Send CASE messages using exchange

### DIFF
--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -261,8 +261,6 @@ CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & 
 CHIP_ERROR ChannelContext::HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                                 System::PacketBufferHandle && msg)
 {
-    if (IsCasePairing())
-        return mStateVars.mPreparing.mCasePairingSession->HandlePeerMessage(packetHeader, peerAddress, std::move(msg));
     return CHIP_ERROR_INCORRECT_STATE;
 }
 
@@ -270,13 +268,17 @@ void ChannelContext::EnterCasePairingState()
 {
     mStateVars.mPreparing.mState              = PrepareState::kCasePairing;
     mStateVars.mPreparing.mCasePairingSession = Platform::New<CASESession>();
+
+    ExchangeContext * ctxt = mExchangeManager->NewContext(SecureSessionHandle(), mStateVars.mPreparing.mCasePairingSession);
+    VerifyOrReturn(ctxt != nullptr);
+
     // TODO: currently only supports IP/UDP paring
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(mStateVars.mPreparing.mAddress);
     CHIP_ERROR err = mStateVars.mPreparing.mCasePairingSession->EstablishSession(
         addr, &mStateVars.mPreparing.mBuilder.GetOperationalCredentialSet(),
         Optional<NodeId>::Value(mExchangeManager->GetSessionMgr()->GetLocalNodeId()),
-        mStateVars.mPreparing.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), this);
+        mStateVars.mPreparing.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -27,7 +27,7 @@
 #include <channel/Channel.h>
 #include <lib/core/ReferenceCounted.h>
 #include <lib/mdns/platform/Mdns.h>
-#include <transport/CASESession.h>
+#include <protocols/secure_channel/CASESession.h>
 #include <transport/PeerConnectionState.h>
 #include <transport/SecureSessionMgr.h>
 

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -4,6 +4,8 @@ static_library("secure_channel") {
   output_name = "libSecureChannel"
 
   sources = [
+    "CASESession.cpp",
+    "CASESession.h",
     "NetworkProvisioning.cpp",
     "NetworkProvisioning.h",
     "PASESession.cpp",

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -203,13 +203,13 @@ private:
                     SessionEstablishmentDelegate * delegate);
 
     CHIP_ERROR SendSigmaR1();
-    CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(const PacketHeader & header, const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleSigmaR1(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR1(const System::PacketBufferHandle & msg);
     CHIP_ERROR SendSigmaR2();
-    CHIP_ERROR HandleSigmaR2_and_SendSigmaR3(const PacketHeader & header, const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleSigmaR2(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR2_and_SendSigmaR3(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR2(const System::PacketBufferHandle & msg);
     CHIP_ERROR SendSigmaR3();
-    CHIP_ERROR HandleSigmaR3(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR3(const System::PacketBufferHandle & msg);
 
     CHIP_ERROR SendSigmaR1Resume();
     CHIP_ERROR HandleSigmaR1Resume_and_SendSigmaR2Resume(const PacketHeader & header, const System::PacketBufferHandle & msg);
@@ -226,7 +226,7 @@ private:
     CHIP_ERROR ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen);
 
     void SendErrorMsg(SigmaErrorType errorCode);
-    void HandleErrorMsg(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    void HandleErrorMsg(const System::PacketBufferHandle & msg);
 
     // TODO: Remove this and replace with system method to retrieve current time
     CHIP_ERROR SetEffectiveTime(void);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -28,11 +28,11 @@
 #include <core/CHIPSafeCasts.h>
 #include <credentials/CHIPCert.h>
 #include <credentials/CHIPOperationalCredentials.h>
+#include <protocols/secure_channel/CASESession.h>
 #include <stdarg.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/UnitTestRegistration.h>
-#include <transport/CASESession.h>
 
 #include "credentials/tests/CHIPCert_test_vectors.h"
 

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -22,8 +22,6 @@ static_library("transport") {
   sources = [
     "AdminPairingTable.cpp",
     "AdminPairingTable.h",
-    "CASESession.cpp",
-    "CASESession.h",
     "PeerConnectionState.h",
     "PeerConnections.h",
     "RendezvousSessionDelegate.h",

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -23,7 +23,6 @@ chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
   test_sources = [
-    "TestCASESession.cpp",
     "TestPeerConnections.cpp",
     "TestSecureSession.cpp",
     "TestSecureSessionMgr.cpp",


### PR DESCRIPTION
 #### Problem
CASE messages are sent directly using SecureSessionMgr, which is UDP based. It should instead use Exchange and CRMP.

 #### Summary of Changes
Move CASESession code to `protocols/secure_channel`, and use Exchange and CRMP to send and receive the messages.