### PR TITLE
Remove unnecessary code from RendezvousSession class

### DIFF
--- a/src/protocols/secure_channel/RendezvousSession.cpp
+++ b/src/protocols/secure_channel/RendezvousSession.cpp
@@ -90,14 +90,6 @@ CHIP_ERROR RendezvousSession::Init(const RendezvousParameters & params, Messagin
 
 RendezvousSession::~RendezvousSession()
 {
-    ReleasePairingSessionHandle();
-
-    if (mTransport != nullptr)
-    {
-        chip::Platform::Delete(mTransport);
-        mTransport = nullptr;
-    }
-
     mDelegate = nullptr;
 }
 
@@ -122,31 +114,44 @@ void RendezvousSession::OnSessionEstablished()
 
     CHIP_ERROR err = mSecureSessionMgr->NewPairing(
         Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
-        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, direction, mAdmin->GetAdminId(), mTransport);
+        mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession, direction, mAdmin->GetAdminId(), nullptr);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        OnRendezvousError(err);
         return;
     }
 
-    InitPairingSessionHandle();
+    Cleanup();
 
-    UpdateState(State::kRendezvousComplete);
-    if (!mParams.IsController())
+    if (mParams.HasAdvertisementDelegate())
     {
-        OnRendezvousConnectionClosed();
+        mParams.GetAdvertisementDelegate()->RendezvousComplete();
+    }
+
+    if (mDelegate != nullptr)
+    {
+        mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingSuccess, CHIP_NO_ERROR);
+        mDelegate->OnRendezvousComplete();
     }
 }
 
-void RendezvousSession::OnNetworkProvisioningError(CHIP_ERROR err)
+void RendezvousSession::Cleanup()
 {
-    OnRendezvousError(err);
+    if (!mParams.IsController())
+    {
+        mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
+    }
+
+    if (mParams.HasAdvertisementDelegate())
+    {
+        mParams.GetAdvertisementDelegate()->StopAdvertisement();
+    }
 }
 
-void RendezvousSession::OnNetworkProvisioningComplete()
-{
-    UpdateState(State::kRendezvousComplete);
-}
+void RendezvousSession::OnNetworkProvisioningError(CHIP_ERROR err) {}
+
+void RendezvousSession::OnNetworkProvisioningComplete() {}
 
 void RendezvousSession::OnRendezvousConnectionOpened()
 {
@@ -158,127 +163,29 @@ void RendezvousSession::OnRendezvousConnectionOpened()
     CHIP_ERROR err = Pair(mParams.GetSetupPINCode());
     if (err != CHIP_NO_ERROR)
     {
-        OnSessionEstablishmentError(err);
+        OnRendezvousError(err);
     }
 }
 
-void RendezvousSession::OnRendezvousConnectionClosed()
-{
-    UpdateState(State::kInit, CHIP_NO_ERROR);
-}
+void RendezvousSession::OnRendezvousConnectionClosed() {}
 
 void RendezvousSession::OnRendezvousError(CHIP_ERROR err)
 {
-    UpdateState(State::kInit, err);
-}
+    Cleanup();
 
-void RendezvousSession::UpdateState(RendezvousSession::State newState, CHIP_ERROR err)
-{
     if (mDelegate != nullptr)
     {
-        switch (mCurrentState)
-        {
-        case State::kSecurePairing:
-            mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::PBKDFParamRequest);
-            if (CHIP_NO_ERROR == err)
-            {
-                mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingSuccess, err);
-            }
-            else
-            {
-                mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingFailed, err);
-            }
-            break;
-
-        default:
-            break;
-        };
+        mDelegate->OnRendezvousStatusUpdate(RendezvousSessionDelegate::SecurePairingFailed, err);
+        mDelegate->OnRendezvousError(err);
     }
-
-    mCurrentState = newState;
-
-    switch (mCurrentState)
-    {
-    case State::kRendezvousComplete:
-        if (mParams.HasAdvertisementDelegate())
-        {
-            mParams.GetAdvertisementDelegate()->RendezvousComplete();
-        }
-
-        if (mDelegate != nullptr)
-        {
-            mDelegate->OnRendezvousComplete();
-        }
-        break;
-
-    case State::kSecurePairing:
-        // Release the previous session handle
-        ReleasePairingSessionHandle();
-        break;
-
-    case State::kInit:
-        // Release the previous session handle
-        ReleasePairingSessionHandle();
-
-        // Disable rendezvous advertisement
-        if (mParams.HasAdvertisementDelegate())
-        {
-            mParams.GetAdvertisementDelegate()->StopAdvertisement();
-        }
-        if (mTransport)
-        {
-            // Free the transport
-            chip::Platform::Delete(mTransport);
-            mTransport = nullptr;
-        }
-
-        if (CHIP_NO_ERROR != err && mDelegate != nullptr)
-        {
-            mDelegate->OnRendezvousError(err);
-        }
-        break;
-
-    default:
-        break;
-    };
 }
 
 void RendezvousSession::OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
                                           System::PacketBufferHandle msgBuf)
 {}
 
-void RendezvousSession::InitPairingSessionHandle()
-{
-    ReleasePairingSessionHandle();
-    mPairingSessionHandle = chip::Platform::New<SecureSessionHandle>(
-        mPairingSession.PeerConnection().GetPeerNodeId(), mPairingSession.PeerConnection().GetPeerKeyID(), mAdmin->GetAdminId());
-}
-
-void RendezvousSession::ReleasePairingSessionHandle()
-{
-    VerifyOrReturn(mPairingSessionHandle != nullptr);
-
-    Transport::PeerConnectionState * state = mSecureSessionMgr->GetPeerConnectionState(*mPairingSessionHandle);
-    if (state != nullptr)
-    {
-        // Reset the transport and peer address in the active secure channel
-        // This will allow the regular transport (e.g. UDP) to take over the existing secure channel
-        state->SetTransport(nullptr);
-        state->SetPeerAddress(PeerAddress{});
-
-        // When the remote node ID is not specified in the initial rendezvous parameters, the connection state
-        // is created with undefined peer node ID. Update it now.
-        if (state->GetPeerNodeId() == kUndefinedNodeId)
-            state->SetPeerNodeId(mParams.GetRemoteNodeId().ValueOr(kUndefinedNodeId));
-    }
-
-    chip::Platform::Delete(mPairingSessionHandle);
-    mPairingSessionHandle = nullptr;
-}
-
 CHIP_ERROR RendezvousSession::WaitForPairing(uint32_t setupPINCode)
 {
-    UpdateState(State::kSecurePairing);
     return mPairingSession.WaitForPairing(setupPINCode, kSpake2p_Iteration_Count,
                                           reinterpret_cast<const unsigned char *>(kSpake2pKeyExchangeSalt),
                                           strlen(kSpake2pKeyExchangeSalt), mNextKeyId++, this);
@@ -286,7 +193,6 @@ CHIP_ERROR RendezvousSession::WaitForPairing(uint32_t setupPINCode)
 
 CHIP_ERROR RendezvousSession::WaitForPairing(const PASEVerifier & verifier)
 {
-    UpdateState(State::kSecurePairing);
     return mPairingSession.WaitForPairing(verifier, mNextKeyId++, this);
 }
 
@@ -295,21 +201,9 @@ CHIP_ERROR RendezvousSession::Pair(uint32_t setupPINCode)
     Messaging::ExchangeContext * ctxt = mExchangeManager->NewContext(SecureSessionHandle(), &mPairingSession);
     ReturnErrorCodeIf(ctxt == nullptr, CHIP_ERROR_INTERNAL);
 
-    UpdateState(State::kSecurePairing);
     CHIP_ERROR err = mPairingSession.Pair(mParams.GetPeerAddress(), setupPINCode, mNextKeyId++, ctxt, this);
     ctxt->Release();
     return err;
 }
 
-void RendezvousSession::SendNetworkCredentials(const char * ssid, const char * passwd)
-{
-    mNetworkProvision.SendNetworkCredentials(ssid, passwd);
-}
-
-void RendezvousSession::SendThreadCredentials(ByteSpan threadData)
-{
-    mNetworkProvision.SendThreadCredentials(threadData);
-}
-
-void RendezvousSession::SendOperationalCredentials() {}
 } // namespace chip

--- a/src/protocols/secure_channel/RendezvousSession.h
+++ b/src/protocols/secure_channel/RendezvousSession.h
@@ -68,18 +68,10 @@ class SecureSessionHandle;
  */
 class RendezvousSession : public SessionEstablishmentDelegate,
                           public RendezvousSessionDelegate,
-                          public RendezvousDeviceCredentialsDelegate,
                           public NetworkProvisioningDelegate,
                           public TransportMgrDelegate
 {
 public:
-    enum State : uint8_t
-    {
-        kInit = 0,
-        kSecurePairing,
-        kRendezvousComplete,
-    };
-
     RendezvousSession(RendezvousSessionDelegate * delegate) : mDelegate(delegate) {}
     ~RendezvousSession() override;
 
@@ -116,11 +108,6 @@ public:
     void OnRendezvousConnectionClosed() override;
     void OnRendezvousError(CHIP_ERROR err) override;
 
-    //////////// RendezvousDeviceCredentialsDelegate Implementation ///////////////
-    void SendNetworkCredentials(const char * ssid, const char * passwd) override;
-    void SendThreadCredentials(ByteSpan threadData) override;
-    void SendOperationalCredentials() override;
-
     //////////// NetworkProvisioningDelegate Implementation ///////////////
     void OnNetworkProvisioningError(CHIP_ERROR error) override;
     void OnNetworkProvisioningComplete() override;
@@ -148,7 +135,6 @@ private:
     CHIP_ERROR WaitForPairing(uint32_t setupPINCode);
     CHIP_ERROR WaitForPairing(const PASEVerifier & verifier);
 
-    Transport::Base * mTransport          = nullptr; ///< Underlying transport
     RendezvousSessionDelegate * mDelegate = nullptr; ///< Underlying transport events
     RendezvousParameters mParams;                    ///< Rendezvous configuration
 
@@ -156,17 +142,12 @@ private:
     NetworkProvisioning mNetworkProvision;
     Messaging::ExchangeManager * mExchangeManager = nullptr;
     TransportMgrBase * mTransportMgr;
-    uint16_t mNextKeyId                         = 0;
-    SecureSessionMgr * mSecureSessionMgr        = nullptr;
-    SecureSessionHandle * mPairingSessionHandle = nullptr;
+    uint16_t mNextKeyId                  = 0;
+    SecureSessionMgr * mSecureSessionMgr = nullptr;
 
     Transport::AdminPairingInfo * mAdmin = nullptr;
 
-    RendezvousSession::State mCurrentState = State::kInit;
-    void UpdateState(RendezvousSession::State newState, CHIP_ERROR err = CHIP_NO_ERROR);
-
-    void InitPairingSessionHandle();
-    void ReleasePairingSessionHandle();
+    void Cleanup();
 };
 
 } // namespace chip


### PR DESCRIPTION
 #### Problem
Since network provisioning has moved to cluster implementation, the RendezvousSession is only maintaining state of PASE session. The class doesn't need to maintain state, and the code flow could be simplified.

 #### Summary of Changes
Removed unnecessary code blocks, and streamlined state maintenance.

