### PR TITLE
[platform] Add Lock in SendMessage in ExchangeManager

### DIFF
--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -163,6 +163,22 @@ extern PlatformManager & PlatformMgr();
  */
 extern PlatformManagerImpl & PlatformMgrImpl();
 
+/**
+ * The RAII wrapper of CHIP Platform lock.
+ */
+class CHIPPlatformLock
+{
+public:
+    CHIPPlatformLock() { PlatformMgr().LockChipStack(); }
+    ~CHIPPlatformLock() { PlatformMgr().UnlockChipStack(); }
+
+private:
+    // No copy, move or assignment.
+    CHIPPlatformLock(const CHIPPlatformLock &)  = delete;
+    CHIPPlatformLock(const CHIPPlatformLock &&) = delete;
+    CHIPPlatformLock & operator=(const CHIPPlatformLock &) = delete;
+};
+
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
     mEventLoopTask          = NULL;
     mChipTimerActive        = false;
 
-    mChipStackLock = xSemaphoreCreateMutex();
+    mChipStackLock = xSemaphoreCreateRecursiveMutex();
     if (mChipStackLock == NULL)
     {
         ChipLogError(DeviceLayer, "Failed to create CHIP stack lock");
@@ -82,19 +82,19 @@ exit:
 template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_LockChipStack(void)
 {
-    xSemaphoreTake(mChipStackLock, portMAX_DELAY);
+    xSemaphoreTakeRecursive(mChipStackLock, portMAX_DELAY);
 }
 
 template <class ImplClass>
 bool GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_TryLockChipStack(void)
 {
-    return xSemaphoreTake(mChipStackLock, 0) == pdTRUE;
+    return xSemaphoreTakeRecursive(mChipStackLock, 0) == pdTRUE;
 }
 
 template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_UnlockChipStack(void)
 {
-    xSemaphoreGive(mChipStackLock);
+    xSemaphoreGiveRecursive(mChipStackLock);
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.cpp
@@ -43,10 +43,8 @@ namespace Internal {
 template class GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>;
 
 template <class ImplClass>
-CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
+CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitPlatformObjects(void)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     vTaskSetTimeOutState(&mNextTimerBaseTime);
     mNextTimerDurationTicks = 0;
     mEventLoopTask          = NULL;
@@ -56,7 +54,7 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
     if (mChipStackLock == NULL)
     {
         ChipLogError(DeviceLayer, "Failed to create CHIP stack lock");
-        ExitNow(err = CHIP_ERROR_NO_MEMORY);
+        return CHIP_ERROR_NO_MEMORY;
     }
 
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_QUEUE) && CHIP_CONFIG_FREERTOS_USE_STATIC_QUEUE
@@ -68,15 +66,20 @@ CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
     if (mChipEventQueue == NULL)
     {
         ChipLogError(DeviceLayer, "Failed to allocate CHIP event queue");
-        ExitNow(err = CHIP_ERROR_NO_MEMORY);
+        return CHIP_ERROR_NO_MEMORY;
     }
 
-    // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
-    err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
-    SuccessOrExit(err);
+    return CHIP_NO_ERROR;
+}
 
-exit:
-    return err;
+template <class ImplClass>
+CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_InitChipStack(void)
+{
+    ReturnErrorOnFailure(_InitPlatformObjects());
+
+    // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
+    ReturnErrorOnFailure(GenericPlatformManagerImpl<ImplClass>::_InitChipStack());
+    return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
@@ -65,6 +65,10 @@ protected:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack();
+
+    // InitPlatformObjects allows app can init the platform related objects for computing only, without enable RF stack, this is
+    // used for unit tests for FreeRTOS.
+    CHIP_ERROR _InitPlatformObjects();
     void _LockChipStack(void);
     bool _TryLockChipStack(void);
     void _UnlockChipStack(void);

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.cpp
@@ -64,8 +64,11 @@ template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_InitChipStack()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+    pthread_mutexattr_t lock_attr;
 
-    mChipStackLock = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutexattr_init(&lock_attr);
+    pthread_mutexattr_settype(&lock_attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&mChipStackLock, &lock_attr);
 
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.cpp
@@ -48,6 +48,7 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    // Zephyr mutex is already recursive lock.
     k_mutex_init(&mChipStackLock);
 
     k_msgq_init(&mChipEventQueue, reinterpret_cast<char *>(&mChipEventRingBuffer), sizeof(ChipDeviceEvent),

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -37,6 +37,7 @@
 #include <core/CHIPKeyIds.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
 #include <support/logging/CHIPLogging.h>
@@ -84,6 +85,8 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 
     VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INTERNAL);
 
+    DeviceLayer::CHIPPlatformLock platformLock;
+
     state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(mSecureSession);
 
     // If a group message is to be transmitted to a destination node whose message counter is unknown.
@@ -106,7 +109,6 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
     {
         err = SendMessageImpl(protocolId, msgType, std::move(msgBuf), sendFlags, state);
     }
-
     return err;
 }
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -85,7 +85,11 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 
     VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INTERNAL);
 
+    // TODO(#6220): We add this check to make platforms that does not implemented full platform (i.e. Android) can compile, and does
+    // not means that those platforms do not need this.
+#if CONFIG_DEVICE_LAYER
     DeviceLayer::CHIPPlatformLock platformLock;
+#endif
 
     state = mExchangeMgr->GetSessionMgr()->GetPeerConnectionState(mSecureSession);
 

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -53,6 +53,11 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
     return 0;
 }
 
+CHIP_ERROR PlatformManagerImpl::InitPlatformObjects()
+{
+    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_InitPlatformObjects();
+}
+
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -51,6 +51,9 @@ public:
     CHIP_ERROR InitLwIPCoreLock(void);
     static void HandleESPSystemEvent(void * arg, esp_event_base_t eventBase, int32_t eventId, void * eventData);
 
+    // ===== Only call generic platform init routine, for ESP32 unit tests only.
+    CHIP_ERROR InitPlatformObjects();
+
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
 

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -81,6 +81,13 @@ extern "C" void app_main()
         exit(err);
     }
 
+    err = PlatformMgrImpl().InitPlatformObjects();
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "PlatformMgr().InitPlatformObjects() failed: %s", ErrorStr(err));
+        exit(err);
+    }
+
     // Initialize the LwIP core lock.  This must be done before the ESP
     // tcpip_adapter layer is initialized.
     err = PlatformMgrImpl().InitLwIPCoreLock();

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -237,7 +237,6 @@ exit:
             ChipLogError(Inet, "Secure transport could not find a valid PeerConnection: %s", errStr);
         }
     }
-
     return err;
 }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

ExchangeContext->SendMessage is run outside the mainloop of CHIP, thus in rare cases, the response of the message may comes before the SendMessage returns, and this will cause program crash or misbehavior.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

1. Introduce a RAII style ChipStackLock class for lock CHIP stack.
2. Change ChipStackLock to recursive mutex (Zephyr mutexes are always recursive: https://docs.zephyrproject.org/latest/reference/kernel/synchronization/mutexes.html#reentrant-locking)
3. Lock ChipStack in SendMessage

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6155

Please also help verify if #6123 is also be fixed by this.

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
