### PR TITLE
[dns-sd] Fix operational advertising

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -311,7 +311,7 @@ public:
         }
         else if (i == 2)
         {
-            app::Mdns::AdvertiseCommisioning();
+            app::Mdns::AdvertiseCommisionable();
             OpenDefaultPairingWindow(ResetAdmins::kNo, PairingWindowAdvertisement::kMdns);
         }
     }

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -65,9 +65,6 @@ int main(int argc, char * argv[])
     // Init ZCL Data Model and CHIP App Server
     InitServer();
 
-    // Init Mdns Server
-    app::Mdns::StartServer();
-
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
 exit:

--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -111,9 +111,8 @@ CHIP_ERROR AdvertiseOperational()
 }
 
 /// Set MDNS commisioning advertisement
-CHIP_ERROR AdvertiseCommisioning()
+CHIP_ERROR AdvertiseCommisionable()
 {
-
     auto advertiseParameters = chip::Mdns::CommissionAdvertisingParameters().SetPort(CHIP_PORT).EnableIpV4(true);
 
     uint8_t mac[8];
@@ -171,7 +170,7 @@ void StartServer()
 // so configuraton should be added to enable commissioning advertising based on supported
 // Rendezvous methods.
 #if !CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        err = app::Mdns::AdvertiseCommisioning();
+        err = app::Mdns::AdvertiseCommisionable();
 #endif
     }
 

--- a/src/app/server/Mdns.h
+++ b/src/app/server/Mdns.h
@@ -23,11 +23,11 @@ namespace chip {
 namespace app {
 namespace Mdns {
 
-/// Set MDNS operational advertisement
+/// Start operational advertising
 CHIP_ERROR AdvertiseOperational();
 
-/// Set MDNS commisioning advertisement
-CHIP_ERROR AdvertiseCommisioning();
+/// Start commisionable node advertising
+CHIP_ERROR AdvertiseCommisionable();
 
 /// (Re-)starts the minmdns server
 void StartServer();


### PR DESCRIPTION
 #### Problem
After #5337 has been merged, operational advertising no longer works correctly since at the time the advertising is started, nodeID stored in the admin table is not yet initialized and equals 0. Hence an incorrect service instance name is advertised.

 #### Summary of Changes
Start operational advertising when the device is assigned an IP address. It must happen after exchanging some zcl commands, and receipt of any message over a secure channel initializes the nodeID. In the future, e2e commissioning flow will probably take care of that in a different way.

May fix #6216