### PR TITLE
Increase limit of max number test suits

### DIFF
--- a/src/lib/support/UnitTestRegistration.cpp
+++ b/src/lib/support/UnitTestRegistration.cpp
@@ -18,10 +18,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <support/UnitTestRegistration.h>
+#include <support/logging/CHIPLogging.h>
 
 namespace chip {
 
-const size_t kTestSuitesMax = 64;
+const size_t kTestSuitesMax = 128;
 
 typedef struct
 {
@@ -45,6 +46,7 @@ CHIP_ERROR RegisterUnitTests(UnitTestTriggerFunction tests)
 {
     if (gs_test_suites.num_test_suites >= kTestSuitesMax)
     {
+        ChipLogError(Support, "Test suits limit reached");
         return CHIP_ERROR_NO_MEMORY;
     }
 


### PR DESCRIPTION
Number of test cases is reaching its limit, which is causing zephyr CI fail. Also add an log to help diagnose the problem when it happens.