### PR TITLE
Return correct error code when sending large ping

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -161,7 +161,7 @@ CHIP_ERROR SendEchoRequest(streamer_t * stream)
     char * requestData = nullptr;
 
     uint32_t size = gPingArguments.GetEchoReqSize();
-    VerifyOrExit(size <= kMaxPayloadSize, err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
+    VerifyOrExit(size <= kMaxPayloadSize, err = CHIP_ERROR_MESSAGE_TOO_LONG);
 
     requestData = static_cast<char *>(chip::Platform::MemoryAlloc(size));
     VerifyOrExit(requestData != nullptr, err = CHIP_ERROR_NO_MEMORY);


### PR DESCRIPTION
 #### Problem
Sending a ping request larger than supported message size returns incorrect error code.

 #### Summary of Changes
Fix the error code as per specifications.
