### PR TITLE
Remove duplicated way to set flag kFlagResponseExpected

### DIFF
--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -196,7 +196,7 @@ private:
      *  is set or not in sendFlags when send a message over exchange.
      *
      *  @param[in]  inResponseExpected  A Boolean indicating whether (true) or not
-     *                                  (false) a response is expected on this
+     *                                  (false) a response is currently expected on this
      *                                  exchange.
      */
     void SetResponseExpected(bool inResponseExpected);

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -182,7 +182,22 @@ private:
     void Free();
     void Reset();
 
+    /**
+     *  Determine whether a response is expected for messages sent over
+     *  this exchange.
+     *
+     *  @return Returns 'true' if response expected, else 'false'.
+     */
     bool IsResponseExpected() const;
+
+    /**
+     *  Set whether a response is expected on this exchange based on if flag kExpectResponse
+     *  is set or not in sendFlags when send a message over exchange.
+     *
+     *  @param[in]  inResponseExpected  A Boolean indicating whether (true) or not
+     *                                  (false) a response is expected on this
+     *                                  exchange.
+     */
     void SetResponseExpected(bool inResponseExpected);
 
     /**

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -72,23 +72,6 @@ public:
     bool IsInitiator() const;
 
     /**
-     *  Determine whether a response is expected for messages sent over
-     *  this exchange.
-     *
-     *  @return Returns 'true' if response expected, else 'false'.
-     */
-    bool IsResponseExpected() const;
-
-    /**
-     *  Set whether a response is expected on this exchange.
-     *
-     *  @param[in]  inResponseExpected  A Boolean indicating whether (true) or not
-     *                                  (false) a response is expected on this
-     *                                  exchange.
-     */
-    void SetResponseExpected(bool inResponseExpected);
-
-    /**
      *  Send a CHIP message on this exchange.
      *
      *  @param[in]    protocolId    The protocol identifier of the CHIP message to be sent.
@@ -198,6 +181,9 @@ private:
                             ExchangeDelegateBase * delegate);
     void Free();
     void Reset();
+
+    bool IsResponseExpected() const;
+    void SetResponseExpected(bool inResponseExpected);
 
     /**
      *  Search for an existing exchange that the message applies to.

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -192,8 +192,8 @@ private:
     bool IsResponseExpected() const;
 
     /**
-     *  Set whether a response is expected on this exchange based on if flag kExpectResponse
-     *  is set or not in sendFlags when send a message over exchange.
+     *  Track whether we are now expecting a response to a message sent via this exchange (because that
+     *  message had the kExpectResponse flag set in its sendFlags).
      *
      *  @param[in]  inResponseExpected  A Boolean indicating whether (true) or not
      *                                  (false) a response is currently expected on this

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -183,8 +183,9 @@ private:
     void Reset();
 
     /**
-     *  Determine whether a response is expected for messages sent over
-     *  this exchange.
+     *  Determine whether a response is currently expected for a message that was sent over
+     *  this exchange.  While this is true, attempts to send other messages that expect a response
+     *  will fail.
      *
      *  @return Returns 'true' if response expected, else 'false'.
      */


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, we have two way to set flag kFlagResponseExpected in ExchangeContext, by calling SetResponseExpected() or set kExpectResponse in sendFlags.

If an outgoing message does expect a response, and the sender calls SetResponseExpected and set  kExpectResponse in sendFlags, the response timer will not be armed since it will find there is already one 'response expected' message outstanding.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Make SetResponseExpected/IsResponseExpected private in ExchangeContext since we expect the protocol only set the kFlagResponseExpected flag through sendFlags.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
