### PR TITLE
Fix typo in gn_build.sh

### DIFF
--- a/gn_build.sh
+++ b/gn_build.sh
@@ -170,7 +170,7 @@ echo
 _chip_banner "Build: GN configure"
 
 gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/debug" --args='target_os="all"'"$extra_args$user_args"
-gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/release" --args='target_os="all" is_debug=false'"$extra_arg$user_args"
+gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/release" --args='target_os="all" is_debug=false'"$extra_args$user_args"
 
 _chip_banner "Build: Ninja build"
 


### PR DESCRIPTION
"extra_args" is misspelled as "extra_arg" when generating out/release. This
results in some arguments being dropped (debug works fine).