### PR TITLE
Added discovering Thread network as a result of ScanNetworks command.

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -62,6 +62,19 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
     return true;
 }
 
+bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, ByteSpan ssid, uint64_t breadcrumb,
+                                                            uint32_t timeoutMs)
+{
+    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnScanNetworksCommandCallbackInternal(
+        nullptr, emberAfCurrentEndpoint(), ssid, breadcrumb, timeoutMs);
+
+    // TODO: Remove sending default response and replace it with sending Scan Networks Response.
+    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
+                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+
+    return true;
+}
+
 // TODO: The following commands needed to be implemented.
 // These commands are not implemented thus not handled yet, return false so ember will return a error.
 
@@ -83,11 +96,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
     return false;
 }
 
-bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, ByteSpan ssid, uint64_t breadcrumb,
-                                                            uint32_t timeoutMs)
-{
-    return false;
-}
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj, ByteSpan operationalDataset,
                                                                    uint64_t breadcrumb, uint32_t timeoutMs)
 {

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -35,6 +35,8 @@ EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Co
                                                                          uint32_t timeoutMs);
 EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID,
                                                                         uint64_t breadcrumb, uint32_t timeoutMs);
+EmberAfNetworkCommissioningError OnScanNetworksCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid,
+                                                                       uint64_t breadcrumb, uint32_t timeoutMs);
 } // namespace NetworkCommissioning
 
 } // namespace clusters

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <support/CodeUtils.h>
+#include <support/ThreadOperationalDataset.h>
 
 namespace chip {
 
@@ -122,6 +123,9 @@ public:
     };
 
     struct ThreadPollingConfig;
+
+    struct ThreadDiscoveryResult;
+    typedef void (*ThreadDiscoveryResultCallback)(ThreadDiscoveryResult & aResult);
 
     // WiFi station methods
     WiFiStationMode GetWiFiStationMode();
@@ -234,6 +238,18 @@ struct ConnectivityManager::ThreadPollingConfig
                                              when the device is acting as a sleepy end node. */
 
     void Clear() { memset(this, 0, sizeof(*this)); }
+};
+
+// TODO: Align structure with the spec issue #2427 discussion result.
+struct ConnectivityManager::ThreadDiscoveryResult
+{
+    unsigned int discoveryResponseVersion : 4;
+    bool discoveryResponseNativeCommissionerFlag : 1;
+    uint8_t extendedPanId[chip::Thread::kSizeExtendedPanId];
+    char networkName[chip::Thread::kSizeNetworkName];
+    uint8_t steeringDataLength;
+    uint8_t steeringData[chip::Thread::kSizeSteeringData];
+    uint16_t joinerUdpPort;
 };
 
 /**

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -81,6 +81,7 @@ public:
     CHIP_ERROR GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
     CHIP_ERROR GetExternalIPv6Address(chip::Inet::IPAddress & addr);
     CHIP_ERROR GetPollPeriod(uint32_t & buf);
+    CHIP_ERROR DiscoverNetworks(ConnectivityManager::ThreadDiscoveryResultCallback discoveryResultCallback);
 
     CHIP_ERROR JoinerStart();
     CHIP_ERROR SetThreadProvision(ByteSpan aDataset);
@@ -340,6 +341,11 @@ inline CHIP_ERROR ThreadStackManager::GetExternalIPv6Address(chip::Inet::IPAddre
 inline CHIP_ERROR ThreadStackManager::GetPollPeriod(uint32_t & buf)
 {
     return static_cast<ImplClass *>(this)->_GetPollPeriod(buf);
+}
+
+inline CHIP_ERROR ThreadStackManager::DiscoverNetworks(ConnectivityManager::ThreadDiscoveryResultCallback discoveryResultCallback)
+{
+    return static_cast<ImplClass *>(this)->_DiscoverNetworks(discoveryResultCallback);
 }
 
 inline CHIP_ERROR ThreadStackManager::JoinerStart()

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -37,6 +37,7 @@ constexpr size_t kSizeOperationalDataset = 254;
 
 constexpr size_t kSizeNetworkName     = 16;
 constexpr size_t kSizeExtendedPanId   = 8;
+constexpr size_t kSizeSteeringData    = 16;
 constexpr size_t kSizeMasterKey       = 16;
 constexpr size_t kSizeMeshLocalPrefix = 8;
 constexpr size_t kSizePSKc            = 16;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -412,6 +412,11 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_DiscoverNetworks(ConnectivityManager::ThreadDiscoveryResultCallback discoveryResultCallback)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_JoinerStart()
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -88,6 +88,8 @@ public:
 
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
 
+    CHIP_ERROR _DiscoverNetworks(ConnectivityManager::ThreadDiscoveryResultCallback discoveryResultCallback);
+
     CHIP_ERROR _JoinerStart();
 
     ~ThreadStackManagerImpl() = default;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <openthread/instance.h>
+#include <openthread/link.h>
 #include <openthread/netdata.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
@@ -89,6 +90,7 @@ protected:
     CHIP_ERROR _GetFactoryAssignedEUI64(uint8_t (&buf)[8]);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
+    CHIP_ERROR _DiscoverNetworks(ConnectivityManager::ThreadDiscoveryResultCallback discoveryResultCallback);
     void _OnWoBLEAdvertisingStart(void);
     void _OnWoBLEAdvertisingStop(void);
 
@@ -114,6 +116,7 @@ private:
 
     otInstance * mOTInst;
     ConnectivityManager::ThreadPollingConfig mPollingConfig;
+    ConnectivityManager::ThreadDiscoveryResultCallback mDiscoveryResultCallback;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
@@ -150,6 +153,8 @@ private:
     static void OnSrpClientStateChange(const otSockAddr * aServerSockAddr, void * aContext);
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
+    static void OnDiscoveryResult(otActiveScanResult * aResult, void * aContext);
 
     static void OnJoinerComplete(otError aError, void * aContext);
     void OnJoinerComplete(otError aError);


### PR DESCRIPTION
 #### Problem
Currently NetworkCommissioning ScanNetworks command is not handled by accessory device and it responds with default not supported response.

 #### Summary of Changes
That is initial PR adding only part of necessary implementation tracked in https://github.com/project-chip/connectedhomeip/issues/6201.
* Added OnScanNetworksCommandCallbackInternal implementation, calling Thread Discover method, but without creating ScanNetworksResponse.
* Added implementation of Thread Discover() method.
* Added initial ThreadDiscoveryResult structure describing Thread data that should take place in DiscoveryResponse field. The type may will probably need further alignment, depending on the https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/2427 discussion result.
* Added printing scanned networks information.


