### PR TITLE
[QPG6100] Apply size optimizations

### DIFF
--- a/src/lwip/qpg6100/lwipopts.h
+++ b/src/lwip/qpg6100/lwipopts.h
@@ -50,16 +50,25 @@
 
 #define LWIP_SOCKET 0
 
-// TODO: seems like this is unnecessary on Thread-only platforms
+#ifdef INET_CONFIG_ENABLE_RAW_ENDPOINT
 #define LWIP_RAW 1
 #define MEMP_NUM_RAW_PCB (5)
+#else
+#define LWIP_RAW 0
+#define MEMP_NUM_RAW_PCB 0
+#endif // INET_CONFIG_ENABLE_RAW_ENDPOINT
+#ifdef INET_CONFIG_ENABLE_TCP_ENDPOINT
+#define LWIP_TCP 1
+#else
+#define LWIP_TCP 0
+#define MEMP_NUM_TCP_PCB 0
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 // TODO: verify count
 #define MEMP_NUM_UDP_PCB (7)
 
-#define LWIP_HAVE_LOOPIF (0)
-
 // TODO: not sure why this is disabled
+#define LWIP_HAVE_LOOPIF (0)
 #define LWIP_NETIF_LOOPBACK (0)
 
 #define MEMP_NUM_NETCONN (0)

--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -29,6 +29,12 @@ lwip_api = true
 
 chip_inet_config_enable_ipv4 = false
 chip_inet_config_enable_dns_resolver = false
+chip_inet_config_enable_tcp_endpoint = false
+chip_inet_config_enable_raw_endpoint = false
+
+# Size opt's
+#chip_progress_logging = false
+chip_detail_logging = false
 
 chip_build_tests = false
 


### PR DESCRIPTION
### Problem
QPG6100 area filling up with latest development.

### Solution
Tuning down over-dimensioned/unneeded features.

* Lower NVM area reserved - 8kB flash
* Disable Detail logging - 4kB flash
* Remove TCP/RAW from inet and LWIP - 14 kB flash - 2kB static RAM

Frees up 26kB flash/2kB static RAM
