### PR TITLE
Resurrect TestPASESession unit test

### DIFF
--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -19,12 +19,30 @@ import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite("tests") {
-  output_name = "libMessagingLayerTests"
+static_library("helpers") {
+  output_name = "libMessagingTestHelpers"
+  output_dir = "${root_out_dir}/lib"
 
   sources = [
     "MessagingContext.cpp",
     "MessagingContext.h",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  deps = [
+    "${chip_root}/src/messaging",
+    "${chip_root}/src/protocols",
+    "${chip_root}/src/transport",
+    "${chip_root}/src/transport/raw/tests:helpers",
+    "${nlio_root}:nlio",
+  ]
+}
+
+chip_test_suite("tests") {
+  output_name = "libMessagingLayerTests"
+
+  sources = [
     "TestExchangeMgr.cpp",
     "TestMessagingLayer.h",
     "TestReliableMessageProtocol.cpp",
@@ -33,6 +51,7 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    ":helpers",
     "${chip_root}/src/inet/tests:helpers",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#include <messaging/tests/MessagingContext.h>
+#include "MessagingContext.h"
 
 #include <support/CodeUtils.h>
 #include <support/ErrorStr.h>
@@ -53,13 +53,13 @@ CHIP_ERROR MessagingContext::Shutdown()
     return IOContext::Shutdown();
 }
 
-Messaging::ExchangeContext * MessagingContext::NewExchangeToPeer(Messaging::ExchangeDelegate * delegate)
+Messaging::ExchangeContext * MessagingContext::NewExchangeToPeer(Messaging::ExchangeDelegateBase * delegate)
 {
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
     return mExchangeManager.NewContext({ GetDestinationNodeId(), GetPeerKeyId(), GetAdminId() }, delegate);
 }
 
-Messaging::ExchangeContext * MessagingContext::NewExchangeToLocal(Messaging::ExchangeDelegate * delegate)
+Messaging::ExchangeContext * MessagingContext::NewExchangeToLocal(Messaging::ExchangeDelegateBase * delegate)
 {
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
     return mExchangeManager.NewContext({ GetSourceNodeId(), GetLocalKeyId(), GetAdminId() }, delegate);

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -52,18 +52,30 @@ public:
         Inet::IPAddress::FromString("127.0.0.1", addr);
         return addr;
     }
-    static constexpr NodeId GetSourceNodeId() { return 123654; }
-    static constexpr NodeId GetDestinationNodeId() { return 111222333; }
+    NodeId GetSourceNodeId() { return mSourceNodeId; }
+    NodeId GetDestinationNodeId() { return mDestinationNodeId; }
 
-    static constexpr uint16_t GetLocalKeyId() { return 1; }
-    static constexpr uint16_t GetPeerKeyId() { return 2; }
-    static constexpr uint16_t GetAdminId() { return 0; }
+    void SetSourceNodeId(NodeId nodeId) { mSourceNodeId = nodeId; }
+    void SetDestinationNodeId(NodeId nodeId) { mDestinationNodeId = nodeId; }
+
+    uint16_t GetLocalKeyId() { return mLocalKeyId; }
+    uint16_t GetPeerKeyId() { return mPeerKeyId; }
+
+    void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
+    void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
+
+    uint16_t GetAdminId() { return mSrcAdminId; }
+    void SetAdminId(Transport::AdminId id)
+    {
+        mSrcAdminId  = id;
+        mDestAdminId = id;
+    }
 
     SecureSessionMgr & GetSecureSessionManager() { return mSecureSessionMgr; }
     Messaging::ExchangeManager & GetExchangeManager() { return mExchangeManager; }
 
-    Messaging::ExchangeContext * NewExchangeToPeer(Messaging::ExchangeDelegate * delegate);
-    Messaging::ExchangeContext * NewExchangeToLocal(Messaging::ExchangeDelegate * delegate);
+    Messaging::ExchangeContext * NewExchangeToPeer(Messaging::ExchangeDelegateBase * delegate);
+    Messaging::ExchangeContext * NewExchangeToLocal(Messaging::ExchangeDelegateBase * delegate);
 
     Credentials::OperationalCredentialSet & GetOperationalCredentialSet() { return mOperationalCredentialSet; }
 
@@ -71,6 +83,10 @@ private:
     SecureSessionMgr mSecureSessionMgr;
     Messaging::ExchangeManager mExchangeManager;
 
+    NodeId mSourceNodeId      = 123654;
+    NodeId mDestinationNodeId = 111222333;
+    uint16_t mLocalKeyId      = 1;
+    uint16_t mPeerKeyId       = 2;
     Optional<Transport::PeerAddress> mPeer;
     SecurePairingUsingTestSecret mPairingPeerToLocal;
     SecurePairingUsingTestSecret mPairingLocalToPeer;

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -52,19 +52,19 @@ public:
         Inet::IPAddress::FromString("127.0.0.1", addr);
         return addr;
     }
-    NodeId GetSourceNodeId() { return mSourceNodeId; }
-    NodeId GetDestinationNodeId() { return mDestinationNodeId; }
+    NodeId GetSourceNodeId() const { return mSourceNodeId; }
+    NodeId GetDestinationNodeId() const { return mDestinationNodeId; }
 
     void SetSourceNodeId(NodeId nodeId) { mSourceNodeId = nodeId; }
     void SetDestinationNodeId(NodeId nodeId) { mDestinationNodeId = nodeId; }
 
-    uint16_t GetLocalKeyId() { return mLocalKeyId; }
-    uint16_t GetPeerKeyId() { return mPeerKeyId; }
+    uint16_t GetLocalKeyId() const { return mLocalKeyId; }
+    uint16_t GetPeerKeyId() const { return mPeerKeyId; }
 
     void SetLocalKeyId(uint16_t id) { mLocalKeyId = id; }
     void SetPeerKeyId(uint16_t id) { mPeerKeyId = id; }
 
-    uint16_t GetAdminId() { return mSrcAdminId; }
+    uint16_t GetAdminId() const { return mSrcAdminId; }
     void SetAdminId(Transport::AdminId id)
     {
         mSrcAdminId  = id;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -95,7 +95,7 @@ void PASESession::Clear()
 
     if (mExchangeCtxt != nullptr)
     {
-        mExchangeCtxt->Release();
+        mExchangeCtxt->Close();
         mExchangeCtxt = nullptr;
     }
 }
@@ -299,7 +299,7 @@ CHIP_ERROR PASESession::Pair(const Transport::PeerAddress peerAddress, uint32_t 
     CHIP_ERROR err = Init(myKeyId, peerSetUpPINCode, delegate);
     SuccessOrExit(err);
 
-    mExchangeCtxt = exchangeCtxt->Retain();
+    mExchangeCtxt = exchangeCtxt;
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout);
 
     mConnectionState.SetPeerAddress(peerAddress);
@@ -758,7 +758,7 @@ void PASESession::OnMessageReceived(ExchangeContext * ec, const PacketHeader & p
 
     if (mExchangeCtxt == nullptr)
     {
-        mExchangeCtxt = ec->Retain();
+        mExchangeCtxt = ec;
         mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout);
     }
 

--- a/src/protocols/secure_channel/RendezvousSession.cpp
+++ b/src/protocols/secure_channel/RendezvousSession.cpp
@@ -202,7 +202,6 @@ CHIP_ERROR RendezvousSession::Pair(uint32_t setupPINCode)
     ReturnErrorCodeIf(ctxt == nullptr, CHIP_ERROR_INTERNAL);
 
     CHIP_ERROR err = mPairingSession.Pair(mParams.GetPeerAddress(), setupPINCode, mNextKeyId++, ctxt, this);
-    ctxt->Release();
     return err;
 }
 

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -8,11 +8,15 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libSecureChannelTests"
 
-  test_sources = [ "TestStatusReport.cpp" ]
+  test_sources = [
+    "TestPASESession.cpp",
+    "TestStatusReport.cpp",
+  ]
 
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging/tests:helpers",
     "${chip_root}/src/protocols/secure_channel",
     "${nlio_root}:nlio",
     "${nlunit_test_root}:nlunit-test",

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -58,7 +58,7 @@ public:
 
     bool CanSendToPeer(const PeerAddress & address) override { return true; }
 
-    uint32_t mSentMessageCount     = 0;
+    uint32_t mSentMessageCount   = 0;
     CHIP_ERROR mMessageSendError = CHIP_NO_ERROR;
 };
 
@@ -122,7 +122,7 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
-    gLoopback.mSentMessageCount   = 0;
+    gLoopback.mSentMessageCount = 0;
     gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
 
     PASESession pairing1;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -44,13 +44,13 @@ using TestContext = chip::Test::MessagingContext;
 class LoopbackTransport : public Transport::Base
 {
 public:
-    /// Transports are required to have a constructor that takes exactly one argument
+    /// Transports are required to have an init method that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         ReturnErrorOnFailure(mMessageSendError);
-        mNumMessageSend++;
+        mSentMessageCount++;
         HandleMessageReceived(header, address, std::move(msgBuf));
 
         return CHIP_NO_ERROR;
@@ -58,7 +58,7 @@ public:
 
     bool CanSendToPeer(const PeerAddress & address) override { return true; }
 
-    uint32_t mNumMessageSend     = 0;
+    uint32_t mSentMessageCount     = 0;
     CHIP_ERROR mMessageSendError = CHIP_NO_ERROR;
 };
 
@@ -120,9 +120,9 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite,
                    pairing.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, context, &delegate) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessageSend == 1);
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
-    gLoopback.mNumMessageSend   = 0;
+    gLoopback.mSentMessageCount   = 0;
     gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
 
     PASESession pairing1;
@@ -142,7 +142,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
     TestSecurePairingDelegate delegateAccessory;
     PASESession pairingAccessory;
 
-    gLoopback.mNumMessageSend = 0;
+    gLoopback.mSentMessageCount = 0;
 
     NL_TEST_ASSERT(inSuite, pairingCommissioner.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, pairingAccessory.MessageDispatch().Init(&gTransportMgr) == CHIP_NO_ERROR);
@@ -160,7 +160,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, P
                    pairingCommissioner.Pair(Transport::PeerAddress(Transport::Type::kBle), 1234, 0, contextCommissioner,
                                             &delegateCommissioner) == CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessageSend == 5);
+    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 }
@@ -258,7 +258,7 @@ static nlTestSuite sSuite =
 };
 // clang-format on
 
-TestContext sContext;
+static TestContext sContext;
 
 // clang-format on
 //

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -44,9 +44,6 @@ using TestContext = chip::Test::MessagingContext;
 class LoopbackTransport : public Transport::Base
 {
 public:
-    /// Transports are required to have an init method that takes exactly one argument
-    CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
-
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         ReturnErrorOnFailure(mMessageSendError);

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -79,13 +79,10 @@ public:
     void OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                            System::PacketBufferHandle buffer) override
     {
-        IsOnMessageReceivedCalled = true;
         ec->Close();
     }
 
     void OnResponseTimeout(ExchangeContext * ec) override {}
-
-    bool IsOnMessageReceivedCalled = false;
 };
 
 void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)


### PR DESCRIPTION
 #### Problem
`TestPASESession` unit test is disabled.

 #### Summary of Changes
The PASE session code was modified to use exchange context. This required reworking of test transport plumbing.
