### PR TITLE
Use exchange to send CASE session establishment messages

### DIFF
--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -261,8 +261,6 @@ CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & 
 CHIP_ERROR ChannelContext::HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
                                                 System::PacketBufferHandle && msg)
 {
-    if (IsCasePairing())
-        return mStateVars.mPreparing.mCasePairingSession->HandlePeerMessage(packetHeader, peerAddress, std::move(msg));
     return CHIP_ERROR_INCORRECT_STATE;
 }
 
@@ -270,13 +268,17 @@ void ChannelContext::EnterCasePairingState()
 {
     mStateVars.mPreparing.mState              = PrepareState::kCasePairing;
     mStateVars.mPreparing.mCasePairingSession = Platform::New<CASESession>();
+
+    ExchangeContext * ctxt = mExchangeManager->NewContext(SecureSessionHandle(), mStateVars.mPreparing.mCasePairingSession);
+    VerifyOrReturn(ctxt != nullptr);
+
     // TODO: currently only supports IP/UDP paring
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(mStateVars.mPreparing.mAddress);
     CHIP_ERROR err = mStateVars.mPreparing.mCasePairingSession->EstablishSession(
         addr, &mStateVars.mPreparing.mBuilder.GetOperationalCredentialSet(),
         Optional<NodeId>::Value(mExchangeManager->GetSessionMgr()->GetLocalNodeId()),
-        mStateVars.mPreparing.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), this);
+        mStateVars.mPreparing.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -276,9 +276,8 @@ void ChannelContext::EnterCasePairingState()
     Transport::PeerAddress addr;
     addr.SetTransportType(Transport::Type::kUdp).SetIPAddress(mStateVars.mPreparing.mAddress);
     CHIP_ERROR err = mStateVars.mPreparing.mCasePairingSession->EstablishSession(
-        addr, &mStateVars.mPreparing.mBuilder.GetOperationalCredentialSet(),
-        Optional<NodeId>::Value(mExchangeManager->GetSessionMgr()->GetLocalNodeId()),
-        mStateVars.mPreparing.mBuilder.GetPeerNodeId(), mExchangeManager->GetNextKeyId(), ctxt, this);
+        addr, &mStateVars.mPreparing.mBuilder.GetOperationalCredentialSet(), mStateVars.mPreparing.mBuilder.GetPeerNodeId(),
+        mExchangeManager->GetNextKeyId(), ctxt, this);
     if (err != CHIP_NO_ERROR)
     {
         ExitCasePairingState();

--- a/src/channel/ChannelContext.h
+++ b/src/channel/ChannelContext.h
@@ -27,7 +27,7 @@
 #include <channel/Channel.h>
 #include <lib/core/ReferenceCounted.h>
 #include <lib/mdns/platform/Mdns.h>
-#include <transport/CASESession.h>
+#include <protocols/secure_channel/CASESession.h>
 #include <transport/PeerConnectionState.h>
 #include <transport/SecureSessionMgr.h>
 

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -4,6 +4,8 @@ static_library("secure_channel") {
   output_name = "libSecureChannel"
 
   sources = [
+    "CASESession.cpp",
+    "CASESession.h",
     "NetworkProvisioning.cpp",
     "NetworkProvisioning.h",
     "PASESession.cpp",

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1093,7 +1093,7 @@ CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const Pack
     VerifyOrReturnError(ec != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     // mExchangeCtxt can be nullptr if this is the first message (CASE_SigmaR1) received by CASESession
-    // via UnsolicitedMessageHandler. The exchance context is allocated by exchange manager and provided
+    // via UnsolicitedMessageHandler. The exchange context is allocated by exchange manager and provided
     // to the handler (CASESession object).
     if (mExchangeCtxt != nullptr)
     {

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1088,7 +1088,7 @@ exit:
 }
 
 CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const PacketHeader & packetHeader,
-                                                const PayloadHeader & payloadHeader, System::PacketBufferHandle msg)
+                                                const PayloadHeader & payloadHeader, System::PacketBufferHandle & msg)
 {
     VerifyOrReturnError(ec != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -1134,7 +1134,7 @@ CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const Pack
 void CASESession::OnMessageReceived(ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                                     System::PacketBufferHandle msg)
 {
-    CHIP_ERROR err = ValidateReceivedMessage(ec, packetHeader, payloadHeader, std::move(msg));
+    CHIP_ERROR err = ValidateReceivedMessage(ec, packetHeader, payloadHeader, msg);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -203,13 +203,13 @@ private:
                     SessionEstablishmentDelegate * delegate);
 
     CHIP_ERROR SendSigmaR1();
-    CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(const PacketHeader & header, const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleSigmaR1(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR1(const System::PacketBufferHandle & msg);
     CHIP_ERROR SendSigmaR2();
-    CHIP_ERROR HandleSigmaR2_and_SendSigmaR3(const PacketHeader & header, const System::PacketBufferHandle & msg);
-    CHIP_ERROR HandleSigmaR2(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR2_and_SendSigmaR3(const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR2(const System::PacketBufferHandle & msg);
     CHIP_ERROR SendSigmaR3();
-    CHIP_ERROR HandleSigmaR3(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    CHIP_ERROR HandleSigmaR3(const System::PacketBufferHandle & msg);
 
     CHIP_ERROR SendSigmaR1Resume();
     CHIP_ERROR HandleSigmaR1Resume_and_SendSigmaR2Resume(const PacketHeader & header, const System::PacketBufferHandle & msg);
@@ -226,7 +226,7 @@ private:
     CHIP_ERROR ComputeIPK(const uint16_t sessionID, uint8_t * ipk, size_t ipkLen);
 
     void SendErrorMsg(SigmaErrorType errorCode);
-    void HandleErrorMsg(const PacketHeader & header, const System::PacketBufferHandle & msg);
+    void HandleErrorMsg(const System::PacketBufferHandle & msg);
 
     // TODO: Remove this and replace with system method to retrieve current time
     CHIP_ERROR SetEffectiveTime(void);

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -232,7 +232,7 @@ private:
     void Clear();
 
     CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
-                                       const PayloadHeader & payloadHeader, System::PacketBufferHandle msg);
+                                       const PayloadHeader & payloadHeader, System::PacketBufferHandle & msg);
 
     SessionEstablishmentDelegate * mDelegate = nullptr;
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -63,7 +63,6 @@ struct CASESessionSerializable
     uint16_t mMessageDigestLen;
     uint8_t mMessageDigest[kSHA256_Hash_Length];
     uint8_t mPairingComplete;
-    NodeId mLocalNodeId;
     NodeId mPeerNodeId;
     uint16_t mLocalKeyId;
     uint16_t mPeerKeyId;
@@ -86,14 +85,13 @@ public:
      *
      * @param operationalCredentialSet      CHIP Certificate Set used to store the chain root of trust an validate peer node
      *                                      certificates
-     * @param myNodeId                      Node id of local node
      * @param myKeyId                       Key ID to be assigned to the secure session on the peer node
      * @param delegate                      Callback object
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR WaitForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, Optional<NodeId> myNodeId,
-                                           uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR WaitForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId,
+                                           SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -102,7 +100,6 @@ public:
      * @param peerAddress                   Address of peer with which to establish a session.
      * @param operationalCredentialSet      CHIP Certificate Set used to store the chain root of trust an validate peer node
      *                                      certificates
-     * @param myNodeId                      Node id of local node
      * @param peerNodeId                    Node id of the peer node
      * @param myKeyId                       Key ID to be assigned to the secure session on the peer node
      * @param exchangeCtxt                  The exchange context to send and receive messages with the peer
@@ -111,8 +108,8 @@ public:
      * @return CHIP_ERROR      The result of initialization
      */
     CHIP_ERROR EstablishSession(const Transport::PeerAddress peerAddress, OperationalCredentialSet * operationalCredentialSet,
-                                Optional<NodeId> myNodeId, NodeId peerNodeId, uint16_t myKeyId,
-                                Messaging::ExchangeContext * exchangeCtxt, SessionEstablishmentDelegate * delegate);
+                                NodeId peerNodeId, uint16_t myKeyId, Messaging::ExchangeContext * exchangeCtxt,
+                                SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief
@@ -199,8 +196,7 @@ private:
         kUnexpected           = 0xff,
     };
 
-    CHIP_ERROR Init(OperationalCredentialSet * operationalCredentialSet, Optional<NodeId> myNodeId, uint16_t myKeyId,
-                    SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR Init(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId, SessionEstablishmentDelegate * delegate);
 
     CHIP_ERROR SendSigmaR1();
     CHIP_ERROR HandleSigmaR1_and_SendSigmaR2(const System::PacketBufferHandle & msg);
@@ -260,8 +256,6 @@ private:
     };
 
 protected:
-    NodeId mLocalNodeId = kUndefinedNodeId;
-
     bool mPairingComplete = false;
 
     Transport::PeerConnectionState mConnectionState;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -231,6 +231,9 @@ private:
 
     void Clear();
 
+    CHIP_ERROR ValidateReceivedMessage(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
+                                       const PayloadHeader & payloadHeader, System::PacketBufferHandle msg);
+
     SessionEstablishmentDelegate * mDelegate = nullptr;
 
     Protocols::SecureChannel::MsgType mNextExpectedMsg = Protocols::SecureChannel::MsgType::CASE_SigmaErr;

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -32,7 +32,6 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::SendMessageImpl(SecureSessionHa
                                                                  System::PacketBufferHandle && message,
                                                                  EncryptedPacketBufferHandle * retainedMessage)
 {
-    ChipLogProgress(ExchangeManager, "SessionEstablishmentExchangeDispatch::SendMessageImpl  mTransportMgr %p", mTransportMgr);
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(message));
     if (mTransportMgr != nullptr)
     {

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -9,11 +9,13 @@ chip_test_suite("tests") {
   output_name = "libSecureChannelTests"
 
   test_sources = [
+    "TestCASESession.cpp",
     "TestPASESession.cpp",
     "TestStatusReport.cpp",
   ]
 
   public_deps = [
+    "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging/tests:helpers",

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -28,11 +28,11 @@
 #include <core/CHIPSafeCasts.h>
 #include <credentials/CHIPCert.h>
 #include <credentials/CHIPOperationalCredentials.h>
+#include <protocols/secure_channel/CASESession.h>
 #include <stdarg.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
 #include <support/UnitTestRegistration.h>
-#include <transport/CASESession.h>
 
 #include "credentials/tests/CHIPCert_test_vectors.h"
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -108,12 +108,8 @@ void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     TestCASESecurePairingDelegate delegate;
     CASESession pairing;
 
-    NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForSessionEstablishment(&accessoryDevOpCred, Optional<NodeId>::Value(1), 0, nullptr) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite,
-                   pairing.WaitForSessionEstablishment(&accessoryDevOpCred, Optional<NodeId>::Value(1), 0, &delegate) ==
-                       CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, pairing.WaitForSessionEstablishment(&accessoryDevOpCred, 0, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, pairing.WaitForSessionEstablishment(&accessoryDevOpCred, 0, &delegate) == CHIP_NO_ERROR);
 }
 
 void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
@@ -128,11 +124,11 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context = ctx.NewExchangeToLocal(&pairing);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                            Optional<NodeId>::Value(1), 2, 0, nullptr, nullptr) != CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred, 2, 0, nullptr,
+                                            nullptr) != CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                            Optional<NodeId>::Value(1), 2, 0, context, &delegate) == CHIP_NO_ERROR);
+                   pairing.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred, 2, 0, context,
+                                            &delegate) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
@@ -146,8 +142,8 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ExchangeContext * context1  = ctx.NewExchangeToLocal(&pairing1);
 
     NL_TEST_ASSERT(inSuite,
-                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                             Optional<NodeId>::Value(1), 2, 0, context1, &delegate) == CHIP_ERROR_BAD_REQUEST);
+                   pairing1.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred, 2, 0, context1,
+                                             &delegate) == CHIP_ERROR_BAD_REQUEST);
     gLoopback.mMessageSendError = CHIP_NO_ERROR;
 }
 
@@ -173,12 +169,10 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(&pairingCommissioner);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForSessionEstablishment(&accessoryDevOpCred, Optional<NodeId>::Value(1), 0,
-                                                                &delegateAccessory) == CHIP_NO_ERROR);
+                   pairingAccessory.WaitForSessionEstablishment(&accessoryDevOpCred, 0, &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
-                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred,
-                                                        Optional<NodeId>::Value(2), 1, 0, contextCommissioner,
-                                                        &delegateCommissioner) == CHIP_NO_ERROR);
+                   pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred, 1, 0,
+                                                        contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -67,6 +67,7 @@ public:
     CHIP_ERROR mMessageSendError = CHIP_NO_ERROR;
 };
 
+namespace {
 TransportMgrBase gTransportMgr;
 LoopbackTransport gLoopback;
 
@@ -81,6 +82,7 @@ P256SerializedKeypair accessoryOpKeysSerialized;
 
 P256Keypair commissionerOpKeys;
 P256Keypair accessoryOpKeys;
+} // namespace
 
 enum
 {

--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -22,8 +22,6 @@ static_library("transport") {
   sources = [
     "AdminPairingTable.cpp",
     "AdminPairingTable.h",
-    "CASESession.cpp",
-    "CASESession.h",
     "PeerConnectionState.h",
     "PeerConnections.h",
     "RendezvousSessionDelegate.h",

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -23,7 +23,6 @@ chip_test_suite("tests") {
   output_name = "libTransportLayerTests"
 
   test_sources = [
-    "TestCASESession.cpp",
     "TestPeerConnections.cpp",
     "TestSecureSession.cpp",
     "TestSecureSessionMgr.cpp",


### PR DESCRIPTION
 #### Problem

CASE messages are sent directly using SecureSessionMgr, which is UDP based. It should instead use Exchange and CRMP.

 #### Summary of Changes

Move CASESession code to protocols/secure_channel, and use Exchange and CRMP to send and receive the messages.
