### PR TITLE
[python] make python-dev-ctrl less verbose

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -42,7 +42,7 @@ ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=false"
 
 # Compiles python files
 ninja -C "$OUTPUT_ROOT" python

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -272,7 +272,7 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
 {
     CHIP_ERROR err         = CHIP_NO_ERROR;
     bool controlOpComplete = false;
-    ChipLogProgress(DeviceLayer, "HandlePlatformSpecificBLEEvent %d", apEvent->Type);
+    ChipLogDetail(DeviceLayer, "HandlePlatformSpecificBLEEvent %d", apEvent->Type);
     switch (apEvent->Type)
     {
     case DeviceEventType::kPlatformLinuxBLECentralConnected:
@@ -476,7 +476,7 @@ void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
     CHIP_ERROR err                 = CHIP_NO_ERROR;
     System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(value, len);
 
-    ChipLogProgress(DeviceLayer, "Indication received, conn = %p", conId);
+    ChipLogDetail(DeviceLayer, "Indication received, conn = %p", conId);
 
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
 


### PR DESCRIPTION

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The current python-dev-ctrl are continuously printing heartbeat packets,
making the output too verbose and hard to use.
I've been asked by multiple users what does that mean and many of them
mistook these lines for a sucessfull ZCL transaction.


 #### Summary of Changes

Use `detailed` log level for heartbeat packets and modify the log level when building
python dev ctrl.