### PR TITLE
[wip] [shell] add protocol-server command

### DIFF
--- a/examples/shell/README.md
+++ b/examples/shell/README.md
@@ -35,6 +35,7 @@ Done
 -   [help](#help)
 -   [otcli](README_OTCLI.md)
 -   [ping](#ping)
+-   [protocol-server](#protocol-server)
 -   [rand](#rand)
 -   [version](#version)
 
@@ -53,6 +54,7 @@ Display a list of all top-level commands supported and a brief description.
   device          Device Layer commands
   otcli           Dispatch OpenThread CLI command
   ping            Using Echo Protocol to measure packet loss across network paths
+  protocol-server Setup CHIP protocol server
   exit            Exit the shell application
   help            List out all top level commands
   version         Output the software version

--- a/examples/shell/esp32/main/CMakeLists.txt
+++ b/examples/shell/esp32/main/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CHIP_SHELL_DIR "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/she
 
 idf_component_register(SRCS main.cpp
                       "${CHIP_SHELL_DIR}/shell_common/cmd_ping.cpp"
+                      "${CHIP_SHELL_DIR}/shell_common/cmd_protocol_server.cpp"
                       PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src"
                       "${CHIP_SHELL_DIR}/shell_common/include"

--- a/examples/shell/esp32/main/main.cpp
+++ b/examples/shell/esp32/main/main.cpp
@@ -39,6 +39,7 @@ static void chip_shell_task(void * args)
     int ret = chip::Shell::streamer_init(chip::Shell::streamer_get());
     assert(ret == 0);
     cmd_ping_init();
+    cmd_protocol_server_init();
     while (true)
     {
         const char * prompt = LOG_COLOR_I "> " LOG_RESET_COLOR;

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(app PRIVATE
     ${APP_ROOT}/shell_common/cmd_misc.cpp
     ${APP_ROOT}/shell_common/cmd_otcli.cpp
     ${APP_ROOT}/shell_common/cmd_ping.cpp    
+    ${APP_ROOT}/shell_common/cmd_protocol_server.cpp
     ${APP_ROOT}/shell_common/cmd_btp.cpp
     ${APP_ROOT}/standalone/main.cpp
 )

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -38,6 +38,7 @@ static_library("shell_common") {
     "cmd_misc.cpp",
     "cmd_otcli.cpp",
     "cmd_ping.cpp",
+    "cmd_protocol_server.cpp",
   ]
 
   public_deps = [

--- a/examples/shell/shell_common/cmd_protocol_server.cpp
+++ b/examples/shell/shell_common/cmd_protocol_server.cpp
@@ -1,0 +1,220 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "shell/streamer.h"
+#include <ChipShellCollection.h>
+
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/echo/Echo.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <shell/shell_core.h>
+#include <support/ErrorStr.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/TCP.h>
+#include <transport/raw/UDP.h>
+
+using chip::Shell::shell_command_t;
+using chip::Shell::streamer_get;
+using chip::Shell::streamer_printf;
+using chip::Transport::TcpListenParameters;
+using chip::Transport::UdpListenParameters;
+
+namespace {
+
+class EchoServerCmd
+{
+public:
+    EchoServerCmd() = default;
+
+    CHIP_ERROR Start(bool tcp, bool echoServer)
+    {
+        if (mConnected)
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+        chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+        mAdminInfo = mAdmins.AssignAdminId(kAdminId, chip::kTestDeviceNodeId);
+        if (mAdminInfo == NULL)
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+        if (tcp)
+        {
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+            mTcp = tcp;
+#if INET_CONFIG_ENABLE_IPV4
+            ReturnErrorOnFailure(mTCPManager.Init(
+                TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4),
+                TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6)));
+#else  // INET_CONFIG_ENABLE_IPV4
+            ReturnErrorOnFailure(mTCPManager.Init(
+                TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6)));
+#endif // INET_CONFIG_ENABLE_IPV4
+            ReturnErrorOnFailure(
+                mSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &mTCPManager, &mAdmins));
+#else  // INET_CONFIG_ENABLE_TCP_ENDPOINT
+            return CHIP_ERROR_INVALID_ARGUMENT;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+        }
+        else
+        {
+#if INET_CONFIG_ENABLE_IPV4
+            ReturnErrorOnFailure(mUDPManager.Init(
+                UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4),
+                UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6)));
+#else
+            ReturnErrorOnFailure(mUDPManager.Init(
+                UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6)));
+#endif // INET_CONFIG_ENABLE_IPV4
+            ReturnErrorOnFailure(
+                mSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &mUDPManager, &mAdmins));
+        }
+        ReturnErrorOnFailure(mExchangeManager.Init(&mSessionManager));
+
+        if (echoServer)
+        {
+            ReturnErrorOnFailure(mEchoServer.Init(&mExchangeManager));
+            mEchoServer.SetEchoRequestReceived(EchoServerCmd::HandleEchoRequestReceived);
+        }
+
+        ReturnErrorOnFailure(mSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &mTestPairing,
+                                                        chip::SecureSessionMgr::PairingDirection::kResponder, kAdminId));
+        mConnected = true;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Stop()
+    {
+        if (!mConnected)
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+        if (mTcp)
+        {
+            mTCPManager.Close();
+        }
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+        mUDPManager.Close();
+        mEchoServer.Shutdown();
+        mExchangeManager.Shutdown();
+        mSessionManager.Shutdown();
+        mAdmins.ReleaseAdminId(kAdminId);
+        mAdmins.Reset();
+        mConnected = false;
+
+        return CHIP_NO_ERROR;
+    }
+
+private:
+    static void HandleEchoRequestReceived(chip::Messaging::ExchangeContext * ec, chip::System::PacketBufferHandle payload)
+    {
+        streamer_printf(streamer_get(), "Echo Request, len=%u ... sending response.\n", payload->DataLength());
+    }
+
+    EchoServerCmd(const EchoServerCmd &) = delete;
+    EchoServerCmd & operator=(const EchoServerCmd &) = delete;
+
+    bool mTcp       = false;
+    bool mConnected = false;
+
+    chip::Protocols::Echo::EchoServer mEchoServer;
+#if INET_CONFIG_ENABLE_IPV4
+    chip::TransportMgr<chip::Transport::UDP, chip::Transport::UDP> mUDPManager;
+#else
+    chip::TransportMgr<chip::Transport::UDP> mUDPManager;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    static constexpr size_t kMaxTcpActiveConnectionCount = 4;
+    static constexpr size_t kMaxTcpPendingPackets        = 4;
+#if INET_CONFIG_ENABLE_IPV4
+    chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>,
+                       chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>>
+        mTCPManager;
+#else  // INET_CONFIG_ENABLE_IPV4
+    chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> mTCPManager;
+#endif // INET_CONFIG_ENABLE_IPV4
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+
+    chip::SecureSessionMgr mSessionManager;
+    chip::SecurePairingUsingTestSecret mTestPairing;
+
+    chip::Messaging::ExchangeManager mExchangeManager;
+
+    chip::Transport::AdminPairingTable mAdmins;
+    chip::Transport::AdminPairingInfo * mAdminInfo     = nullptr;
+    static constexpr chip::Transport::AdminId kAdminId = 0;
+};
+
+EchoServerCmd gEchoServerCmd;
+
+} // namespace
+
+int cmd_protocol_server(int argc, char ** argv)
+{
+    bool tcp         = false;
+    bool stop        = false;
+    bool echoServer  = false;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    if (argc >= 1 && strcmp(argv[0], "stop") == 0)
+    {
+        stop = true;
+    }
+    else if (argc <= 0 || strcmp(argv[0], "start") != 0)
+    {
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+        streamer_printf(streamer_get(), "protocol-server start|stop [--tcp] [--echo]\n");
+#else
+        streamer_printf(streamer_get(), "ping-responder start|stop [--echo]\n");
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+        return 0;
+    }
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--tcp") == 0)
+        {
+            tcp = true;
+        }
+        else if (strcmp(argv[i], "--echo") == 0)
+        {
+            echoServer = true;
+        }
+    }
+
+    if (stop)
+    {
+        error = gEchoServerCmd.Stop();
+    }
+    else
+    {
+        error = gEchoServerCmd.Start(tcp, echoServer);
+    }
+
+    return error;
+}
+
+static shell_command_t cmds_protocol_server[] = {
+    { &cmd_protocol_server, "protocol-server", "Setup CHIP protocol server" },
+};
+
+extern "C" void cmd_protocol_server_init()
+{
+    shell_register(cmds_protocol_server, 1);
+}

--- a/examples/shell/shell_common/include/ChipShellCollection.h
+++ b/examples/shell/shell_common/include/ChipShellCollection.h
@@ -25,4 +25,5 @@ void cmd_device_init(void);
 void cmd_misc_init(void);
 void cmd_otcli_init(void);
 void cmd_ping_init(void);
+void cmd_protocol_server_init(void);
 }

--- a/examples/shell/standalone/main.cpp
+++ b/examples/shell/standalone/main.cpp
@@ -46,6 +46,7 @@ int main()
     cmd_btp_init();
     cmd_otcli_init();
     cmd_ping_init();
+    cmd_protocol_server_init();
 
     shell_task(nullptr);
     return 0;

--- a/src/lib/shell/streamer_esp32.cpp
+++ b/src/lib/shell/streamer_esp32.cpp
@@ -64,7 +64,7 @@ int streamer_esp32_init(streamer_t * streamer)
     esp_vfs_dev_uart_use_driver(0);
     esp_console_config_t console_config = {
         .max_cmdline_length = 256,
-        .max_cmdline_args   = 8,
+        .max_cmdline_args   = 16,
     };
     ESP_ERROR_CHECK(esp_console_init(&console_config));
     linenoiseSetMultiLine(1);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The test event asks the vendors to implement their own ping responder.
However, we lack an echo responder reference design for embedded applications.

 #### Summary of Changes

Implement one in chip-shell as a reference.

#### Usage for ESP32 devices

Config `Default WiFi SSID` and `Default WiFi Password` correctly.
After booting the device, wait until the device is connected to WiFi.
```
> chip protocol-server start --echo
```

Fixes https://github.com/project-chip/connectedhomeip/issues/6274