### PR TITLE
Make sure to relink executables after linker script changes

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -153,6 +153,8 @@ efr32_executable("lighting_app") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG21.ld"
   }
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   if (chip_print_memory_usage) {

--- a/examples/lighting-app/k32w/BUILD.gn
+++ b/examples/lighting-app/k32w/BUILD.gn
@@ -80,6 +80,8 @@ k32w_executable("light_app") {
 
   ldscript = "${k32w_platform_dir}/app/ldscripts/chip-k32w061-linker.ld"
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   output_dir = root_out_dir

--- a/examples/lighting-app/qpg6100/BUILD.gn
+++ b/examples/lighting-app/qpg6100/BUILD.gn
@@ -70,6 +70,8 @@ qpg6100_executable("lighting_app") {
 
   ldscript = "${qpg6100_sdk_root}/qpg6100/ldscripts/chip-qpg6100-example.ld"
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   output_dir = root_out_dir

--- a/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
@@ -106,6 +106,8 @@ ti_simplelink_executable("lock_app") {
 
   ldscript = "${ti_simplelink_sdk_root}/source/ti/dmm/apps/common/freertos/cc13x2x7_cc26x2x7.lds"
 
+  inputs = [ ldscript ]
+
   ldflags = [
     "-L${ti_simplelink_sdk_root}/source",
     rebase_path("${target_gen_dir}/sysconfig/ti_utils_build_linker.cmd.genlibs",

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -113,6 +113,8 @@ efr32_executable("lock_app") {
 
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
+  inputs = [ ldscript ]
+
   if (chip_print_memory_usage) {
     ldflags += [
       "-Wl,--print-memory-usage",

--- a/examples/lock-app/k32w/BUILD.gn
+++ b/examples/lock-app/k32w/BUILD.gn
@@ -85,6 +85,8 @@ k32w_executable("lock_app") {
 
   ldscript = "${k32w_platform_dir}/app/ldscripts/chip-k32w061-linker.ld"
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 }
 

--- a/examples/lock-app/qpg6100/BUILD.gn
+++ b/examples/lock-app/qpg6100/BUILD.gn
@@ -70,6 +70,8 @@ qpg6100_executable("lock_app") {
 
   ldscript = "${qpg6100_sdk_root}/qpg6100/ldscripts/chip-qpg6100-example.ld"
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   output_dir = root_out_dir

--- a/examples/persistent-storage/efr32/BUILD.gn
+++ b/examples/persistent-storage/efr32/BUILD.gn
@@ -75,6 +75,8 @@ efr32_executable("persistent_storage") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG21.ld"
   }
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   output_dir = root_out_dir

--- a/examples/persistent-storage/qpg6100/BUILD.gn
+++ b/examples/persistent-storage/qpg6100/BUILD.gn
@@ -65,6 +65,8 @@ qpg6100_executable("persistent_storage") {
 
   ldscript = "${qpg6100_sdk_root}/qpg6100/ldscripts/chip-qpg6100-example.ld"
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 }
 

--- a/examples/pigweed-app/efr32/BUILD.gn
+++ b/examples/pigweed-app/efr32/BUILD.gn
@@ -80,6 +80,8 @@ efr32_executable("pigweed_app") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG21.ld"
   }
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   output_dir = root_out_dir

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -119,6 +119,8 @@ efr32_executable("window_app") {
     ldscript = "${examples_plat_dir}/ldscripts/efr32-MG21.ld"
   }
 
+  inputs = [ ldscript ]
+
   ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
 
   if (chip_print_memory_usage) {


### PR DESCRIPTION
The linker script is passed in ldflags, which isn't tracked
automatically, so incremental builds don't re-trigger linking correctly
when it changes.

Add it to inputs to force a re-link if the timestamp changes.