### PR TITLE
Add OnNetwork pairing command to chip-tool

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -32,6 +32,12 @@ public:
     PairBypass() : PairingCommand("bypass", PairingMode::Bypass, PairingNetworkType::None) {}
 };
 
+class PairOnNetwork : public PairingCommand
+{
+public:
+    PairOnNetwork() : PairingCommand("onnetwork", PairingMode::OnNetwork, PairingNetworkType::None) {}
+};
+
 class PairBleWiFi : public PairingCommand
 {
 public:
@@ -61,8 +67,8 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<Unpair>(),        make_unique<PairBypass>(), make_unique<PairBleWiFi>(),
-        make_unique<PairBleThread>(), make_unique<PairSoftAP>(), make_unique<Ethernet>(),
+        make_unique<Unpair>(),     make_unique<PairBypass>(), make_unique<PairBleWiFi>(),   make_unique<PairBleThread>(),
+        make_unique<PairSoftAP>(), make_unique<Ethernet>(),   make_unique<PairOnNetwork>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -36,6 +36,9 @@ CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, Node
         .mDeviceAddressUpdateDelegate = this,
     };
 
+    err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
+
     err = mCommissioner.Init(localId, params, this);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));
 
@@ -70,6 +73,7 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::Ble:
         err = Pair(remoteId, PeerAddress::BLE());
         break;
+    case PairingMode::OnNetwork:
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort));
         break;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -30,6 +30,7 @@ enum class PairingMode
     Ble,
     SoftAP,
     Ethernet,
+    OnNetwork,
 };
 
 enum class PairingNetworkType
@@ -75,6 +76,7 @@ public:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
             break;
+        case PairingMode::OnNetwork:
         case PairingMode::SoftAP:
             AddArgument("fabric-id", 0, UINT64_MAX, &mFabricId);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -492,6 +492,11 @@ void InitServer(AppDelegate * delegate)
     InitDataModelHandler();
     gCallbacks.SetDelegate(delegate);
 
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+    err = PersistedStorage::KeyValueStoreMgrImpl().Init("chip.store");
+    SuccessOrExit(err);
+#endif
+
     err = gRendezvousServer.Init(delegate, &gServerStorage);
     SuccessOrExit(err);
 


### PR DESCRIPTION
 #### Problem

This PR add a `onnetwork` pairing command to `chip-tool`. It allows to pair with a local server with `chip_config_network_layer_ble=false` in `src/ble/ble.gni`.

 #### Summary of Changes
 * Add `on network` pairing command to `chip-tool`
 * Initialize the `KVS` for Darwin into `src/app/server`