### PR TITLE
Disable CRMP when PASE uses BLE

### DIFF
--- a/src/protocols/secure_channel/RendezvousSession.h
+++ b/src/protocols/secure_channel/RendezvousSession.h
@@ -28,7 +28,6 @@
 #include <protocols/secure_channel/NetworkProvisioning.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
-#include <protocols/secure_channel/SessionEstablishmentExchangeDispatch.h>
 #include <support/BufferWriter.h>
 #include <transport/AdminPairingTable.h>
 #include <transport/RendezvousSessionDelegate.h>

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -45,10 +45,8 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::OnMessageReceived(const Payload
                                                                    const Transport::PeerAddress & peerAddress,
                                                                    ReliableMessageContext * reliableMessageContext)
 {
-    ReturnErrorOnFailure(ExchangeMessageDispatch::OnMessageReceived(payloadHeader, messageId, peerAddress, reliableMessageContext));
     mPeerAddress = peerAddress;
-
-    return CHIP_NO_ERROR;
+    return ExchangeMessageDispatch::OnMessageReceived(payloadHeader, messageId, peerAddress, reliableMessageContext);
 }
 
 bool SessionEstablishmentExchangeDispatch::MessagePermitted(uint16_t protocol, uint8_t type)

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -59,9 +59,8 @@ protected:
 
     bool IsTransportReliable() override
     {
-        // If we are not using BLE as the transport, the underlying transport is UDP based.
-        // (return true only if BLE is being used as the transport)
-        return (mTransportMgr == nullptr);
+        // If the underlying transport is not UDP.
+        return (mPeerAddress.GetTransportType() != Transport::Type::kUdp);
     }
 
 private:


### PR DESCRIPTION
 #### Problem
PASE running over BLE is using CRMP. BLE is providing reliable transfers, so CRMP should be disabled.

 #### Summary of Changes
Check the type of transport to detect if CRMP should be enabled.
