### PR TITLE
Bugfix: Linux KeyValueStoreManagerImpl::_Get always returning CHIP_ERROR_BUFFER_TOO_SMALL

### DIFF
--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
-    else if (err != CHIP_NO_ERROR)
+    else if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_BUFFER_TOO_SMALL))
     {
         return err;
     }


### PR DESCRIPTION
Bugfix: Linux KeyValueStoreManagerImpl::_Get was returning CHIP_ERROR_BUFFER_TOO_SMALL when sufficient buffer was provided. Fixes
regression introduced by #5620