### PR TITLE
Move PacketHeader encoding/decoding from various Transport wrappers to upper layer

### DIFF
--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -251,29 +251,6 @@ void ChannelContext::HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, cons
     }
 }
 
-<<<<<<< HEAD
-=======
-// Session establishment
-CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
-                                                           System::PacketBufferHandle msgIn)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    ReturnErrorOnFailure(header.EncodeBeforeData(msgIn));
-
-    err = mExchangeManager->GetSessionMgr()->GetTransportManager()->SendMessage(peerAddress, std::move(msgIn));
-    ReturnErrorOnFailure(err);
-
-    return err;
-}
-
-CHIP_ERROR ChannelContext::HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                                System::PacketBufferHandle && msg)
-{
-    return CHIP_ERROR_INCORRECT_STATE;
-}
-
->>>>>>> Move encoding from transport layer to messaging layer
 void ChannelContext::EnterCasePairingState()
 {
     mStateVars.mPreparing.mState              = PrepareState::kCasePairing;

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -259,13 +259,12 @@ CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = header.EncodeBeforeData(msgIn);
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(header.EncodeBeforeData(msgIn));
+    ReturnErrorOnFailure(err);
 
     err = mExchangeManager->GetSessionMgr()->GetTransportManager()->SendMessage(peerAddress, std::move(msgIn));
-    SuccessOrExit(err);
+    ReturnErrorOnFailure(err);
 
-exit:
     return err;
 }
 

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -260,7 +260,6 @@ CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     ReturnErrorOnFailure(header.EncodeBeforeData(msgIn));
-    ReturnErrorOnFailure(err);
 
     err = mExchangeManager->GetSessionMgr()->GetTransportManager()->SendMessage(peerAddress, std::move(msgIn));
     ReturnErrorOnFailure(err);

--- a/src/channel/ChannelContext.cpp
+++ b/src/channel/ChannelContext.cpp
@@ -251,6 +251,31 @@ void ChannelContext::HandleNodeIdResolve(CHIP_ERROR error, uint64_t nodeId, cons
     }
 }
 
+<<<<<<< HEAD
+=======
+// Session establishment
+CHIP_ERROR ChannelContext::SendSessionEstablishmentMessage(const PacketHeader & header, const Transport::PeerAddress & peerAddress,
+                                                           System::PacketBufferHandle msgIn)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = header.EncodeBeforeData(msgIn);
+    SuccessOrExit(err);
+
+    err = mExchangeManager->GetSessionMgr()->GetTransportManager()->SendMessage(peerAddress, std::move(msgIn));
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ChannelContext::HandlePairingMessage(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
+                                                System::PacketBufferHandle && msg)
+{
+    return CHIP_ERROR_INCORRECT_STATE;
+}
+
+>>>>>>> Move encoding from transport layer to messaging layer
 void ChannelContext::EnterCasePairingState()
 {
     mStateVars.mPreparing.mState              = PrepareState::kCasePairing;

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -369,10 +369,13 @@ void ExchangeManager::OnConnectionExpired(SecureSessionHandle session, SecureSes
     }
 }
 
-void ExchangeManager::OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                                        System::PacketBufferHandle msgBuf)
+void ExchangeManager::OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf)
 {
-    auto peer = header.GetSourceNodeId();
+    PacketHeader header;
+
+    ReturnOnFailure(header.DecodeAndConsume(msgBuf));
+
+    Optional<NodeId> peer = header.GetSourceNodeId();
     if (!peer.HasValue())
     {
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -251,8 +251,7 @@ private:
     void OnConnectionExpired(SecureSessionHandle session, SecureSessionMgr * mgr) override;
 
     // TransportMgrDelegate interface for rendezvous sessions
-    void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                           System::PacketBufferHandle msgBuf) override;
+    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) override;
 
     CHIP_ERROR QueueReceivedMessageAndSync(Transport::PeerConnectionState * state, System::PacketBufferHandle msgBuf) override;
 };

--- a/src/messaging/MessageCounterSync.cpp
+++ b/src/messaging/MessageCounterSync.cpp
@@ -207,10 +207,9 @@ void MessageCounterSyncMgr::ProcessPendingGroupMsgs(NodeId peerNodeId)
 
             if (packetHeader.GetSourceNodeId().HasValue() && packetHeader.GetSourceNodeId().Value() == peerNodeId)
             {
-                (entry.msgBuf)->ConsumeHead(headerSize);
-
                 // Reprocess message.
-                mExchangeMgr->GetSessionMgr()->HandleGroupMessageReceived(packetHeader, std::move(entry.msgBuf));
+                mExchangeMgr->GetSessionMgr()->HandleGroupMessageReceived(packetHeader.GetEncryptionKeyID(),
+                                                                          std::move(entry.msgBuf));
 
                 // Explicitly free any buffer owned by this handle.  The
                 // HandleGroupMessageReceived() call should really handle this, but

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -57,7 +57,7 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         HandleMessageReceived(address, std::move(msgBuf));
         return CHIP_NO_ERROR;

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -59,7 +59,7 @@ public:
 
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        HandleMessageReceived(header, address, std::move(msgBuf));
+        HandleMessageReceived(address, std::move(msgBuf));
         return CHIP_NO_ERROR;
     }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -65,10 +65,8 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        ReturnErrorOnFailure(header.EncodeBeforeData(msgBuf));
-
         gSendMessageCount++;
 
         return CHIP_NO_ERROR;

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -32,10 +32,14 @@ CHIP_ERROR SessionEstablishmentExchangeDispatch::SendMessageImpl(SecureSessionHa
                                                                  System::PacketBufferHandle && message,
                                                                  EncryptedPacketBufferHandle * retainedMessage)
 {
+    PacketHeader packetHeader;
+
     ReturnErrorOnFailure(payloadHeader.EncodeBeforeData(message));
+    ReturnErrorOnFailure(packetHeader.EncodeBeforeData(message));
+
     if (mTransportMgr != nullptr)
     {
-        return mTransportMgr->SendMessage(PacketHeader(), mPeerAddress, std::move(message));
+        return mTransportMgr->SendMessage(mPeerAddress, std::move(message));
     }
 
     return CHIP_ERROR_INCORRECT_STATE;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -52,7 +52,7 @@ using TestContext = chip::Test::MessagingContext;
 class LoopbackTransport : public Transport::Base
 {
 public:
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -56,7 +56,7 @@ public:
     {
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;
-        HandleMessageReceived(header, address, std::move(msgBuf));
+        HandleMessageReceived(address, std::move(msgBuf));
 
         return CHIP_NO_ERROR;
     }

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -44,7 +44,7 @@ using TestContext = chip::Test::MessagingContext;
 class LoopbackTransport : public Transport::Base
 {
 public:
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -48,7 +48,7 @@ public:
     {
         ReturnErrorOnFailure(mMessageSendError);
         mSentMessageCount++;
-        HandleMessageReceived(header, address, std::move(msgBuf));
+        HandleMessageReceived(address, std::move(msgBuf));
 
         return CHIP_NO_ERROR;
     }

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, E
     VerifyOrReturnError(!msgBuf.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(!msgBuf->HasChainedBuffer(), CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
-    // Advancing the start to encrypted header, since the transport will attach the packet header on top of it
+    // Advancing the start to encrypted header, since SendMessage will attach the packet header on top of it.
     PacketHeader packetHeader;
     ReturnErrorOnFailure(packetHeader.DecodeAndConsume(msgBuf));
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -319,9 +319,9 @@ void SecureSessionMgr::CancelExpiryTimer()
     }
 }
 
-void SecureSessionMgr::HandleGroupMessageReceived(const PacketHeader & packetHeader, System::PacketBufferHandle msgBuf)
+void SecureSessionMgr::HandleGroupMessageReceived(uint16_t keyId, System::PacketBufferHandle msgBuf)
 {
-    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetEncryptionKeyID(), nullptr);
+    PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(keyId, nullptr);
     VerifyOrReturn(state != nullptr, ChipLogError(Inet, "Failed to find the peer connection state"));
 
     OnMessageReceived(state->GetPeerAddress(), std::move(msgBuf));
@@ -391,9 +391,8 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
         // Queue the message as needed for sync with destination node.
         if (mCB != nullptr)
         {
-            // We should encode the packetHeader into the buffer before storing the buffer into the queue.
-            // The encoded packetHeader needs to be peeled off during re-processing after the peer message
-            // counter is synced.
+            // We should encode the packetHeader into the buffer before storing the buffer into the queue since the
+            // stored buffer will be re-processed by OnMessageReceived after the peer message counter is synced.
             ReturnOnFailure(packetHeader.EncodeBeforeData(msg));
             err = mCB->QueueReceivedMessageAndSync(state, std::move(msg));
             VerifyOrReturn(err == CHIP_NO_ERROR);

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -145,8 +145,6 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     PeerConnectionState * state = nullptr;
-    uint8_t * msgStart          = nullptr;
-    uint16_t msgLen             = 0;
     NodeId localNodeId          = mLocalNodeId;
 
     Transport::AdminPairingInfo * admin = nullptr;
@@ -186,12 +184,6 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     err = packetHeader.EncodeBeforeData(msgBuf);
     SuccessOrExit(err);
 
-    // The start of buffer points to the beginning of the encrypted header, and the length of buffer
-    // contains both the encrypted header and encrypted data.
-    // Locally store the start and length of the retained buffer after accounting for the size of packet header.
-    msgStart = static_cast<uint8_t *>(msgBuf->Start());
-    msgLen   = static_cast<uint16_t>(msgBuf->DataLength());
-
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
@@ -219,10 +211,6 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
 
     if (bufferRetainSlot != nullptr)
     {
-        // Rewind the start and len of the buffer back to pre-send state for following possible retransmition.
-        encryptedMsg->SetStart(msgStart);
-        encryptedMsg->SetDataLength(msgLen);
-
         (*bufferRetainSlot) = std::move(encryptedMsg);
     }
 

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -336,12 +336,15 @@ void SecureSessionMgr::HandleGroupMessageReceived(const PacketHeader & packetHea
     PeerConnectionState * state = mPeerConnections.FindPeerConnectionState(packetHeader.GetEncryptionKeyID(), nullptr);
     VerifyOrReturn(state != nullptr, ChipLogError(Inet, "Failed to find the peer connection state"));
 
-    OnMessageReceived(packetHeader, state->GetPeerAddress(), std::move(msgBuf));
+    OnMessageReceived(state->GetPeerAddress(), std::move(msgBuf));
 }
 
-void SecureSessionMgr::OnMessageReceived(const PacketHeader & packetHeader, const PeerAddress & peerAddress,
-                                         System::PacketBufferHandle msg)
+void SecureSessionMgr::OnMessageReceived(const PeerAddress & peerAddress, System::PacketBufferHandle msg)
 {
+    PacketHeader packetHeader;
+
+    ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
+
     if (packetHeader.GetFlags().Has(Header::FlagValues::kSecure))
     {
         SecureMessageDispatch(packetHeader, peerAddress, std::move(msg));

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -317,12 +317,10 @@ protected:
      * @brief
      *   Handle received secure message. Implements TransportMgrDelegate
      *
-     * @param header    the received message header
      * @param source    the source address of the package
      * @param msgBuf    the buffer of (encrypted) payload
      */
-    void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                           System::PacketBufferHandle msgBuf) override;
+    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) override;
 
 private:
     /**

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -318,7 +318,7 @@ protected:
      *   Handle received secure message. Implements TransportMgrDelegate
      *
      * @param source    the source address of the package
-     * @param msgBuf    the buffer of (encrypted) payload
+     * @param msgBuf    the buffer containing a full CHIP message (except for the optional length field).
      */
     void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) override;
 

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -287,10 +287,10 @@ public:
      *   Called when a cached group message that was waiting for message counter
      *   sync shold be reprocessed.
      *
-     * @param packetHeader  The message header
+     * @param keyId         The encryption Key ID of the message buffer
      * @param msgBuf        The received message
      */
-    void HandleGroupMessageReceived(const PacketHeader & packetHeader, System::PacketBufferHandle msgBuf);
+    void HandleGroupMessageReceived(uint16_t keyId, System::PacketBufferHandle msgBuf);
 
     /**
      * @brief

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -48,7 +48,7 @@ public:
      *   Handle received secure message.
      *
      * @param source    the source address of the package
-     * @param msgBuf    the buffer of (encrypted) payload
+     * @param msgBuf    the buffer containing a full CHIP message (except for the optional length field).
      */
     virtual void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) = 0;
 };

--- a/src/transport/TransportMgr.h
+++ b/src/transport/TransportMgr.h
@@ -47,12 +47,10 @@ public:
      * @brief
      *   Handle received secure message.
      *
-     * @param header    the received message header
      * @param source    the source address of the package
      * @param msgBuf    the buffer of (encrypted) payload
      */
-    virtual void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                                   System::PacketBufferHandle msgBuf) = 0;
+    virtual void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) = 0;
 };
 
 template <typename... TransportTypes>

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -22,10 +22,9 @@
 
 namespace chip {
 
-CHIP_ERROR TransportMgrBase::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                                         System::PacketBufferHandle && msgBuf)
+CHIP_ERROR TransportMgrBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
 {
-    return mTransport->SendMessage(header, address, std::move(msgBuf));
+    return mTransport->SendMessage(address, std::move(msgBuf));
 }
 
 void TransportMgrBase::Disconnect(const Transport::PeerAddress & address)

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -51,19 +51,17 @@ void TransportMgrBase::Close()
     mTransport        = nullptr;
 }
 
-void TransportMgrBase::HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                             System::PacketBufferHandle msg)
+void TransportMgrBase::HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle msg)
 {
     if (mSecureSessionMgr != nullptr)
     {
-        mSecureSessionMgr->OnMessageReceived(packetHeader, peerAddress, std::move(msg));
+        mSecureSessionMgr->OnMessageReceived(peerAddress, std::move(msg));
     }
     else
     {
         char addrBuffer[Transport::PeerAddress::kMaxToStringSize];
         peerAddress.ToString(addrBuffer);
-        ChipLogError(Inet, "%s message from %s is dropped since no corresponding handler is set in TransportMgr.",
-                     packetHeader.GetFlags().Has(Header::FlagValues::kSecure) ? "Encrypted" : "Unencrypted", addrBuffer);
+        ChipLogError(Inet, "message from %s is dropped since no corresponding handler is set in TransportMgr.", addrBuffer);
     }
 }
 

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -44,8 +44,7 @@ public:
 
     void SetSecureSessionMgr(TransportMgrDelegate * secureSessionMgr) { mSecureSessionMgr = secureSessionMgr; }
 
-    void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                               System::PacketBufferHandle msg) override;
+    void HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle msg) override;
 
 private:
     TransportMgrDelegate * mSecureSessionMgr = nullptr;

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -35,8 +35,7 @@ class TransportMgrBase : public Transport::RawTransportDelegate
 public:
     CHIP_ERROR Init(Transport::Base * transport);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                           System::PacketBufferHandle && msgBuf);
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf);
 
     void Close();
 

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -163,16 +163,7 @@ void BLEBase::OnBleConnectionError(BLE_ERROR err)
 
 void BLEBase::OnEndPointMessageReceived(BLEEndPoint * endPoint, PacketBufferHandle buffer)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    PacketHeader header;
-    if ((err = header.DecodeAndConsume(buffer)) != CHIP_NO_ERROR)
-    {
-        ChipLogError(Inet, "Failed to receive BLE message: %s", ErrorStr(err));
-        return;
-    }
-
-    HandleMessageReceived(header, Transport::PeerAddress(Transport::Type::kBle), std::move(buffer));
+    HandleMessageReceived(Transport::PeerAddress(Transport::Type::kBle), std::move(buffer));
 }
 
 void BLEBase::OnEndPointConnectComplete(BLEEndPoint * endPoint, BLE_ERROR err)

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -94,13 +94,10 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLEBase::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                                System::PacketBufferHandle msgBuf)
+CHIP_ERROR BLEBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
 {
     ReturnErrorCodeIf(address.GetTransportType() != Type::kBle, CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorCodeIf(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
-
-    ReturnErrorOnFailure(header.EncodeBeforeData(msgBuf));
 
     if (mState == State::kConnected)
     {

--- a/src/transport/raw/BLE.h
+++ b/src/transport/raw/BLE.h
@@ -82,8 +82,7 @@ public:
      */
     CHIP_ERROR Init(const BleListenParameters & param);
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                           System::PacketBufferHandle msgBuf) override;
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override
     {

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -37,8 +37,7 @@ class RawTransportDelegate
 {
 public:
     virtual ~RawTransportDelegate() {}
-    virtual void HandleMessageReceived(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,
-                                       System::PacketBufferHandle msg) = 0;
+    virtual void HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle msg) = 0;
 };
 
 /**
@@ -88,9 +87,9 @@ protected:
      * Method used by subclasses to notify that a packet has been received after
      * any associated headers have been decoded.
      */
-    void HandleMessageReceived(const PacketHeader & header, const PeerAddress & source, System::PacketBufferHandle && buffer)
+    void HandleMessageReceived(const PeerAddress & source, System::PacketBufferHandle && buffer)
     {
-        mDelegate->HandleMessageReceived(header, source, std::move(buffer));
+        mDelegate->HandleMessageReceived(source, std::move(buffer));
     }
 
     RawTransportDelegate * mDelegate;

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -63,7 +63,7 @@ public:
      *
      * On connection-oriented transports, sending a message implies connecting to the target first.
      */
-    virtual CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) = 0;
+    virtual CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) = 0;
 
     /**
      * Determine if this transport can SendMessage to the specified peer address.

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -360,10 +360,7 @@ CHIP_ERROR TCPBase::ProcessSingleMessage(const PeerAddress & peerAddress, Active
         message->SetDataLength(messageSize);
     }
 
-    PacketHeader header;
-    ReturnErrorOnFailure(header.DecodeAndConsume(message));
-
-    HandleMessageReceived(header, peerAddress, std::move(message));
+    HandleMessageReceived(peerAddress, std::move(message));
     return CHIP_NO_ERROR;
 }
 

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::
     // Sent buffer data format is:
     //    - packet size as a uint16_t
     //    - actual data
-    
+
     VerifyOrReturnError(address.GetTransportType() == Type::kTcp, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(kPacketSizeBytes + msgBuf->DataLength() <= std::numeric_limits<uint16_t>::max(),

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -170,6 +170,10 @@ TCPBase::ActiveConnectionState * TCPBase::FindActiveConnection(const Inet::TCPEn
 
 CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
 {
+    // Sent buffer data format is:
+    //    - packet size as a uint16_t
+    //    - actual data
+    
     VerifyOrReturnError(address.GetTransportType() == Type::kTcp, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(kPacketSizeBytes + msgBuf->DataLength() <= std::numeric_limits<uint16_t>::max(),

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -168,36 +168,20 @@ TCPBase::ActiveConnectionState * TCPBase::FindActiveConnection(const Inet::TCPEn
     return nullptr;
 }
 
-CHIP_ERROR TCPBase::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                                System::PacketBufferHandle msgBuf)
+CHIP_ERROR TCPBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
 {
-    // Sent buffer data format is:
-    //    - packet size as a uint16_t (inludes size of header and actual data)
-    //    - header
-    //    - actual data
-    const size_t prefixSize = header.EncodeSizeBytes() + kPacketSizeBytes;
-
     VerifyOrReturnError(address.GetTransportType() == Type::kTcp, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(prefixSize + msgBuf->DataLength() <= std::numeric_limits<uint16_t>::max(), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(kPacketSizeBytes + msgBuf->DataLength() <= std::numeric_limits<uint16_t>::max(),
+                        CHIP_ERROR_INVALID_ARGUMENT);
 
-    // The check above about prefixSize + msgBuf->DataLength() means prefixSize
-    // definitely fits in uint16_t.
-    VerifyOrReturnError(msgBuf->EnsureReservedSize(static_cast<uint16_t>(prefixSize)), CHIP_ERROR_NO_MEMORY);
+    // The check above about kPacketSizeBytes + msgBuf->DataLength() means it definitely fits in uint16_t.
+    VerifyOrReturnError(msgBuf->EnsureReservedSize(static_cast<uint16_t>(kPacketSizeBytes)), CHIP_ERROR_NO_MEMORY);
 
-    msgBuf->SetStart(msgBuf->Start() - prefixSize);
-
-    // Length is actual data, without considering the length bytes themselves
-    VerifyOrReturnError(msgBuf->DataLength() >= kPacketSizeBytes, CHIP_ERROR_INTERNAL);
+    msgBuf->SetStart(msgBuf->Start() - kPacketSizeBytes);
 
     uint8_t * output = msgBuf->Start();
     LittleEndian::Write16(output, static_cast<uint16_t>(msgBuf->DataLength() - kPacketSizeBytes));
-
-    uint16_t actualEncodedHeaderSize;
-    ReturnErrorOnFailure(header.Encode(output, msgBuf->DataLength(), &actualEncodedHeaderSize));
-
-    // header encoding has to match space that we allocated
-    VerifyOrReturnError(prefixSize == actualEncodedHeaderSize + kPacketSizeBytes, CHIP_ERROR_INTERNAL);
 
     // Reuse existing connection if one exists, otherwise a new one
     // will be established

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -163,7 +163,7 @@ public:
      */
     void Close() override;
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override;
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override;
 
     void Disconnect(const PeerAddress & address) override;
 

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -181,7 +181,7 @@ private:
      * @tparam N the index of the underlying transport to run SendMessage throug.
      *
      * @param address where to send the message
-     * @param msgBuf the data to send.
+     * @param msgBuf the message to send.  Includes all CHIP message fields except optional length.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
     CHIP_ERROR SendMessageImpl(const PeerAddress & address, System::PacketBufferHandle && msgBuf)

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -81,9 +81,9 @@ template <typename... TransportTypes>
 class Tuple : public Base
 {
 public:
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        return SendMessageImpl<0>(header, address, std::move(msgBuf));
+        return SendMessageImpl<0>(address, std::move(msgBuf));
     }
 
     bool CanSendToPeer(const PeerAddress & address) override { return CanSendToPeerImpl<0>(address); }
@@ -180,26 +180,25 @@ private:
      *
      * @tparam N the index of the underlying transport to run SendMessage throug.
      *
-     * @param header the message header to send
      * @param address where to send the message
      * @param msgBuf the data to send.
      */
     template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle && msgBuf)
+    CHIP_ERROR SendMessageImpl(const PeerAddress & address, System::PacketBufferHandle && msgBuf)
     {
         Base * base = &std::get<N>(mTransports);
         if (base->CanSendToPeer(address))
         {
-            return base->SendMessage(header, address, std::move(msgBuf));
+            return base->SendMessage(address, std::move(msgBuf));
         }
-        return SendMessageImpl<N + 1>(header, address, std::move(msgBuf));
+        return SendMessageImpl<N + 1>(address, std::move(msgBuf));
     }
 
     /**
      * SendMessageImpl when N is out of range. Always returns an error code.
      */
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    CHIP_ERROR SendMessageImpl(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf)
+    CHIP_ERROR SendMessageImpl(const PeerAddress & address, System::PacketBufferHandle msgBuf)
     {
         return CHIP_ERROR_NO_MESSAGE_HANDLER;
     }

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -85,7 +85,7 @@ void UDP::Close()
     mState = State::kNotReady;
 }
 
-CHIP_ERROR UDP::SendMessage(const PacketHeader & header, const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
+CHIP_ERROR UDP::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf)
 {
     VerifyOrReturnError(address.GetTransportType() == Type::kUdp, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
@@ -97,8 +97,6 @@ CHIP_ERROR UDP::SendMessage(const PacketHeader & header, const Transport::PeerAd
     addrInfo.DestAddress = address.GetIPAddress();
     addrInfo.DestPort    = address.GetPort();
     addrInfo.Interface   = address.GetInterface();
-
-    ReturnErrorOnFailure(header.EncodeBeforeData(msgBuf));
 
     return mUDPEndPoint->SendMsg(&addrInfo, std::move(msgBuf));
 }

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -109,13 +109,8 @@ void UDP::OnUdpReceive(Inet::IPEndPointBasis * endPoint, System::PacketBufferHan
     UDP * udp               = reinterpret_cast<UDP *>(endPoint->AppState);
     PeerAddress peerAddress = PeerAddress::UDP(pktInfo->SrcAddress, pktInfo->SrcPort);
 
-    PacketHeader header;
-    err = header.DecodeAndConsume(buffer);
-    SuccessOrExit(err);
+    udp->HandleMessageReceived(peerAddress, std::move(buffer));
 
-    udp->HandleMessageReceived(header, peerAddress, std::move(buffer));
-
-exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Inet, "Failed to receive UDP message: %s", ErrorStr(err));

--- a/src/transport/raw/UDP.h
+++ b/src/transport/raw/UDP.h
@@ -110,8 +110,7 @@ public:
      */
     void Close() override;
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const Transport::PeerAddress & address,
-                           System::PacketBufferHandle msgBuf) override;
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle msgBuf) override;
 
     bool CanSendToPeer(const Transport::PeerAddress & address) override
     {

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -89,13 +89,8 @@ public:
         mCallback     = callback;
         mCallbackData = callback_data;
     }
-    void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                           System::PacketBufferHandle msgBuf) override
+    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) override
     {
-        NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
-        NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
-        NL_TEST_ASSERT(mSuite, header.GetMessageId() == kMessageId);
-
         if (mCallback)
         {
             int err = mCallback(msgBuf->Start(), msgBuf->DataLength(), mReceiveHandlerCallCount, mCallbackData);

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -65,6 +65,10 @@ public:
         CHIP_ERROR err = packetHeader.DecodeAndConsume(msgBuf);
         NL_TEST_ASSERT(mSuite, err == CHIP_NO_ERROR);
 
+        NL_TEST_ASSERT(mSuite, packetHeader.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
+        NL_TEST_ASSERT(mSuite, packetHeader.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
+        NL_TEST_ASSERT(mSuite, packetHeader.GetMessageId() == kMessageId);
+
         size_t data_len = msgBuf->DataLength();
         int compare     = memcmp(msgBuf->Start(), PAYLOAD, data_len);
         NL_TEST_ASSERT(mSuite, compare == 0);

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -58,13 +58,8 @@ public:
     MockTransportMgrDelegate(nlTestSuite * inSuite) : mSuite(inSuite) {}
     ~MockTransportMgrDelegate() override {}
 
-    void OnMessageReceived(const PacketHeader & header, const Transport::PeerAddress & source,
-                           System::PacketBufferHandle msgBuf) override
+    void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle msgBuf) override
     {
-        NL_TEST_ASSERT(mSuite, header.GetSourceNodeId() == Optional<NodeId>::Value(kSourceNodeId));
-        NL_TEST_ASSERT(mSuite, header.GetDestinationNodeId() == Optional<NodeId>::Value(kDestinationNodeId));
-        NL_TEST_ASSERT(mSuite, header.GetMessageId() == kMessageId);
-
         size_t data_len = msgBuf->DataLength();
         int compare     = memcmp(msgBuf->Start(), PAYLOAD, data_len);
         NL_TEST_ASSERT(mSuite, compare == 0);

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -65,7 +65,7 @@ public:
 
     CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
-        HandleMessageReceived(header, address, std::move(msgBuf));
+        HandleMessageReceived(address, std::move(msgBuf));
         return CHIP_NO_ERROR;
     }
 
@@ -82,9 +82,7 @@ public:
     {
         System::PacketBufferHandle recvdMsg = msgBuf.CloneData();
 
-        ReturnErrorOnFailure(header.EncodeBeforeData(msgBuf));
-
-        HandleMessageReceived(header, address, std::move(recvdMsg));
+        HandleMessageReceived(address, std::move(recvdMsg));
         return CHIP_NO_ERROR;
     }
 

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -63,7 +63,7 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         HandleMessageReceived(address, std::move(msgBuf));
         return CHIP_NO_ERROR;
@@ -78,7 +78,7 @@ public:
     /// Transports are required to have a constructor that takes exactly one argument
     CHIP_ERROR Init(const char * unused) { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR SendMessage(const PacketHeader & header, const PeerAddress & address, System::PacketBufferHandle msgBuf) override
+    CHIP_ERROR SendMessage(const PeerAddress & address, System::PacketBufferHandle msgBuf) override
     {
         System::PacketBufferHandle recvdMsg = msgBuf.CloneData();
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, PacketHeader encoding/decoding is done in each Transport wrappers (TCP, UDP, BLE), but PacketHeader is defined as part of CHIP message payload, it should be encoded into packet buffer before handing packet buffer over to the transport and decoded after receiving buffer from the transport.

We don't need to conduct wired buffer rewinding in CRMP if PacketHeader encoding/decoding is conducted in upper layer.  

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Move PacketHeader encoding/decoding from various Transport wrappers to upper layer.
2. Remove buffer rewinding in SecureSessionMgr::SendMessage for CRMP.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6332

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
