### PR TITLE
Print the uncommited changes from ZAP templates before failing the jo…

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -49,4 +49,5 @@ jobs:
             - name: Check for uncommited changes
               run: |
                 git add .
+                git diff-index HEAD --
                 git diff-index --quiet HEAD --


### PR DESCRIPTION
…b in zap_templates.yaml

 #### Problem

When the CI job under `zap_templates.yaml` fails, there is not much information. This PR add `git diff-index HEAD --` to the log to show which changes have not been committed. 

 #### Summary of Changes
 * Add `git diff-index HEAD --` to `.github/workflows/zap_templates.yaml` before succeeding/failing.