### PR TITLE
Run command failure: CHIP Error 4003 (0x00000FA3): Incorrect state wh…

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -30,7 +30,9 @@ public:
     /////////// DiscoverCommand Interface /////////
     CHIP_ERROR RunCommand(NodeId remoteId, uint64_t fabricId) override
     {
+        ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(nullptr));
         ReturnErrorOnFailure(chip::Mdns::Resolver::Instance().SetResolverDelegate(this));
+        ChipLogProgress(chipTool, "Mdns: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Mdns::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetFabricId(fabricId),
                                                               chip::Inet::kIPAddressType_Any);
     }
@@ -61,6 +63,7 @@ public:
     {
         ChipDevice * device;
         ReturnErrorOnFailure(mCommissioner.GetDevice(remoteId, &device));
+        ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return mCommissioner.UpdateDevice(device, fabricId);
     }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -325,6 +325,7 @@ void PairingCommand::OnEnableNetworkResponse(void * context, uint8_t errorCode, 
 CHIP_ERROR PairingCommand::UpdateNetworkAddress()
 {
     ReturnErrorOnFailure(mCommissioner.GetDevice(mRemoteId, &mDevice));
+    ChipLogProgress(chipTool, "Mdns: Updating NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", mRemoteId, mFabricId);
     return mCommissioner.UpdateDevice(mDevice, mFabricId);
 }
 


### PR DESCRIPTION
…en running 'chip-tool discover resolve'

 #### Problem
 `chip-tool` fails with `Run command failure: CHIP Error 4003 (0x00000FA3): Incorrect state` when running the `resolve` command.

 #### Summary of Changes
  * Fix the error
  * Add some logs to let the user knows `chip-tool` is looking over mdns instead of making it looks like it hangs.