### PR TITLE
Fix CI

### DIFF
--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -666,8 +666,6 @@ public:
      * a faulty state. (Some configurations may not actually perform any check.)
      *
      * @note  A null handle is not considered faulty.
-     *
-     *  @param[in] aPacket - the packet buffer handle to check.
      */
     void Check() const
     {


### PR DESCRIPTION
```
/Users/runner/work/connectedhomeip/connectedhomeip/src/system/SystemPacketBuffer.h:670:20: warning: parameter 'aPacket' not found in the function declaration [-Wdocumentation]
     *  @param[in] aPacket - the packet buffer handle to check.
                   ^~~~~~~
```