### PR TITLE
Cannot check size of pre-encrypted message payload

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -134,8 +134,6 @@ CHIP_ERROR SecureSessionMgr::SendEncryptedMessage(SecureSessionHandle session, E
     PacketHeader packetHeader;
     ReturnErrorOnFailure(packetHeader.DecodeAndConsume(msgBuf));
 
-    VerifyOrReturnError(msgBuf->TotalLength() <= kMaxAppMessageLen + packetHeader.EncodeSizeBytes(), CHIP_ERROR_MESSAGE_TOO_LONG);
-
     PayloadHeader payloadHeader;
     return SendMessage(session, payloadHeader, packetHeader, std::move(msgBuf), bufferRetainSlot,
                        EncryptionState::kPayloadIsEncrypted);


### PR DESCRIPTION
 #### Problem
The `SecureSessionMgr::SendEncryptedMessage` is currently trying to check the length of an encrypted application message. But it cannot be measured deterministically, as payload header has optional fields and is encrypted. Only way to correctly check the length is to decrypt the message.

 #### Summary of Changes
The message length is checked when the message is first encrypted. So, there should never be a condition where a valid encrypted message has an invalid length.

Decrypting the message to check the length seems like an overkill. This PR removes the length check for the encrypted message.