### PR TITLE
descrease clusterinfo pool

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -52,7 +52,7 @@
 #define CHIP_MAX_NUM_READ_CLIENT 1
 #define CHIP_MAX_NUM_READ_HANDLER 1
 #define CHIP_MAX_REPORTS_IN_FLIGHT 1
-#define IM_SERVER_MAX_NUM_PATH_GROUPS 256
+#define IM_SERVER_MAX_NUM_PATH_GROUPS 8
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
Summary of Changes:
-- Decrease clusterInfo pool from 256 to 8, currently we only have
one read handler, and don't need large pool. when we have multiple read
or subscription handler on particular device, vendor can override the
pool maximum value.
