### PR TITLE
Add a thread id to Darwin logging

### DIFF
--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -8,9 +8,12 @@
 
 #include <os/log.h>
 
+#include <inttypes.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 namespace chip {
 namespace Logging {
@@ -18,8 +21,15 @@ namespace Platform {
 
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
+    timeval time;
+    gettimeofday(&time, NULL);
+    long ms = (time.tv_sec * 1000) + (time.tv_usec / 1000);
+
+    uint64_t ktid;
+    pthread_threadid_np(NULL, &ktid);
+
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "CHIP: [%s] ", module);
+    int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [0x%" PRIx64 "] CHIP: [%s] ", ms, ktid, module);
     static os_log_t log = os_log_create("com.zigbee.chip", "all");
     if (prefixLen < 0)
     {


### PR DESCRIPTION
 #### Problem

It is unclear on which threads stuffs are happening at the moment with darwin logging.

 #### Summary of Changes
 * Add a thread id for darwin logging