### PR TITLE
optimize cluster info structure memory

### DIFF
--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -29,6 +29,11 @@ enum class AttributePathFlags : uint8_t
     kListIndexValid = 0x02,
 };
 
+/**
+ *
+ * @brief This is used to record attribute path, and can pass attribute path info between IM and ember library.
+ *
+ */
 struct AttributePathParams
 {
     AttributePathParams(NodeId aNodeId, EndpointId aEndpointId, ClusterId aClusterId, FieldId aFieldId, ListIndex aListIndex,
@@ -65,11 +70,11 @@ struct AttributePathParams
         }
         return true;
     }
-    chip::NodeId mNodeId         = 0;
-    chip::EndpointId mEndpointId = 0;
-    chip::ClusterId mClusterId   = 0;
-    chip::FieldId mFieldId       = 0;
-    chip::ListIndex mListIndex   = 0;
+    NodeId mNodeId         = 0;
+    ClusterId mClusterId   = 0;
+    ListIndex mListIndex   = 0;
+    EndpointId mEndpointId = 0;
+    FieldId mFieldId       = 0;
     BitFlags<AttributePathFlags> mFlags;
 };
 } // namespace app

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -26,11 +26,11 @@ namespace app {
 
 /**
  *
- * @brief This is used to record the cluster's attribute path in server side read or subscription client interested in, for read interaction,
- * read handler would mark those interested clusterInfo as dirty when receiving read request, then reporting engine would send out those
- * dirty changes to client per interested clusterInfo, considering IM timed interaction, reporting engine would send out the dirty changes with delay.
- * For subscription, in server side, if user modifies some of interested clusters, and those corresponding clusterInfo would be marked dirty,
- * reporting engine would send them out.
+ * @brief This is used to record the cluster's attribute path in server side read or subscription client interested in, for read
+ * interaction, read handler would mark those interested clusterInfo as dirty when receiving read request, then reporting engine
+ * would send out those dirty changes to client per interested clusterInfo, considering IM timed interaction, reporting engine would
+ * send out the dirty changes with delay. For subscription, in server side, if user modifies some of interested clusters, and those
+ * corresponding clusterInfo would be marked dirty, reporting engine would send them out.
  *
  */
 struct ClusterInfo

--- a/src/app/ClusterInfo.h
+++ b/src/app/ClusterInfo.h
@@ -23,6 +23,16 @@
 
 namespace chip {
 namespace app {
+
+/**
+ *
+ * @brief This is used to record the cluster's attribute path in server side read or subscription client interested in, for read interaction,
+ * read handler would mark those interested clusterInfo as dirty when receiving read request, then reporting engine would send out those
+ * dirty changes to client per interested clusterInfo, considering IM timed interaction, reporting engine would send out the dirty changes with delay.
+ * For subscription, in server side, if user modifies some of interested clusters, and those corresponding clusterInfo would be marked dirty,
+ * reporting engine would send them out.
+ *
+ */
 struct ClusterInfo
 {
     ClusterInfo(const AttributePathParams & aAttributePathParams, bool aDirty) :

--- a/src/app/CommandPathParams.h
+++ b/src/app/CommandPathParams.h
@@ -32,7 +32,7 @@ enum class CommandPathFlags : uint8_t
 
 /**
  *
- * @brief This is used to record command path, and can pass command path info between IM and ember library.
+ * @brief This is used to record a command path.
  *
  */
 struct CommandPathParams

--- a/src/app/CommandPathParams.h
+++ b/src/app/CommandPathParams.h
@@ -30,6 +30,11 @@ enum class CommandPathFlags : uint8_t
     kGroupIdValid    = 0x02,
 };
 
+/**
+ *
+ * @brief This is used to record command path, and can pass command path info between IM and ember library.
+ *
+ */
 struct CommandPathParams
 {
     CommandPathParams(EndpointId aEndpointId, GroupId aGroupId, ClusterId aClusterId, CommandId aCommandId,

--- a/src/app/EventPathParams.h
+++ b/src/app/EventPathParams.h
@@ -24,7 +24,7 @@ namespace chip {
 namespace app {
 /**
  *
- * @brief This is used to record IM event path, and can pass event path info between IM and ember library.
+ * @brief This is used to record an M event path.
  *
  */
 struct EventPathParams

--- a/src/app/EventPathParams.h
+++ b/src/app/EventPathParams.h
@@ -22,6 +22,11 @@
 
 namespace chip {
 namespace app {
+/**
+ *
+ * @brief This is used to record IM event path, and can pass event path info between IM and ember library.
+ *
+ */
 struct EventPathParams
 {
     EventPathParams(NodeId aNodeId, EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId, bool aIsUrgent) :


### PR DESCRIPTION
Summary of Changes:
-- Optimize the memory from 24 bytes to 16 bytes for attributePathParams
-- Update description for attributePathParams, clusterPathParams,
eventPathParams, clusterInfo.
