### PR TITLE
Add Pairing API in CHIPFramework that takes in an onboarding payload …

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
 		B20252972459E34F00F97062 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* CHIP.framework */; };
+		B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */ = {isa = PBXBuildFile; fileRef = B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */; };
 		B2E0D7B1245B0B5C003C5B48 /* CHIP.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A8245B0B5C003C5B48 /* CHIP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E0D7B2245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A9245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */; };
@@ -110,6 +112,8 @@
 		B20252912459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B20252962459E34F00F97062 /* CHIPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CHIPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B202529D2459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPOnboardingPayloadParser.h; sourceTree = "<group>"; };
+		B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPOnboardingPayloadParser.m; sourceTree = "<group>"; };
 		B2E0D7A8245B0B5C003C5B48 /* CHIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIP.h; sourceTree = "<group>"; };
 		B2E0D7A9245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPManualSetupPayloadParser.h; sourceTree = "<group>"; };
 		B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPError.mm; sourceTree = "<group>"; };
@@ -222,6 +226,8 @@
 				B2E0D7AB245B0B5C003C5B48 /* CHIPError.h */,
 				B2E0D7AA245B0B5C003C5B48 /* CHIPError.mm */,
 				991DC08A247704DC00C13860 /* CHIPLogging.h */,
+				B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */,
+				B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */,
 				B2E0D7A9245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h */,
 				B2E0D7AD245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.mm */,
 				B2E0D7AC245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h */,
@@ -261,6 +267,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2CB7163B252E8A7B0026E2BB /* CHIPDevicePairingDelegateBridge.h in Headers */,
+				B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */,
 				2CB7163F252F731E0026E2BB /* CHIPDevicePairingDelegate.h in Headers */,
 				2C222AD0255C620600E446B9 /* CHIPDevice.h in Headers */,
 				991DC0842475F45400C13860 /* CHIPDeviceController.h in Headers */,
@@ -419,6 +426,7 @@
 				1EC4CE5D25CC26E900D7304F /* CHIPClustersObjc.mm in Sources */,
 				1E9BD1C72621AFF100FC3246 /* attribute-size.cpp in Sources */,
 				B2E0D7B3245B0B5C003C5B48 /* CHIPError.mm in Sources */,
+				B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */,
 				1EC4CE5E25CC26E900D7304F /* call-command-handler.cpp in Sources */,
 				1EC4CE3B25CC263E00D7304F /* reporting-default-configuration.cpp in Sources */,
 				1EC4CE4F25CC267700D7304F /* process-cluster-message.cpp in Sources */,

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -19,6 +19,7 @@
 #define CHIP_DEVICE_CONTROLLER_H
 
 #import <Foundation/Foundation.h>
+#import "CHIPOnboardingPayloadParser.h"
 
 @class CHIPDevice;
 
@@ -35,16 +36,24 @@ NS_ASSUME_NONNULL_BEGIN
      discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
+
 - (BOOL)pairDevice:(uint64_t)deviceID
            address:(NSString *)address
               port:(uint16_t)port
      discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
+
 - (BOOL)pairDeviceWithoutSecurity:(uint64_t)deviceID
                           address:(NSString *)address
                              port:(uint16_t)port
                             error:(NSError * __autoreleasing *)error;
+
+- (BOOL)pairDevice:(uint64_t)deviceID
+ onboardingPayload:(NSString *)onboardingPayload
+onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
+             error:(NSError * __autoreleasing *)error;
+
 - (void)setListenPort:(uint16_t)port;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -18,8 +18,8 @@
 #ifndef CHIP_DEVICE_CONTROLLER_H
 #define CHIP_DEVICE_CONTROLLER_H
 
-#import "CHIPOnboardingPayloadParser.h"
 #import <Foundation/Foundation.h>
+#import <CHIP/CHIPOnboardingPayloadParser.h>
 
 @class CHIPDevice;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -18,8 +18,8 @@
 #ifndef CHIP_DEVICE_CONTROLLER_H
 #define CHIP_DEVICE_CONTROLLER_H
 
-#import <Foundation/Foundation.h>
 #import <CHIP/CHIPOnboardingPayloadParser.h>
+#import <Foundation/Foundation.h>
 
 @class CHIPDevice;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -18,8 +18,9 @@
 #ifndef CHIP_DEVICE_CONTROLLER_H
 #define CHIP_DEVICE_CONTROLLER_H
 
-#import <CHIP/CHIPOnboardingPayloadParser.h>
 #import <Foundation/Foundation.h>
+
+#import <CHIP/CHIPOnboardingPayloadParser.h>
 
 @class CHIPDevice;
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -18,8 +18,8 @@
 #ifndef CHIP_DEVICE_CONTROLLER_H
 #define CHIP_DEVICE_CONTROLLER_H
 
-#import <Foundation/Foundation.h>
 #import "CHIPOnboardingPayloadParser.h"
+#import <Foundation/Foundation.h>
 
 @class CHIPDevice;
 
@@ -50,9 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
                             error:(NSError * __autoreleasing *)error;
 
 - (BOOL)pairDevice:(uint64_t)deviceID
- onboardingPayload:(NSString *)onboardingPayload
-onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
-             error:(NSError * __autoreleasing *)error;
+        onboardingPayload:(NSString *)onboardingPayload
+    onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
+                    error:(NSError * __autoreleasing *)error;
 
 - (void)setListenPort:(uint16_t)port;
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -22,6 +22,7 @@
 #import "CHIPLogging.h"
 #import "CHIPPersistentStorageDelegateBridge.h"
 #import "gen/CHIPClustersObjc.h"
+#import "CHIPSetupPayload.h"
 
 #include <platform/CHIPDeviceBuildConfig.h>
 
@@ -262,6 +263,27 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     });
 
     return success;
+}
+
+- (BOOL)pairDevice:(uint64_t)deviceID
+ onboardingPayload:(NSString *)onboardingPayload
+onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
+             error:(NSError * __autoreleasing *)error
+{
+    BOOL didSucceed = NO;
+    CHIPSetupPayload *setupPayload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:onboardingPayload
+                                                                                            ofType:onboardingPayloadType
+                                                                                            error:error];
+    if (setupPayload)
+    {
+        uint16_t discriminator = setupPayload.discriminator.unsignedShortValue;
+        uint32_t setupPINCode = setupPayload.setUpPINCode.unsignedIntValue;
+        didSucceed = [self pairDevice:deviceID discriminator:discriminator setupPINCode:setupPINCode error:error];
+    } else
+    {
+        CHIP_LOG_ERROR("Failed to create CHIPSetupPayload for pairing with error %@", *error);
+    }
+    return didSucceed;
 }
 
 - (BOOL)unpairDevice:(uint64_t)deviceID error:(NSError * __autoreleasing *)error

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -21,8 +21,8 @@
 #import "CHIPError.h"
 #import "CHIPLogging.h"
 #import "CHIPPersistentStorageDelegateBridge.h"
-#import "gen/CHIPClustersObjc.h"
 #import "CHIPSetupPayload.h"
+#import "gen/CHIPClustersObjc.h"
 
 #include <platform/CHIPDeviceBuildConfig.h>
 
@@ -266,21 +266,19 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 }
 
 - (BOOL)pairDevice:(uint64_t)deviceID
- onboardingPayload:(NSString *)onboardingPayload
-onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
-             error:(NSError * __autoreleasing *)error
+        onboardingPayload:(NSString *)onboardingPayload
+    onboardingPayloadType:(CHIPOnboardingPayloadType)onboardingPayloadType
+                    error:(NSError * __autoreleasing *)error
 {
     BOOL didSucceed = NO;
-    CHIPSetupPayload *setupPayload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:onboardingPayload
-                                                                                            ofType:onboardingPayloadType
-                                                                                            error:error];
-    if (setupPayload)
-    {
+    CHIPSetupPayload * setupPayload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:onboardingPayload
+                                                                                             ofType:onboardingPayloadType
+                                                                                              error:error];
+    if (setupPayload) {
         uint16_t discriminator = setupPayload.discriminator.unsignedShortValue;
         uint32_t setupPINCode = setupPayload.setUpPINCode.unsignedIntValue;
         didSucceed = [self pairDevice:deviceID discriminator:discriminator setupPINCode:setupPINCode error:error];
-    } else
-    {
+    } else {
         CHIP_LOG_ERROR("Failed to create CHIPSetupPayload for pairing with error %@", *error);
     }
     return didSucceed;

--- a/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.h
@@ -1,0 +1,39 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class CHIPSetupPayload;
+
+typedef NS_ENUM(NSUInteger, CHIPOnboardingPayloadType) {
+    CHIPOnboardingPayloadTypeQRCode = 0,
+    CHIPOnboardingPayloadTypeManualCode,
+    CHIPOnboardingPayloadTypeNFC,
+    CHIPOnboardingPayloadTypeAdmin,
+};
+
+@interface CHIPOnboardingPayloadParser : NSObject
+
++ (CHIPSetupPayload * __nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                           ofType:(CHIPOnboardingPayloadType)type
+                                                            error:(NSError * __autoreleasing *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.h
@@ -30,9 +30,9 @@ typedef NS_ENUM(NSUInteger, CHIPOnboardingPayloadType) {
 
 @interface CHIPOnboardingPayloadParser : NSObject
 
-+ (CHIPSetupPayload * __nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                           ofType:(CHIPOnboardingPayloadType)type
-                                                            error:(NSError * __autoreleasing *)error;
++ (nullable CHIPSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                         ofType:(CHIPOnboardingPayloadType)type
+                                                          error:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
+++ b/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
@@ -22,9 +22,9 @@
 
 @implementation CHIPOnboardingPayloadParser
 
-+ (CHIPSetupPayload * __nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                           ofType:(CHIPOnboardingPayloadType)type
-                                                            error:(NSError * __autoreleasing *)error
++ (nullable CHIPSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                         ofType:(CHIPOnboardingPayloadType)type
+                                                          error:(NSError * __autoreleasing *)error
 {
     CHIPSetupPayload * payload;
     switch (type) {
@@ -42,16 +42,16 @@
     return payload;
 }
 
-+ (CHIPSetupPayload * __nullable)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                                  error:(NSError * __autoreleasing *)error
++ (nullable CHIPSetupPayload *)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                error:(NSError * __autoreleasing *)error
 {
     CHIPQRCodeSetupPayloadParser * qrCodeParser =
         [[CHIPQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
     return [qrCodeParser populatePayload:error];
 }
 
-+ (CHIPSetupPayload * __nullable)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                                      error:(NSError * __autoreleasing *)error
++ (nullable CHIPSetupPayload *)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                    error:(NSError * __autoreleasing *)error
 {
     CHIPManualSetupPayloadParser * manualParser =
         [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];

--- a/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
+++ b/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
@@ -22,23 +22,22 @@
 
 @implementation CHIPOnboardingPayloadParser
 
-
 + (CHIPSetupPayload * __nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
                                                            ofType:(CHIPOnboardingPayloadType)type
                                                             error:(NSError * __autoreleasing *)error
 {
-    CHIPSetupPayload *payload;
+    CHIPSetupPayload * payload;
     switch (type) {
-        case CHIPOnboardingPayloadTypeManualCode:
-        case CHIPOnboardingPayloadTypeAdmin:
-            payload = [self setupPayloadForManualCodeOnboardingPayload:onboardingPayload error:error];
-            break;
-        case CHIPOnboardingPayloadTypeQRCode:
-        case CHIPOnboardingPayloadTypeNFC:
-            payload = [self setupPayloadForQRCodeOnboardingPayload:onboardingPayload error:error];
-            break;
-        default:
-            break;
+    case CHIPOnboardingPayloadTypeManualCode:
+    case CHIPOnboardingPayloadTypeAdmin:
+        payload = [self setupPayloadForManualCodeOnboardingPayload:onboardingPayload error:error];
+        break;
+    case CHIPOnboardingPayloadTypeQRCode:
+    case CHIPOnboardingPayloadTypeNFC:
+        payload = [self setupPayloadForQRCodeOnboardingPayload:onboardingPayload error:error];
+        break;
+    default:
+        break;
     }
     return payload;
 }
@@ -46,14 +45,16 @@
 + (CHIPSetupPayload * __nullable)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
                                                                   error:(NSError * __autoreleasing *)error
 {
-    CHIPQRCodeSetupPayloadParser *qrCodeParser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
+    CHIPQRCodeSetupPayloadParser * qrCodeParser =
+        [[CHIPQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
     return [qrCodeParser populatePayload:error];
 }
 
 + (CHIPSetupPayload * __nullable)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
                                                                       error:(NSError * __autoreleasing *)error
 {
-    CHIPManualSetupPayloadParser *manualParser = [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];
+    CHIPManualSetupPayloadParser * manualParser =
+        [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];
     return [manualParser populatePayload:error];
 }
 @end

--- a/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
+++ b/src/darwin/Framework/CHIP/CHIPOnboardingPayloadParser.m
@@ -1,0 +1,59 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPOnboardingPayloadParser.h"
+#import "CHIPManualSetupPayloadParser.h"
+#import "CHIPQRCodeSetupPayloadParser.h"
+#import "CHIPSetupPayload.h"
+
+@implementation CHIPOnboardingPayloadParser
+
+
++ (CHIPSetupPayload * __nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
+                                                           ofType:(CHIPOnboardingPayloadType)type
+                                                            error:(NSError * __autoreleasing *)error
+{
+    CHIPSetupPayload *payload;
+    switch (type) {
+        case CHIPOnboardingPayloadTypeManualCode:
+        case CHIPOnboardingPayloadTypeAdmin:
+            payload = [self setupPayloadForManualCodeOnboardingPayload:onboardingPayload error:error];
+            break;
+        case CHIPOnboardingPayloadTypeQRCode:
+        case CHIPOnboardingPayloadTypeNFC:
+            payload = [self setupPayloadForQRCodeOnboardingPayload:onboardingPayload error:error];
+            break;
+        default:
+            break;
+    }
+    return payload;
+}
+
++ (CHIPSetupPayload * __nullable)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                  error:(NSError * __autoreleasing *)error
+{
+    CHIPQRCodeSetupPayloadParser *qrCodeParser = [[CHIPQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
+    return [qrCodeParser populatePayload:error];
+}
+
++ (CHIPSetupPayload * __nullable)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
+                                                                      error:(NSError * __autoreleasing *)error
+{
+    CHIPManualSetupPayloadParser *manualParser = [[CHIPManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];
+    return [manualParser populatePayload:error];
+}
+@end

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -49,7 +49,7 @@
         _requiresCustomFlow = setupPayload.requiresCustomFlow == 1;
         _rendezvousInformation = [self valueOf:setupPayload.rendezvousInformation];
         _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator];
-        _setUpPINCode = [NSNumber numberWithUnsignedLong:setupPayload.setUpPINCode];
+        _setUpPINCode = [NSNumber numberWithUnsignedInt:setupPayload.setUpPINCode];
 
         [self getSerialNumber:setupPayload];
     }

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -20,6 +20,7 @@
 // module headers
 #import "CHIPManualSetupPayloadParser.h"
 #import "CHIPQRCodeSetupPayloadParser.h"
+#import "CHIPOnboardingPayloadParser.h"
 #import "CHIPSetupPayload.h"
 
 // additional includes
@@ -33,6 +34,110 @@
 @end
 
 @implementation CHIPSetupPayloadParserTests
+
+- (void)testOnboardingPayloadParser_Manual_NoError
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
+    
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 2560);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertTrue(payload.requiresCustomFlow);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationNone);
+}
+
+- (void)testOnboardingPayloadParser_Manual_WrongType
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    
+    XCTAssertNil(payload);
+    XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
+}
+
+- (void)testOnboardingPayloadParser_Admin_NoError
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
+    
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 2560);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertTrue(payload.requiresCustomFlow);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationNone);
+}
+
+- (void)testOnboardingPayloadParser_Admin_WrongType
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    
+    XCTAssertNil(payload);
+    XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
+}
+
+- (void)testOnboardingPayloadParser_QRCode_NoError
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertFalse(payload.requiresCustomFlow);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
+}
+
+- (void)testOnboardingPayloadParser_QRCode_WrongType
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
+    
+    XCTAssertNil(payload);
+    XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);
+}
+
+- (void)testOnboardingPayloadParser_NFC_NoError
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeNFC error:&error];
+    
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertFalse(payload.requiresCustomFlow);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
+    XCTAssertEqual(payload.rendezvousInformation, kRendezvousInformationSoftAP);
+}
+
+- (void)testOnboardingPayloadParser_NFC_WrongType
+{
+    NSError *error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
+    
+    XCTAssertNil(payload);
+    XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);
+}
 
 - (void)testManualParser
 {

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -39,7 +39,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
-    
+
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
@@ -56,7 +56,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
-    
+
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
 }
@@ -65,7 +65,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
-    
+
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
@@ -82,7 +82,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
-    
+
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
 }
@@ -91,7 +91,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
-    
+
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
@@ -108,7 +108,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
-    
+
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);
 }
@@ -117,7 +117,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeNFC error:&error];
-    
+
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
@@ -134,7 +134,7 @@
 {
     NSError *error;
     CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
-    
+
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);
 }

--- a/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPSetupPayloadParserTests.m
@@ -19,8 +19,8 @@
  */
 // module headers
 #import "CHIPManualSetupPayloadParser.h"
-#import "CHIPQRCodeSetupPayloadParser.h"
 #import "CHIPOnboardingPayloadParser.h"
+#import "CHIPQRCodeSetupPayloadParser.h"
 #import "CHIPSetupPayload.h"
 
 // additional includes
@@ -37,8 +37,10 @@
 
 - (void)testOnboardingPayloadParser_Manual_NoError
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
+                                                                                        ofType:CHIPOnboardingPayloadTypeManualCode
+                                                                                         error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -54,8 +56,10 @@
 
 - (void)testOnboardingPayloadParser_Manual_WrongType
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
+                                                                                        ofType:CHIPOnboardingPayloadTypeQRCode
+                                                                                         error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
@@ -63,8 +67,10 @@
 
 - (void)testOnboardingPayloadParser_Admin_NoError
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
+                                                                                        ofType:CHIPOnboardingPayloadTypeAdmin
+                                                                                         error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -80,8 +86,10 @@
 
 - (void)testOnboardingPayloadParser_Admin_WrongType
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
+                                                                                        ofType:CHIPOnboardingPayloadTypeQRCode
+                                                                                         error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeInvalidArgument);
@@ -89,8 +97,10 @@
 
 - (void)testOnboardingPayloadParser_QRCode_NoError
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeQRCode error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000"
+                                                                                        ofType:CHIPOnboardingPayloadTypeQRCode
+                                                                                         error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -106,8 +116,10 @@
 
 - (void)testOnboardingPayloadParser_QRCode_WrongType
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000" ofType:CHIPOnboardingPayloadTypeAdmin error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L900000"
+                                                                                        ofType:CHIPOnboardingPayloadTypeAdmin
+                                                                                         error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);
@@ -115,8 +127,11 @@
 
 - (void)testOnboardingPayloadParser_NFC_NoError
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeNFC error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload =
+        [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3"
+                                                               ofType:CHIPOnboardingPayloadTypeNFC
+                                                                error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -132,8 +147,11 @@
 
 - (void)testOnboardingPayloadParser_NFC_WrongType
 {
-    NSError *error;
-    CHIPSetupPayload * payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3" ofType:CHIPOnboardingPayloadTypeManualCode error:&error];
+    NSError * error;
+    CHIPSetupPayload * payload =
+        [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:@"CH:R5L90UV200A3L90A33P0GQ670.QT52B.E23O6DE044U1077U.3"
+                                                               ofType:CHIPOnboardingPayloadTypeManualCode
+                                                                error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, CHIPErrorCodeIntegrityCheckFailed);


### PR DESCRIPTION
Exposes an API in CHIPFramework which allows onboarding payload string to be passed in instead of discriminator/setupPINCode.

This API parses the onboarding payload string into a CHIPSetupPayload and then calls the pairing API.