### PR TITLE
Reland "Fix CheckExchangeMessages crashes when malicious packet is sent"

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -316,6 +316,14 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         // AND The message was received from the peer node associated with the exchange
         && (mSecureSession == session)
 
+        // AND The message must come with a source Node ID.
+        && (packetHeader.GetSourceNodeId().HasValue())
+
+        // AND The message's source Node ID matches the peer Node ID associated with the exchange, or the peer Node ID of the
+        // exchange is 'any'.
+        && ((mSecureSession.GetPeerNodeId() == kAnyNodeId) ||
+            (mSecureSession.GetPeerNodeId() == packetHeader.GetSourceNodeId().Value()))
+
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast
         //    case, the initiator is ill defined)

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -316,13 +316,10 @@ bool ExchangeContext::MatchExchange(SecureSessionHandle session, const PacketHea
         // AND The message was received from the peer node associated with the exchange
         && (mSecureSession == session)
 
-        // AND The message must come with a source Node ID.
-        && (packetHeader.GetSourceNodeId().HasValue())
-
         // AND The message's source Node ID matches the peer Node ID associated with the exchange, or the peer Node ID of the
         // exchange is 'any'.
         && ((mSecureSession.GetPeerNodeId() == kAnyNodeId) ||
-            (mSecureSession.GetPeerNodeId() == packetHeader.GetSourceNodeId().Value()))
+            (packetHeader.GetSourceNodeId().HasValue() && mSecureSession.GetPeerNodeId() == packetHeader.GetSourceNodeId().Value()))
 
         // AND The message was sent by an initiator and the exchange context is a responder (IsInitiator==false)
         //    OR The message was sent by a responder and the exchange context is an initiator (IsInitiator==true) (for the broadcast

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -153,9 +153,9 @@ void CheckExchangeMessages(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // send a malicious packet
-    // TODO: https://github.com/project-chip/connectedhomeip/issues/4635
-    // ec1->SendMessage(0x0001, 0x0002, System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
-    //                 SendFlags(Messaging::SendMessageFlags::kNone));
+    ec1->SendMessage(Protocols::Id(VendorId::Common, 0x0001), 0x0002,
+                     System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize),
+                     SendFlags(Messaging::SendMessageFlags::kNoAutoRequestAck));
     NL_TEST_ASSERT(inSuite, !mockUnsolicitedAppDelegate.IsOnMessageReceivedCalled);
 
     // send a good packet


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
This is reland of https://github.com/project-chip/connectedhomeip/pull/6120 which was reverted because of regression in PASE.

The root cause of the regression is PASE is moved from transport layer to exchange, and packets exchanged during PASE do not have Source Node ID, so the following check in MatchExchange is no more valid.  

  // AND The message must come with a source Node ID.
  && (packetHeader.GetSourceNodeId().HasValue())

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Fix CheckExchangeMessages crashes when malicious packet is sent

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes ##4635

 #### Test
 I don't have ESP32, so I used python device controller and lighting example to verify this change. I expect the PASE logic is same cross different platforms.
 
 chip-device-ctrl > connect -ip 192.168.86.157 20202021 12344321
Device is assigned with nodeid = 12344321
CHIP:BLE: Assigned local session key ID 0
CHIP:BLE: Sent PBKDF param request
CHIP:BLE: Received PBKDF param response
CHIP:BLE: Sent spake2p msg1
CHIP:BLE: Received spake2p msg2
CHIP:BLE: Peer assigned session key ID 0
CHIP:BLE: Sent spake2p msg3
CHIP:IN: New pairing for device 0x0000000000bc5c01, key 0!!
CHIP:CTL: Remote device completed SPAKE2+ handshake

CHIP:CTL: AsyncSetKeyValue: PairedDevicebc5c01=EAABEbyplB3xp6cuEWz2SFVrAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAFcvAAAAAAAMTkyLjE2OC44Ni4xNTcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkrAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA
CHIP:CTL: AsyncSetKeyValue: ListPairedDevices0=AVy8AAAAAAA=
CHIP:CTL: AsyncSetKeyValue: StartKeyID=1
Secure Session to Device Established
Device temporary node id (**this does not match spec**): 12344321
chip-device-ctrl >

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
