### PR TITLE
add IM event generation

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -20,6 +20,20 @@ declare_args() {
   # Enable strict schema checks.
   chip_enable_schema_check =
       is_debug && (current_os == "linux" || current_os == "mac")
+
+  # Mutex implementation: posix, freertos, zephyr.
+  chip_im_config_critical_section = ""
+}
+
+# TODO: Add locker support for different platform
+if (chip_im_config_critical_section == "") {
+  if (current_os == "freertos") {
+    chip_im_config_critical_section = "rtos"
+  } else if (current_os == "zephyr") {
+    chip_im_config_critical_section = "zephyr"
+  } else {
+    chip_im_config_critical_section = "posix"
+  }
 }
 
 config("app_config") {
@@ -38,6 +52,7 @@ static_library("app") {
     "Command.h",
     "CommandHandler.cpp",
     "CommandSender.cpp",
+    "EventManagement.cpp",
     "InteractionModelEngine.cpp",
     "MessageDef/AttributeDataElement.cpp",
     "MessageDef/AttributeDataElement.h",
@@ -94,6 +109,16 @@ static_library("app") {
     "reporting/Engine.cpp",
     "reporting/Engine.h",
   ]
+
+  if (chip_im_config_critical_section == "posix") {
+    sources += [ "CriticalSectionImplPosix.cpp" ]
+  } else if (chip_im_config_critical_section == "rtos") {
+    sources += [ "CriticalSectionImplRtos.cpp" ]
+  } else if (chip_im_config_critical_section == "zephyr") {
+    sources += [ "CriticalSectionImplZephyr.cpp" ]
+  } else {
+    assert(false, "Unknown IM critical section implementation.")
+  }
 
   public_deps = [
     "${chip_root}/src/lib/support",

--- a/src/app/CriticalSection.h
+++ b/src/app/CriticalSection.h
@@ -1,0 +1,28 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace app {
+void CriticalSectionEnter();
+
+void CriticalSectionExit();
+
+} // namespace app
+} // namespace chip

--- a/src/app/CriticalSectionImplPosix.cpp
+++ b/src/app/CriticalSectionImplPosix.cpp
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <cassert>
+#include <pthread.h>
+
+namespace chip {
+namespace app {
+
+static pthread_mutex_t eventLocker = PTHREAD_MUTEX_INITIALIZER;
+
+void CriticalSectionEnter()
+{
+    int err = pthread_mutex_lock(&eventLocker);
+    assert(err == 0);
+}
+
+void CriticalSectionExit()
+{
+    int err = pthread_mutex_unlock(&eventLocker);
+    assert(err == 0);
+}
+} // namespace app
+} // namespace chip

--- a/src/app/CriticalSectionImplRtos.cpp
+++ b/src/app/CriticalSectionImplRtos.cpp
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CriticalSection.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+namespace chip {
+namespace app {
+void CriticalSectionEnter()
+{
+    // TODO: Add freertos lock, it seems in EFR32, it needs portENTER_CRITICAL, in ESP32, it needs portENTER_CRITICAL(mux)
+    // taskENTER_CRITICAL();
+}
+
+void CriticalSectionExit()
+{
+    // taskEXIT_CRITICAL();
+}
+} // namespace app
+} // namespace chip

--- a/src/app/CriticalSectionImplZephyr.cpp
+++ b/src/app/CriticalSectionImplZephyr.cpp
@@ -1,0 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+namespace chip {
+namespace app {
+void CriticalSectionEnter() {}
+
+void CriticalSectionExit() {}
+} // namespace app
+} // namespace chip

--- a/src/app/EventLoggingDelegate.h
+++ b/src/app/EventLoggingDelegate.h
@@ -1,0 +1,72 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the classes corresponding to CHIP Interaction Model Event Generatorr Delegate.
+ *
+ */
+
+#pragma once
+
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <messaging/ExchangeContext.h>
+#include <system/SystemPacketBuffer.h>
+
+namespace chip {
+namespace app {
+/**
+ * An EventLoggingDelegate is used to fill event log data with cluster-specific information.
+ *
+ * Allows application to append any type of TLV data as part of an event log entry. Events
+ * have a standard header applicable to all events and this class provides the
+ * ability to add additional data past such standard header.
+ */
+class EventLoggingDelegate
+{
+public:
+    virtual ~EventLoggingDelegate() {}
+
+    /**
+     *  @brief
+     *    A function that supplies eventData element for the event logging subsystem.
+     *
+     *  Functions of this type are expected to provide the eventData
+     *  element for the event logging subsystem. The functions of this
+     *  type are called after the event subsystem has generated all
+     *  required event metadata. The function is called with a
+     *  chip::TLV::TLVWriter object into which it will emit a single TLV element
+     *  tagged kTag_EventData; the value of that element MUST be a
+     *  structure containing the event data. The event data itself must
+     *  be structured using context tags.
+     *
+     *
+     *  @param[inout] aWriter A reference to the chip::TLV::TLVWriter object to be
+     *                         used for event data serialization.
+     *
+     *  @retval #CHIP_NO_ERROR  On success.
+     *
+     *  @retval other           An appropriate error signaling to the
+     *                          caller that the serialization of event
+     *                          data could not be completed.
+     *
+     */
+    virtual CHIP_ERROR WriteEvent(chip::TLV::TLVWriter & aWriter) = 0;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -1,0 +1,177 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/util/basic-types.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <system/SystemPacketBuffer.h>
+
+constexpr size_t kNumPriorityLevel = 3;
+namespace chip {
+namespace app {
+
+/**
+ * @brief
+ *   The Priority of the log entry.
+ *
+ * @details
+ * Priority is used as a way to filter events before they are
+ * actually emitted into the log. After the event is in the log, we
+ * make no further provisions to expunge it from the log.
+ * The priority level serves to prioritize event storage. If an
+ * event of high priority is added to a full buffer, events are
+ * dropped in order of priority (and age) to accommodate it. As such,
+ * priority levels only have relative value. If a system is
+ * using only one priority level, events are dropped only in order
+ * of age, like a ring buffer.
+ */
+
+enum class PriorityLevel : uint8_t
+{
+
+    First = 0,
+    /**
+     *  Debug priority denotes log entries of interest to the
+     *  developers of the system and is used primarily in the
+     *  development phase. Debug priority logs are
+     *  not accounted for in the bandwidth or power budgets of the
+     *  constrained devices; as a result, they must be used only over
+     *  a limited time span in production systems.
+     */
+
+    Debug = First,
+    /**
+     * Info priority denotes log entries that provide extra insight
+     * and diagnostics into the running system. Info logging level may
+     * be used over an extended period of time in a production system,
+     * or may be used as the default log level in a field trial. On
+     * the constrained devices, the entries logged with Info level must
+     * be accounted for in the bandwidth and memory budget, but not in
+     * the power budget.
+     */
+    Info = 1,
+
+    /**
+     * Critical priority denotes events whose loss would
+     * directly impact customer-facing features. Applications may use
+     * loss of Production Critical events to indicate system failure.
+     * On constrained devices, entries logged with Critical
+     * priority must be accounted for in the power and memory budget,
+     * as it is expected that they are always logged and offloaded
+     * from the device.
+     */
+    Critical = 2,
+    Last     = Critical,
+    Invalid  = Last + 1,
+
+};
+
+/**
+ * @brief
+ *   The structure that provides a full resolution of the cluster.
+ */
+struct EventSchema
+{
+    EventSchema(NodeId aNodeId, EndpointId aEndpointId, ClusterId aClusterId, EventId aEventId, PriorityLevel aPriority) :
+        mNodeId(aNodeId), mEndpointId(aEndpointId), mClusterId(aClusterId), mEventId(aEventId), mPriority(aPriority)
+    {}
+    NodeId mNodeId          = 0;
+    EndpointId mEndpointId  = 0;
+    ClusterId mClusterId    = 0;
+    EventId mEventId        = 0;
+    PriorityLevel mPriority = PriorityLevel::Invalid;
+};
+
+/**
+ * @brief
+ *   The struct that provides an application set system or UTC timestamp.
+ */
+struct Timestamp
+{
+    enum class Type
+    {
+        kInvalid = 0,
+        kSystem,
+        kUTC
+    };
+    Timestamp() {}
+    Timestamp(Type aType) : mType(aType) { mValue = 0; }
+    Timestamp(Type aType, uint64_t aValue) : mType(aType), mValue(aValue) {}
+    static Timestamp UTC(uint64_t aValue)
+    {
+        Timestamp timestamp(Type::kUTC, aValue);
+        return timestamp;
+    }
+    static Timestamp System(uint64_t aValue)
+    {
+        Timestamp timestamp(Type::kSystem, aValue);
+        return timestamp;
+    }
+
+    Type mType      = Type::kInvalid;
+    uint64_t mValue = 0;
+};
+
+/**
+ *   The structure that provides options for the different event fields.
+ */
+class EventOptions
+{
+public:
+    enum class Type
+    {
+        kUrgent = 0,
+        kNotUrgent,
+    };
+    EventOptions(void) : mTimestamp(Timestamp::Type::kInvalid), mpEventSchema(nullptr), mUrgent(Type::kNotUrgent) {}
+
+    EventOptions(Type aType) : mTimestamp(Timestamp::Type::kInvalid), mpEventSchema(nullptr), mUrgent(aType) {}
+
+    EventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp), mpEventSchema(nullptr), mUrgent(Type::kNotUrgent) {}
+
+    EventOptions(Timestamp aTimestamp, Type aUrgent) : mTimestamp(aTimestamp), mpEventSchema(nullptr), mUrgent(aUrgent) {}
+    Timestamp mTimestamp;
+
+    EventSchema * mpEventSchema = nullptr; /**< A pointer to the schema of the cluster instance.*/
+
+    Type mUrgent = Type::kNotUrgent; /**< A flag denoting that the event is time sensitive.  When set, it causes the event log to be
+                                        flushed. */
+};
+
+/**
+ * @brief
+ *   Structure for copying event lists on output.
+ */
+struct EventLoadOutContext
+{
+    EventLoadOutContext(TLV::TLVWriter & aWriter, PriorityLevel aPriority, EventNumber aStartingEventNumber) :
+        mWriter(aWriter), mPriority(aPriority), mStartingEventNumber(aStartingEventNumber),
+        mCurrentSystemTime(Timestamp::Type::kSystem), mCurrentEventNumber(0), mCurrentUTCTime(Timestamp::Type::kUTC), mFirst(true)
+    {}
+
+    TLV::TLVWriter & mWriter;
+    PriorityLevel mPriority          = PriorityLevel::Invalid;
+    EventNumber mStartingEventNumber = 0;
+    Timestamp mCurrentSystemTime;
+    EventNumber mCurrentEventNumber = 0;
+    Timestamp mCurrentUTCTime;
+    bool mFirst = true;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -1,0 +1,860 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/CriticalSection.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPEventLoggingConfig.h>
+#include <core/CHIPTLVUtilities.hpp>
+#include <inttypes.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <support/logging/CHIPLogging.h>
+#include <system/SystemTimer.h>
+
+using namespace chip::TLV;
+
+namespace chip {
+namespace app {
+static EventManagement sInstance;
+
+/**
+ * @brief
+ *   A TLVReader backed by CircularEventBuffer
+ */
+class CircularEventReader : public TLV::TLVReader
+{
+public:
+    /**
+     * @brief
+     *   Initializes a TLVReader object backed by CircularEventBuffer
+     *
+     * Reading begins in the CircularTLVBuffer belonging to this
+     * CircularEventBuffer.  When the reader runs out of data, it begins
+     * to read from the previous CircularEventBuffer.
+     *
+     * @param[in] apBuf A pointer to a fully initialized CircularEventBuffer
+     *
+     */
+    void Init(CircularEventBufferWrapper * apBuf);
+
+    virtual ~CircularEventReader() = default;
+};
+
+EventManagement & EventManagement::GetInstance(void)
+{
+    return sInstance;
+}
+
+struct ReclaimEventCtx
+{
+    CircularEventBuffer * mpEventBuffer = nullptr;
+    size_t mSpaceNeededForMovedEvent    = 0;
+};
+
+/**
+ * @brief
+ *  Internal structure for traversing event list.
+ */
+struct CopyAndAdjustDeltaTimeContext
+{
+    CopyAndAdjustDeltaTimeContext(TLVWriter * aWriter, EventLoadOutContext * inContext) : mpWriter(aWriter), mpContext(inContext) {}
+
+    TLV::TLVWriter * mpWriter       = nullptr;
+    EventLoadOutContext * mpContext = nullptr;
+};
+
+/**
+ * @brief
+ *  Internal structure for traversing events.
+ */
+struct EventEnvelopeContext
+{
+    EventEnvelopeContext() {}
+
+    uint16_t mFieldsToRead = 0;
+    /* PriorityLevel and DeltaSystemTimestamp are there if that is not first event when putting events in report*/
+    Timestamp mDeltaSystemTime = Timestamp::System(0);
+    Timestamp mDeltaUtc        = Timestamp::UTC(0);
+    PriorityLevel mPriority    = PriorityLevel::First;
+};
+
+EventManagement::EventManagement(Messaging::ExchangeManager * apExchangeMgr, int aNumBuffers,
+                                 CircularEventBuffer * apCircularEventBuffer,
+                                 const LogStorageResources * const apLogStorageResources)
+{
+    Init(apExchangeMgr, aNumBuffers, apCircularEventBuffer, apLogStorageResources);
+}
+
+void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, int aNumBuffers,
+                           CircularEventBuffer * apCircularEventBuffer, const LogStorageResources * const apLogStorageResources)
+{
+    CircularEventBuffer * current = nullptr;
+    CircularEventBuffer * prev    = nullptr;
+    CircularEventBuffer * next    = nullptr;
+
+    VerifyOrDie(aNumBuffers > 0);
+
+    mpExchangeMgr = apExchangeManager;
+
+    for (int bufferIndex = 0; bufferIndex < aNumBuffers; bufferIndex++)
+    {
+        next = (bufferIndex < aNumBuffers - 1) ? &apCircularEventBuffer[bufferIndex + 1] : nullptr;
+
+        current = &apCircularEventBuffer[bufferIndex];
+        current->Init(apLogStorageResources[bufferIndex].mpBuffer, apLogStorageResources[bufferIndex].mBufferSize, prev, next,
+                      apLogStorageResources[bufferIndex].mPriority);
+
+        prev = current;
+
+        current->mProcessEvictedElement = AlwaysFail;
+        current->mAppData               = nullptr;
+        current->InitCounter(apLogStorageResources[bufferIndex].InitializeCounter());
+    }
+
+    mpEventBuffer = apCircularEventBuffer;
+    mState        = EventManagementStates::Idle;
+    mBytesWritten = 0;
+}
+
+CHIP_ERROR EventManagement::CopyToNextBuffer(CircularEventBuffer * apEventBuffer)
+{
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    CHIP_ERROR err                   = CHIP_NO_ERROR;
+    CircularEventBuffer * nextBuffer = apEventBuffer->GetNextCircularEventBuffer();
+    if (nextBuffer == nullptr)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    CircularEventBuffer backup = *nextBuffer;
+
+    // Set up the next buffer s.t. it fails if needs to evict an element
+    nextBuffer->mProcessEvictedElement = AlwaysFail;
+
+    writer.Init(*nextBuffer);
+
+    // Set up the reader s.t. it is positioned to read the head event
+    reader.Init(*apEventBuffer);
+
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = writer.CopyElement(reader);
+    SuccessOrExit(err);
+
+    err = writer.Finalize();
+    SuccessOrExit(err);
+
+    ChipLogProgress(EventLogging, "Copy Event to next buffer with priority %d", nextBuffer->GetPriorityLevel());
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        *nextBuffer = backup;
+    }
+    return err;
+}
+
+CHIP_ERROR EventManagement::EnsureSpaceInCircularBuffer(size_t aRequiredSpace)
+{
+    CHIP_ERROR err                    = CHIP_NO_ERROR;
+    size_t requiredSpace              = aRequiredSpace;
+    CircularEventBuffer * eventBuffer = mpEventBuffer;
+    ReclaimEventCtx ctx;
+
+    // check whether we actually need to do anything, exit if we don't
+    VerifyOrExit(requiredSpace > eventBuffer->AvailableDataLength(), err = CHIP_NO_ERROR);
+
+    while (true)
+    {
+        // check that the request can ultimately be satisfied.
+        VerifyOrExit(requiredSpace <= eventBuffer->GetTotalDataLength(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+
+        if (requiredSpace > eventBuffer->AvailableDataLength())
+        {
+            ctx.mpEventBuffer             = eventBuffer;
+            ctx.mSpaceNeededForMovedEvent = 0;
+
+            eventBuffer->mProcessEvictedElement = EvictEvent;
+            eventBuffer->mAppData               = &ctx;
+            err                                 = eventBuffer->EvictHead();
+
+            // one of two things happened: either the element was evicted immediately if the head's priority is same as current
+            // buffer(final one), or we figured out how much space we need to evict it into the next buffer, the check happens in
+            // EvictEvent function
+
+            if (err != CHIP_NO_ERROR)
+            {
+                VerifyOrExit(ctx.mSpaceNeededForMovedEvent != 0, /* no-op, return err */);
+                VerifyOrExit(eventBuffer->GetNextCircularEventBuffer() != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+                if (ctx.mSpaceNeededForMovedEvent <= eventBuffer->GetNextCircularEventBuffer()->AvailableDataLength())
+                {
+                    // we can copy the event outright.  copy event and
+                    // subsequently evict head s.t. evicting the head
+                    // element always succeeds.
+                    // Since we're calling CopyElement and we've checked
+                    // that there is space in the next buffer, we don't expect
+                    // this to fail.
+                    err = CopyToNextBuffer(eventBuffer);
+                    SuccessOrExit(err);
+                    // success; evict head unconditionally
+                    eventBuffer->mProcessEvictedElement = nullptr;
+                    err                                 = eventBuffer->EvictHead();
+                    // if unconditional eviction failed, this
+                    // means that we have no way of further
+                    // clearing the buffer.  fail out and let the
+                    // caller know that we could not honor the
+                    // request
+                    SuccessOrExit(err);
+                    continue;
+                }
+                // we cannot copy event outright. We remember the
+                // current required space in mRequiredSpaceForEvicted, we note the
+                // space requirements for the event in the current
+                // buffer and make that space in the next buffer.
+                eventBuffer->SetRequiredSpaceforEvicted(requiredSpace);
+                eventBuffer = eventBuffer->GetNextCircularEventBuffer();
+
+                // Sanity check: return error  here on null event buffer.  If
+                // eventBuffer->mpNext were null, then the `EvictBuffer`
+                // would have succeeded -- the event was
+                // already in the final buffer.
+                VerifyOrExit(eventBuffer != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+                requiredSpace = ctx.mSpaceNeededForMovedEvent;
+            }
+        }
+        else
+        {
+            // this branch is only taken when we go back in the buffer chain since we have free/spare enough space in next buffer,
+            // and need to retry to copy event from current buffer to next buffer, and free space for current buffer
+            if (eventBuffer == mpEventBuffer)
+                break;
+            eventBuffer   = eventBuffer->GetPreviousCircularEventBuffer();
+            requiredSpace = eventBuffer->GetRequiredSpaceforEvicted();
+            err           = CHIP_NO_ERROR;
+        }
+    }
+
+    // On exit, configure the top-level s.t. it will always fail to evict an element
+    mpEventBuffer->mProcessEvictedElement = AlwaysFail;
+    mpEventBuffer->mAppData               = nullptr;
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR EventManagement::CalculateEventSize(EventLoggingDelegate * apDelegate, const EventOptions * apOptions,
+                                               uint32_t & requiredSize)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    System::PacketBufferTLVWriter writer;
+    EventLoadOutContext ctxt       = EventLoadOutContext(writer, apOptions->mpEventSchema->mPriority,
+                                                   GetPriorityBuffer(apOptions->mpEventSchema->mPriority)->GetLastEventNumber());
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(kMaxEventSizeReserve);
+    if (buf.IsNull())
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    writer.Init(std::move(buf));
+
+    ctxt.mCurrentEventNumber       = GetPriorityBuffer(apOptions->mpEventSchema->mPriority)->GetLastEventNumber();
+    ctxt.mCurrentSystemTime.mValue = GetPriorityBuffer(apOptions->mpEventSchema->mPriority)->GetLastEventSystemTimestamp();
+    err                            = ConstructEvent(&ctxt, apDelegate, apOptions);
+    if (CHIP_NO_ERROR == err)
+    {
+        requiredSize = writer.GetLengthWritten();
+    }
+    return err;
+}
+
+CHIP_ERROR EventManagement::ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate,
+                                           const EventOptions * apOptions)
+{
+
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    TLVWriter checkpoint = apContext->mWriter;
+    TLV::TLVType dataContainerType;
+    EventDataElement::Builder eventDataElementBuilder;
+    EventPath::Builder eventPathBuilder;
+    uint64_t deltatime = 0;
+
+    VerifyOrExit(apContext->mCurrentEventNumber >= apContext->mStartingEventNumber,
+                 /* no-op: don't write event, but advance current event Number */);
+
+    VerifyOrExit(apOptions != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(apOptions->mTimestamp.mType != Timestamp::Type::kInvalid, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    eventDataElementBuilder.Init(&(apContext->mWriter));
+    eventPathBuilder = eventDataElementBuilder.CreateEventPathBuilder();
+    err              = eventPathBuilder.GetError();
+    SuccessOrExit(err);
+
+    // TODO: Revisit NodeId since the the encoding spec and the IM seem to disagree on how this stuff works
+    eventPathBuilder.NodeId(apOptions->mpEventSchema->mNodeId)
+        .EndpointId(apOptions->mpEventSchema->mEndpointId)
+        .ClusterId(apOptions->mpEventSchema->mClusterId)
+        .EventId(apOptions->mpEventSchema->mEventId)
+        .EndOfEventPath();
+    err = eventPathBuilder.GetError();
+    SuccessOrExit(err);
+
+    eventDataElementBuilder.PriorityLevel(static_cast<uint8_t>(apContext->mPriority));
+
+    // TODO: need to add utc and systen system check here
+    deltatime = apOptions->mTimestamp.mValue - apContext->mCurrentSystemTime.mValue;
+    eventDataElementBuilder.DeltaSystemTimestamp(deltatime);
+    err = eventDataElementBuilder.GetError();
+    SuccessOrExit(err);
+
+    err = apContext->mWriter.StartContainer(ContextTag(EventDataElement::kCsTag_Data), TLV::kTLVType_Structure, dataContainerType);
+    SuccessOrExit(err);
+    // Callback to write the EventData
+    err = apDelegate->WriteEvent(apContext->mWriter);
+    SuccessOrExit(err);
+
+    err = apContext->mWriter.EndContainer(dataContainerType);
+    SuccessOrExit(err);
+
+    eventDataElementBuilder.EndOfEventDataElement();
+    SuccessOrExit(eventDataElementBuilder.GetError());
+
+    err = apContext->mWriter.Finalize();
+    SuccessOrExit(err);
+
+    apContext->mFirst = false;
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        apContext->mWriter = checkpoint;
+    }
+    else
+    {
+        // update these variables since ConstructEvent can be used to track the
+        // state of a set of events over multiple calls.
+        apContext->mCurrentEventNumber++;
+        if (apContext->mCurrentSystemTime.mType == Timestamp::Type::kSystem)
+        {
+            apContext->mCurrentSystemTime = apOptions->mTimestamp;
+        }
+    }
+    return err;
+}
+
+void EventManagement::CreateEventManagement(Messaging::ExchangeManager * apExchangeManager, int aNumBuffers,
+                                            CircularEventBuffer * apCircularEventBuffer,
+                                            const LogStorageResources * const apLogStorageResources)
+{
+
+    sInstance.Init(apExchangeManager, aNumBuffers, apCircularEventBuffer, apLogStorageResources);
+    static_assert(std::is_trivially_destructible<EventManagement>::value, "EventManagement must be trivially destructible");
+}
+
+/**
+ * @brief Perform any actions we need to on shutdown.
+ */
+void EventManagement::DestroyEventManagement()
+{
+    CriticalSectionEnter();
+    sInstance.mState        = EventManagementStates::Shutdown;
+    sInstance.mpEventBuffer = nullptr;
+    sInstance.mpExchangeMgr = nullptr;
+    CriticalSectionExit();
+}
+
+EventNumber CircularEventBuffer::VendEventNumber()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    // Assign event Number to the buffer's counter's value.
+    mLastEventNumber = static_cast<EventNumber>(mpEventNumberCounter->GetValue());
+
+    // Now advance the counter.
+    err = mpEventNumberCounter->Advance();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(EventLogging, "%s Advance() for priority %d failed with %d", __FUNCTION__, mPriority, err);
+    }
+
+    return mLastEventNumber;
+}
+
+EventNumber EventManagement::GetLastEventNumber(PriorityLevel aPriority)
+{
+    return GetPriorityBuffer(aPriority)->GetLastEventNumber();
+}
+
+EventNumber EventManagement::GetFirstEventNumber(PriorityLevel aPriority)
+{
+    return GetPriorityBuffer(aPriority)->GetFirstEventNumber();
+}
+
+CircularEventBuffer * EventManagement::GetPriorityBuffer(PriorityLevel aPriority) const
+{
+    CircularEventBuffer * buf = mpEventBuffer;
+    while (!buf->IsFinalDestinationForPriority(aPriority))
+    {
+        buf = buf->GetNextCircularEventBuffer();
+        assert(buf != nullptr);
+        // code guarantees that every PriorityLevel has a buffer destination.
+    }
+    return buf;
+}
+
+CHIP_ERROR EventManagement::CopyAndAdjustDeltaTime(const TLVReader & aReader, size_t aDepth, void * apContext)
+{
+    CHIP_ERROR err;
+    CopyAndAdjustDeltaTimeContext * ctx = static_cast<CopyAndAdjustDeltaTimeContext *>(apContext);
+    TLVReader reader(aReader);
+
+    // TODO: Add UTC timestamp support
+    if (aReader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_DeltaSystemTimestamp))
+    {
+        if (ctx->mpContext->mFirst) // First event gets a timestamp, subsequent ones get a delta T
+        {
+            err = ctx->mpWriter->Put(TLV::ContextTag(EventDataElement::kCsTag_SystemTimestamp),
+                                     ctx->mpContext->mCurrentSystemTime.mValue);
+        }
+        else
+        {
+            err = ctx->mpWriter->CopyElement(reader);
+        }
+    }
+    else
+    {
+        err = ctx->mpWriter->CopyElement(reader);
+    }
+
+    // First event in the sequence gets a event number neatly packaged
+    // right after the priority to keep tags ordered
+    if (aReader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_PriorityLevel))
+    {
+        if (ctx->mpContext->mFirst)
+        {
+            err = ctx->mpWriter->Put(TLV::ContextTag(EventDataElement::kCsTag_Number), ctx->mpContext->mCurrentEventNumber);
+        }
+    }
+
+    return err;
+}
+
+CHIP_ERROR EventManagement::LogEvent(EventLoggingDelegate * apDelegate, EventOptions & aEventOptions, EventNumber & aEventNumber)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CriticalSectionEnter();
+
+    VerifyOrExit(mState != EventManagementStates::Shutdown, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(aEventOptions.mpEventSchema != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = LogEventPrivate(apDelegate, aEventOptions, aEventNumber);
+
+exit:
+    CriticalSectionExit();
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, EventOptions & aEventOptions,
+                                            EventNumber & aEventNumber)
+{
+    CircularTLVWriter writer;
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    uint32_t requestSize           = 0;
+    aEventNumber                   = 0;
+    CircularEventBuffer checkpoint = *mpEventBuffer;
+    CircularEventBuffer * buffer   = nullptr;
+    EventLoadOutContext ctxt       = EventLoadOutContext(writer, aEventOptions.mpEventSchema->mPriority,
+                                                   GetPriorityBuffer(aEventOptions.mpEventSchema->mPriority)->GetLastEventNumber());
+    Timestamp timestamp(Timestamp::Type::kSystem, System::Timer::GetCurrentEpoch());
+    EventOptions opts = EventOptions(timestamp);
+    // Start the event container (anonymous structure) in the circular buffer
+    writer.Init(*mpEventBuffer);
+
+    // check whether the entry is to be logged or discarded silently
+    VerifyOrExit(aEventOptions.mpEventSchema->mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY, /* no-op */);
+
+    // Create all event specific data
+    // Timestamp; encoded as a delta time
+    if (aEventOptions.mTimestamp.mType == Timestamp::Type::kSystem)
+    {
+        opts.mTimestamp = aEventOptions.mTimestamp;
+    }
+
+    if (GetPriorityBuffer(aEventOptions.mpEventSchema->mPriority)->GetFirstEventSystemTimestamp() == 0)
+    {
+        GetPriorityBuffer(aEventOptions.mpEventSchema->mPriority)->UpdateFirstLastEventTime(opts.mTimestamp);
+    }
+
+    opts.mUrgent       = aEventOptions.mUrgent;
+    opts.mpEventSchema = aEventOptions.mpEventSchema;
+
+    ctxt.mCurrentEventNumber       = GetPriorityBuffer(opts.mpEventSchema->mPriority)->GetLastEventNumber();
+    ctxt.mCurrentSystemTime.mValue = GetPriorityBuffer(opts.mpEventSchema->mPriority)->GetLastEventSystemTimestamp();
+
+    err = CalculateEventSize(apDelegate, &opts, requestSize);
+    SuccessOrExit(err);
+
+    // Ensure we have space in the in-memory logging queues
+    err = EnsureSpaceInCircularBuffer(requestSize);
+    SuccessOrExit(err);
+
+    err = ConstructEvent(&ctxt, apDelegate, &opts);
+    SuccessOrExit(err);
+
+    // Check the number of bytes written.  If the event is too large
+    // to be evicted from subsequent buffers, drop it now.
+    buffer = mpEventBuffer;
+    while (true)
+    {
+        VerifyOrExit(buffer->GetTotalDataLength() >= writer.GetLengthWritten(), err = CHIP_ERROR_BUFFER_TOO_SMALL);
+        if (buffer->IsFinalDestinationForPriority(opts.mpEventSchema->mPriority))
+        {
+            break;
+        }
+        else
+        {
+            buffer = buffer->GetNextCircularEventBuffer();
+            assert(buffer != nullptr);
+            // code guarantees that every PriorityLevel has a buffer destination.
+        }
+    }
+
+    mBytesWritten += writer.GetLengthWritten();
+
+exit:
+    ChipLogFunctError(err);
+    if (err != CHIP_NO_ERROR)
+    {
+        *mpEventBuffer = checkpoint;
+    }
+    else if (opts.mpEventSchema->mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY)
+    {
+        CircularEventBuffer * currentBuffer = GetPriorityBuffer(opts.mpEventSchema->mPriority);
+        aEventNumber                        = currentBuffer->VendEventNumber();
+        currentBuffer->UpdateFirstLastEventTime(opts.mTimestamp);
+
+#if CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
+        ChipLogDetail(EventLogging,
+                      "LogEvent event number: %u schema priority: %u cluster id: 0x%x event id: 0x%x sys timestamp: 0x%" PRIx64,
+                      aEventNumber, opts.mpEventSchema->mPriority, opts.mpEventSchema->mClusterId, opts.mpEventSchema->mEventId,
+                      opts.mTimestamp.mValue);
+#endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
+
+        ScheduleFlushIfNeeded(opts.mUrgent);
+    }
+
+    return err;
+}
+
+CHIP_ERROR EventManagement::CopyEvent(const TLVReader & aReader, TLVWriter & aWriter, EventLoadOutContext * apContext)
+{
+    TLVReader reader;
+    TLVType containerType;
+    CopyAndAdjustDeltaTimeContext context(&aWriter, apContext);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    reader.Init(aReader);
+    err = reader.EnterContainer(containerType);
+    SuccessOrExit(err);
+
+    err = aWriter.StartContainer(AnonymousTag, kTLVType_Structure, containerType);
+    SuccessOrExit(err);
+
+    err = TLV::Utilities::Iterate(reader, CopyAndAdjustDeltaTime, &context, false /*recurse*/);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    SuccessOrExit(err);
+
+    err = aWriter.EndContainer(containerType);
+    SuccessOrExit(err);
+
+    err = aWriter.Finalize();
+    SuccessOrExit(err);
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+
+CHIP_ERROR EventManagement::EventIterator(const TLVReader & aReader, size_t aDepth, EventLoadOutContext * apEventLoadOutContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLVReader innerReader;
+    TLVType tlvType;
+    EventEnvelopeContext event;
+
+    innerReader.Init(aReader);
+    err = innerReader.EnterContainer(tlvType);
+    SuccessOrExit(err);
+
+    err = TLV::Utilities::Iterate(innerReader, FetchEventParameters, &event, false /*recurse*/);
+    VerifyOrExit(event.mFieldsToRead == kRequiredEventField, err = CHIP_NO_ERROR);
+
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    SuccessOrExit(err);
+
+    if (event.mPriority == apEventLoadOutContext->mPriority)
+    {
+        apEventLoadOutContext->mCurrentSystemTime.mValue += event.mDeltaSystemTime.mValue;
+        VerifyOrExit(apEventLoadOutContext->mCurrentEventNumber < apEventLoadOutContext->mStartingEventNumber,
+                     err = CHIP_EVENT_ID_FOUND);
+        apEventLoadOutContext->mCurrentEventNumber++;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR EventManagement::CopyEventsSince(const TLVReader & aReader, size_t aDepth, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVWriter checkpoint;
+    EventLoadOutContext * loadOutContext = static_cast<EventLoadOutContext *>(apContext);
+    err                                  = EventIterator(aReader, aDepth, loadOutContext);
+    if (err == CHIP_EVENT_ID_FOUND)
+    {
+        // checkpoint the writer
+        checkpoint = loadOutContext->mWriter;
+
+        err = CopyEvent(aReader, loadOutContext->mWriter, loadOutContext);
+
+        // CHIP_NO_ERROR and CHIP_END_OF_TLV signify a
+        // successful copy.  In all other cases, roll back the
+        // writer state back to the checkpoint, i.e., the state
+        // before we began the copy operation.
+        VerifyOrExit((err == CHIP_NO_ERROR) || (err == CHIP_END_OF_TLV), loadOutContext->mWriter = checkpoint);
+
+        loadOutContext->mCurrentSystemTime.mValue = 0;
+        loadOutContext->mFirst                    = false;
+        loadOutContext->mCurrentEventNumber++;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR EventManagement::FetchEventsSince(TLVWriter & aWriter, PriorityLevel aPriority, EventNumber & aEventNumber)
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    const bool recurse = false;
+    TLVReader reader;
+    CircularEventBufferWrapper bufWrapper;
+    EventLoadOutContext context(aWriter, aPriority, aEventNumber);
+
+    CircularEventBuffer * buf = mpEventBuffer;
+    CriticalSectionEnter();
+
+    while (!buf->IsFinalDestinationForPriority(aPriority))
+    {
+        buf = buf->GetNextCircularEventBuffer();
+    }
+
+    context.mCurrentSystemTime.mValue = buf->GetFirstEventSystemTimestamp();
+    context.mCurrentEventNumber       = buf->GetFirstEventNumber();
+    err                               = GetEventReader(reader, aPriority, &bufWrapper);
+    SuccessOrExit(err);
+
+    err = TLV::Utilities::Iterate(reader, CopyEventsSince, &context, recurse);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+
+exit:
+    aEventNumber = context.mCurrentEventNumber;
+    CriticalSectionExit();
+
+    return err;
+}
+
+CHIP_ERROR EventManagement::GetEventReader(TLVReader & aReader, PriorityLevel aPriority, CircularEventBufferWrapper * apBufWrapper)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    CircularEventReader reader;
+    CircularEventBuffer * buffer = GetPriorityBuffer(aPriority);
+    VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
+    apBufWrapper->mpCurrent = buffer;
+    reader.Init(apBufWrapper);
+    aReader.Init(reader);
+exit:
+    return err;
+}
+
+CHIP_ERROR EventManagement::FetchEventParameters(const TLVReader & aReader, size_t aDepth, void * apContext)
+{
+    CHIP_ERROR err                  = CHIP_NO_ERROR;
+    EventEnvelopeContext * envelope = static_cast<EventEnvelopeContext *>(apContext);
+    TLVReader reader;
+    uint16_t extPriority; // Note: the type here matches the type case in EventManagement::LogEvent, priority section
+    reader.Init(aReader);
+
+    if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_PriorityLevel))
+    {
+        err = reader.Get(extPriority);
+        SuccessOrExit(err);
+        envelope->mPriority = static_cast<PriorityLevel>(extPriority);
+        envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_PriorityLevel;
+    }
+
+    if (reader.GetTag() == TLV::ContextTag(EventDataElement::kCsTag_DeltaSystemTimestamp))
+    {
+        err = reader.Get(envelope->mDeltaSystemTime.mValue);
+        SuccessOrExit(err);
+
+        envelope->mFieldsToRead |= 1 << EventDataElement::kCsTag_DeltaSystemTimestamp;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR EventManagement::EvictEvent(CHIPCircularTLVBuffer & apBuffer, void * apAppData, TLVReader & aReader)
+{
+    ReclaimEventCtx * ctx             = static_cast<ReclaimEventCtx *>(apAppData);
+    CircularEventBuffer * eventBuffer = ctx->mpEventBuffer;
+    TLVType containerType;
+    EventEnvelopeContext context;
+    const bool recurse = false;
+    CHIP_ERROR err;
+    PriorityLevel imp = PriorityLevel::Invalid;
+
+    // pull out the delta time, pull out the priority
+    err = aReader.Next();
+    SuccessOrExit(err);
+
+    err = aReader.EnterContainer(containerType);
+    SuccessOrExit(err);
+
+    err = TLV::Utilities::Iterate(aReader, FetchEventParameters, &context, recurse);
+    if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    SuccessOrExit(err);
+
+    err = aReader.ExitContainer(containerType);
+
+    SuccessOrExit(err);
+
+    imp = static_cast<PriorityLevel>(context.mPriority);
+
+    if (eventBuffer->IsFinalDestinationForPriority(imp))
+    {
+        // event is getting dropped.  Increase the event number and first timestamp.
+        EventNumber numEventsToDrop = 1;
+        eventBuffer->RemoveEvent(numEventsToDrop);
+        eventBuffer->SetFirstEventSystemTimestamp(eventBuffer->GetFirstEventSystemTimestamp() + context.mDeltaSystemTime.mValue);
+        ChipLogProgress(EventLogging,
+                        "Dropped events from buffer with priority %d due to overflow: { event priority_level: %d, count: %d };",
+                        eventBuffer->GetPriorityLevel(), imp, numEventsToDrop);
+        ctx->mSpaceNeededForMovedEvent = 0;
+    }
+    else
+    {
+        // event is not getting dropped. Note how much space it requires, and return.
+        ctx->mSpaceNeededForMovedEvent = aReader.GetLengthRead();
+        err                            = CHIP_END_OF_TLV;
+    }
+
+exit:
+    return err;
+}
+
+CHIP_ERROR EventManagement::ScheduleFlushIfNeeded(EventOptions::Type aUrgent)
+{
+    // TODO: Implement ScheduleFlushIfNeeded
+    return CHIP_NO_ERROR;
+}
+
+void CircularEventBuffer::Init(uint8_t * apBuffer, uint32_t aBufferLength, CircularEventBuffer * apPrev,
+                               CircularEventBuffer * apNext, PriorityLevel aPriorityLevel)
+{
+    CHIPCircularTLVBuffer::Init(apBuffer, aBufferLength);
+    mpPrev                     = apPrev;
+    mpNext                     = apNext;
+    mPriority                  = aPriorityLevel;
+    mFirstEventNumber          = 1;
+    mLastEventNumber           = 0;
+    mFirstEventSystemTimestamp = Timestamp::System(0);
+    mLastEventSystemTimestamp  = Timestamp::System(0);
+    mpEventNumberCounter       = nullptr;
+}
+
+bool CircularEventBuffer::IsFinalDestinationForPriority(PriorityLevel aPriority) const
+{
+    return !((mpNext != nullptr) && (mpNext->mPriority <= aPriority));
+}
+
+void CircularEventBuffer::UpdateFirstLastEventTime(Timestamp aEventTimestamp)
+{
+    if (mFirstEventSystemTimestamp.mValue == 0)
+    {
+        mFirstEventSystemTimestamp = aEventTimestamp;
+        mLastEventSystemTimestamp  = aEventTimestamp;
+    }
+    mLastEventSystemTimestamp = aEventTimestamp;
+}
+
+void CircularEventBuffer::RemoveEvent(EventNumber aNumEvents)
+{
+    mFirstEventNumber = mFirstEventNumber + aNumEvents;
+}
+
+void CircularEventReader::Init(CircularEventBufferWrapper * apBufWrapper)
+{
+    CircularEventBuffer * prev;
+
+    if (apBufWrapper->mpCurrent == nullptr)
+        return;
+
+    TLVReader::Init(*apBufWrapper, apBufWrapper->mpCurrent->DataLength());
+    mMaxLen = apBufWrapper->mpCurrent->DataLength();
+    for (prev = apBufWrapper->mpCurrent->GetPreviousCircularEventBuffer(); prev != nullptr;
+         prev = prev->GetPreviousCircularEventBuffer())
+    {
+        CircularEventBufferWrapper bufWrapper;
+        bufWrapper.mpCurrent = prev;
+        mMaxLen += prev->DataLength();
+    }
+}
+
+CHIP_ERROR CircularEventBufferWrapper::GetNextBuffer(TLVReader & aReader, const uint8_t *& aBufStart, uint32_t & aBufLen)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    mpCurrent->GetNextBuffer(aReader, aBufStart, aBufLen);
+    SuccessOrExit(err);
+
+    if ((aBufLen == 0) && (mpCurrent->GetPreviousCircularEventBuffer() != nullptr))
+    {
+        mpCurrent = mpCurrent->GetPreviousCircularEventBuffer();
+        aBufStart = nullptr;
+        err       = GetNextBuffer(aReader, aBufStart, aBufLen);
+    }
+
+exit:
+    ChipLogFunctError(err);
+    return err;
+}
+} // namespace app
+} // namespace chip

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -1,0 +1,562 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * @brief
+ *   Management of the CHIP Event Logging.
+ *
+ */
+#pragma once
+
+#include "EventLoggingDelegate.h"
+#include "EventLoggingTypes.h"
+#include <app/MessageDef/EventDataElement.h>
+#include <app/util/basic-types.h>
+#include <core/CHIPCircularTLVBuffer.h>
+#include <messaging/ExchangeMgr.h>
+#include <support/PersistedCounter.h>
+
+#define CHIP_CONFIG_EVENT_GLOBAL_PRIORITY PriorityLevel::Debug
+
+namespace chip {
+namespace app {
+constexpr size_t kMaxEventSizeReserve = 512;
+constexpr uint16_t kRequiredEventField =
+    (1 << EventDataElement::kCsTag_PriorityLevel) | (1 << EventDataElement::kCsTag_DeltaSystemTimestamp);
+
+/**
+ * @brief
+ *   Internal event buffer, built around the TLV::CHIPCircularTLVBuffer
+ */
+
+class CircularEventBuffer : public TLV::CHIPCircularTLVBuffer
+{
+public:
+    /**
+     * @brief
+     *   A constructor for the CircularEventBuffer (internal API).
+     */
+    CircularEventBuffer() : CHIPCircularTLVBuffer(nullptr, 0){};
+
+    /**
+     * @brief
+     *   A Init for the CircularEventBuffer (internal API).
+     *
+     * @param[in] apBuffer       The actual storage to use for event storage.
+     *
+     * @param[in] aBufferLength The length of the \c apBuffer in bytes.
+     *
+     * @param[in] apPrev         The pointer to CircularEventBuffer storing
+     *                           events of lesser priority.
+     *
+     * @param[in] apNext         The pointer to CircularEventBuffer storing
+     *                           events of greater priority.
+     *
+     * @param[in] apNext         CircularEventBuffer prioty level
+     */
+    void Init(uint8_t * apBuffer, uint32_t aBufferLength, CircularEventBuffer * apPrev, CircularEventBuffer * apNext,
+              PriorityLevel aPriorityLevel);
+
+    /**
+     * @brief
+     *   A helper function that determines whether the event of
+     *   specified priority is final destination
+     *
+     * @param[in]   aPriority   Priority of the event.
+     *
+     * @retval true/false event's priority is same as current buffer's priority, otherwise, false
+     */
+    bool IsFinalDestinationForPriority(PriorityLevel aPriority) const;
+
+    /**
+     * @brief
+     *   Allocate a new event Number based on the event priority, and advance the counter
+     *   if we have one.
+     *
+     * @return EventNumber Event Number for this priority.
+     */
+    EventNumber VendEventNumber();
+
+    /**
+     * @brief
+     *   Remove the number of event
+     *
+     *   @param[in]   aNumEvents   the number of the event.
+     */
+    void RemoveEvent(EventNumber aNumEvents);
+
+    /**
+     * @brief
+     *   Given a timestamp of an event, compute the delta time to store in the log
+     *
+     * @param aEventTimestamp The event timestamp.
+     *
+     */
+    void UpdateFirstLastEventTime(Timestamp aEventTimestamp);
+
+    void InitCounter(MonotonicallyIncreasingCounter * apEventNumberCounter)
+    {
+        if (apEventNumberCounter == nullptr)
+        {
+            mNonPersistedCounter.Init(1);
+            mpEventNumberCounter = &(mNonPersistedCounter);
+            return;
+        }
+        mpEventNumberCounter = apEventNumberCounter;
+        mFirstEventNumber    = mpEventNumberCounter->GetValue();
+    }
+
+    PriorityLevel GetPriorityLevel() { return mPriority; }
+
+    CircularEventBuffer * GetPreviousCircularEventBuffer() { return mpPrev; }
+    CircularEventBuffer * GetNextCircularEventBuffer() { return mpNext; }
+
+    void SetRequiredSpaceforEvicted(size_t aRequiredSpace) { mRequiredSpaceForEvicted = aRequiredSpace; }
+    size_t GetRequiredSpaceforEvicted() { return mRequiredSpaceForEvicted; }
+
+    EventNumber GetFirstEventNumber() { return mFirstEventNumber; }
+    EventNumber GetLastEventNumber() { return mLastEventNumber; }
+
+    uint64_t GetFirstEventSystemTimestamp() { return mFirstEventSystemTimestamp.mValue; }
+    void SetFirstEventSystemTimestamp(uint64_t aValue) { mLastEventSystemTimestamp.mValue = aValue; }
+
+    uint64_t GetLastEventSystemTimestamp() { return mLastEventSystemTimestamp.mValue; }
+
+    virtual ~CircularEventBuffer() = default;
+
+private:
+    CircularEventBuffer * mpPrev = nullptr; //< A pointer CircularEventBuffer storing events less important events
+    CircularEventBuffer * mpNext = nullptr; //< A pointer CircularEventBuffer storing events more important events
+
+    PriorityLevel mPriority =
+        PriorityLevel::Invalid; //< The buffer is the final bucket for events of this priority.  Events of lesser priority are
+    //< dropped when they get bumped out of this buffer
+
+    // The counter we're going to actually use.
+    MonotonicallyIncreasingCounter * mpEventNumberCounter = nullptr;
+
+    // The backup counter to use if no counter is provided for us.
+    MonotonicallyIncreasingCounter mNonPersistedCounter;
+
+    size_t mRequiredSpaceForEvicted = 0;  //< Required space for previous buffer to evict event to new buffer
+    EventNumber mFirstEventNumber   = 0;  //< First event Number stored in the logging subsystem for this priority
+    EventNumber mLastEventNumber    = 0;  //< Last event Number vended for this priority
+    Timestamp mFirstEventSystemTimestamp; //< The timestamp of the first event in this buffer
+    Timestamp mLastEventSystemTimestamp;  //< The timestamp of the last event in this buffer
+};
+
+class CircularEventReader;
+
+/**
+ * @brief
+ *   A CircularEventBufferWrapper which has a pointer to the "current CircularEventBuffer". When trying to locate next buffer,
+ *   if nothing left there update its CircularEventBuffer until the buffer with data has been found,
+ *   the tlv reader will have a pointer to this impl.
+ */
+class CircularEventBufferWrapper : public TLV::CHIPCircularTLVBuffer
+{
+public:
+    CircularEventBufferWrapper() : CHIPCircularTLVBuffer(nullptr, 0), mpCurrent(nullptr){};
+    CircularEventBuffer * mpCurrent;
+
+private:
+    CHIP_ERROR GetNextBuffer(chip::TLV::TLVReader & aReader, const uint8_t *& aBufStart, uint32_t & aBufLen) override;
+};
+
+enum class EventManagementStates
+{
+    Idle       = 1, //< No log offload in progress, log offload can begin without any constraints
+    InProgress = 2, //< Log offload in progress
+    Shutdown   = 3  //< Not capable of performing any logging operation
+};
+
+/**
+ * @brief
+ *   A helper class used in initializing logging management.
+ *
+ * The class is used to encapsulate the resources allocated by the caller and denotes
+ * resources to be used in logging events of a particular priority.  Note that
+ * while resources referring to the counters are used exclusively by the
+ * particular priority level, the buffers are shared between `this` priority
+ * level and events that are "more" important.
+ */
+
+struct LogStorageResources
+{
+    // TODO: Update CHIPCircularTLVBuffer with size_t for buffer size, then use ByteSpan
+    uint8_t * mpBuffer =
+        nullptr; // Buffer to be used as a storage at the particular priority level and shared with more important events.
+                 // Must not be nullptr.  Must be large enough to accommodate the largest event emitted by the system.
+    uint32_t mBufferSize = 0; //< The size, in bytes, of the `mBuffer`.
+    Platform::PersistedStorage::Key * mCounterKey =
+        nullptr;                // Name of the key naming persistent counter for events of this priority.  When NULL, the persistent
+                                // counters will not be used for this priority level.
+    uint32_t mCounterEpoch = 0; // The interval used in incrementing persistent counters.  When 0, the persistent counters will not
+                                // be used for this priority level.
+    PersistedCounter * mpCounterStorage = nullptr; // application provided storage for persistent counter for this priority level.
+    PriorityLevel mPriority =
+        PriorityLevel::Invalid; // Log priority level associated with the resources provided in this structure.
+    PersistedCounter * InitializeCounter() const
+    {
+        if (mpCounterStorage != nullptr && mCounterKey != nullptr && mCounterEpoch != 0)
+        {
+            return (mpCounterStorage->Init(*mCounterKey, mCounterEpoch) != CHIP_NO_ERROR) ? mpCounterStorage : nullptr;
+        }
+        return nullptr;
+    }
+};
+
+/**
+ * @brief
+ *   A class for managing the in memory event logs.
+ *   Assume we have two importance levels. DEBUG and CRITICAL, for simplicity,
+ *   A new incoming event will always get logged in buffer with debug buffer no matter it is Debug or CRITICAL event.
+ *   In order for it to get logged, we need to free up space.  So we look at the tail of the buffer.
+ *   If the tail of the buffer contains a DEBUG event, that will be dropped.  If the tail of the buffer contains
+ *   a CRITICAL event, that  event will be 'promoted' to the next level of buffers, where it will undergo the same procedure
+ *   The outcome of this management policy is that the critical buffer is dedicated to the critical events, and the
+ *   debug buffer is shared between critical and debug events.
+ */
+
+class EventManagement
+{
+public:
+    /**
+     * @brief
+     *   EventManagement constructor
+     *
+     * Initialize the EventManagement with an array of LogStorageResources.  The
+     * array must provide a resource for each valid priority level, the elements
+     * of the array must be in increasing numerical value of priority (and in
+     * increasing priority); the first element in the array corresponds to the
+     * resources allocated for least important events, and the last element
+     * corresponds to the most critical events.
+     *
+     * @param[in] apExchangeManager         ExchangeManager to be used with this logging subsystem
+     *
+     * @param[in] aNumBuffers  Number of elements in inLogStorageResources array
+     *
+     * @param[in] apCircularEventBuffer  An array of CircularEventBuffer for each priority level.
+     *
+     * @param[in] apLogStorageResources  An array of LogStorageResources for each priority level.
+     *
+     */
+    EventManagement(Messaging::ExchangeManager * apExchangeManager, int aNumBuffers, CircularEventBuffer * apCircularEventBuffer,
+                    const LogStorageResources * const apLogStorageResources);
+
+    void Init(Messaging::ExchangeManager * apExchangeManager, int aNumBuffers, CircularEventBuffer * apCircularEventBuffer,
+              const LogStorageResources * const apLogStorageResources);
+    /**
+     * @brief
+     *   EventManagement default constructor. Provided primarily to make the compiler happy.
+     *
+
+     * @return EventManagement
+     */
+    EventManagement(){};
+
+    static EventManagement & GetInstance();
+
+    /**
+     * @brief Create EventManagement object and initialize the logging management
+     *   subsystem with provided resources.
+     *
+     * Initialize the EventManagement with an array of LogStorageResources.  The
+     * array must provide a resource for each valid priority level, the elements
+     * of the array must be in increasing numerical value of priority (and in
+     * decreasing priority); the first element in the array corresponds to the
+     * resources allocated for the most critical events, and the last element
+     * corresponds to the least important events.
+     *
+     * @param[in] apExchangeManager         ExchangeManager to be used with this logging subsystem
+     *
+     * @param[in] aNumBuffers  Number of elements in inLogStorageResources array
+     *
+     * @param[in] apCircularEventBuffer  An array of CircularEventBuffer for each priority level.
+     * @param[in] apLogStorageResources  An array of LogStorageResources for each priority level.
+     *
+     * @note This function must be called prior to the logging being used.
+     */
+    static void CreateEventManagement(Messaging::ExchangeManager * apExchangeManager, int aNumBuffers,
+                                      CircularEventBuffer * apCircularEventBuffer,
+                                      const LogStorageResources * const apLogStorageResources);
+
+    static void DestroyEventManagement();
+
+    /**
+     * @brief
+     *   Log an event via a EventLoggingDelegate, with options.
+     *
+     * The EventLoggingDelegate writes the event metadata and calls the `apDelegate`
+     * with an TLV::TLVWriter reference so that the user code can emit
+     * the event data directly into the event log.  This form of event
+     * logging minimizes memory consumption, as event data is serialized
+     * directly into the target buffer.  The event data MUST contain
+     * context tags to be interpreted within the schema identified by
+     * `ClusterID` and `EventId`. The tag of the first element will be
+     * ignored; the event logging system will replace it with the
+     * eventData tag.
+     *
+     * The event is logged if the schema priority exceeds the logging
+     * threshold specified in the LoggingConfiguration.  If the event's
+     * priority does not meet the current threshold, it is dropped and
+     * the function returns a `0` as the resulting event ID.
+     *
+     * This variant of the invocation permits the caller to set any
+     * combination of `EventOptions`:
+     * - timestamp, when 0 defaults to the current time at the point of
+     *   the call,
+     * - "root" section of the event source (event source and cluster ID);
+     *   if NULL, it defaults to the current device. the event is marked as
+     *   relating to the device that is making the call,
+     *
+     * @param[in] apDelegate The EventLoggingDelegate to serialize the event data
+     *
+     * @param[in] aEventOptions    The options for the event metadata.
+     *
+     * @param[out] aEventNumber The event Number if the event was written to the
+     *                         log, 0 otherwise.
+     *
+     * @return CHIP_ERROR  CHIP Error Code
+     */
+    CHIP_ERROR LogEvent(EventLoggingDelegate * apDelegate, EventOptions & aEventOptions, EventNumber & aEventNumber);
+
+    /**
+     * @brief
+     *   A helper method to get tlv reader along with buffer has data from particular priority
+     *
+     * @param[inout] aReader A reference to the reader that will be
+     *                        initialized with the backing storage from
+     *                        the event log
+     *
+     * @param[in] aPriority The starting priority for the reader.
+     *                         Note that in this case the starting
+     *                         priority is somewhat counter intuitive:
+     *                         more important events share the buffers
+     *                         with less priority events, in addition to
+     *                         their dedicated buffers.  As a result, the
+     *                         reader will traverse the least data when
+     *                         the Debug priority is passed in.
+     *
+     * @param[in] apBufWrapper CircularEventBufferWrapper
+     * @return                 #CHIP_NO_ERROR Unconditionally.
+     */
+    CHIP_ERROR GetEventReader(chip::TLV::TLVReader & aReader, PriorityLevel aPriority,
+                              app::CircularEventBufferWrapper * apBufWrapper);
+
+    /**
+     * @brief
+     *   A function to retrieve events of specified priority since a specified event ID.
+     *
+     * Given a TLV::TLVWriter, an priority type, and an event ID, the
+     * function will fetch events of specified priority since the
+     * specified event.  The function will continue fetching events until
+     * it runs out of space in the TLV::TLVWriter or in the log. The function
+     * will terminate the event writing on event boundary.
+     *
+     * @param[in] aWriter     The writer to use for event storage
+     *
+     * @param[in] aPriority The priority of events to be fetched
+     *
+     * @param[inout] aEventNumber On input, the Event number immediately
+     *                         prior to the one we're fetching.  On
+     *                         completion, the event number of the last event
+     *                         fetched.
+     *
+     * @retval #CHIP_END_OF_TLV             The function has reached the end of the
+     *                                       available log entries at the specified
+     *                                       priority level
+     *
+     * @retval #CHIP_ERROR_NO_MEMORY        The function ran out of space in the
+     *                                       aWriter, more events in the log are
+     *                                       available.
+     *
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL The function ran out of space in the
+     *                                       aWriter, more events in the log are
+     *                                       available.
+     *
+     */
+    CHIP_ERROR FetchEventsSince(chip::TLV::TLVWriter & aWriter, PriorityLevel aPriority, EventNumber & aEventNumber);
+
+    /**
+     * @brief
+     *  Schedule a log offload task.
+     *
+     * The function decides whether to schedule a task offload process,
+     * and if so, it schedules the `LoggingFlushHandler` to be run
+     * asynchronously on the Chip thread.
+     *
+     * The decision to schedule a flush is dependent on three factors:
+     *
+     * -- an explicit request to flush the buffer
+     *
+     * -- the state of the event buffer and the amount of data not yet
+     *    synchronized with the event consumers
+     *
+     * -- whether there is an already pending request flush request event.
+     *
+     * The explicit request to schedule a flush is passed via an input
+     * parameter.
+     *
+     * The automatic flush is typically scheduled when the event buffers
+     * contain enough data to merit starting a new offload.  Additional
+     * triggers -- such as minimum and maximum time between offloads --
+     * may also be taken into account depending on the offload strategy.
+     *
+     *
+     * @param aUrgent  indiate whether the flush should be scheduled if it is urgent
+     *
+     * @retval #CHIP_ERROR_INCORRECT_STATE EventManagement module was not initialized fully.
+     * @retval #CHIP_NO_ERROR              On success.
+     */
+    CHIP_ERROR ScheduleFlushIfNeeded(EventOptions::Type aUrgent);
+
+    /**
+     * @brief
+     *   Fetch the most recently vended Number for a particular priority level
+     *
+     * @param aPriority Priority level
+     *
+     * @return EventNumber most recently vended event Number for that event priority
+     */
+    EventNumber GetLastEventNumber(PriorityLevel aPriority);
+
+    /**
+     * @brief
+     *   Fetch the first event Number currently stored for a particular priority level
+     *
+     * @param aPriority Priority level
+     *
+     * @return EventNumber First currently stored event Number for that event priority
+     */
+    EventNumber GetFirstEventNumber(PriorityLevel aPriority);
+
+private:
+    CHIP_ERROR CalculateEventSize(EventLoggingDelegate * apDelegate, const EventOptions * apOptions, uint32_t & requiredSize);
+    /**
+     * @brief Helper function for writing event header and data according to event
+     *   logging protocol.
+     *
+     * @param[inout] apContext   EventLoadOutContext, initialized with stateful
+     *                          information for the buffer. State is updated
+     *                          and preserved by ConstructEvent using this context.
+     *
+     * @param[in] apDelegate The EventLoggingDelegate to serialize the event data
+     *
+     * @param[in] apOptions     EventOptions describing timestamp and other tags
+     *                          relevant to this event.
+     *
+     */
+    CHIP_ERROR ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate, const EventOptions * apOptions);
+
+    // Internal function to log event
+    CHIP_ERROR LogEventPrivate(EventLoggingDelegate * apDelegate, EventOptions & aEventOptions, EventNumber & aEventNumber);
+
+    /**
+     * @brief copy the event outright to next buffer with higher priority
+     *
+     * @param[in] apEventBuffer  CircularEventBuffer
+     *
+     */
+    CHIP_ERROR CopyToNextBuffer(CircularEventBuffer * apEventBuffer);
+
+    /**
+     * @brief eusure current buffer has enough space, if not, when current buffer is final destination of last tail's event
+     * priority, we need to drop event, otherwises, move the last event to the buffer with higher priority
+     *
+     * @param[in] aRequiredSpace  require space
+     *
+     */
+    CHIP_ERROR EnsureSpaceInCircularBuffer(size_t aRequiredSpace);
+
+    /**
+     * @brief
+     *   Internal API used to implement #FetchEventsSince
+     *
+     * Iterator function to used to copy an event from the log into a
+     * TLVWriter. The included apContext contains the context of the copy
+     * operation, including the TLVWriter that will hold the copy of an
+     * event.  If event cannot be written as a whole, the TLVWriter will
+     * be rolled back to event boundary.
+     *
+     * @retval #CHIP_END_OF_TLV             Function reached the end of the event
+     * @retval #CHIP_ERROR_NO_MEMORY        Function could not write a portion of
+     *                                       the event to the TLVWriter.
+     * @retval #CHIP_ERROR_BUFFER_TOO_SMALL Function could not write a
+     *                                       portion of the event to the TLVWriter.
+     */
+    static CHIP_ERROR CopyEventsSince(const TLV::TLVReader & aReader, size_t aDepth, void * apContext);
+
+    /**
+     * @brief Internal iterator function used to scan and filter though event logs
+     *
+     * The function is used to scan through the event log to find events matching the spec in the supplied context.
+     * Particularly, it would check against mStartingEventNumber, and skip fetched event.
+     */
+    static CHIP_ERROR EventIterator(const TLV::TLVReader & aReader, size_t aDepth, EventLoadOutContext * apEventLoadOutContext);
+
+    /**
+     * @brief Internal iterator function used to fetch event into EventEnvelopeContext, then EventIterator would filter event
+     * based upon EventEnvelopeContext
+     *
+     */
+    static CHIP_ERROR FetchEventParameters(const TLV::TLVReader & aReader, size_t aDepth, void * apContext);
+
+    /**
+     * @brief Internal iterator function used to scan and filter though event logs
+     * First event gets a timestamp, subsequent ones get a delta T
+     * First event in the sequence gets a event number neatly packaged
+     */
+    static CHIP_ERROR CopyAndAdjustDeltaTime(const TLV::TLVReader & aReader, size_t aDepth, void * apContext);
+
+    /**
+     * @brief checking if the tail's event can be moved to higher priority, if not, dropped, if yes, note how much space it
+     * requires, and return.
+     */
+    static CHIP_ERROR EvictEvent(chip::TLV::CHIPCircularTLVBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader);
+    static CHIP_ERROR AlwaysFail(chip::TLV::CHIPCircularTLVBuffer & aBuffer, void * apAppData, TLV::TLVReader & aReader)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    };
+
+    /**
+     * @brief copy event from circular buffer to target buffer for report
+     */
+    static CHIP_ERROR CopyEvent(const TLV::TLVReader & aReader, TLV::TLVWriter & aWriter, EventLoadOutContext * apContext);
+
+    /**
+     * @brief
+     *   A function to get the circular buffer for particular priority
+     *
+     * @param aPriority PriorityLevel
+     *
+     * @return A pointer for the CircularEventBuffer
+     */
+    CircularEventBuffer * GetPriorityBuffer(PriorityLevel aPriority) const;
+
+    // EventBuffer for debug level,
+    CircularEventBuffer * mpEventBuffer        = nullptr;
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    EventManagementStates mState               = EventManagementStates::Idle;
+    uint32_t mBytesWritten                     = 0;
+};
+} // namespace app
+} // namespace chip

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestClusterInfo.cpp",
     "TestCommandInteraction.cpp",
     "TestCommandPathParams.cpp",
+    "TestEventLogging.cpp",
     "TestEventPathParams.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -1,0 +1,300 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements a test for  CHIP Interaction Model Event logging
+ *
+ */
+
+#include <app/EventLoggingDelegate.h>
+#include <app/EventLoggingTypes.h>
+#include <app/EventManagement.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPTLV.h>
+#include <core/CHIPTLVDebug.hpp>
+#include <core/CHIPTLVUtilities.hpp>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <protocols/secure_channel/PASESession.h>
+#include <support/ErrorStr.h>
+#include <support/UnitTestRegistration.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/TLVPacketBufferBackingStore.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/raw/UDP.h>
+
+#include <nlunit-test.h>
+
+namespace {
+
+static const chip::NodeId kTestDeviceNodeId     = 0x18B4300000000001ULL;
+static const chip::ClusterId kLivenessClusterId = 0x00000022;
+static const uint32_t kLivenessChangeEvent      = 1;
+static const chip::EndpointId kTestEndpointId   = 2;
+static const uint64_t kLivenessDeviceStatus     = chip::TLV::ContextTag(1);
+static const chip::Transport::AdminId gAdminId  = 0;
+static chip::TransportMgr<chip::Transport::UDP> gTransportManager;
+static chip::System::Layer gSystemLayer;
+
+static uint8_t gDebugEventBuffer[128];
+static uint8_t gInfoEventBuffer[128];
+static uint8_t gCritEventBuffer[128];
+static chip::app::CircularEventBuffer gCircularEventBuffer[3];
+
+chip::SecureSessionMgr gSessionManager;
+chip::Messaging::ExchangeManager gExchangeManager;
+
+void InitializeChip(nlTestSuite * apSuite)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
+    chip::Transport::AdminPairingTable admins;
+    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, kTestDeviceNodeId);
+
+    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
+
+    err = chip::Platform::MemoryInit();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    gSystemLayer.Init(nullptr);
+
+    err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &admins);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = gExchangeManager.Init(&gSessionManager);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+void InitializeEventLogging()
+{
+    chip::app::LogStorageResources logStorageResources[] = {
+        { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), nullptr, 0, nullptr, chip::app::PriorityLevel::Debug },
+        { &gInfoEventBuffer[0], sizeof(gInfoEventBuffer), nullptr, 0, nullptr, chip::app::PriorityLevel::Info },
+        { &gCritEventBuffer[0], sizeof(gCritEventBuffer), nullptr, 0, nullptr, chip::app::PriorityLevel::Critical },
+    };
+
+    chip::app::EventManagement::CreateEventManagement(
+        &gExchangeManager, sizeof(logStorageResources) / sizeof(logStorageResources[0]), gCircularEventBuffer, logStorageResources);
+}
+
+void SimpleDumpWriter(const char * aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+
+    vprintf(aFormat, args);
+
+    va_end(args);
+}
+
+void PrintEventLog()
+{
+    chip::TLV::TLVReader reader;
+    size_t elementCount;
+    chip::app::CircularEventBufferWrapper bufWrapper;
+    chip::app::EventManagement::GetInstance().GetEventReader(reader, chip::app::PriorityLevel::Debug, &bufWrapper);
+
+    chip::TLV::Utilities::Count(reader, elementCount, false);
+    printf("Found %zu elements\n", elementCount);
+    chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
+}
+
+static void CheckLogState(nlTestSuite * apSuite, chip::app::EventManagement & aLogMgmt, size_t expectedNumEvents,
+                          chip::app::PriorityLevel aPriority)
+{
+    CHIP_ERROR err;
+    chip::TLV::TLVReader reader;
+    size_t elementCount;
+    chip::app::CircularEventBufferWrapper bufWrapper;
+    err = aLogMgmt.GetEventReader(reader, aPriority, &bufWrapper);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    err = chip::TLV::Utilities::Count(reader, elementCount, false);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(apSuite, elementCount == expectedNumEvents);
+    printf("Num Events: %zu\n", elementCount);
+}
+
+static void CheckLogReadOut(nlTestSuite * apSuite, chip::app::EventManagement & alogMgmt, chip::app::PriorityLevel priority,
+                            chip::EventNumber startingEventNumber, size_t expectedNumEvents)
+{
+    CHIP_ERROR err;
+    chip::TLV::TLVReader reader;
+    chip::TLV::TLVWriter writer;
+    uint8_t backingStore[1024];
+    size_t elementCount;
+    writer.Init(backingStore, 1024);
+
+    err = alogMgmt.FetchEventsSince(writer, priority, startingEventNumber);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR || err == CHIP_END_OF_TLV);
+
+    reader.Init(backingStore, writer.GetLengthWritten());
+
+    err = chip::TLV::Utilities::Count(reader, elementCount, false);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, elementCount == expectedNumEvents);
+
+    reader.Init(backingStore, writer.GetLengthWritten());
+    chip::TLV::Debug::Dump(reader, SimpleDumpWriter);
+}
+
+class TestEventGenerator : public chip::app::EventLoggingDelegate
+{
+public:
+    CHIP_ERROR WriteEvent(chip::TLV::TLVWriter & aWriter)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        err            = aWriter.Put(kLivenessDeviceStatus, mStatus);
+        return err;
+    }
+
+    void SetStatus(int32_t aStatus) { mStatus = aStatus; }
+
+private:
+    int32_t mStatus;
+};
+
+static void CheckLogEventWithEvictToNextBuffer(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::EventNumber eid1, eid2, eid3, eid4, eid5, eid6;
+    chip::app::EventSchema schema = { kTestDeviceNodeId, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
+                                      chip::app::PriorityLevel::Info };
+    chip::app::EventOptions options;
+    TestEventGenerator testEventGenerator;
+
+    options.mpEventSchema = &schema;
+
+    chip::app::EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 1, chip::app::PriorityLevel::Debug);
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid2);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 2, chip::app::PriorityLevel::Debug);
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid3);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+    // Start to copy info event to next buffer since current debug buffer is full and info event is higher priority
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid4);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 4, chip::app::PriorityLevel::Info);
+
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid5);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 5, chip::app::PriorityLevel::Info);
+
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid6);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 6, chip::app::PriorityLevel::Info);
+
+    PrintEventLog();
+
+    NL_TEST_ASSERT(apSuite, (eid1 + 1) == eid2);
+    NL_TEST_ASSERT(apSuite, (eid2 + 1) == eid3);
+    NL_TEST_ASSERT(apSuite, (eid3 + 1) == eid4);
+    NL_TEST_ASSERT(apSuite, (eid4 + 1) == eid5);
+    NL_TEST_ASSERT(apSuite, (eid5 + 1) == eid6);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid1, 6);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid2, 5);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid3, 4);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid4, 3);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid5, 2);
+    CheckLogReadOut(apSuite, logMgmt, chip::app::PriorityLevel::Info, eid6, 1);
+}
+
+static void CheckLogEventWithDiscardLowEvent(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::EventNumber eid1, eid2, eid3, eid4, eid5, eid6;
+    chip::app::EventSchema schema = { kTestDeviceNodeId, kTestEndpointId, kLivenessClusterId, kLivenessChangeEvent,
+                                      chip::app::PriorityLevel::Debug };
+    chip::app::EventOptions options;
+    TestEventGenerator testEventGenerator;
+
+    options.mpEventSchema = &schema;
+
+    chip::app::EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid2);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid3);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+    // Start to drop off debug event since debug event can only be saved in debug buffer
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid4);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid5);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options, eid6);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    CheckLogState(apSuite, logMgmt, 3, chip::app::PriorityLevel::Debug);
+}
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+const nlTest sTests[] = { NL_TEST_DEF("CheckLogEventWithEvictToNextBuffer", CheckLogEventWithEvictToNextBuffer),
+                          NL_TEST_DEF("CheckLogEventWithDiscardLowEvent", CheckLogEventWithDiscardLowEvent), NL_TEST_SENTINEL() };
+} // namespace
+
+int TestEventLogging()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+	{
+        "EventLogging",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    InitializeChip(&theSuite);
+    InitializeEventLogging();
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestEventLogging)

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -39,12 +39,12 @@ executable("chip-im-initiator") {
 
 executable("chip-im-responder") {
   sources = [
+    "MockEvents.cpp",
     "chip_im_responder.cpp",
     "common.cpp",
   ]
 
   deps = [
-    "${chip_root}/src/app",
     "${chip_root}/src/app",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",

--- a/src/app/tests/integration/MockEvents.cpp
+++ b/src/app/tests/integration/MockEvents.cpp
@@ -1,0 +1,199 @@
+/*
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares mock event generator and example
+ *
+ */
+
+#include "MockEvents.h"
+#include <app/EventLoggingTypes.h>
+#include <app/EventManagement.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <support/ErrorStr.h>
+#include <system/SystemPacketBuffer.h>
+#include <system/SystemTimer.h>
+#include <transport/SecureSessionMgr.h>
+
+static const chip::NodeId kTestNodeId           = 0x18B4300000000001ULL;
+static const chip::NodeId kTestNodeId1          = 0x18B4300000000002ULL;
+static const chip::ClusterId kLivenessClusterId = 0x00000022;
+static const uint32_t kLivenessChangeEvent      = 1;
+static const chip::EndpointId kTestEndpointId   = 2;
+static const uint64_t kLivenessDeviceStatus     = chip::TLV::ContextTag(1);
+static bool gMockEventStop                      = false;
+static bool gEventIsStopped                     = false;
+
+EventGenerator::EventGenerator(size_t aNumStates, size_t aInitialState) : mNumStates(aNumStates), mState(aInitialState) {}
+
+size_t EventGenerator::GetNumStates()
+{
+    return mNumStates;
+}
+
+LivenessEventGenerator::LivenessEventGenerator(void) : EventGenerator(10, 0) {}
+
+void LivenessEventGenerator::Generate(void)
+{
+    // Scenario: monitoring liveness for two devices -- self and remote.  Remote device goes offline and returns.
+    switch (mState)
+    {
+    case 0:
+        LogLiveness(kTestNodeId, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 1:
+        LogLiveness(kTestNodeId1, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 2:
+        LogLiveness(kTestNodeId, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 3:
+        LogLiveness(kTestNodeId1, kTestEndpointId, LIVENESS_DEVICE_STATUS_UNREACHABLE);
+        break;
+
+    case 4:
+        LogLiveness(kTestNodeId, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 5:
+        LogLiveness(kTestNodeId1, kTestEndpointId, LIVENESS_DEVICE_STATUS_REBOOTING);
+        break;
+
+    case 6:
+        LogLiveness(kTestNodeId, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 7:
+        LogLiveness(kTestNodeId1, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 8:
+        LogLiveness(kTestNodeId, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    case 9:
+        LogLiveness(kTestNodeId1, kTestEndpointId, LIVENESS_DEVICE_STATUS_ONLINE);
+        break;
+
+    default:
+        mState = 0;
+    }
+
+    mState = (mState + 1) % mNumStates;
+}
+
+CHIP_ERROR LivenessEventGenerator::WriteEvent(chip::TLV::TLVWriter & aWriter)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    err            = aWriter.Put(kLivenessDeviceStatus, mStatus);
+    return err;
+}
+
+chip::EventNumber LivenessEventGenerator::LogLiveness(chip::NodeId aNodeId, chip::EndpointId aEndpointId,
+                                                      LivenessDeviceStatus aStatus)
+{
+    chip::app::EventManagement & logManager = chip::app::EventManagement::GetInstance();
+    chip::EventNumber number                = 0;
+    chip::app::EventSchema schema           = {
+        aNodeId, aEndpointId, kLivenessClusterId, kLivenessChangeEvent, chip::app::PriorityLevel::Critical,
+    };
+    chip::app::EventOptions options;
+    mStatus               = static_cast<int32_t>(aStatus);
+    options.mpEventSchema = &schema;
+    logManager.LogEvent(this, options, number);
+    return number;
+}
+
+MockEventGenerator * MockEventGenerator::GetInstance(void)
+{
+    static MockEventGeneratorImpl gMockEventGenerator;
+    return &gMockEventGenerator;
+}
+
+MockEventGeneratorImpl::MockEventGeneratorImpl(void) :
+    mpExchangeMgr(nullptr), mTimeBetweenEvents(0), mEventWraparound(false), mpEventGenerator(nullptr), mEventsLeft(0)
+{}
+
+CHIP_ERROR MockEventGeneratorImpl::Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator,
+                                        int aDelayBetweenEvents, bool aWraparound)
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    mpExchangeMgr      = apExchangeMgr;
+    mpEventGenerator   = apEventGenerator;
+    mTimeBetweenEvents = aDelayBetweenEvents;
+    mEventWraparound   = aWraparound;
+
+    if (mEventWraparound)
+        mEventsLeft = INT32_MAX;
+    else
+        mEventsLeft = mpEventGenerator->GetNumStates();
+
+    if (mTimeBetweenEvents != 0)
+        mpExchangeMgr->GetSessionMgr()->SystemLayer()->StartTimer(mTimeBetweenEvents, HandleNextEvent, this);
+
+    return err;
+}
+
+void MockEventGeneratorImpl::HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState, chip::System::Error aErr)
+{
+    MockEventGeneratorImpl * generator = static_cast<MockEventGeneratorImpl *>(apAppState);
+    if (gMockEventStop)
+    {
+        gEventIsStopped = true;
+        apSystemLayer->CancelTimer(HandleNextEvent, generator);
+    }
+    else
+    {
+        generator->mpEventGenerator->Generate();
+        generator->mEventsLeft--;
+        if ((generator->mEventWraparound) || (generator->mEventsLeft > 0))
+        {
+            apSystemLayer->StartTimer(generator->mTimeBetweenEvents, HandleNextEvent, generator);
+        }
+    }
+}
+
+void MockEventGeneratorImpl::SetEventGeneratorStop()
+{
+    gMockEventStop = true;
+
+    // If the timer is running, make it expire right away.
+    // This helps quit the standalone app in an orderly way without
+    // spurious leaked timers.
+    if (mTimeBetweenEvents != 0)
+        mpExchangeMgr->GetSessionMgr()->SystemLayer()->StartTimer(0, HandleNextEvent, this);
+}
+
+bool MockEventGeneratorImpl::IsEventGeneratorStopped()
+{
+    if (gEventIsStopped)
+    {
+        gMockEventStop  = false;
+        gEventIsStopped = false;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/src/app/tests/integration/MockEvents.h
+++ b/src/app/tests/integration/MockEvents.h
@@ -1,0 +1,98 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2016-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file declares mock event generator and example
+ *
+ */
+#pragma once
+
+#include <app/EventLoggingDelegate.h>
+#include <app/InteractionModelEngine.h>
+#include <core/CHIPCore.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/Flags.h>
+
+class EventGenerator : public chip::app::EventLoggingDelegate
+{
+public:
+    virtual void Generate(void) = 0;
+    virtual size_t GetNumStates(void);
+    virtual ~EventGenerator() = default;
+
+protected:
+    EventGenerator(size_t aNumStates, size_t aInitialState);
+    size_t mNumStates;
+    size_t mState;
+};
+
+class MockEventGenerator
+{
+public:
+    static MockEventGenerator * GetInstance(void);
+    virtual CHIP_ERROR Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator,
+                            int aDelayBetweenEvents, bool aWraparound) = 0;
+    virtual void SetEventGeneratorStop()                               = 0;
+    virtual bool IsEventGeneratorStopped()                             = 0;
+    virtual ~MockEventGenerator()                                      = default;
+};
+
+class MockEventGeneratorImpl : public MockEventGenerator
+{
+public:
+    MockEventGeneratorImpl(void);
+    CHIP_ERROR Init(chip::Messaging::ExchangeManager * apExchangeMgr, EventGenerator * apEventGenerator, int aDelayBetweenEvents,
+                    bool aWraparound);
+    void SetEventGeneratorStop();
+    bool IsEventGeneratorStopped();
+
+private:
+    static void HandleNextEvent(chip::System::Layer * apSystemLayer, void * apAppState, chip::System::Error aErr);
+    chip::Messaging::ExchangeManager * mpExchangeMgr;
+    int mTimeBetweenEvents; //< delay, in miliseconds, between events.
+    bool mEventWraparound;  //< does the event generator run indefinitely, or does it stop after iterating through its states
+    EventGenerator * mpEventGenerator; //< the event generator to use
+    int32_t mEventsLeft;
+};
+
+enum LivenessDeviceStatus
+{
+    LIVENESS_DEVICE_STATUS_UNSPECIFIED    = 0, /// Device status is unspecified
+    LIVENESS_DEVICE_STATUS_ONLINE         = 1, /// Device is sending messages
+    LIVENESS_DEVICE_STATUS_UNREACHABLE    = 2, /// Device is not reachable over network
+    LIVENESS_DEVICE_STATUS_UNINITIALIZED  = 3, /// Device has not been initialized
+    LIVENESS_DEVICE_STATUS_REBOOTING      = 4, /// Device being rebooted
+    LIVENESS_DEVICE_STATUS_UPGRADING      = 5, /// Device offline while upgrading
+    LIVENESS_DEVICE_STATUS_SCHEDULED_DOWN = 6  /// Device on a scheduled downtime
+};
+
+class LivenessEventGenerator : public EventGenerator
+{
+public:
+    LivenessEventGenerator(void);
+    void Generate(void);
+    chip::EventNumber LogLiveness(chip::NodeId aNodeId, chip::EndpointId aEndpointId, LivenessDeviceStatus aStatus);
+    CHIP_ERROR WriteEvent(chip::TLV::TLVWriter & aWriter);
+
+private:
+    int32_t mStatus;
+};

--- a/src/lib/core/CHIPCircularTLVBuffer.cpp
+++ b/src/lib/core/CHIPCircularTLVBuffer.cpp
@@ -82,6 +82,19 @@ CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBuff
  */
 CHIPCircularTLVBuffer::CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength)
 {
+    Init(inBuffer, inBufferLength);
+}
+
+/**
+ * @brief
+ *   CHIPCircularTLVBuffer Init function
+ *
+ * @param[in] inBuffer       A pointer to the backing store for the queue
+ *
+ * @param[in] inBufferLength Length, in bytes, of the backing store
+ */
+void CHIPCircularTLVBuffer::Init(uint8_t * inBuffer, uint32_t inBufferLength)
+{
     mQueue       = inBuffer;
     mQueueSize   = inBufferLength;
     mQueueLength = 0;

--- a/src/lib/core/CHIPCircularTLVBuffer.h
+++ b/src/lib/core/CHIPCircularTLVBuffer.h
@@ -60,11 +60,12 @@ public:
     CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength);
     CHIPCircularTLVBuffer(uint8_t * inBuffer, uint32_t inBufferLength, uint8_t * inHead);
 
+    void Init(uint8_t * inBuffer, uint32_t inBufferLength);
     inline uint8_t * QueueHead() const { return mQueueHead; }
     inline uint8_t * QueueTail() const { return mQueue + ((static_cast<size_t>(mQueueHead - mQueue) + mQueueLength) % mQueueSize); }
     inline uint32_t DataLength() const { return mQueueLength; }
     inline uint32_t AvailableDataLength() const { return mQueueSize - mQueueLength; }
-    inline uint32_t GetQueueSize() const { return mQueueSize; }
+    inline uint32_t GetTotalDataLength() const { return mQueueSize; }
     inline uint8_t * GetQueue() const { return mQueue; }
 
     CHIP_ERROR EvictHead();


### PR DESCRIPTION
Problems:
CHIP IM data model can use read request and subscribe request to retrieve events from device, event delivery is a part of the reportData., which does not exist in zcl ember, we need this for TE3. For IM events, spec define priority level for debug,info,critical. In addition, we need the insertion is high performance.  Need a schema of managing buffers and dedicating space to both critical events and to diagnostic events, which can allow for the CRITICAL events to occupy DEBUG buffers for a time, potentially increasing the amount of buffering available to the critical events.

Summary of Changes:
-- Add LoggingManagement and eventing logging to generate IM events
-- Add unit tests and cirque integration test.
-- Logging of events is gated via the event priority.  Events that
do not meet the current level of priority are never logged.  Events
that do meet the current priority levels are logged into a circular
history buffer.   The history buffer is accessible to any potential
reader/subscriber.  As a result, events are only removed from the
buffer as a result of overwriting an existing event with an event
of equal (or higher) priority.
--The device always maintains a number of circular event buffers
equal to the number of levels of event importance.  Within each
buffer, events are always evicted as a result of wraparound.
Each buffer shares some similarities to a generation in generational GC.
All events are always emitted to the buffer holding most recent events
(to borrow the generational GC terminology, we call it the eden buffer).
Within the eden buffer, events are always continuous.
When, as a result of eden filling up, a LOG_DEBUG or LOG_INFO event
is being evicted, it gets “promoted” to the next higher generation buffer (survivor buffer).
The same strategy applies to each next generation of buffers.
The resulting behavior is that each consecutive buffer generation
contains (potentially mixed) events of increasingly higher importance:
a LOG_DEBUG event will never move past the eden buffer, and
only LOG_CRITICAL events will be present in the final survivor buffer.
