### PR TITLE
[Darwin] Add CHIPDeviceController::PairDevice using an address/port i…

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -35,6 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
      discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
+- (BOOL)pairDevice:(uint64_t)deviceID
+           address:(NSString *)address
+              port:(uint16_t)port
+     discriminator:(uint16_t)discriminator
+      setupPINCode:(uint32_t)setupPINCode
+             error:(NSError * __autoreleasing *)error;
 - (BOOL)pairDeviceWithoutSecurity:(uint64_t)deviceID
                           address:(NSString *)address
                              port:(uint16_t)port

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -218,6 +218,34 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     return success;
 }
 
+- (BOOL)pairDevice:(uint64_t)deviceID
+           address:(NSString *)address
+              port:(uint16_t)port
+     discriminator:(uint16_t)discriminator
+      setupPINCode:(uint32_t)setupPINCode
+             error:(NSError * __autoreleasing *)error
+{
+    __block BOOL success;
+    dispatch_sync(_chipWorkQueue, ^{
+        chip::Inet::IPAddress addr;
+        chip::Inet::IPAddress::FromString([address UTF8String], addr);
+        chip::Transport::PeerAddress peerAddress = chip::Transport::PeerAddress::UDP(addr, port);
+
+        chip::RendezvousParameters params = chip::RendezvousParameters()
+                                                .SetSetupPINCode(setupPINCode)
+                                                .SetDiscriminator(discriminator)
+                                                .SetPeerAddress(peerAddress);
+        CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
+
+        if ([self _isRunning]) {
+            errorCode = self.cppCommissioner->PairDevice(deviceID, params);
+        }
+        success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
+    });
+
+    return success;
+}
+
 - (BOOL)pairDeviceWithoutSecurity:(uint64_t)deviceID
                           address:(NSString *)address
                              port:(uint16_t)port


### PR DESCRIPTION
…n addition to the discriminator and the setupPINCode

 #### Problem

Currently there is no way to pair iOS ChipTool with a device already on the network, except by using `PairDeviceWithoutSecurity`. This PR adds a `pairDevice` method that does not sacrifice security by requiring the spake2+ exchange.

 #### Summary of Changes
  * Add an other `pairDevice` method to the darwin `CHIPDeviceController`