### PR TITLE
Fix android KVS implementation to work across threads

### DIFF
--- a/src/controller/java/AndroidKeyValueStoreManagerImpl.h
+++ b/src/controller/java/AndroidKeyValueStoreManagerImpl.h
@@ -31,15 +31,17 @@ public:
     CHIP_ERROR _Delete(const char * key);
     CHIP_ERROR _Put(const char * key, const void * value, size_t value_size);
 
-    void InitializeMethodForward(JNIEnv * env);
+    void InitializeMethodForward(JavaVM * vm, JNIEnv * env);
 
 private:
-    JNIEnv * mEnv                     = nullptr;
+    JavaVM * mJvm                     = nullptr;
     jclass mKeyValueStoreManagerClass = nullptr;
 
     jmethodID mSetMethod    = nullptr;
     jmethodID mGetMethod    = nullptr;
     jmethodID mDeleteMethod = nullptr;
+
+    JNIEnv * GetEnvForCurrentThread();
 
     // ===== Members for internal use by the following friends.
     friend KeyValueStoreManager & KeyValueStoreMgr();

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -149,7 +149,7 @@ jint JNI_OnLoad(JavaVM * jvm, void * reserved)
     // Get a JNI environment object.
     sJVM->GetEnv((void **) &env, JNI_VERSION_1_6);
 
-    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeMethodForward(env);
+    chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().InitializeMethodForward(sJVM, env);
 
     ChipLogProgress(Controller, "Loading Java class references.");
 


### PR DESCRIPTION
 #### Problem
KVS may be used within different threads and JEnv are thread-specific.


 #### Summary of Changes

 Ensure KVS uses a thread-appropriate jenv.