### PR TITLE
Implement Docker best practices

### DIFF
--- a/integrations/docker/images/chip-build-android/Dockerfile
+++ b/integrations/docker/images/chip-build-android/Dockerfile
@@ -6,10 +6,10 @@ FROM connectedhomeip/chip-build:${VERSION}
 # doesn't work with JDK 11.
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    openjdk-8-jdk \
-    rsync \
-    swig \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    openjdk-8-jdk=8u292-b10-0ubuntu1~20.04 \
+    rsync=3.1.3-8 \
+    swig=4.0.1-5build1 \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 

--- a/integrations/docker/images/chip-build-cirque/Dockerfile
+++ b/integrations/docker/images/chip-build-cirque/Dockerfile
@@ -1,44 +1,47 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Bazel
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       curl gnupg \
-    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg \
-    && mv bazel.gpg /etc/apt/trusted.gpg.d/ \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+       curl=7.68.0-1ubuntu2.5 gnupg=2.2.19-3ubuntu2.1 \
+    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/bazel.gpg \
     && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       bazel \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+       bazel=4.0.0 \
+    && rm -rf /var/lib/apt/lists/ \
     && : # aids diffs
 
 # Docker
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       curl gnupg-agent apt-transport-https ca-certificates \
-       software-properties-common \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+       curl=7.68.0-1ubuntu2.5 gnupg-agent=2.2.19-3ubuntu2.1 apt-transport-https=2.0.5 ca-certificates=20210119~20.04.1 \
+       software-properties-common=0.98.9.4 \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       docker-ce docker-ce-cli containerd.io \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+       docker-ce=5:20.10.6~3-0~ubuntu-focal docker-ce-cli=5:20.10.6~3-0~ubuntu-focal containerd.io=1.4.4-1 \
+    && rm -rf /var/lib/apt/lists/ \
     && : # aids diffs
 
 # Other Cirque prereqs
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-       sudo socat psmisc tigervnc-standalone-server tigervnc-viewer \
-       python3-pip python3-venv python3-setuptools libdbus-glib-1-dev \
-       uuid-runtime libgirepository1.0-dev \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+       sudo=1.8.31-1ubuntu1.2 socat=1.7.3.3-2 psmisc=23.3-1 tigervnc-standalone-server=1.10.1+dfsg-3 tigervnc-viewer=1.10.1+dfsg-3 \
+       python3-pip=20.0.2-5ubuntu1.3 python3-venv=3.8.2-0ubuntu2 python3-setuptools=45.2.0-1 libdbus-glib-1-dev=0.110-5fakssync1 \
+       uuid-runtime=2.34-0.1ubuntu9.1 libgirepository1.0-dev=1.64.1-1~ubuntu20.04.1 \
+    && rm -rf /var/lib/apt/lists/ \
     && : # aids diffs
 
 COPY requirements_nogrpc.txt /requirements.txt
 
 RUN set -x \
-    && pip3 install -r requirements.txt \
+    && pip3 install --no-cache-dir -r requirements.txt \
     && : # aids diffs

--- a/integrations/docker/images/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/chip-build-efr32/Dockerfile
@@ -1,13 +1,12 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
-
-
-
 # GNU ARM Embedded toolchain, cross compiler for various platform builds
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    gcc-arm-none-eabi \
-    binutils-arm-none-eabi \
-    ccache
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    gcc-arm-none-eabi=15:9-2019-q4-0ubuntu1 \
+    binutils-arm-none-eabi=2.34-4ubuntu1+13ubuntu1 \
+    ccache=3.7.7-1 \
+    && rm -rf /var/lib/apt/lists/ \
+    && : # last line

--- a/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32-qemu/Dockerfile
@@ -1,14 +1,13 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build-esp32:${VERSION}
 
+WORKDIR /opt/espressif/qemu
+
 # Setup QEMU emulator for ESP32 platform
 RUN set -x \
-    && mkdir -p /opt/espressif \
-    && git clone --progress --depth 1 --branch esp-develop-20210220 https://github.com/espressif/qemu.git /opt/espressif/qemu-src \
-    && mkdir -p /opt/espressif/qemu \
-    && (cd /opt/espressif/qemu \
+    && git clone --depth 1 --branch esp-develop-20210220 https://github.com/espressif/qemu.git /opt/espressif/qemu-src \
     && ../qemu-src/configure --target-list=xtensa-softmmu --enable-debug --enable-sanitizers --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
-    && make -j8) \
+    && make -j8 \
     && : # last line
 
 ENV QEMU_ESP32_DIR=/opt/espressif/qemu

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -1,16 +1,17 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
+WORKDIR /opt/espressif/esp-idf
+
 # Setup the ESP-IDF
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y python libgcrypt20-dev \
-    && mkdir -p /opt/espressif \
-    && cd /opt/espressif \
-    && git clone --progress -b release/v4.2 https://github.com/espressif/esp-idf.git \
-    && cd esp-idf \
-    && git submodule update --init --progress \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python-is-python2=2.7.17-4 libgcrypt20-dev=1.8.5-5ubuntu1 \
+    && git clone --depth=1 -b release/v4.2 https://github.com/espressif/esp-idf.git /opt/espressif/esp-idf \
+    && git submodule update --init \
     && IDF_TOOLS_PATH=/opt/espressif/tools ./install.sh \
+    && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
 ENV IDF_PATH=/opt/espressif/esp-idf/

--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -1,19 +1,19 @@
 ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION}
 
+WORKDIR /opt/sdk
+
 # Setup the K32W SDK
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    wget=1.20.3-1ubuntu1 unzip=6.0-25ubuntu1 \
     && rm -rf /var/lib/apt/lists/ \
-    && mkdir -p /opt/sdk \
-    && cd /opt/sdk \
     && wget https://mcuxpresso.nxp.com/eclipse/sdk/2.6.3/plugins/com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.3.201911251446.jar \
     && unzip com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.3.201911251446.jar \
-    && rm -rf com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.3.201911251446.jar \
-    && cd sdks \
-    && unzip 5faab205f2663647c5c7ce05c382d2a8.zip \
-    && rm -rf 5faab205f2663647c5c7ce05c382d2a8.zip \
+    && unzip sdks/5faab205f2663647c5c7ce05c382d2a8.zip -d sdks/ \
+    && rm -f com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.3.201911251446.jar \
+    && rm -f sdk/5faab205f2663647c5c7ce05c382d2a8.zip \
     && : # last line
 
 ENV K32W061_SDK_ROOT=/opt/sdk/sdks

--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -8,17 +8,19 @@ ARG NCS_REVISION=v1.5.0
 # nRF Connect SDK dependencies
 # ==================================================
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /opt/NordicSemiconductor/nRF5_tools/install
+
 # Tools for building, flashing and accessing device logs
 RUN set -x \
     && apt-get update \
-    && apt-get install --no-install-recommends -fy device-tree-compiler \
-    && (mkdir -p /opt/NordicSemiconductor/nRF5_tools/install && cd /opt/NordicSemiconductor/nRF5_tools/install \
+    && apt-get install --no-install-recommends -fy device-tree-compiler=1.5.1-1 \
     && curl https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz \
     | tar zxvf - \
-    && cd .. \
-    && tar xvf install/JLink_Linux_V688a_x86_64.tgz \
-    && tar xvf install/nRF-Command-Line-Tools_10_12_1.tar \
-    && rm -rf ./install /var/lib/apt/lists/) \
+    && tar xvf JLink_Linux_V688a_x86_64.tgz -C /opt/NordicSemiconductor/nRF5_tools/ \
+    && tar xvf nRF-Command-Line-Tools_10_12_1.tar -C /opt/NordicSemiconductor/nRF5_tools/ \
+    && rm -rf ./install /var/lib/apt/lists/ \
     && : # last line
 
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
@@ -26,26 +28,28 @@ ENV PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V688a_x86_64:${PATH}
 ENV PATH=${NRF5_TOOLS_ROOT}/mergehex:${NRF5_TOOLS_ROOT}/nrfjprog:${PATH}
 ENV LD_LIBRARY_PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V688a_x86_64:${LD_LIBRARY_PATH}
 
+WORKDIR /opt/ARM-software
+
 # GNU ARM Embedded toolchain, cross compiler for various platform builds
 RUN set -x \
-    && (mkdir -p /opt/ARM-software && cd /opt/ARM-software \
     && curl https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 \
-    | tar jxvf -) \
+    | tar jxvf - \
     && : # last line
 
 ENV ARM_GCC_INSTALL_ROOT=/opt/ARM-software/gcc-arm-none-eabi-9-2019-q4-major/bin/
+
+WORKDIR /opt/NordicSemiconductor/nrfconnect
 
 # ==================================================
 # nRF Connect SDK
 # ==================================================
 RUN set -x \
-    && (mkdir -p /opt/NordicSemiconductor/nrfconnect && cd /opt/NordicSemiconductor/nrfconnect \
-    && python3 -m pip install -U --no-cache-dir pip setuptools wheel cmake west \
+    && python3 -m pip install -U --no-cache-dir pip==21.1 setuptools==56.0.0 wheel==0.36.2 cmake==3.18.4.post1 west==0.10.1 \
     && west init -m https://github.com/nrfconnect/sdk-nrf --mr $NCS_REVISION \
     && west update \
     && python3 -m pip install --no-cache-dir -r zephyr/scripts/requirements.txt \
     && python3 -m pip install --no-cache-dir -r nrf/scripts/requirements.txt \
-    && python3 -m pip install --no-cache-dir -r bootloader/mcuboot/scripts/requirements.txt) \
+    && python3 -m pip install --no-cache-dir -r bootloader/mcuboot/scripts/requirements.txt \
     && echo "source /opt/NordicSemiconductor/nrfconnect/zephyr/zephyr-env.sh" >> ~/.bashrc \
     && : # last line
 

--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -6,61 +6,62 @@ VOLUME "/var/source"
 # base build and check tools and libraries layer
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    autoconf \
-    automake \
-    bison \
-    bridge-utils \
-    clang \
-    clang-format \
-    clang-tidy \
-    curl \
-    flex \
-    g++ \
-    git \
-    gperf \
-    iproute2 \
-    jq \
-    lcov \
-    libavahi-client-dev \
-    libavahi-common-dev \
-    libcairo2-dev \
-    libdbus-1-dev \
-    libdbus-glib-1-dev \
-    libgif-dev \
-    libglib2.0-dev \
-    libical-dev \
-    libjpeg-dev \
-    libdmalloc-dev \
-    libmbedtls-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
-    libnspr4-dev \
-    libpango1.0-dev \
-    libpixman-1-dev \
-    libreadline-dev \
-    libssl-dev \
-    libtool \
-    libudev-dev \
-    libusb-1.0-0 \
-    libusb-dev \
-    libxml2-dev \
-    make \
-    net-tools \
-    ninja-build \
-    openjdk-8-jdk \
-    pkg-config \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-venv \
-    shellcheck \
-    strace \
-    systemd \
-    udev \
-    unzip \
-    wget \
-    zlib1g-dev \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    autoconf=2.69-11.1 \
+    automake=1:1.16.1-4ubuntu6 \
+    bison=2:3.5.1+dfsg-1 \
+    bridge-utils=1.6-2ubuntu1 \
+    clang=1:10.0-50~exp1 \
+    clang-format=1:10.0-50~exp1 \
+    clang-tidy=1:10.0-50~exp1 \
+    curl=7.68.0-1ubuntu2.5 \
+    flex=2.6.4-6.2 \
+    g++=4:9.3.0-1ubuntu2 \
+    git=1:2.25.1-1ubuntu3.1 \
+    gperf=3.1-1build1 \
+    iproute2=5.5.0-1ubuntu1 \
+    jq=1.6-1ubuntu0.20.04.1 \
+    lcov=1.14-2 \
+    libavahi-client-dev=0.7-4ubuntu7 \
+    libavahi-common-dev=0.7-4ubuntu7 \
+    libcairo2-dev=1.16.0-4ubuntu1 \
+    libdbus-1-dev=1.12.16-2ubuntu2.1 \
+    libdbus-glib-1-dev=0.110-5fakssync1 \
+    libgif-dev=5.1.9-1 \
+    libglib2.0-dev=2.64.6-1~ubuntu20.04.3 \
+    libical-dev=3.0.8-1 \
+    libjpeg-dev=8c-2ubuntu8 \
+    libdmalloc-dev=5.5.2-14build1 \
+    libmbedtls-dev=2.16.4-1ubuntu2 \
+    libncurses5-dev=6.2-0ubuntu2 \
+    libncursesw5-dev=6.2-0ubuntu2 \
+    libnspr4-dev=2:4.25-1 \
+    libpango1.0-dev=1.44.7-2ubuntu4 \
+    libpixman-1-dev=0.38.4-0ubuntu1 \
+    libreadline-dev=8.0-4 \
+    libssl-dev=1.1.1f-1ubuntu2.3 \
+    libtool=2.4.6-14 \
+    libudev-dev=245.4-4ubuntu3.6 \
+    libusb-1.0-0=2:1.0.23-2build1 \
+    libusb-dev=2:0.1.12-32 \
+    libxml2-dev=2.9.10+dfsg-5 \
+    make=4.2.1-1.2 \
+    net-tools=1.60+git20180626.aebd88e-1ubuntu1 \
+    ninja-build=1.10.0-1build1 \
+    openjdk-8-jdk=8u292-b10-0ubuntu1~20.04 \
+    pkg-config=0.29.1-0ubuntu4 \
+    python3=3.8.2-0ubuntu2 \
+    python3-dev=3.8.2-0ubuntu2 \
+    python3-pip=20.0.2-5ubuntu1.3 \
+    python3-venv=3.8.2-0ubuntu2 \
+    shellcheck=0.7.0-2build2 \
+    strace=5.5-3ubuntu1 \
+    systemd=245.4-4ubuntu3.6 \
+    udev=245.4-4ubuntu3.6 \
+    unzip=6.0-25ubuntu1 \
+    wget=1.20.3-1ubuntu1 \
+    xz-utils=5.2.4-1ubuntu1 \
+    zlib1g-dev=1:1.2.11.dfsg-2ubuntu1.2 \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
@@ -76,17 +77,24 @@ RUN set -x \
 # Python 2 and PIP
 RUN set -x \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common=0.98.9.4 \
     && add-apt-repository universe \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y python python2 \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python2=2.7.17-2ubuntu4 \
     && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py \
     && python2 get-pip.py \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
 RUN set -x \
-    && pip3 install circleci attrs coloredlogs PyGithub pygit future \
-    portpicker mobly                                                 \
+    && pip3 install --no-cache-dir \
+    circleci==1.2.2 \
+    attrs==20.3.0 \
+    coloredlogs==15.0 \
+    PyGithub==1.55 \
+    pygit==0.1 \
+    future==0.18.2 \
+    portpicker==1.3.1 \
+    mobly==1.10.1 \
     && : # last line
 
 # build and install gn
@@ -102,7 +110,7 @@ RUN set -x \
 
 # Install bloat comparison tools
 RUN set -x \
-    && git clone https://github.com/google/bloaty.git \
+    && git clone --depth=1 https://github.com/google/bloaty.git \
     && mkdir -p bloaty/build \
     && cd bloaty/build \
     && cmake ../ \
@@ -115,13 +123,9 @@ RUN set -x \
 # NodeJS: install a newer version than what apt-get would read
 # This installs the latest LTS version of nodejs
 RUN set -x \
-    && mkdir node_js \
-    && cd node_js \
-    && wget https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
-    && tar xfvJ node-v12.19.0-linux-x64.tar.xz \
-    && mv node-v12.19.0-linux-x64 /opt/ \
-    && ln -s /opt/node-v12.19.0-linux-x64 /opt/node \
+    && curl -o node.tgz -s https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-x64.tar.xz \
+    && mkdir -p /opt/node \
+    && tar xfJ node.tgz --strip-components=1 -C /opt/node \
     && ln -s /opt/node/bin/* /usr/bin \
-    && cd .. \
-    && rm -rf node_js \
+    && rm -f node.tgz \
     && : # last line


### PR DESCRIPTION
 #### Problem
[Hadolint](https://github.com/hadolint/hadolint) is a tool which analyzes Dockerfile and provides applicable best practices.  [Version pinning](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get) reduce failures due to unanticipated changes in required packages. The [CHIP integration Docker images](integrations/docker/images) don't have version pinning implemented.

 #### Summary of Changes
These changes implement version pinning best practice as well as reduce some instructions like using `WORKDIR` Docker  and `--no-install-recommends` apt instructions

