### PR TITLE
Fix incorrect mDNS advertisement

### DIFF
--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -58,17 +58,17 @@ public:
     bool IsIPv4Enabled() const { return mEnableIPv4; }
     Derived & SetMac(chip::ByteSpan mac)
     {
-        mMac = chip::ByteSpan(mMacStorage, std::min(mac.size(), kMaxMacSize));
-        memcpy(mMacStorage, mac.data(), mMac.size());
+        mMacLength = std::min(mac.size(), kMaxMacSize);
+        memcpy(mMacStorage, mac.data(), mMacLength);
         return *reinterpret_cast<Derived *>(this);
     }
-    const chip::ByteSpan GetMac() const { return mMac; }
+    const chip::ByteSpan GetMac() const { return chip::ByteSpan(mMacStorage, mMacLength); }
 
 private:
     uint16_t mPort                   = CHIP_PORT;
     bool mEnableIPv4                 = true;
     uint8_t mMacStorage[kMaxMacSize] = {};
-    chip::ByteSpan mMac              = chip::ByteSpan(mMacStorage, kMaxMacSize);
+    size_t mMacLength                = 0;
 }; // namespace Mdns
 
 /// Defines parameters required for advertising a CHIP node


### PR DESCRIPTION
 #### Problem
The mDNS server's advertisement is always incorrect. 

The Advertisement parameters do not set the Mac Address ByteSpan correctly.

If we have a ByteSpan member with a pointer to another member, and don't define a custom operator= on BaseAdvertisingParams that handles things properly, copy-assignment of BaseAdvertisingParams will end up with the ByteSpan pointing to a member of the assigned-from object, not a member of the assigned-to object.

@andreilitvin's breakdown:
1. Temporary object sets up mMacStorage correctly and mMac = ptr(mMacStorage, length)
2. operator= does binary copy, so final objectis : mMacStorage(good) and  mMac = ptr(tmp.mMacStorage), length
so you get a mMac pointing into no-mans land of temporary storage


 #### Summary of Changes
Updated the Advertisement Params to just carry the storage length instead of a ByteSpan entirely. We can just construct the byte span on demand. 
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
