### PR TITLE
[chip-tool] change default endpoint 1 for networkcommissioning cluster

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -143,5 +143,5 @@ private:
     ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
     chip::Controller::NetworkCommissioningCluster mCluster;
-    chip::EndpointId mEndpointId = 0;
+    chip::EndpointId mEndpointId = 1;
 };


### PR DESCRIPTION
 #### Problem
chip-tool(example) can't pairing to chip-lighting app because of invalid endpoint 

 #### Summary of Changes
chip-lighting-app use endpoint 1 but chip-tool use endpoint 0 by default.
So I have changed to endpoint 1 because.
 
Fixes #6391 
