### PR TITLE
Implemented CHIP Certificate (chip-cert) Tool.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -30,6 +30,8 @@ assert(chip_root == "//")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/build/chip/tools.gni")
 
+import("//src/crypto/crypto.gni")
+
 if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
   declare_args() {
     chip_enable_python_modules =
@@ -107,6 +109,9 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
         "${chip_root}/src/qrcodetool",
         "${chip_root}/src/setup_payload",
       ]
+      if (chip_crypto == "openssl") {
+        deps += [ "${chip_root}/src/tools/chip-cert" ]
+      }
       if (chip_enable_python_modules) {
         deps += [ "${chip_root}/src/controller/python" ]
       }

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -260,7 +260,6 @@ public:
      **/
     bool IsEmpty() const { return RDNCount() == 0; }
 
-protected:
     ChipRDN rdn[CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES];
 
     uint8_t RDNCount() const;

--- a/src/tools/chip-cert/BUILD.gn
+++ b/src/tools/chip-cert/BUILD.gn
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/tools.gni")
+
+import("//build/config/linux/pkg_config.gni")
+
+# TODO: Move it into common BUILD file to avoid multiple runs of pkg_config
+pkg_config("openssl_config") {
+  packages = [ "openssl" ]
+}
+
+assert(chip_build_tools)
+
+executable("chip-cert") {
+  sources = [
+    "CertUtils.cpp",
+    "Cmd_ConvertCert.cpp",
+    "Cmd_ConvertKey.cpp",
+    "Cmd_GenCert.cpp",
+    "Cmd_PrintCert.cpp",
+    "Cmd_ResignCert.cpp",
+    "Cmd_ValidateCert.cpp",
+    "GeneralUtils.cpp",
+    "KeyUtils.cpp",
+    "chip-cert.cpp",
+    "chip-cert.h",
+  ]
+
+  public_configs = [ ":openssl_config" ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/credentials",
+    "${chip_root}/src/crypto",
+    "${chip_root}/src/lib/asn1",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -1,0 +1,678 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements utility functions for reading, writing,
+ *      parsing, resigning, encoding, and decoding CHIP certificates.
+ *
+ */
+
+#define __STDC_FORMAT_MACROS
+
+#include "chip-cert.h"
+
+using namespace chip;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
+{
+    bool res         = true;
+    uint8_t rdnCount = RDNCount();
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        int attrNID;
+        switch (rdn[i].mAttrOID)
+        {
+        case kOID_AttributeType_CommonName:
+            attrNID = NID_commonName;
+            break;
+        case kOID_AttributeType_ChipNodeId:
+            attrNID = gNIDChipNodeId;
+            break;
+        case kOID_AttributeType_ChipFirmwareSigningId:
+            attrNID = gNIDChipFirmwareSigningId;
+            break;
+        case kOID_AttributeType_ChipICAId:
+            attrNID = gNIDChipICAId;
+            break;
+        case kOID_AttributeType_ChipRootId:
+            attrNID = gNIDChipRootId;
+            break;
+        case kOID_AttributeType_ChipFabricId:
+            attrNID = gNIDChipFabricId;
+            break;
+        case kOID_AttributeType_ChipAuthTag1:
+            attrNID = gNIDChipAuthTag1;
+            break;
+        case kOID_AttributeType_ChipAuthTag2:
+            attrNID = gNIDChipAuthTag2;
+            break;
+        default:
+            ExitNow(res = false);
+        }
+
+        if (IsChipDNAttr(rdn[i].mAttrOID))
+        {
+            char chipAttrStr[17];
+            int chipAttrLen;
+
+            if (IsChip64bitDNAttr(rdn[i].mAttrOID))
+            {
+                snprintf(chipAttrStr, sizeof(chipAttrStr), "%016" PRIX64 "", rdn[i].mAttrValue.mChipVal);
+                chipAttrLen = 16;
+            }
+            else
+            {
+                snprintf(chipAttrStr, sizeof(chipAttrStr), "%08" PRIX32 "", static_cast<uint32_t>(rdn[i].mAttrValue.mChipVal));
+                chipAttrLen = 8;
+            }
+
+            if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8, (unsigned char *) chipAttrStr,
+                                            chipAttrLen, -1, 0))
+            {
+                ReportOpenSSLErrorAndExit("X509_NAME_add_entry_by_NID", res = false);
+            }
+        }
+        else
+        {
+            if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8,
+                                            (unsigned char *) rdn[i].mAttrValue.mString.mValue,
+                                            (int) rdn[i].mAttrValue.mString.mLen, -1, 0))
+            {
+                ReportOpenSSLErrorAndExit("X509_NAME_add_entry_by_NID", res = false);
+            }
+        }
+    }
+
+exit:
+    return res;
+}
+
+bool ToolChipDN::HasAttr(chip::ASN1::OID oid) const
+{
+    uint8_t rdnCount = RDNCount();
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        if (oid == rdn[i].mAttrOID)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ToolChipDN::PrintDN(FILE * file, const char * name) const
+{
+    uint8_t rdnCount = RDNCount();
+    char valueStr[128];
+    const char * certDesc = nullptr;
+
+    fprintf(file, "%s: ", name);
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        if (IsChip64bitDNAttr(rdn[i].mAttrOID))
+        {
+            snprintf(valueStr, sizeof(valueStr), "%016" PRIX64, rdn[i].mAttrValue.mChipVal);
+        }
+        else if (IsChip32bitDNAttr(rdn[i].mAttrOID))
+        {
+            snprintf(valueStr, sizeof(valueStr), "%08" PRIX32, static_cast<uint32_t>(rdn[i].mAttrValue.mChipVal));
+        }
+        else
+        {
+            uint32_t len = rdn[i].mAttrValue.mString.mLen;
+            if (len > sizeof(valueStr) - 1)
+            {
+                len = sizeof(valueStr) - 1;
+            }
+            memcpy(valueStr, rdn[i].mAttrValue.mString.mValue, len);
+            valueStr[len] = 0;
+        }
+
+        fprintf(file, "%s=%s", chip::ASN1::GetOIDName(rdn[i].mAttrOID), valueStr);
+        if (certDesc != nullptr)
+        {
+            fprintf(file, " (%s)", certDesc);
+        }
+    }
+}
+
+namespace {
+
+CertFormat DetectCertFormat(uint8_t * cert, uint32_t certLen)
+{
+    static const uint8_t chipRawPrefix[]   = { 0xD5, 0x00, 0x00, 0x08, 0x00, 0x01, 0x00 };
+    static const char * chipB64Prefix      = "1QAACAAB";
+    static const uint32_t chipB64PrefixLen = sizeof(chipB64Prefix) - 1;
+    static const char * pemMarker          = "-----BEGIN CERTIFICATE-----";
+
+    if (certLen > sizeof(chipRawPrefix) && memcmp(cert, chipRawPrefix, sizeof(chipRawPrefix)) == 0)
+    {
+        return kCertFormat_Chip_Raw;
+    }
+
+    if (certLen > chipB64PrefixLen && memcmp(cert, chipB64Prefix, chipB64PrefixLen) == 0)
+    {
+        return kCertFormat_Chip_Base64;
+    }
+
+    if (ContainsPEMMarker(pemMarker, cert, certLen))
+    {
+        return kCertFormat_X509_PEM;
+    }
+
+    return kCertFormat_X509_DER;
+}
+
+bool SetCertSerialNumber(X509 * cert)
+{
+    bool res = true;
+    uint64_t rnd;
+    ASN1_INTEGER * snInt = X509_get_serialNumber(cert);
+
+    // Generate a random value to be used as the serial number.
+    if (!RAND_bytes(reinterpret_cast<uint8_t *>(&rnd), sizeof(rnd)))
+    {
+        ReportOpenSSLErrorAndExit("RAND_bytes", res = false);
+    }
+
+    // Avoid negative numbers.
+    rnd &= 0x7FFFFFFFFFFFFFFF;
+
+    // Store the serial number as an ASN1 integer value within the certificate.
+    if (ASN1_INTEGER_set_uint64(snInt, rnd) == 0)
+    {
+        ReportOpenSSLErrorAndExit("ASN1_INTEGER_set_uint64", res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool SetCertTimeField(ASN1_TIME * asn1Time, const struct tm & value)
+{
+    char timeStr[16];
+
+    // Encode the time as a string in the form YYYYMMDDHHMMSSZ.
+    snprintf(timeStr, sizeof(timeStr), "%04d%02d%02d%02d%02d%02dZ", static_cast<uint16_t>(value.tm_year + 1900) % 9999,
+             static_cast<uint8_t>(value.tm_mon) % kMonthsPerYear + 1, static_cast<uint8_t>(value.tm_mday) % kMaxDaysPerMonth,
+             static_cast<uint8_t>(value.tm_hour) % kHoursPerDay, static_cast<uint8_t>(value.tm_min) % kMinutesPerHour,
+             static_cast<uint8_t>(value.tm_sec) % kSecondsPerMinute);
+
+    // X.509/RFC-5280 mandates that times before 2050 UTC must be encoded as ASN.1 UTCTime values, while
+    // times equal or greater than 2050 must be encoded as GeneralizedTime values.  The only difference
+    // between the two is the number of digits in the year -- 4 for GeneralizedTime, 2 for UTCTime.
+    //
+    // The OpenSSL ASN1_TIME_set_string() function DOES NOT handle picking the correct format based
+    // on the given year.  Thus the caller MUST pass a correctly formatted string or the resultant
+    // certificate will be malformed.
+
+    bool useUTCTime = ((value.tm_year + 1900) < 2050);
+
+    if (!ASN1_TIME_set_string(asn1Time, timeStr + (useUTCTime ? 2 : 0)))
+    {
+        fprintf(stderr, "OpenSSL ASN1_TIME_set_string() failed\n");
+        return false;
+    }
+
+    return true;
+}
+
+bool SetValidityTime(X509 * cert, const struct tm & validFrom, uint32_t validDays)
+{
+    bool res = true;
+    struct tm validTo;
+    time_t validToTime;
+
+    // Compute the validity end date.
+    // Note that this computation is done in local time, despite the fact that the certificate validity times are
+    // UTC.  This is because the standard posix time functions do not make it easy to convert a struct tm containing
+    // UTC to a time_t value without manipulating the TZ environment variable.
+    validTo = validFrom;
+    validTo.tm_mday += validDays;
+    validTo.tm_sec -= 1; // Ensure validity period is exactly a multiple of a day.
+    validTo.tm_isdst = -1;
+    validToTime      = mktime(&validTo);
+    if (validToTime == static_cast<time_t>(-1))
+    {
+        fprintf(stderr, "mktime() failed\n");
+        ExitNow(res = false);
+    }
+    localtime_r(&validToTime, &validTo);
+
+    // Set the certificate's notBefore date.
+    res = SetCertTimeField(X509_get_notBefore(cert), validFrom);
+    VerifyTrueOrExit(res);
+
+    // Set the certificate's notAfter date.
+    res = SetCertTimeField(X509_get_notAfter(cert), validTo);
+    VerifyTrueOrExit(res);
+
+exit:
+    return true;
+}
+
+bool AddExtension(X509 * cert, int extNID, const char * extStr)
+{
+    bool res = true;
+    std::unique_ptr<X509_EXTENSION, void (*)(X509_EXTENSION *)> ex(
+        X509V3_EXT_nconf_nid(nullptr, nullptr, extNID, const_cast<char *>(extStr)), &X509_EXTENSION_free);
+
+    if (!X509_add_ext(cert, ex.get(), -1))
+    {
+        ReportOpenSSLErrorAndExit("X509_add_ext", res = false);
+    }
+
+exit:
+    return res;
+}
+
+/** The key identifier field is derived from the public key using method (1) per RFC5280 (section 4.2.1.2):
+ *
+ *      (1) The keyIdentifier is composed of the 160-bit SHA-1 hash of the
+ *           value of the BIT STRING subjectPublicKey (excluding the tag,
+ *           length, and number of unused bits).
+ */
+bool AddSubjectKeyId(X509 * cert)
+{
+    bool res             = true;
+    ASN1_BIT_STRING * pk = X509_get0_pubkey_bitstr(cert);
+    unsigned char pkHash[EVP_MAX_MD_SIZE];
+    unsigned int pkHashLen;
+    std::unique_ptr<ASN1_STRING, void (*)(ASN1_STRING *)> pkHashOS(ASN1_STRING_type_new(V_ASN1_OCTET_STRING), &ASN1_STRING_free);
+
+    if (!EVP_Digest(pk->data, static_cast<size_t>(pk->length), pkHash, &pkHashLen, EVP_sha1(), nullptr))
+    {
+        ReportOpenSSLErrorAndExit("EVP_Digest", res = false);
+    }
+
+    if (pkHashLen != kKeyIdentifierLength)
+    {
+        fprintf(stderr, "Unexpected hash length returned from EVP_Digest()\n");
+        ExitNow(res = false);
+    }
+
+    if (!ASN1_STRING_set(pkHashOS.get(), pkHash, static_cast<int>(pkHashLen)))
+    {
+        ReportOpenSSLErrorAndExit("ASN1_STRING_set", res = false);
+    }
+
+    if (!X509_add1_ext_i2d(cert, NID_subject_key_identifier, pkHashOS.get(), 0, X509V3_ADD_APPEND))
+    {
+        ReportOpenSSLErrorAndExit("X509_add1_ext_i2d", res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool AddAuthorityKeyId(X509 * cert, X509 * caCert)
+{
+    bool res = true;
+    int isCritical;
+    int index = 0;
+    std::unique_ptr<AUTHORITY_KEYID, void (*)(AUTHORITY_KEYID *)> akid(AUTHORITY_KEYID_new(), &AUTHORITY_KEYID_free);
+
+    akid.get()->keyid =
+        reinterpret_cast<ASN1_OCTET_STRING *>(X509_get_ext_d2i(caCert, NID_subject_key_identifier, &isCritical, &index));
+    if (akid.get()->keyid == nullptr)
+    {
+        ReportOpenSSLErrorAndExit("X509_get_ext_d2i", res = false);
+    }
+
+    if (!X509_add1_ext_i2d(cert, NID_authority_key_identifier, akid.get(), 0, X509V3_ADD_APPEND))
+    {
+        ReportOpenSSLErrorAndExit("X509_add1_ext_i2d", res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool ReadCertPEM(const char * fileName, X509 * cert)
+{
+    bool res    = true;
+    FILE * file = nullptr;
+
+    res = OpenFile(fileName, file);
+    VerifyTrueOrExit(res);
+
+    if (PEM_read_X509(file, &cert, nullptr, nullptr) == nullptr)
+    {
+        ReportOpenSSLErrorAndExit("PEM_read_X509", res = false);
+    }
+
+exit:
+    CloseFile(file);
+    return res;
+}
+
+} // namespace
+
+bool ReadCert(const char * fileName, X509 * cert)
+{
+    CertFormat origCertFmt;
+    return ReadCert(fileName, cert, origCertFmt);
+}
+
+bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
+{
+    bool res          = true;
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+    const uint8_t * p = nullptr;
+    uint32_t certLen  = 0;
+    std::unique_ptr<uint8_t[]> x509CertBuf(new uint8_t[kMaxX509CertBufSize]);
+    std::unique_ptr<uint8_t[]> certBuf;
+
+    res = ReadFileIntoMem(fileName, nullptr, certLen);
+    VerifyTrueOrExit(res);
+
+    certBuf = std::unique_ptr<uint8_t[]>(new uint8_t[certLen]);
+
+    res = ReadFileIntoMem(fileName, certBuf.get(), certLen);
+    VerifyTrueOrExit(res);
+
+    certFmt = DetectCertFormat(certBuf.get(), certLen);
+
+    if (certFmt == kCertFormat_X509_PEM)
+    {
+        res = ReadCertPEM(fileName, cert);
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        if (certFmt == kCertFormat_Chip_Base64)
+        {
+            res = Base64Decode(certBuf.get(), certLen, certBuf.get(), certLen, certLen);
+            VerifyTrueOrExit(res);
+        }
+
+        if (certFmt == kCertFormat_Chip_Base64 || certFmt == kCertFormat_Chip_Raw)
+        {
+            err = ConvertChipCertToX509Cert(certBuf.get(), certLen, x509CertBuf.get(), kMaxX509CertBufSize, certLen);
+            if (err != CHIP_NO_ERROR)
+            {
+                fprintf(stderr, "Error converting certificate: %s\n", chip::ErrorStr(err));
+                ExitNow(res = false);
+            }
+
+            p = x509CertBuf.get();
+        }
+        else
+        {
+            p = certBuf.get();
+        }
+
+        if (d2i_X509(&cert, &p, certLen) == nullptr)
+        {
+            ReportOpenSSLErrorAndExit("d2i_X509", res = false);
+        }
+    }
+
+exit:
+    return res;
+}
+
+bool X509ToChipCert(X509 * cert, uint8_t * certBuf, uint32_t certBufSize, uint32_t & certLen)
+{
+    bool res = true;
+    CHIP_ERROR err;
+    uint8_t * derCert = nullptr;
+    int32_t derCertLen;
+
+    derCertLen = i2d_X509(cert, &derCert);
+    if (derCertLen < 0)
+    {
+        ReportOpenSSLErrorAndExit("i2d_X509", res = false);
+    }
+
+    err = ConvertX509CertToChipCert(derCert, static_cast<uint32_t>(derCertLen), certBuf, certBufSize, certLen);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "ConvertX509CertToChipCert() failed\n%s\n", chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool LoadChipCert(const char * fileName, bool isTrused, ChipCertificateSet & certSet, uint8_t * certBuf, uint32_t certBufSize)
+{
+    bool res = true;
+    CHIP_ERROR err;
+    uint32_t certLen;
+    BitFlags<CertDecodeFlags> decodeFlags;
+    std::unique_ptr<X509, void (*)(X509 *)> cert(X509_new(), &X509_free);
+
+    res = ReadCert(fileName, cert.get());
+    VerifyTrueOrExit(res);
+
+    res = X509ToChipCert(cert.get(), certBuf, certBufSize, certLen);
+    VerifyTrueOrExit(res);
+
+    if (isTrused)
+    {
+        decodeFlags.Set(CertDecodeFlags::kIsTrustAnchor);
+    }
+    else
+    {
+        decodeFlags.Set(CertDecodeFlags::kGenerateTBSHash);
+    }
+
+    err = certSet.LoadCert(certBuf, certLen, decodeFlags);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Error reading %s\n%s\n", fileName, chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
+{
+    bool res    = true;
+    FILE * file = nullptr;
+
+    VerifyOrExit(cert != nullptr, res = false);
+
+    res = OpenFile(fileName, file, true);
+    VerifyTrueOrExit(res);
+
+    if (certFmt == kCertFormat_X509_PEM)
+    {
+        if (PEM_write_X509(file, cert) == 0)
+        {
+            ReportOpenSSLErrorAndExit("PEM_write_X509", res = false);
+        }
+    }
+    else if (certFmt == kCertFormat_X509_DER)
+    {
+        if (i2d_X509_fp(file, cert) == 0)
+        {
+            ReportOpenSSLErrorAndExit("i2d_X509_fp", res = false);
+        }
+    }
+    else if (certFmt == kCertFormat_Chip_Raw || certFmt == kCertFormat_Chip_Base64)
+    {
+        uint8_t * certToWrite      = nullptr;
+        uint32_t certToWriteLen    = 0;
+        uint32_t chipCertLen       = kMaxChipCertBufSize;
+        uint32_t chipCertBase64Len = BASE64_ENCODED_LEN(chipCertLen);
+        std::unique_ptr<uint8_t[]> chipCert(new uint8_t[chipCertLen]);
+        std::unique_ptr<uint8_t[]> chipCertBase64(new uint8_t[chipCertBase64Len]);
+
+        res = X509ToChipCert(cert, chipCert.get(), chipCertLen, chipCertLen);
+        VerifyTrueOrExit(res);
+
+        if (certFmt == kCertFormat_Chip_Base64)
+        {
+            res = Base64Encode(chipCert.get(), chipCertLen, chipCertBase64.get(), chipCertBase64Len, chipCertBase64Len);
+            VerifyTrueOrExit(res);
+
+            certToWrite    = chipCertBase64.get();
+            certToWriteLen = chipCertBase64Len;
+        }
+        else
+        {
+            certToWrite    = chipCert.get();
+            certToWriteLen = chipCertLen;
+        }
+
+        if (fwrite(certToWrite, 1, certToWriteLen, file) != certToWriteLen)
+        {
+            fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
+            ExitNow(res = false);
+        }
+    }
+
+exit:
+    CloseFile(file);
+    return res;
+}
+
+bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
+              uint32_t validDays, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert, EVP_PKEY * newKey)
+{
+    bool res = true;
+
+    VerifyOrExit(subjectDN != nullptr, res = false);
+    VerifyOrExit(caCert != nullptr, res = false);
+    VerifyOrExit(caKey != nullptr, res = false);
+    VerifyOrExit(newCert != nullptr, res = false);
+    VerifyOrExit(newKey != nullptr, res = false);
+
+    // Set the certificate version (must be 2, a.k.a. v3).
+    if (!X509_set_version(newCert, 2))
+    {
+        ReportOpenSSLErrorAndExit("X509_set_version", res = false);
+    }
+
+    // Generate a serial number for the cert.
+    res = SetCertSerialNumber(newCert);
+    VerifyTrueOrExit(res);
+
+    // Set the certificate validity time.
+    res = SetValidityTime(newCert, validFrom, validDays);
+    VerifyTrueOrExit(res);
+
+    // Set the certificate's public key.
+    if (!X509_set_pubkey(newCert, newKey))
+    {
+        ReportOpenSSLErrorAndExit("X509_set_pubkey", res = false);
+    }
+
+    // Set certificate subject DN.
+    res = subjectDN->SetCertSubjectDN(newCert);
+    VerifyTrueOrExit(res);
+
+    // Set the issuer name for the certificate. In the case of a self-signed cert, this will be
+    // the new cert's subject name.
+    if (!X509_set_issuer_name(newCert, X509_get_subject_name(caCert)))
+    {
+        ReportOpenSSLErrorAndExit("X509_set_issuer_name", res = false);
+    }
+
+    // Add the appropriate certificate extensions.
+    if (certType == kCertType_Node)
+    {
+        res = AddExtension(newCert, NID_basic_constraints, "critical,CA:FALSE") &&
+            AddExtension(newCert, NID_key_usage, "critical,digitalSignature,keyEncipherment") &&
+            AddExtension(newCert, NID_ext_key_usage, "critical,clientAuth,serverAuth");
+    }
+    else if (certType == kCertType_FirmwareSigning)
+    {
+        res = AddExtension(newCert, NID_basic_constraints, "critical,CA:FALSE") &&
+            AddExtension(newCert, NID_key_usage, "critical,digitalSignature") &&
+            AddExtension(newCert, NID_ext_key_usage, "critical,codeSigning");
+    }
+    else if (certType == kCertType_ICA || certType == kCertType_Root)
+    {
+        res = AddExtension(newCert, NID_basic_constraints, "critical,CA:TRUE") &&
+            AddExtension(newCert, NID_key_usage, "critical,keyCertSign,cRLSign");
+    }
+    VerifyTrueOrExit(res);
+
+    // Add a subject key id extension for the certificate.
+    res = AddSubjectKeyId(newCert);
+    VerifyTrueOrExit(res);
+
+    // Add the authority key id extension from the signing certificate. For self-signed cert's this will
+    // be the same as new cert's subject key id extension.
+    res = AddAuthorityKeyId(newCert, caCert);
+    VerifyTrueOrExit(res);
+
+    for (uint8_t i = 0; i < futureExtsCount; i++)
+    {
+        res = AddExtension(newCert, futureExts[i].nid, futureExts[i].info);
+        VerifyTrueOrExit(res);
+    }
+
+    // Sign the new certificate.
+    if (!X509_sign(newCert, caKey, EVP_sha256()))
+    {
+        ReportOpenSSLErrorAndExit("X509_sign", res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool ResignCert(X509 * cert, X509 * caCert, EVP_PKEY * caKey)
+{
+    bool res            = true;
+    int authKeyIdExtLoc = -1;
+
+    res = SetCertSerialNumber(cert);
+    VerifyTrueOrExit(res);
+
+    if (!X509_set_issuer_name(cert, X509_get_subject_name(caCert)))
+    {
+        ReportOpenSSLErrorAndExit("X509_set_issuer_name", res = false);
+    }
+
+    // Remove any existing authority key id
+    authKeyIdExtLoc = X509_get_ext_by_NID(cert, NID_authority_key_identifier, -1);
+    if (authKeyIdExtLoc != -1)
+    {
+        if (X509_delete_ext(cert, authKeyIdExtLoc) == nullptr)
+        {
+            ReportOpenSSLErrorAndExit("X509_delete_ext", res = false);
+        }
+    }
+
+    res = AddAuthorityKeyId(cert, caCert);
+    VerifyTrueOrExit(res);
+
+    if (!X509_sign(cert, caKey, EVP_sha256()))
+    {
+        ReportOpenSSLErrorAndExit("X509_sign", res = false);
+    }
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_ConvertCert.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertCert.cpp
@@ -1,0 +1,187 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that converts a CHIP certificate between CHIP TLV and X.509
+ *      formats.
+ *
+ */
+
+#include "chip-cert.h"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+
+#define CMD_NAME "chip-cert convert-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "x509-pem",   kNoArgument, 'p' },
+    { "x509-der",   kNoArgument, 'x' },
+    { "chip",       kNoArgument, 'c' },
+    { "chip-b64",   kNoArgument, 'b' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "  -p, --x509-pem\n"
+    "\n"
+    "       Output certificate in X.509 PEM format.\n"
+    "\n"
+    "  -x, --x509-der\n"
+    "\n"
+    "       Output certificate in X.509 DER format.\n"
+    "\n"
+    "  -c, --chip\n"
+    "\n"
+    "       Output certificate in raw CHIP TLV format.\n"
+    "\n"
+    "  -b --chip-b64\n"
+    "\n"
+    "       Output certificate in CHIP TLV base-64 encoded format.\n"
+    "       This is the default.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ] <in-file> <out-file>\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Convert a certificate between CHIP and X509 forms.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <in-file>\n"
+    "\n"
+    "       The input certificate file name, or - to read from stdin. The\n"
+    "       format of the input certificate is auto-detected and can be any\n"
+    "       of: X.509 PEM, X.509 DER, CHIP base-64 or CHIP raw TLV.\n"
+    "\n"
+    "  <out-file>\n"
+    "\n"
+    "       The output certificate file name, or - to write to stdout.\n"
+    "\n"
+);
+
+OptionSet * gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+const char * gInFileName  = nullptr;
+const char * gOutFileName = nullptr;
+CertFormat gOutCertFormat = kCertFormat_Chip_Base64;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'p':
+        gOutCertFormat = kCertFormat_X509_PEM;
+        break;
+    case 'x':
+        gOutCertFormat = kCertFormat_X509_DER;
+        break;
+    case 'b':
+        gOutCertFormat = kCertFormat_Chip_Base64;
+        break;
+    case 'c':
+        gOutCertFormat = kCertFormat_Chip_Raw;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the input certificate file, or - for stdin.\n", progName);
+        return false;
+    }
+
+    if (argc == 1)
+    {
+        PrintArgError("%s: Please specify the name of the output certificate file, or - for stdout\n", progName);
+        return false;
+    }
+
+    if (argc > 2)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[2]);
+        return false;
+    }
+
+    gInFileName  = argv[0];
+    gOutFileName = argv[1];
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_ConvertCert(int argc, char * argv[])
+{
+    bool res = true;
+    std::unique_ptr<X509, void (*)(X509 *)> cert(X509_new(), &X509_free);
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
+    VerifyTrueOrExit(res);
+
+    res = InitOpenSSL();
+    VerifyTrueOrExit(res);
+
+    res = ReadCert(gInFileName, cert.get());
+    VerifyTrueOrExit(res);
+
+    res = WriteCert(gOutFileName, cert.get(), gOutCertFormat);
+    VerifyTrueOrExit(res);
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_ConvertKey.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertKey.cpp
@@ -1,0 +1,188 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that converts a CHIP private key between CHIP serialized and
+ *      PEM/DER formats.
+ *
+ */
+
+#include "chip-cert.h"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+
+#define CMD_NAME "chip-cert convert-key"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "x509-pem",       kNoArgument, 'p' },
+    { "x509-der",       kNoArgument, 'x' },
+    { "chip",           kNoArgument, 'c' },
+    { "chip-b64",       kNoArgument, 'b' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "   -p, --x509-pem\n"
+    "\n"
+    "       Output the private key in SEC1/RFC-5915 PEM format.\n"
+    "\n"
+    "   -x, --x509-der\n"
+    "\n"
+    "       Output the private key in SEC1/RFC-5915 DER format. \n"
+    "\n"
+    "   -c, --chip\n"
+    "\n"
+    "       Output the private key in raw CHIP serialized format.\n"
+    "\n"
+    "   -b, --chip-b64\n"
+    "\n"
+    "       Output the private key in base-64 encoded CHIP serialized format.\n"
+    "       This is the default.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ] <in-file> <out-file>\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Convert a private key between CHIP and PEM/DER forms."
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "   <in-file>\n"
+    "\n"
+    "       The input private key file name, or - to read from stdin. The\n"
+    "       format of the input key is auto-detected and can be any\n"
+    "       of: PEM, DER, CHIP base-64 or CHIP raw.\n"
+    "\n"
+    "   <out-file>\n"
+    "\n"
+    "       The output private key file name, or - to write to stdout.\n"
+    "\n"
+);
+
+OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-ormat on
+
+const char * gInFileName = nullptr;
+const char * gOutFileName = nullptr;
+KeyFormat gOutFormat = kKeyFormat_Chip_Base64;
+
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'p':
+        gOutFormat = kKeyFormat_X509_PEM;
+        break;
+    case 'x':
+        gOutFormat = kKeyFormat_X509_DER;
+        break;
+    case 'b':
+        gOutFormat = kKeyFormat_Chip_Base64;
+        break;
+    case 'c':
+        gOutFormat = kKeyFormat_Chip_Raw;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the input key file, or - for stdin.\n", progName);
+        return false;
+    }
+
+    if (argc == 1)
+    {
+        PrintArgError("%s: Please specify the name of the output key file, or - for stdout\n", progName);
+        return false;
+    }
+
+    if (argc > 2)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[2]);
+        return false;
+    }
+
+    gInFileName  = argv[0];
+    gOutFileName = argv[1];
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_ConvertKey(int argc, char * argv[])
+{
+    bool res       = true;
+    std::unique_ptr<EVP_PKEY,void(*)(EVP_PKEY*)> key(EVP_PKEY_new(), &EVP_PKEY_free);
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
+    VerifyTrueOrExit(res);
+
+    res = InitOpenSSL();
+    VerifyTrueOrExit(res);
+
+    res = ReadKey(gInFileName, key.get());
+    VerifyTrueOrExit(res);
+
+    res = WritePrivateKey(gOutFileName, key.get(), gOutFormat);
+    VerifyTrueOrExit(res);
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -1,0 +1,525 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that generates a CHIP certificate.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include "chip-cert.h"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert gen-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "type",             kArgumentRequired, 't' },
+    { "subject-chip-id",  kArgumentRequired, 'i' },
+    { "subject-fab-id",   kArgumentRequired, 'f' },
+    { "subject-at",       kArgumentRequired, 'a' },
+    { "subject-cn-u",     kArgumentRequired, 'c' },
+    { "future-ext-sub",   kArgumentRequired, 'x' },
+    { "future-ext-info",  kArgumentRequired, '2' },
+    { "key",              kArgumentRequired, 'k' },
+    { "ca-cert",          kArgumentRequired, 'C' },
+    { "ca-key",           kArgumentRequired, 'K' },
+    { "out",              kArgumentRequired, 'o' },
+    { "out-key",          kArgumentRequired, 'O' },
+    { "out-format",       kArgumentRequired, 'F' },
+    { "valid-from",       kArgumentRequired, 'V' },
+    { "lifetime",         kArgumentRequired, 'l' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "   -t, --type <cert-type>\n"
+    "\n"
+    "       Certificate type to be generated. Valid certificate type values are:\n"
+    "           r - root certificate\n"
+    "           c - CA certificate\n"
+    "           n - node certificate\n"
+    "           f - firmware signing certificate\n"
+    "\n"
+    "   -i, --subject-chip-id <hex-digits>\n"
+    "\n"
+    "       Subject DN CHIP Id attribute (in hex). For Node Certificate it is CHIP Node Id attribute.\n"
+    "          - for Root certificate it is ChipRootId\n"
+    "          - for intermediate CA certificate it is ChipICAId\n"
+    "          - for Node certificate it is ChipNodeId\n"
+    "          - for Firmware Signing certificate it is ChipFirmwareSigningId\n"
+    "\n"
+    "   -f, --subject-fab-id <hex-digits>\n"
+    "\n"
+    "       Subject DN Fabric Id attribute (in hex).\n"
+    "\n"
+    "   -a, --subject-at <hex-digits>\n"
+    "\n"
+    "       Subject DN CHIP Authentication Tag (in hex).\n"
+    "\n"
+    "   -c, --subject-cn-u <string>\n"
+    "\n"
+    "       Subject DN Common Name attribute encoded as UTF8String.\n"
+    "\n"
+    "   -x, --future-ext-sub <string>\n"
+    "\n"
+    "       NID_subject_alt_name extension to be added to the list of certificate extensions.\n"
+    "\n"
+    "   -2, --future-ext-info <string>\n"
+    "\n"
+    "       NID_info_access extension to be added to the list of certificate extensions.\n"
+    "\n"
+    "   -C, --ca-cert <file>\n"
+    "\n"
+    "       File containing CA certificate to be used to sign the new certificate.\n"
+    "\n"
+    "   -K, --ca-key <file>\n"
+    "\n"
+    "       File containing CA private key to be used to sign the new certificate.\n"
+    "\n"
+    "   -k, --key <file>\n"
+    "\n"
+    "       File containing the public and private keys for the new certificate.\n"
+    "       If not specified, a new key pair will be generated.\n"
+    "\n"
+    "   -o, --out <file>\n"
+    "\n"
+    "       File to contain the new certificate.\n"
+    "\n"
+    "   -O, --out-key <file>\n"
+    "\n"
+    "       File to contain the public/private key for the new certificate.\n"
+    "       This option must be specified if the --key option is not.\n"
+    "\n"
+    "  -F, --out-format <format>\n"
+    "\n"
+    "       Specifies format of the output certificate and private key.\n"
+    "       If not specified, the default base-64 encoded CHIP format is used.\n"
+    "       Supported format parametes are:\n"
+    "           x509-pem  - X.509 PEM format\n"
+    "           x509-der  - X.509 DER format\n"
+    "           chip      - raw CHIP TLV format\n"
+    "           chip-b64  - base-64 encoded CHIP TLV format (default)\n"
+    "\n"
+    "   -V, --valid-from <YYYY>-<MM>-<DD> [ <HH>:<MM>:<SS> ]\n"
+    "\n"
+    "       The start date for the certificate's validity period. If not specified,\n"
+    "       the validity period starts on the current day.\n"
+    "\n"
+    "   -l, --lifetime <days>\n"
+    "\n"
+    "       The lifetime for the new certificate, in whole days.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ]\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Generate a CHIP certificate"
+);
+
+OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+ToolChipDN gSubjectDN;
+uint8_t gCertType                    = kCertType_NotSpecified;
+bool gSelfSign                       = false;
+const char * gCACertFileName         = nullptr;
+const char * gCAKeyFileName          = nullptr;
+const char * gInKeyFileName          = nullptr;
+const char * gOutCertFileName        = nullptr;
+const char * gOutKeyFileName         = nullptr;
+CertFormat gOutCertFormat            = kCertFormat_Chip_Base64;
+KeyFormat gOutKeyFormat              = kKeyFormat_Chip_Base64;
+uint32_t gValidDays                  = 0;
+FutureExtension gFutureExtensions[3] = { { 0, nullptr } };
+uint8_t gFutureExtensionsCount       = 0;
+struct tm gValidFrom;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint64_t chip64bitAttr;
+    OID attrOID;
+
+    switch (id)
+    {
+    case 't':
+        if (strlen(arg) == 1)
+        {
+            if (*arg == 'n')
+            {
+                gCertType = kCertType_Node;
+            }
+            else if (*arg == 'f')
+            {
+                gCertType = kCertType_FirmwareSigning;
+            }
+            else if (*arg == 'c')
+            {
+                gCertType = kCertType_ICA;
+            }
+            else if (*arg == 'r')
+            {
+                gCertType = kCertType_Root;
+                gSelfSign = true;
+            }
+        }
+
+        if (gCertType == kCertType_NotSpecified)
+        {
+            PrintArgError("%s: Invalid value specified for the certificate type: %s\n", progName, arg);
+            return false;
+        }
+        break;
+
+    case 'i':
+        if (!ParseChip64bitAttr(arg, chip64bitAttr))
+        {
+            PrintArgError("%s: Invalid value specified for subject chip id attribute: %s\n", progName, arg);
+            return false;
+        }
+
+        switch (gCertType)
+        {
+        case kCertType_Node:
+            attrOID = kOID_AttributeType_ChipNodeId;
+            break;
+        case kCertType_FirmwareSigning:
+            attrOID = kOID_AttributeType_ChipFirmwareSigningId;
+            break;
+        case kCertType_ICA:
+            attrOID = kOID_AttributeType_ChipICAId;
+            break;
+        case kCertType_Root:
+            attrOID = kOID_AttributeType_ChipRootId;
+            break;
+        default:
+            PrintArgError("%s: Certificate type argument should be specified prior to subject attribute: %s\n", progName, arg);
+            return false;
+        }
+
+        err = gSubjectDN.AddAttribute(attrOID, chip64bitAttr);
+        if (err != CHIP_NO_ERROR)
+        {
+            fprintf(stderr, "Failed to add subject DN attribute: %s\n", chip::ErrorStr(err));
+            return false;
+        }
+        break;
+
+    case 'a':
+        if (!ParseChip64bitAttr(arg, chip64bitAttr))
+        {
+            PrintArgError("%s: Invalid value specified for the subject authentication tag attribute: %s\n", progName, arg);
+            return false;
+        }
+
+        if (!gSubjectDN.HasAttr(kOID_AttributeType_ChipAuthTag1))
+        {
+            attrOID = kOID_AttributeType_ChipAuthTag1;
+        }
+        else if (!gSubjectDN.HasAttr(kOID_AttributeType_ChipAuthTag2))
+        {
+            attrOID = kOID_AttributeType_ChipAuthTag2;
+        }
+        else
+        {
+            PrintArgError("%s: Too many authentication tag attributes are specified: %s\n", progName, arg);
+            return false;
+        }
+
+        err = gSubjectDN.AddAttribute(attrOID, chip64bitAttr);
+        if (err != CHIP_NO_ERROR)
+        {
+            fprintf(stderr, "Failed to add subject DN attribute: %s\n", chip::ErrorStr(err));
+            return false;
+        }
+        break;
+
+    case 'f':
+        if (!ParseChip64bitAttr(arg, chip64bitAttr))
+        {
+            PrintArgError("%s: Invalid value specified for subject fabric id attribute: %s\n", progName, arg);
+            return false;
+        }
+
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_ChipFabricId, chip64bitAttr);
+        if (err != CHIP_NO_ERROR)
+        {
+            fprintf(stderr, "Failed to add Fabric Id attribute to the subject DN: %s\n", chip::ErrorStr(err));
+            return false;
+        }
+        break;
+
+    case 'c':
+        err = gSubjectDN.AddAttribute(kOID_AttributeType_CommonName, reinterpret_cast<const uint8_t *>(arg),
+                                      static_cast<uint32_t>(strlen(arg)));
+        if (err != CHIP_NO_ERROR)
+        {
+            fprintf(stderr, "Failed to add Common Name attribute to the subject DN: %s\n", chip::ErrorStr(err));
+            return false;
+        }
+        break;
+    case 'x':
+        gFutureExtensions[gFutureExtensionsCount].nid  = NID_subject_alt_name;
+        gFutureExtensions[gFutureExtensionsCount].info = arg;
+        gFutureExtensionsCount++;
+        break;
+    case '2':
+        gFutureExtensions[gFutureExtensionsCount].nid  = NID_info_access;
+        gFutureExtensions[gFutureExtensionsCount].info = arg;
+        gFutureExtensionsCount++;
+        break;
+    case 'k':
+        gInKeyFileName = arg;
+        break;
+    case 'C':
+        gCACertFileName = arg;
+        break;
+    case 'K':
+        gCAKeyFileName = arg;
+        break;
+    case 'o':
+        gOutCertFileName = arg;
+        break;
+    case 'O':
+        gOutKeyFileName = arg;
+        break;
+    case 'F':
+        if (strcmp(arg, "x509-pem") == 0)
+        {
+            gOutCertFormat = kCertFormat_X509_PEM;
+            gOutKeyFormat  = kKeyFormat_X509_PEM;
+        }
+        else if (strcmp(arg, "x509-der") == 0)
+        {
+            gOutCertFormat = kCertFormat_X509_DER;
+            gOutKeyFormat  = kKeyFormat_X509_DER;
+        }
+        else if (strcmp(arg, "chip") == 0)
+        {
+            gOutCertFormat = kCertFormat_Chip_Raw;
+            gOutKeyFormat  = kKeyFormat_Chip_Raw;
+        }
+        else if (strcmp(arg, "chip-b64") == 0)
+        {
+            gOutCertFormat = kCertFormat_Chip_Base64;
+            gOutKeyFormat  = kKeyFormat_Chip_Base64;
+        }
+        else
+        {
+            PrintArgError("%s: Invalid value specified for the output format: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case 'V':
+        if (!ParseDateTime(arg, gValidFrom))
+        {
+            PrintArgError("%s: Invalid value specified for certificate validity date: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    case 'l':
+        if (!ParseInt(arg, gValidDays))
+        {
+            PrintArgError("%s: Invalid value specified for certificate lifetime: %s\n", progName, arg);
+            return false;
+        }
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_GenCert(int argc, char * argv[])
+{
+    CHIP_ERROR err   = CHIP_NO_ERROR;
+    bool res         = true;
+    uint8_t certType = kCertType_NotSpecified;
+    std::unique_ptr<X509, void (*)(X509 *)> newCert(X509_new(), &X509_free);
+    std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> newKey(EVP_PKEY_new(), &EVP_PKEY_free);
+
+    {
+        time_t now         = time(nullptr);
+        gValidFrom         = *gmtime(&now);
+        gValidFrom.tm_hour = 0;
+        gValidFrom.tm_min  = 0;
+        gValidFrom.tm_sec  = 0;
+    }
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets);
+    VerifyTrueOrExit(res);
+
+    if (gSubjectDN.IsEmpty())
+    {
+        fprintf(stderr, "Please specify the subject DN attributes.\n");
+        ExitNow(res = false);
+    }
+
+    err = gSubjectDN.GetCertType(certType);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Invalid certificate subject attribute specified: %s\n", chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+    if (certType != gCertType)
+    {
+        fprintf(stderr, "Please specify certificate type that matches subject DN attributes.\n");
+        ExitNow(res = false);
+    }
+
+    if (gCACertFileName == nullptr && !gSelfSign)
+    {
+        fprintf(stderr, "Please specify the CA certificate file name using the --ca-cert option.\n");
+        ExitNow(res = false);
+    }
+    else if (gCACertFileName != nullptr && gSelfSign)
+    {
+        fprintf(stderr, "Please don't specify --ca-cert option for the self signed certificate. \n");
+        ExitNow(res = false);
+    }
+
+    if (gCACertFileName != nullptr && gCAKeyFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the CA key file name using the --ca-key option.\n");
+        ExitNow(res = false);
+    }
+
+    if (gOutCertFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the file name for the new certificate using the --out option.\n");
+        ExitNow(res = false);
+    }
+
+    if (gInKeyFileName == nullptr && gOutKeyFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the file name for the new public/private key using the --out-key option.\n");
+        ExitNow(res = false);
+    }
+
+    if (gValidDays == 0)
+    {
+        fprintf(stderr, "Please specify the lifetime (in dys) for the new certificate using the --lifetime option.\n");
+        ExitNow(res = false);
+    }
+
+    if (strcmp(gOutCertFileName, "-") != 0 && access(gOutCertFileName, R_OK) == 0)
+    {
+        fprintf(stderr,
+                "Output certificate file already exists (%s)\n"
+                "To replace the file, please remove it and re-run the command.\n",
+                gOutCertFileName);
+        ExitNow(res = false);
+    }
+
+    if (gOutKeyFileName != nullptr && access(gOutKeyFileName, R_OK) == 0)
+    {
+        fprintf(stderr,
+                "Output key file already exists (%s)\n"
+                "To replace the file, please remove it and re-run the command.\n",
+                gOutKeyFileName);
+        ExitNow(res = false);
+    }
+
+    res = InitOpenSSL();
+    VerifyTrueOrExit(res);
+
+    if (gInKeyFileName != nullptr)
+    {
+        res = ReadKey(gInKeyFileName, newKey.get());
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        res = GenerateKeyPair(newKey.get());
+        VerifyTrueOrExit(res);
+    }
+
+    if (gSelfSign)
+    {
+        res = MakeCert(gCertType, &gSubjectDN, newCert.get(), newKey.get(), gValidFrom, gValidDays, gFutureExtensions,
+                       gFutureExtensionsCount, newCert.get(), newKey.get());
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        std::unique_ptr<X509, void (*)(X509 *)> caCert(X509_new(), &X509_free);
+        std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> caKey(EVP_PKEY_new(), &EVP_PKEY_free);
+
+        res = ReadCert(gCACertFileName, caCert.get());
+        VerifyTrueOrExit(res);
+
+        res = ReadKey(gCAKeyFileName, caKey.get());
+        VerifyTrueOrExit(res);
+
+        res = MakeCert(gCertType, &gSubjectDN, caCert.get(), caKey.get(), gValidFrom, gValidDays, gFutureExtensions,
+                       gFutureExtensionsCount, newCert.get(), newKey.get());
+        VerifyTrueOrExit(res);
+    }
+
+    res = WriteCert(gOutCertFileName, newCert.get(), gOutCertFormat);
+    VerifyTrueOrExit(res);
+
+    if (gOutKeyFileName != nullptr)
+    {
+        res = WritePrivateKey(gOutKeyFileName, newKey.get(), gOutKeyFormat);
+        VerifyTrueOrExit(res);
+    }
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -1,0 +1,399 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that prints the contents of a CHIP certificate.
+ *
+ */
+
+#include "chip-cert.h"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert print-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "out",           kArgumentRequired, 'o' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "   -o, --out\n"
+    "\n"
+    "       The output printed certificate file name. If not specified\n"
+    "       or if specified - then output is writen to stdout.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Print a CHIP certificate.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <cert-file>\n"
+    "\n"
+    "       A file containing a CHIP certificate.\n"
+    "\n"
+);
+
+OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+const char * gInFileName  = nullptr;
+const char * gOutFileName = nullptr;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'o':
+        gOutFileName = arg;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the certificate to be printed.\n", progName);
+        return false;
+    }
+
+    if (argc > 1)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+        return false;
+    }
+
+    gInFileName = argv[0];
+
+    return true;
+}
+
+void Indent(FILE * file, int count)
+{
+    while (count--)
+    {
+        fputc(' ', file);
+    }
+}
+
+void PrintHexField(FILE * file, const char * name, int indent, uint16_t count, const uint8_t * data, int countPerRow = 16)
+{
+    Indent(file, indent);
+    indent += fprintf(file, "%s: ", name);
+
+    for (uint16_t i = 0; i < count; i++)
+    {
+        if (i != 0 && i != count && i % countPerRow == 0)
+        {
+            fprintf(file, "\n");
+            Indent(file, indent);
+        }
+
+        fprintf(file, "%02X ", data[i]);
+    }
+
+    fprintf(file, "\n");
+}
+
+void PrintEpochTime(FILE * file, const char * name, int indent, uint32_t epochTime)
+{
+    chip::ASN1::ASN1UniversalTime asn1Time;
+
+    ChipEpochToASN1Time(epochTime, asn1Time);
+
+    Indent(file, indent);
+    fprintf(file, "%s: ", name);
+
+    fprintf(file, "0x%08" PRIX32 "  ( %04" PRId16 "/%02" PRId8 "/%02" PRId8 " %02" PRId8 ":%02" PRId8 ":%02" PRId8 " )\n",
+            epochTime, asn1Time.Year, asn1Time.Month, asn1Time.Day, asn1Time.Hour, asn1Time.Minute, asn1Time.Second);
+}
+
+void PrintDN(FILE * file, const char * name, int indent, const ChipDN * dn)
+{
+    uint8_t rdnCount = dn->RDNCount();
+    char valueStr[128];
+
+    Indent(file, indent);
+    indent += fprintf(file, "%s: [[ ", name);
+
+    for (uint8_t i = 0; i < rdnCount; i++)
+    {
+        if (IsChip64bitDNAttr(dn->rdn[i].mAttrOID))
+        {
+            snprintf(valueStr, sizeof(valueStr), "%016" PRIX64, dn->rdn[i].mAttrValue.mChipVal);
+        }
+        else if (IsChip32bitDNAttr(dn->rdn[i].mAttrOID))
+        {
+            snprintf(valueStr, sizeof(valueStr), "%08" PRIX32, static_cast<uint32_t>(dn->rdn[i].mAttrValue.mChipVal));
+        }
+        else
+        {
+            uint32_t len = dn->rdn[i].mAttrValue.mString.mLen;
+            if (len > sizeof(valueStr) - 1)
+            {
+                len = sizeof(valueStr) - 1;
+            }
+            memcpy(valueStr, dn->rdn[i].mAttrValue.mString.mValue, len);
+            valueStr[len] = 0;
+        }
+
+        fprintf(file, "%s = %s", chip::ASN1::GetOIDName(dn->rdn[i].mAttrOID), valueStr);
+        if (i == rdnCount - 1)
+        {
+            fprintf(file, " ]]\n");
+        }
+        else
+        {
+            fprintf(file, ",\n");
+            Indent(file, indent);
+        }
+    }
+}
+
+bool PrintCert(const char * fileName, X509 * cert)
+{
+    bool res       = true;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    FILE * file    = nullptr;
+    ChipCertificateSet certSet;
+    const ChipCertificateData * certData;
+    chip::BitFlags<CertDecodeFlags> decodeFlags;
+    std::unique_ptr<uint8_t[]> certBuf(new uint8_t[kMaxChipCertBufSize]);
+    uint32_t certLen;
+    int indent = 4;
+
+    VerifyOrExit(cert != nullptr, res = false);
+
+    res = OpenFile(fileName, file, true);
+    VerifyTrueOrExit(res);
+
+    res = X509ToChipCert(cert, certBuf.get(), kMaxChipCertBufSize, certLen);
+    VerifyTrueOrExit(res);
+
+    err = certSet.Init(1, 1024);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+    err = certSet.LoadCert(certBuf.get(), certLen, decodeFlags);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Error reading %s: %s\n", fileName, chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+    certData = certSet.GetLastCert();
+
+    fprintf(file, "CHIP Certificate:\n");
+
+    Indent(file, indent);
+    fprintf(file, "Signature Algo  : %s\n", GetOIDName(certData->mSigAlgoOID));
+
+    PrintDN(file, "Issuer          ", indent, &certData->mIssuerDN);
+
+    PrintEpochTime(file, "Not Before      ", indent, certData->mNotBeforeTime);
+
+    PrintEpochTime(file, "Not After       ", indent, certData->mNotAfterTime);
+
+    PrintDN(file, "Subject         ", indent, &certData->mSubjectDN);
+
+    Indent(file, indent);
+    fprintf(file, "Public Key Algo : %s\n", GetOIDName(certData->mPubKeyAlgoOID));
+
+    Indent(file, indent);
+    fprintf(file, "Curve Id        : %s\n", GetOIDName(certData->mPubKeyCurveOID));
+
+    PrintHexField(file, "Public Key      ", indent, certData->mPublicKeyLen, certData->mPublicKey);
+
+    Indent(file, indent);
+    fprintf(file, "Extensions:\n");
+
+    indent += 4;
+    if (certData->mCertFlags.Has(CertFlags::kIsCA))
+    {
+        Indent(file, indent);
+        fprintf(file, "Is CA            : true\n");
+    }
+
+    if (certData->mCertFlags.Has(CertFlags::kPathLenConstraintPresent))
+    {
+        Indent(file, indent);
+        fprintf(file, "Path Length Const: %u\n", (unsigned) certData->mPathLenConstraint);
+    }
+
+    if (certData->mCertFlags.Has(CertFlags::kExtPresent_KeyUsage))
+    {
+        Indent(file, indent);
+        fprintf(file, "Key Usage        : ");
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kDigitalSignature))
+        {
+            fprintf(file, "DigitalSignature ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kNonRepudiation))
+        {
+            fprintf(file, "NonRepudiation ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kKeyEncipherment))
+        {
+            fprintf(file, "KeyEncipherment ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kDataEncipherment))
+        {
+            fprintf(file, "DataEncipherment ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kKeyAgreement))
+        {
+            fprintf(file, "KeyAgreement ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kKeyCertSign))
+        {
+            fprintf(file, "KeyCertSign ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kCRLSign))
+        {
+            fprintf(file, "CRLSign ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kEncipherOnly))
+        {
+            fprintf(file, "EncipherOnly ");
+        }
+        if (certData->mKeyUsageFlags.Has(KeyUsageFlags::kDecipherOnly))
+        {
+            fprintf(file, "DecipherOnly ");
+        }
+        fprintf(file, "\n");
+    }
+
+    if (certData->mCertFlags.Has(CertFlags::kExtPresent_ExtendedKeyUsage))
+    {
+        Indent(file, indent);
+        fprintf(file, "Key Purpose      : ");
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kServerAuth))
+        {
+            fprintf(file, "ServerAuth ");
+        }
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kClientAuth))
+        {
+            fprintf(file, "ClientAuth ");
+        }
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kCodeSigning))
+        {
+            fprintf(file, "CodeSigning ");
+        }
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kEmailProtection))
+        {
+            fprintf(file, "EmailProtection ");
+        }
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kTimeStamping))
+        {
+            fprintf(file, "TimeStamping ");
+        }
+        if (certData->mKeyPurposeFlags.Has(KeyPurposeFlags::kOCSPSigning))
+        {
+            fprintf(file, "OCSPSigning ");
+        }
+        fprintf(file, "\n");
+    }
+
+    if (certData->mCertFlags.Has(CertFlags::kExtPresent_SubjectKeyId))
+    {
+        PrintHexField(file, "Subject Key Id   ", indent, certData->mSubjectKeyId.mLen, certData->mSubjectKeyId.mId,
+                      certData->mSubjectKeyId.mLen);
+    }
+
+    if (certData->mCertFlags.Has(CertFlags::kExtPresent_AuthKeyId))
+    {
+        PrintHexField(file, "Authority Key Id ", indent, certData->mAuthKeyId.mLen, certData->mAuthKeyId.mId,
+                      certData->mAuthKeyId.mLen);
+    }
+
+    indent -= 4;
+    Indent(file, indent);
+    fprintf(file, "Signature:\n");
+    indent += 4;
+    PrintHexField(file, "r", indent, certData->mSignature.RLen, certData->mSignature.R);
+    PrintHexField(file, "s", indent, certData->mSignature.SLen, certData->mSignature.S);
+
+exit:
+    CloseFile(file);
+    return res;
+}
+
+} // namespace
+
+bool Cmd_PrintCert(int argc, char * argv[])
+{
+    bool res = true;
+    std::unique_ptr<X509, void (*)(X509 *)> cert(X509_new(), &X509_free);
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
+    VerifyTrueOrExit(res);
+
+    res = ReadCert(gInFileName, cert.get());
+    VerifyTrueOrExit(res);
+
+    res = PrintCert(gOutFileName, cert.get());
+    VerifyTrueOrExit(res);
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_ResignCert.cpp
+++ b/src/tools/chip-cert/Cmd_ResignCert.cpp
@@ -1,0 +1,221 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that re-signs a CHIP certificate.
+ *
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#include "chip-cert.h"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert resign-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "cert",       kArgumentRequired, 'c' },
+    { "out",        kArgumentRequired, 'o' },
+    { "ca-cert",    kArgumentRequired, 'C' },
+    { "ca-key",     kArgumentRequired, 'K' },
+    { "self",       kNoArgument,       's' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "  -c, --cert <file>\n"
+    "\n"
+    "       File containing the certificate to be re-signed.\n"
+    "\n"
+    "  -o, --out <file>\n"
+    "\n"
+    "       File to contain the re-signed certificate.\n"
+    "\n"
+    "  -C, --ca-cert <file>\n"
+    "\n"
+    "       File containing CA certificate to be used to re-sign the certificate.\n"
+    "\n"
+    "  -K, --ca-key <file>\n"
+    "\n"
+    "       File containing CA private key to be used to re-sign the certificate.\n"
+    "\n"
+    "  -s, --self\n"
+    "\n"
+    "       Generate a self-signed certificate.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ]\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Resign a CHIP certificate using a new CA certificate/key."
+);
+
+OptionSet * gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+const char * gInCertFileName  = nullptr;
+const char * gOutCertFileName = nullptr;
+const char * gCACertFileName  = nullptr;
+const char * gCAKeyFileName   = nullptr;
+bool gSelfSign                = false;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'c':
+        gInCertFileName = arg;
+        break;
+    case 'o':
+        gOutCertFileName = arg;
+        break;
+    case 'C':
+        gCACertFileName = arg;
+        break;
+    case 'K':
+        gCAKeyFileName = arg;
+        break;
+    case 's':
+        gSelfSign = true;
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_ResignCert(int argc, char * argv[])
+{
+    bool res = true;
+    CertFormat inCertFmt;
+    std::unique_ptr<X509, void (*)(X509 *)> cert(X509_new(), &X509_free);
+    std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> caKey(EVP_PKEY_new(), &EVP_PKEY_free);
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets);
+    VerifyTrueOrExit(res);
+
+    if (gInCertFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify certificate to be resigned using --cert option.\n");
+        ExitNow(res = false);
+    }
+
+    if (gOutCertFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the file name for the new certificate using the --out option.\n");
+        ExitNow(res = false);
+    }
+
+    if (gCACertFileName == nullptr && !gSelfSign)
+    {
+        fprintf(stderr,
+                "Please specify a CA certificate to be used to sign the new certificate (using\n"
+                "the --ca-cert option) or --self to generate a self-signed certificate.\n");
+        ExitNow(res = false);
+    }
+    else if (gCACertFileName != nullptr && gSelfSign)
+    {
+        fprintf(stderr, "Please specify only one of --ca-cert and --self.\n");
+        ExitNow(res = false);
+    }
+
+    if (gCAKeyFileName == nullptr)
+    {
+        fprintf(stderr, "Please specify the CA key file name using the --ca-key option.\n");
+        ExitNow(res = false);
+    }
+
+    if (access(gOutCertFileName, R_OK) == 0)
+    {
+        fprintf(stderr,
+                "Output certificate file already exists (%s)\n"
+                "To replace the file, please remove it and re-run the command.\n",
+                gOutCertFileName);
+        ExitNow(res = false);
+    }
+
+    res = InitOpenSSL();
+    VerifyTrueOrExit(res);
+
+    res = ReadCert(gInCertFileName, cert.get(), inCertFmt);
+    VerifyTrueOrExit(res);
+
+    res = ReadKey(gCAKeyFileName, caKey.get());
+    VerifyTrueOrExit(res);
+
+    if (!gSelfSign)
+    {
+        std::unique_ptr<X509, void (*)(X509 *)> caCert(X509_new(), &X509_free);
+
+        res = ReadCert(gCACertFileName, caCert.get());
+        VerifyTrueOrExit(res);
+
+        res = ResignCert(cert.get(), caCert.get(), caKey.get());
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        res = ResignCert(cert.get(), cert.get(), caKey.get());
+        VerifyTrueOrExit(res);
+    }
+
+    res = WriteCert(gOutCertFileName, cert.get(), inCertFmt);
+    VerifyTrueOrExit(res);
+
+exit:
+    return res;
+}

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -1,0 +1,198 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'chip-cert' tool
+ *      that validates a CHIP certificate.
+ *
+ */
+
+#include "chip-cert.h"
+
+#include "vector"
+
+namespace {
+
+using namespace chip::ArgParser;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+#define CMD_NAME "chip-cert validate-cert"
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+
+// clang-format off
+OptionDef gCmdOptionDefs[] =
+{
+    { "cert",           kArgumentRequired,  'c' },
+    { "trusted-cert",   kArgumentRequired,  't' },
+    { }
+};
+
+const char * const gCmdOptionHelp =
+    "  -c, --cert <cert-file>\n"
+    "\n"
+    "       A file containing an untrusted CHIP certificate to be used during\n"
+    "       validation. Usually, it is Intermediate CA certificate.\n"
+    "\n"
+    "  -t, --trusted-cert <cert-file>\n"
+    "\n"
+    "       A file containing a trusted CHIP certificate to be used during\n"
+    "       validation. Usually, it is trust anchor root certificate.\n"
+    "\n"
+    ;
+
+OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+
+HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [ <options...> ] <target-cert-file>\n",
+    CHIP_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Validate a chain of CHIP certificates.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <target-cert-file>\n"
+    "\n"
+    "      A file containing the certificate to be validated.\n"
+    "\n"
+);
+
+OptionSet * gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    nullptr
+};
+// clang-format on
+
+enum
+{
+    kMaxCerts        = 16,
+    kTestCertBufSize = 1024, // Size of buffer needed to hold any of the test certificates
+                             // (in either CHIP or DER form), or to decode the certificates.
+};
+
+const char * gTargetCertFileName = nullptr;
+const char * gCACertFileNames[kMaxCerts - 1];
+bool gCACertIsTrusted[kMaxCerts - 1];
+size_t gNumCertFileNames = 0;
+
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
+{
+    switch (id)
+    {
+    case 'c':
+    case 't':
+        gCACertFileNames[gNumCertFileNames]   = arg;
+        gCACertIsTrusted[gNumCertFileNames++] = (id == 't');
+        break;
+    default:
+        PrintArgError("%s: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the certificate to be validated.\n", progName);
+        return false;
+    }
+
+    if (argc > 1)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+        return false;
+    }
+
+    gTargetCertFileName = argv[0];
+
+    return true;
+}
+
+} // namespace
+
+bool Cmd_ValidateCert(int argc, char * argv[])
+{
+    bool res       = true;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    ChipCertificateSet certSet;
+    const ChipCertificateData * certToBeValidated;
+    ChipCertificateData * validatedCert;
+    ValidationContext context;
+    uint8_t certsBuf[kMaxCerts * kMaxChipCertBufSize];
+
+    context.Reset();
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    res = ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs);
+    VerifyTrueOrExit(res);
+
+    err = certSet.Init(kMaxCerts, kTestCertBufSize);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Failed to initialize certificate set: %s\n", chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+    for (size_t i = 0; i < gNumCertFileNames; i++)
+    {
+        res = LoadChipCert(gCACertFileNames[i], gCACertIsTrusted[i], certSet, &certsBuf[i * kMaxChipCertBufSize],
+                           kMaxChipCertBufSize);
+        VerifyTrueOrExit(res);
+    }
+
+    res =
+        LoadChipCert(gTargetCertFileName, false, certSet, &certsBuf[gNumCertFileNames * kMaxChipCertBufSize], kMaxChipCertBufSize);
+    VerifyTrueOrExit(res);
+
+    certToBeValidated = certSet.GetLastCert();
+
+    context.Reset();
+    res = chip::UnixEpochToChipEpochTime(static_cast<uint32_t>(time(nullptr)), context.mEffectiveTime);
+    VerifyTrueOrExit(res);
+
+    err = certSet.FindValidCert(certToBeValidated->mSubjectDN, certToBeValidated->mSubjectKeyId, context, validatedCert);
+    if (err != CHIP_NO_ERROR)
+    {
+        fprintf(stderr, "Failed certificate chain validation: %s\n", chip::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+exit:
+    certSet.Release();
+    return res;
+}

--- a/src/tools/chip-cert/GeneralUtils.cpp
+++ b/src/tools/chip-cert/GeneralUtils.cpp
@@ -1,0 +1,259 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements utility functions for OpenSSL, base-64
+ *      encoding and decoding, date and time parsing, EUI64 parsing,
+ *      OID translation, and file reading.
+ *
+ */
+
+#include "chip-cert.h"
+
+using namespace chip;
+using namespace chip::Credentials;
+using namespace chip::ASN1;
+
+int gNIDChipNodeId;
+int gNIDChipFirmwareSigningId;
+int gNIDChipICAId;
+int gNIDChipRootId;
+int gNIDChipFabricId;
+int gNIDChipAuthTag1;
+int gNIDChipAuthTag2;
+int gNIDChipCurveP256 = EC_curve_nist2nid("P-256");
+
+bool InitOpenSSL()
+{
+    bool res = true;
+
+    OPENSSL_malloc_init();
+
+    ERR_load_crypto_strings();
+    OpenSSL_add_all_algorithms();
+
+    gNIDChipNodeId = OBJ_create("1.3.6.1.4.1.37244.1.1", "ChipNodeId", "ChipNodeId");
+    if (gNIDChipNodeId == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipFirmwareSigningId = OBJ_create("1.3.6.1.4.1.37244.1.2", "ChipFirmwareSigningId", "ChipFirmwareSigningId");
+    if (gNIDChipFirmwareSigningId == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipICAId = OBJ_create("1.3.6.1.4.1.37244.1.3", "ChipICAId", "ChipICAId");
+    if (gNIDChipICAId == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipRootId = OBJ_create("1.3.6.1.4.1.37244.1.4", "ChipRootId", "ChipRootId");
+    if (gNIDChipICAId == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipFabricId = OBJ_create("1.3.6.1.4.1.37244.1.5", "ChipFabricId", "ChipFabricId");
+    if (gNIDChipFabricId == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipAuthTag1 = OBJ_create("1.3.6.1.4.1.37244.1.6", "ChipAuthTag1", "ChipAuthTag1");
+    if (gNIDChipAuthTag1 == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    gNIDChipAuthTag2 = OBJ_create("1.3.6.1.4.1.37244.1.7", "ChipAuthTag2", "ChipAuthTag2");
+    if (gNIDChipAuthTag2 == 0)
+    {
+        ReportOpenSSLErrorAndExit("OBJ_create", res = false);
+    }
+
+    ASN1_STRING_TABLE_add(gNIDChipNodeId, 16, 16, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipFirmwareSigningId, 16, 16, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipICAId, 16, 16, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipRootId, 16, 16, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipFabricId, 16, 16, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipAuthTag1, 8, 8, B_ASN1_UTF8STRING, 0);
+    ASN1_STRING_TABLE_add(gNIDChipAuthTag2, 8, 8, B_ASN1_UTF8STRING, 0);
+
+exit:
+    return res;
+}
+
+bool Base64Encode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen)
+{
+    bool res = true;
+
+    VerifyOrExit(outBuf != nullptr, res = false);
+    VerifyOrExit(outBufSize >= BASE64_ENCODED_LEN(inDataLen), res = false);
+
+    outDataLen = chip::Base64Encode32(inData, inDataLen, Uint8::to_char(outBuf));
+
+exit:
+    return res;
+}
+
+bool Base64Decode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen)
+{
+    bool res = true;
+
+    VerifyOrExit(outBuf != nullptr, res = false);
+    VerifyOrExit(outBufSize >= BASE64_MAX_DECODED_LEN(inDataLen), res = false);
+
+    outDataLen = chip::Base64Decode32(Uint8::to_const_char(inData), inDataLen, outBuf);
+    VerifyOrExit(outDataLen != UINT32_MAX, res = false);
+
+exit:
+    return res;
+}
+
+bool IsBase64String(const char * str, uint32_t strLen)
+{
+    for (; strLen > 0; strLen--, str++)
+    {
+        if (!isalnum(*str) && *str != '+' && *str != '/' && *str != '=' && !isspace(*str))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ContainsPEMMarker(const char * marker, const uint8_t * data, uint32_t dataLen)
+{
+    size_t markerLen = strlen(marker);
+
+    if (dataLen > markerLen)
+    {
+        for (uint32_t i = 0; i <= dataLen - markerLen; i++)
+        {
+            if (strncmp(reinterpret_cast<char *>(const_cast<uint8_t *>(data + i)), marker, markerLen) == 0)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool ParseChip64bitAttr(const char * str, uint64_t & val)
+{
+    char * parseEnd;
+
+    errno = 0;
+    val   = strtoull(str, &parseEnd, 16);
+    return parseEnd > str && *parseEnd == 0 && (val != ULLONG_MAX || errno == 0);
+}
+
+bool ParseDateTime(const char * str, struct tm & date)
+{
+    const char * p;
+
+    memset(&date, 0, sizeof(date));
+
+    if ((p = strptime(str, "%Y-%m-%d %H:%M:%S", &date)) == nullptr && (p = strptime(str, "%Y/%m/%d %H:%M:%S", &date)) == nullptr &&
+        (p = strptime(str, "%Y%m%d%H%M%SZ", &date)) == nullptr && (p = strptime(str, "%Y-%m-%d", &date)) == nullptr &&
+        (p = strptime(str, "%Y/%m/%d", &date)) == nullptr && (p = strptime(str, "%Y%m%d", &date)) == nullptr)
+    {
+        return false;
+    }
+
+    if (*p != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool OpenFile(const char * fileName, FILE *& file, bool toWrite)
+{
+    bool res = true;
+
+    if (fileName != nullptr && strcmp(fileName, "-") != 0)
+    {
+        file = fopen(fileName, toWrite ? "w+" : "r");
+        if (file == nullptr)
+        {
+            fprintf(stderr, "Unable to open %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
+            ExitNow(res = false);
+        }
+    }
+    else
+    {
+        file = toWrite ? stdout : stdin;
+    }
+
+exit:
+    return res;
+}
+
+void CloseFile(FILE *& file)
+{
+    if (file != nullptr)
+    {
+        fclose(file);
+        file = nullptr;
+    }
+}
+
+bool ReadFileIntoMem(const char * fileName, uint8_t * data, uint32_t & dataLen)
+{
+    bool res    = true;
+    FILE * file = nullptr;
+    long int fileLen;
+    size_t readRes;
+
+    res = OpenFile(fileName, file, false);
+    VerifyTrueOrExit(res);
+
+    fseek(file, 0, SEEK_END);
+    fileLen = ftell(file);
+    fseek(file, 0, SEEK_SET);
+    if (fileLen < 0 || ferror(file))
+    {
+        fprintf(stderr, "Error reading %s: %s\n", fileName, strerror(errno));
+        ExitNow(res = false);
+    }
+
+    VerifyOrExit(fileLen <= UINT32_MAX, res = false);
+
+    dataLen = static_cast<uint32_t>(fileLen);
+
+    if (data != nullptr)
+    {
+        readRes = fread(data, 1, static_cast<size_t>(dataLen), file);
+        if (readRes < static_cast<size_t>(dataLen) || ferror(file))
+        {
+            fprintf(stderr, "Error reading %s: %s\n", fileName, strerror(errno));
+            ExitNow(res = false);
+        }
+    }
+
+exit:
+    CloseFile(file);
+    return res;
+}

--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -1,0 +1,313 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements utility functions for reading, parsing,
+ *      encoding, and decoding CHIP key material.
+ *
+ */
+
+#include "chip-cert.h"
+#include <protocols/Protocols.h>
+#include <support/BufferWriter.h>
+
+using namespace chip;
+using namespace chip::Protocols;
+using namespace chip::ASN1;
+using namespace chip::TLV;
+using namespace chip::Crypto;
+
+namespace {
+
+KeyFormat DetectKeyFormat(const uint8_t * key, uint32_t keyLen)
+{
+    static uint32_t p256SerializedKeypairLen = kP256_PublicKey_Length + kP256_PrivateKey_Length;
+    static const char * ecPEMMarker          = "-----BEGIN EC PRIVATE KEY-----";
+    static const char * pkcs8PEMMarker       = "-----BEGIN PRIVATE KEY-----";
+    static const char * ecPUBPEMMarker       = "-----BEGIN PUBLIC KEY-----";
+
+    if (keyLen == p256SerializedKeypairLen)
+    {
+        return kKeyFormat_Chip_Raw;
+    }
+
+    if (keyLen == BASE64_ENCODED_LEN(p256SerializedKeypairLen))
+    {
+        return kKeyFormat_Chip_Base64;
+    }
+
+    if (ContainsPEMMarker(ecPEMMarker, key, keyLen) || ContainsPEMMarker(pkcs8PEMMarker, key, keyLen))
+    {
+        return kKeyFormat_X509_PEM;
+    }
+
+    if (ContainsPEMMarker(ecPUBPEMMarker, key, keyLen))
+    {
+        return kKeyFormat_X509_PUBKEY_PEM;
+    }
+
+    return kKeyFormat_X509_DER;
+}
+
+bool SerializeKeyPair(EVP_PKEY * key, uint8_t * chipKey, uint32_t chipKeyBufSize, uint32_t & chipKeyLen)
+{
+    bool res                 = true;
+    const BIGNUM * privKeyBN = nullptr;
+    const EC_GROUP * group   = nullptr;
+    const EC_KEY * ecKey     = nullptr;
+    const EC_POINT * ecPoint = nullptr;
+    uint8_t * pubKey         = chipKey;
+    uint8_t * privKey        = chipKey + kP256_PublicKey_Length;
+    size_t pubKeyLen         = 0;
+    int privKeyLen           = 0;
+
+    VerifyOrExit(chipKeyBufSize >= kP256_PublicKey_Length + kP256_PrivateKey_Length, res = false);
+
+    ecKey = EVP_PKEY_get1_EC_KEY(key);
+    VerifyOrExit(ecKey != nullptr, res = false);
+
+    privKeyBN = EC_KEY_get0_private_key(ecKey);
+    VerifyOrExit(privKeyBN != nullptr, res = false);
+
+    group = EC_KEY_get0_group(ecKey);
+    VerifyOrExit(group != nullptr, res = false);
+
+    ecPoint = EC_KEY_get0_public_key(ecKey);
+    VerifyOrExit(ecPoint != nullptr, res = false);
+
+    pubKeyLen =
+        EC_POINT_point2oct(group, ecPoint, POINT_CONVERSION_UNCOMPRESSED, Uint8::to_uchar(pubKey), kP256_PublicKey_Length, nullptr);
+    VerifyOrExit(pubKeyLen == kP256_PublicKey_Length, res = false);
+
+    privKeyLen = BN_bn2binpad(privKeyBN, privKey, kP256_PrivateKey_Length);
+    VerifyOrExit(privKeyLen == kP256_PrivateKey_Length, res = false);
+
+    chipKeyLen = kP256_PublicKey_Length + kP256_PrivateKey_Length;
+
+exit:
+    return res;
+}
+
+bool DeserializeKeyPair(const uint8_t * keyPair, uint32_t keyPairLen, EVP_PKEY * key)
+{
+    bool res                = true;
+    int result              = 0;
+    const uint8_t * pubKey  = keyPair;
+    uint32_t pubKeyLen      = kP256_PublicKey_Length;
+    const uint8_t * privKey = keyPair + pubKeyLen;
+    uint32_t privKeyLen     = kP256_PrivateKey_Length;
+    std::unique_ptr<EC_GROUP, void (*)(EC_GROUP *)> group(EC_GROUP_new_by_curve_name(gNIDChipCurveP256), &EC_GROUP_free);
+    std::unique_ptr<EC_POINT, void (*)(EC_POINT *)> ecPoint(EC_POINT_new(group.get()), &EC_POINT_free);
+    std::unique_ptr<EC_KEY, void (*)(EC_KEY *)> ecKey(EC_KEY_new_by_curve_name(gNIDChipCurveP256), &EC_KEY_free);
+    std::unique_ptr<BIGNUM, void (*)(BIGNUM *)> privKeyBN(BN_new(), &BN_clear_free);
+
+    ERR_clear_error();
+
+    VerifyOrExit(key != nullptr, res = false);
+    VerifyOrExit(keyPair != nullptr, res = false);
+    VerifyOrExit(keyPairLen == privKeyLen + pubKeyLen, res = false);
+
+    result = EC_POINT_oct2point(group.get(), ecPoint.get(), pubKey, pubKeyLen, nullptr);
+    VerifyOrExit(result == 1, res = false);
+
+    result = EC_KEY_set_public_key(ecKey.get(), ecPoint.get());
+    VerifyOrExit(result == 1, res = false);
+
+    VerifyOrExit(BN_bin2bn(privKey, static_cast<int>(privKeyLen), privKeyBN.get()) != nullptr, res = false);
+
+    result = EC_KEY_set_private_key(ecKey.get(), privKeyBN.get());
+    VerifyOrExit(result == 1, res = false);
+
+    result = EVP_PKEY_set1_EC_KEY(key, ecKey.get());
+    VerifyOrExit(result == 1, res = false);
+
+exit:
+    return res;
+}
+
+} // namespace
+
+bool ReadKey(const char * fileName, EVP_PKEY * key)
+{
+    bool res            = true;
+    uint32_t keyDataLen = 0;
+    KeyFormat keyFormat = kKeyFormat_Unknown;
+    std::unique_ptr<uint8_t[]> keyData;
+
+    res = ReadFileIntoMem(fileName, nullptr, keyDataLen);
+    VerifyTrueOrExit(res);
+
+    keyData = std::unique_ptr<uint8_t[]>(new uint8_t[keyDataLen]);
+
+    res = ReadFileIntoMem(fileName, keyData.get(), keyDataLen);
+    VerifyTrueOrExit(res);
+
+    keyFormat = DetectKeyFormat(keyData.get(), keyDataLen);
+
+    if (keyFormat == kKeyFormat_Chip_Base64)
+    {
+        res = Base64Decode(keyData.get(), keyDataLen, keyData.get(), keyDataLen, keyDataLen);
+        VerifyTrueOrExit(res);
+
+        keyFormat = kKeyFormat_Chip_Raw;
+    }
+
+    if (keyFormat == kKeyFormat_Chip_Raw)
+    {
+        res = DeserializeKeyPair(keyData.get(), keyDataLen, key);
+        VerifyTrueOrExit(res);
+    }
+    else
+    {
+        std::unique_ptr<BIO, void (*)(BIO *)> keyBIO(
+            BIO_new_mem_buf(static_cast<const void *>(keyData.get()), static_cast<int>(keyDataLen)), &BIO_free_all);
+
+        if (keyFormat == kKeyFormat_X509_PUBKEY_PEM)
+        {
+            EC_KEY * ecKey = EC_KEY_new();
+
+            if (PEM_read_bio_EC_PUBKEY(keyBIO.get(), &ecKey, nullptr, nullptr) == nullptr)
+            {
+                ReportOpenSSLErrorAndExit("PEM_read_bio_EC_PUBKEY", res = false);
+            }
+
+            if (EVP_PKEY_set1_EC_KEY(key, ecKey) != 1)
+            {
+                ReportOpenSSLErrorAndExit("EVP_PKEY_set1_EC_KEY", res = false);
+            }
+        }
+        else if (keyFormat == kKeyFormat_X509_PEM)
+        {
+            if (PEM_read_bio_PrivateKey(keyBIO.get(), &key, nullptr, nullptr) == nullptr)
+            {
+                ReportOpenSSLErrorAndExit("PEM_read_bio_PrivateKey", res = false);
+            }
+        }
+        else
+        {
+            if (d2i_PrivateKey_bio(keyBIO.get(), &key) == nullptr)
+            {
+                ReportOpenSSLErrorAndExit("d2i_PrivateKey_bio", res = false);
+            }
+        }
+    }
+
+    if (EC_GROUP_get_curve_name(EC_KEY_get0_group(EVP_PKEY_get1_EC_KEY(key))) != gNIDChipCurveP256)
+    {
+        fprintf(stderr, "Specified key uses unsupported Elliptic Curve\n");
+        ExitNow(res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool GenerateKeyPair(EVP_PKEY * key)
+{
+    bool res = true;
+    std::unique_ptr<EC_KEY, void (*)(EC_KEY *)> ecKey(EC_KEY_new_by_curve_name(gNIDChipCurveP256), &EC_KEY_free);
+
+    VerifyOrExit(key != nullptr, res = false);
+
+    if (!EC_KEY_generate_key(ecKey.get()))
+    {
+        ReportOpenSSLErrorAndExit("EC_KEY_generate_key", res = false);
+    }
+
+    if (!EVP_PKEY_set1_EC_KEY(key, ecKey.get()))
+    {
+        ReportOpenSSLErrorAndExit("EVP_PKEY_set1_EC_KEY", res = false);
+    }
+
+exit:
+    return res;
+}
+
+bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
+{
+    bool res                  = true;
+    FILE * file               = nullptr;
+    uint8_t * keyToWrite      = nullptr;
+    uint32_t keyToWriteLen    = 0;
+    uint32_t chipKeyLen       = kP256_PublicKey_Length + kP256_PrivateKey_Length;
+    uint32_t chipKeyBase64Len = BASE64_ENCODED_LEN(chipKeyLen);
+    std::unique_ptr<uint8_t[]> chipKey(new uint8_t[chipKeyLen]);
+    std::unique_ptr<uint8_t[]> chipKeyBase64(new uint8_t[chipKeyBase64Len]);
+
+    VerifyOrExit(key != nullptr, res = false);
+
+    res = OpenFile(fileName, file, true);
+    VerifyTrueOrExit(res);
+
+    if (EVP_PKEY_type(EVP_PKEY_id(key)) != EVP_PKEY_EC)
+    {
+        fprintf(stderr, "Unsupported private key type\n");
+        ExitNow(res = false);
+    }
+
+    switch (keyFmt)
+    {
+    case kKeyFormat_X509_PEM:
+        if (PEM_write_ECPrivateKey(file, EVP_PKEY_get1_EC_KEY(key), nullptr, nullptr, 0, nullptr, nullptr) == 0)
+        {
+            ReportOpenSSLErrorAndExit("PEM_write_PrivateKey", res = false);
+        }
+        break;
+    case kKeyFormat_X509_DER:
+        if (i2d_ECPrivateKey_fp(file, EVP_PKEY_get1_EC_KEY(key)) == 0)
+        {
+            ReportOpenSSLErrorAndExit("i2d_PrivateKey_fp", res = false);
+        }
+        break;
+    case kKeyFormat_Chip_Raw:
+    case kKeyFormat_Chip_Base64:
+        res = SerializeKeyPair(key, chipKey.get(), chipKeyLen, chipKeyLen);
+        VerifyTrueOrExit(res);
+
+        if (keyFmt == kKeyFormat_Chip_Base64)
+        {
+            res = Base64Encode(chipKey.get(), chipKeyLen, chipKeyBase64.get(), chipKeyBase64Len, chipKeyBase64Len);
+            VerifyTrueOrExit(res);
+
+            keyToWrite    = chipKeyBase64.get();
+            keyToWriteLen = chipKeyBase64Len;
+        }
+        else
+        {
+            keyToWrite    = chipKey.get();
+            keyToWriteLen = chipKeyLen;
+        }
+
+        if (fwrite(keyToWrite, 1, keyToWriteLen, file) != keyToWriteLen)
+        {
+            fprintf(stderr, "Unable to write to %s\n%s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
+            ExitNow(res = false);
+        }
+        break;
+    default:
+        fprintf(stderr, "Unsupported private key format");
+        ExitNow(res = false);
+    }
+
+exit:
+    CloseFile(file);
+
+    return res;
+}

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -1,0 +1,80 @@
+# CHIP Certificate Tool
+
+## Introduction
+
+CHIP Certificate Tool (chip-cert) provides command line interface (CLI) utility
+used for generating and manipulating CHIP certificates and CHIP private keys
+material.
+
+## Directory Structure
+
+### <code>/src/tools/chip-cert</code>
+
+This directory contains various command handler for the 'chip-cert' tool that:
+
+-   generate CHIP certificate
+-   convert CHIP certificate format
+-   convert CHIP private key format
+-   validate CHIP certificate chain
+-   resign CHIP certificate
+-   print CHIP certificate
+
+## Usage Examples
+
+Specify 'help' option for the detailed 'chip-cert' tool usage instructions:
+
+```
+./chip-cert help
+```
+
+Specify '--help' option for detail instructions on usage of each command:
+
+```
+./chip-cert gen-cert --help
+```
+
+Example command that can be used to generate CHIP root certificate and private
+key:
+
+```
+./chip-cert gen-cert --type r --subject-chip-id CACACACA00000001 --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key Chip-Root-Key.pem --out Chip-Root-Cert.pem --out-format x509-pem
+```
+
+The root certificate/key output of last command can then be used to generate
+CHIP Intermediate CA (ICA) certificate and private key:
+
+```
+./chip-cert gen-cert --type c --subject-chip-id CACACACA00000002 --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key Chip-Root-Key.pem --ca-cert Chip-Root-Cert.pem --out-key Chip-ICA-Key.pem --out Chip-ICA-Cert.pem --out-format x509-pem
+```
+
+The generated ICA certificate/key can then be used to sign multiple CHIP Node
+certificates:
+
+```
+./chip-cert gen-cert --type n --subject-chip-id DEDEDEDE0000001D --subject-fab-id FAB000000000001D --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key Chip-ICA-Key.pem --ca-cert Chip-ICA-Cert.pem --out-key Chip-Node-Key.chip-b64 --out Chip-Node-Cert.chip-b64 --out-format chip-b64
+```
+
+Note that in the last example the generated Node certificate and private key are
+stored in base-64 encoded CHIP native format and not in PEM format as in the
+previous examples.
+
+Now the 'chip-cert' tool can be used to validate generated Node certificate:
+
+```
+./chip-cert validate-cert Chip-Node-Cert.chip-b64 -c Chip-ICA-Cert.pem -t Chip-Root-Cert.pem
+```
+
+Typically, CA services generate certificates in a standard X.509 PEM format.
+They can then use this 'chip-cert' tool to convert certificate into raw CHIP TLV
+format before provisioning device with operational credentials:
+
+```
+./chip-cert convert-cert Chip-ICA-Cert.pem  Chip-ICA-Cert.chip --chip
+```
+
+Developers can use this tool to print the content of a CHIP certificate in a
+human friendly/readable form:
+
+```
+./chip-cert print-cert Chip-ICA-Cert.chip
+```

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -1,0 +1,128 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the CHIP certificate (chip-cert) command line tool.
+ *
+ *      The 'chip-cert' command line tool is used, primarily, for generating
+ *      and manipulating CHIP certificate and private key material.
+ *
+ */
+
+#include "chip-cert.h"
+
+namespace chip {
+namespace Logging {
+namespace Platform {
+
+void LogV(const char * module, uint8_t category, const char * msg, va_list v) {}
+
+} // namespace Platform
+} // namespace Logging
+} // namespace chip
+
+namespace {
+
+// clang-format off
+const char * const sHelp =
+    "Usage: chip <command> [ <args...> ]\n"
+    "\n"
+    "Commands:\n"
+    "\n"
+    "    gen-cert -- Generate a CHIP certificate.\n"
+    "\n"
+    "    convert-cert -- Convert a certificate between CHIP and X509 form.\n"
+    "\n"
+    "    convert-key -- Convert a private key between CHIP and PEM/DER form.\n"
+    "\n"
+    "    resign-cert -- Resign a CHIP certificate using a new CA key.\n"
+    "\n"
+    "    validate-cert -- Validate a CHIP certificate chain.\n"
+    "\n"
+    "    print-cert -- Print a CHIP certificate.\n"
+    "\n"
+    "    version -- Print the program version and exit.\n"
+    "\n";
+// clang-format on
+
+/**
+ * Print to standard output the program version information.
+ *
+ * @return Unconditionally returns true.
+ *
+ */
+bool PrintVersion(void)
+{
+    printf("chip " CHIP_VERSION_STRING "\n" COPYRIGHT_STRING);
+
+    return true;
+}
+
+} // namespace
+
+extern "C" int main(int argc, char * argv[])
+{
+    bool res = false;
+
+    chip::Platform::MemoryInit();
+
+    if (argc == 1)
+    {
+        fprintf(stderr, "Please specify a command, or 'help' for help.\n");
+    }
+    else if (strcasecmp(argv[1], "help") == 0 || strcasecmp(argv[1], "--help") == 0 || strcasecmp(argv[1], "-h") == 0)
+    {
+        res = (fputs(sHelp, stdout) != EOF);
+    }
+    else if (strcasecmp(argv[1], "version") == 0 || strcasecmp(argv[1], "--version") == 0 || strcasecmp(argv[1], "-v") == 0)
+    {
+        res = PrintVersion();
+    }
+    else if (strcasecmp(argv[1], "gen-cert") == 0 || strcasecmp(argv[1], "gencert") == 0)
+    {
+        res = Cmd_GenCert(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "convert-cert") == 0 || strcasecmp(argv[1], "convertcert") == 0)
+    {
+        res = Cmd_ConvertCert(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "convert-key") == 0 || strcasecmp(argv[1], "convertkey") == 0)
+    {
+        res = Cmd_ConvertKey(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "resign-cert") == 0 || strcasecmp(argv[1], "resigncert") == 0)
+    {
+        res = Cmd_ResignCert(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "validate-cert") == 0 || strcasecmp(argv[1], "validatecert") == 0)
+    {
+        res = Cmd_ValidateCert(argc - 1, argv + 1);
+    }
+    else if (strcasecmp(argv[1], "print-cert") == 0 || strcasecmp(argv[1], "printcert") == 0)
+    {
+        res = Cmd_PrintCert(argc - 1, argv + 1);
+    }
+    else
+    {
+        fprintf(stderr, "Unrecognized command: %s\n", argv[1]);
+    }
+
+    return res ? 0 : -1;
+}

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -1,0 +1,190 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the public API symbols, constants, and interfaces
+ *      for the 'chip-cert' command line tool.
+ *
+ *      The 'chip-cert' tool is a command line interface (CLI) utility
+ *      used, primarily, for generating and manipulating CHIP
+ *      certificate and private key material.
+ *
+ */
+
+#pragma once
+
+#include <ctype.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <memory>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <openssl/bn.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/x509v3.h>
+
+#include <CHIPVersion.h>
+#include <asn1/ASN1.h>
+#include <asn1/ASN1OID.h>
+#include <core/CHIPConfig.h>
+#include <core/CHIPCore.h>
+#include <core/CHIPSafeCasts.h>
+#include <credentials/CHIPCert.h>
+#include <support/Base64.h>
+#include <support/CHIPArgParser.hpp>
+#include <support/CHIPMem.h>
+#include <support/CodeUtils.h>
+#include <support/ErrorStr.h>
+#include <support/TimeUtils.h>
+
+using chip::ASN1::OID;
+
+#define COPYRIGHT_STRING                                                                                                           \
+    "Copyright (c) 2021 Project CHIP Authors.\nCopyright (c) 2019 Google LLC.\nCopyright (c) 2013-2017 Nest Labs, Inc.\nAll "      \
+    "rights reserved.\n"
+
+enum CertFormat
+{
+    kCertFormat_Unknown = 0,
+    kCertFormat_X509_DER,
+    kCertFormat_X509_PEM,
+    kCertFormat_Chip_Raw,
+    kCertFormat_Chip_Base64
+};
+
+enum KeyFormat
+{
+    kKeyFormat_Unknown = 0,
+    kKeyFormat_X509_DER,
+    kKeyFormat_X509_PEM,
+    kKeyFormat_X509_PUBKEY_PEM,
+    kKeyFormat_Chip_Raw,
+    kKeyFormat_Chip_Base64
+};
+
+enum
+{
+    kMaxChipCertBufSize = 450,  // Maximum size of a buffer needed to hold CHIP TLV encoded certificates.
+                                // CHIP certificate in TLV format shouldn't exceed 400 bytes.
+                                // chip-cert tool allows support for larger size certificates,
+                                // which might be generated for negative testing purposes.
+    kMaxX509CertBufSize = 1200, // Maximum size of a buffer needed to hold/encode X.509 certificates in DER form.
+                                // CHIP certificate in X.509 DER form shouldn't exceed 600 bytes.
+                                // chip-cert tool allows support for larger size certificates,
+                                // which might be generated for negative testing purposes.
+                                // Also, CHIP to X.509 certificate convertor (ASN1 encoder) requires additional
+                                // space in the buffer to store the deffered length list.
+};
+
+struct FutureExtension
+{
+    int nid;
+    const char * info;
+};
+
+class ToolChipDN : public chip::Credentials::ChipDN
+{
+public:
+    bool SetCertSubjectDN(X509 * cert) const;
+    bool HasAttr(chip::ASN1::OID oid) const;
+    void PrintDN(FILE * file, const char * name) const;
+};
+
+extern bool Cmd_GenCert(int argc, char * argv[]);
+extern bool Cmd_ConvertCert(int argc, char * argv[]);
+extern bool Cmd_ConvertKey(int argc, char * argv[]);
+extern bool Cmd_ResignCert(int argc, char * argv[]);
+extern bool Cmd_ValidateCert(int argc, char * argv[]);
+extern bool Cmd_PrintCert(int argc, char * argv[]);
+
+extern bool ReadCert(const char * fileName, X509 * cert);
+extern bool ReadCert(const char * fileName, X509 * cert, CertFormat & origCertFmt);
+extern bool LoadChipCert(const char * fileName, bool isTrused, chip::Credentials::ChipCertificateSet & certSet, uint8_t * certBuf,
+                         uint32_t certBufSize);
+extern bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt);
+
+extern bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
+                     uint32_t validDays, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert,
+                     EVP_PKEY * newKey);
+extern bool ResignCert(X509 * cert, X509 * caCert, EVP_PKEY * caKey);
+
+extern bool GenerateKeyPair(EVP_PKEY * key);
+extern bool ReadKey(const char * fileName, EVP_PKEY * key);
+extern bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
+
+extern bool X509ToChipCert(X509 * cert, uint8_t * certBuf, uint32_t certBufSize, uint32_t & certLen);
+
+extern bool InitOpenSSL();
+extern bool Base64Encode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
+extern bool Base64Decode(const uint8_t * inData, uint32_t inDataLen, uint8_t * outBuf, uint32_t outBufSize, uint32_t & outDataLen);
+extern bool IsBase64String(const char * str, uint32_t strLen);
+extern bool ContainsPEMMarker(const char * marker, const uint8_t * data, uint32_t dataLen);
+extern bool ParseChip64bitAttr(const char * str, uint64_t & val);
+extern bool ParseDateTime(const char * str, struct tm & date);
+extern bool ReadFileIntoMem(const char * fileName, uint8_t * data, uint32_t & dataLen);
+extern bool OpenFile(const char * fileName, FILE *& file, bool toWrite = false);
+extern void CloseFile(FILE *& file);
+
+extern int gNIDChipNodeId;
+extern int gNIDChipFirmwareSigningId;
+extern int gNIDChipICAId;
+extern int gNIDChipRootId;
+extern int gNIDChipFabricId;
+extern int gNIDChipAuthTag1;
+extern int gNIDChipAuthTag2;
+extern int gNIDChipCurveP256;
+
+/**
+ *  @def VerifyTrueOrExit(aStatus)
+ *
+ *  @brief
+ *    Checks for the specified status, which is expected to be 'true',
+ *    and branches to the local label 'exit' if the status is 'false'.
+ *
+ *  @param[in]  aStatus     A boolean status to be evaluated.
+ */
+#define VerifyTrueOrExit(aStatus) nlEXPECT(aStatus, exit)
+
+/**
+ *  @def ReportOpenSSLErrorAndExit(aFunct, ACTION)
+ *
+ *  @brief
+ *    Prints error, which was result of execusion of the specified OpenSSL
+ *    function, then performs specified actions and branches to the local label 'exit'.
+ *
+ *  @param[in]  aFunct      Name of an OpenSSL function that reported an error.
+ */
+#define ReportOpenSSLErrorAndExit(aFunct, ...)                                                                                     \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        fprintf(stderr, "OpenSSL %s() failed\n", aFunct);                                                                          \
+        ERR_print_errors_fp(stderr);                                                                                               \
+        __VA_ARGS__;                                                                                                               \
+        goto exit;                                                                                                                 \
+    } while (0)


### PR DESCRIPTION
chip-cert tool provides command line interface (CLI) utility used
for generating and manipulating CHIP certificates and CHIP
private keys material.

chip-tool supports the following commands:
  - generate CHIP certificate
  - convert CHIP certificate format
  - convert CHIP private key format
  - validate CHIP certificate chain
  - resign CHIP certificate
  - print CHIP certificate

Ticket: #6035 