### PR TITLE
Disable CRMP if we send/receive messages not over UDP transport

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -113,8 +113,7 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
                                             const SendFlags & sendFlags, Transport::PeerConnectionState * state)
 {
-    CHIP_ERROR err                     = CHIP_NO_ERROR;
-    bool reliableTransmissionRequested = true;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Don't let method get called on a freed object.
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() > 0);
@@ -123,6 +122,8 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
     // originally generated it tries to close it as a result of
     // an error arising below. at the end, we have to close it.
     Retain();
+
+    bool reliableTransmissionRequested = true;
 
     // If sending via UDP and NoAutoRequestAck send flag is not specificed, request reliable transmission.
     if (state && state->GetPeerAddress().GetTransportType() != Transport::Type::kUdp)

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -113,7 +113,8 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
 CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle msgBuf,
                                             const SendFlags & sendFlags, Transport::PeerConnectionState * state)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                     = CHIP_NO_ERROR;
+    bool reliableTransmissionRequested = true;
 
     // Don't let method get called on a freed object.
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() > 0);
@@ -123,7 +124,15 @@ CHIP_ERROR ExchangeContext::SendMessageImpl(Protocols::Id protocolId, uint8_t ms
     // an error arising below. at the end, we have to close it.
     Retain();
 
-    bool reliableTransmissionRequested = !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck);
+    // If sending via UDP and NoAutoRequestAck send flag is not specificed, request reliable transmission.
+    if (state && state->GetPeerAddress().GetTransportType() != Transport::Type::kUdp)
+    {
+        reliableTransmissionRequested = false;
+    }
+    else
+    {
+        reliableTransmissionRequested = !sendFlags.Has(SendMessageFlags::kNoAutoRequestAck);
+    }
 
     ExchangeMessageDispatch * dispatch = GetMessageDispatch();
     ApplicationExchangeDispatch defaultDispatch;

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -65,7 +65,7 @@ CHIP_ERROR ExchangeMessageDispatch::SendMessage(SecureSessionHandle session, uin
 #endif
     }
 
-    if (!IsTransportReliable() && reliableMessageContext->AutoRequestAck() && mReliableMessageMgr != nullptr &&
+    if (IsReliableTransmissionAllowed() && reliableMessageContext->AutoRequestAck() && mReliableMessageMgr != nullptr &&
         isReliableTransmission)
     {
         payloadHeader.SetNeedsAck(true);
@@ -105,7 +105,7 @@ CHIP_ERROR ExchangeMessageDispatch::OnMessageReceived(const PayloadHeader & payl
     ReturnErrorCodeIf(!MessagePermitted(payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetMessageType()),
                       CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (!IsTransportReliable())
+    if (IsReliableTransmissionAllowed())
     {
         if (payloadHeader.IsAckMsg() && payloadHeader.GetAckId().HasValue())
         {

--- a/src/messaging/ExchangeMessageDispatch.h
+++ b/src/messaging/ExchangeMessageDispatch.h
@@ -63,7 +63,7 @@ protected:
     virtual CHIP_ERROR SendMessageImpl(SecureSessionHandle session, PayloadHeader & payloadHeader,
                                        System::PacketBufferHandle && message, EncryptedPacketBufferHandle * retainedMessage) = 0;
 
-    virtual bool IsTransportReliable() { return false; }
+    virtual bool IsReliableTransmissionAllowed() { return true; }
 
 private:
     ReliableMessageMgr * mReliableMessageMgr = nullptr;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -344,11 +344,11 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     VerifyOrReturnError(rc != nullptr, err);
 
-    const ExchangeMessageDispatch * transport = rc->GetExchangeContext()->GetMessageDispatch();
-    VerifyOrExit(transport != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    const ExchangeMessageDispatch * dispatcher = rc->GetExchangeContext()->GetMessageDispatch();
+    VerifyOrExit(dispatcher != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     err =
-        transport->ResendMessage(rc->GetExchangeContext()->GetSecureSession(), std::move(entry->retainedBuf), &entry->retainedBuf);
+        dispatcher->ResendMessage(rc->GetExchangeContext()->GetSecureSession(), std::move(entry->retainedBuf), &entry->retainedBuf);
     SuccessOrExit(err);
 
     // Update the counters

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -57,10 +57,10 @@ protected:
 
     bool MessagePermitted(uint16_t protocol, uint8_t type) override;
 
-    bool IsTransportReliable() override
+    bool IsReliableTransmissionAllowed() override
     {
-        // If the underlying transport is not UDP.
-        return (mPeerAddress.GetTransportType() != Transport::Type::kUdp);
+        // If the underlying transport is UDP.
+        return (mPeerAddress.GetTransportType() == Transport::Type::kUdp);
     }
 
 private:


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

I found CRMP  is always enabled regardless of low level transport for application dispatch. This is regression from recent changes.

Currently, we use IsTransportReliable() to decide if to enable CRMP, this logic is wrong since TransportMgr is a tuple which can support TCP and UDP simultaneously.

We need to use the destination address instead to decide if use CRMP:
1. For PASE/CASE message exchange, we don't have PeerConnectionState, we can relay on the SessionEstablishmentExchangeDispatch to do this check since it has the peer destination address.

2. For Application message exchange, we can get the peer address form PeerConnectionState, and do the check.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Disable CRMP if we send/receive messages not over UDP transport

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6026

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
