### PR TITLE
Ensure memory is allocated for the mInfoPtr field of Cancellable into…

### DIFF
--- a/src/app/util/CHIPDeviceCallbacksMgr.h
+++ b/src/app/util/CHIPDeviceCallbacksMgr.h
@@ -29,6 +29,7 @@
 #include <app/util/basic-types.h>
 #include <core/CHIPCallback.h>
 #include <core/CHIPError.h>
+#include <support/CHIPPlatformMemory.h>
 #include <support/DLLUtil.h>
 
 namespace chip {
@@ -69,6 +70,7 @@ private:
         if (CHIP_NO_ERROR == err)
         {
             ca->Cancel();
+            CHIPPlatformMemoryFree(ca->mInfoPtr);
             queue.Dequeue(ca);
         }
 
@@ -81,7 +83,7 @@ private:
         Callback::Cancelable * ca = &queue;
         while (ca != nullptr && ca->mNext != &queue)
         {
-            if (*reinterpret_cast<T *>(&ca->mNext->mInfoPtr) == info)
+            if (*reinterpret_cast<T *>(ca->mNext->mInfoPtr) == info)
             {
                 *callback = ca->mNext;
                 return CHIP_NO_ERROR;

--- a/src/lib/core/CHIPCallback.h
+++ b/src/lib/core/CHIPCallback.h
@@ -50,7 +50,7 @@ public:
     Cancelable * mNext;
     Cancelable * mPrev;
 
-    void * mInfoPtr;
+    void * mInfoPtr = nullptr;
     uint64_t mInfoScalar;
 
     /**


### PR DESCRIPTION
… CHIPCallbacksMgr

 #### Problem

`CHIPCallbacksMgr` is doing a `memcpy` into the `Cancellable::mInfoPtr` field. But this field is never allocated.

 #### Summary of Changes
 * Allocate/free the memory where it needs to be.