### PR TITLE
Make sure string data is available when passed to the registered completion handler

### DIFF
--- a/examples/chip-tool/gen/CHIPClustersObjc.mm
+++ b/examples/chip-tool/gen/CHIPClustersObjc.mm
@@ -104,16 +104,15 @@ public:
 
     static void CallbackFn(void * context, chip::ByteSpan value)
     {
+        NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
+
         CHIPStringAttributeCallbackBridge * callback = reinterpret_cast<CHIPStringAttributeCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 if (callback->mOctetString) {
-                    NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
                     callback->mHandler(nil, @ { @"value" : data });
                 } else {
-                    NSString * str = [[NSString alloc] initWithBytes:value.data()
-                                                              length:value.size()
-                                                            encoding:NSUTF8StringEncoding];
+                    NSString * str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     callback->mHandler(nil, @ { @"value" : str });
                 }
 

--- a/src/app/zap-templates/templates/app/CHIPClustersObjc-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClustersObjc-src.zapt
@@ -88,17 +88,18 @@ public:
 
     static void CallbackFn(void * context, chip::ByteSpan value)
     {
+        NSData * data = [NSData dataWithBytes: value.data() length: value.size()];
+
         CHIPStringAttributeCallbackBridge * callback = reinterpret_cast<CHIPStringAttributeCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 if (callback->mOctetString)
                 {
-                    NSData *data = [NSData dataWithBytes: value.data() length: value.size()];
                     callback->mHandler(nil, @{ @"value": data });
                 }
                 else
                 {
-                    NSString * str = [[NSString alloc] initWithBytes:value.data() length:value.size() encoding:NSUTF8StringEncoding];
+                    NSString * str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     callback->mHandler(nil, @{ @"value": str });
                 }
 

--- a/src/controller/python/gen/CHIPClustersObjc.mm
+++ b/src/controller/python/gen/CHIPClustersObjc.mm
@@ -104,16 +104,15 @@ public:
 
     static void CallbackFn(void * context, chip::ByteSpan value)
     {
+        NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
+
         CHIPStringAttributeCallbackBridge * callback = reinterpret_cast<CHIPStringAttributeCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 if (callback->mOctetString) {
-                    NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
                     callback->mHandler(nil, @ { @"value" : data });
                 } else {
-                    NSString * str = [[NSString alloc] initWithBytes:value.data()
-                                                              length:value.size()
-                                                            encoding:NSUTF8StringEncoding];
+                    NSString * str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     callback->mHandler(nil, @ { @"value" : str });
                 }
 

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -104,16 +104,15 @@ public:
 
     static void CallbackFn(void * context, chip::ByteSpan value)
     {
+        NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
+
         CHIPStringAttributeCallbackBridge * callback = reinterpret_cast<CHIPStringAttributeCallbackBridge *>(context);
         if (callback && callback->mQueue) {
             dispatch_async(callback->mQueue, ^{
                 if (callback->mOctetString) {
-                    NSData * data = [NSData dataWithBytes:value.data() length:value.size()];
                     callback->mHandler(nil, @ { @"value" : data });
                 } else {
-                    NSString * str = [[NSString alloc] initWithBytes:value.data()
-                                                              length:value.size()
-                                                            encoding:NSUTF8StringEncoding];
+                    NSString * str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     callback->mHandler(nil, @ { @"value" : str });
                 }
 


### PR DESCRIPTION

 #### Problem

From the Darwin CI, I have seen this stack. It likely happens because the `chip::ByteSpan` underlying data has been freed but those are read from a block.

```
[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
2021-04-30T23:47:20.1064600Z *** First throw call stack:
2021-04-30T23:47:20.1064930Z (
2021-04-30T23:47:20.1065460Z 	0   CoreFoundation                      0x00007fff36934727 __exceptionPreprocess + 250
2021-04-30T23:47:20.1066200Z 	1   libobjc.A.dylib                     0x00007fff6f8b3a9e objc_exception_throw + 48
2021-04-30T23:47:20.1067010Z 	2   CoreFoundation                      0x00007fff369e3796 _CFThrowFormattedException + 194
2021-04-30T23:47:20.1068480Z 	3   CoreFoundation                      0x00007fff369ee15b -[__NSPlaceholderDictionary initWithObjects:forKeys:count:].cold.5 + 0
2021-04-30T23:47:20.1070310Z 	4   CoreFoundation                      0x00007fff3683f1b5 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 235
2021-04-30T23:47:20.1071410Z 	5   CoreFoundation                      0x00007fff3683f0b0 +[NSDictionary dictionaryWithObjects:forKeys:count:] + 49
2021-04-30T23:47:20.1073150Z 	6   CHIP                                0x00000001058f867c ___ZN33CHIPStringAttributeCallbackBridge10CallbackFnEPvN4chip4SpanIhEE_block_invoke + 652
2021-04-30T23:47:20.1074790Z 	7   libdispatch.dylib                   0x00007fff709f96c4 _dispatch_call_block_and_release + 12
2021-04-30T23:47:20.1075550Z 	8   libdispatch.dylib                   0x00007fff709fa658 _dispatch_client_callout + 8
2021-04-30T23:47:20.1076610Z 	9   libdispatch.dylib                   0x00007fff70a05cab _dispatch_main_queue_callback_4CF + 936
2021-04-30T23:47:20.1077480Z 	10  CoreFoundation                      0x00007fff368f7b23 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
2021-04-30T23:47:20.1078230Z 	11  CoreFoundation                      0x00007fff368b77aa __CFRunLoopRun + 2042
2021-04-30T23:47:20.1078980Z 	12  CoreFoundation                      0x00007fff368b6953 CFRunLoopRunSpecific + 466
2021-04-30T23:47:20.1080320Z 	13  XCTest                              0x0000000102cbb82b -[XCTWaiter waitForExpectations:timeout:enforceOrder:] + 823
2021-04-30T23:47:20.1081890Z 	14  XCTest                              0x0000000102c357cc -[XCTestCase(AsynchronousTesting) waitForExpectationsWithTimeout:handler:] + 252
2021-04-30T23:47:20.1084010Z 	15  CHIPTests                           0x00000001057743c3 -[CHIPClustersTests testSendClusterBasicReadAttributeSoftwareVersionString] + 723
2021-04-30T23:47:20.1085360Z 	16  CoreFoundation                      0x00007fff3689a3bc __invoking___ + 140
2021-04-30T23:47:20.1086410Z 	17  CoreFoundation                      0x00007fff3689a256 -[NSInvocation invoke] + 303
2021-04-30T23:47:20.1087520Z 	18  XCTest                              0x0000000102c4ad3a __24-[XCTestCase invokeTest]_block_invoke_3 + 52
2021-04-30T23:47:20.1088660Z 	19  XCTest                              0x0000000102c4acee __24-[XCTestCase invokeTest]_block_invoke_2 + 297
2021-04-30T23:47:20.1090190Z 	20  XCTest                              0x0000000102cda59a -[XCTMemoryChecker _assertInvalidObjectsDeallocatedAfterScope:] + 65
2021-04-30T23:47:20.1092040Z 	21  XCTest                              0x0000000102c558ea -[XCTestCase assertInvalidObjectsDeallocatedAfterScope:] + 61
2021-04-30T23:47:20.1093520Z 	22  XCTest                              0x0000000102c4ab82 __24-[XCTestCase invokeTest]_block_invoke.231 + 199
2021-04-30T23:47:20.1096100Z 	23  XCTest                              0x0000000102cbf6d8 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 179
2021-04-30T23:47:20.1098870Z 	24  XCTest                              0x0000000102c4a645 -[XCTestCase invokeTest] + 1037
2021-04-30T23:47:20.1099960Z 	25  XCTest                              0x0000000102c4c023 __26-[XCTestCase performTest:]_block_invoke_2 + 43
2021-04-30T23:47:20.1102560Z 	26  XCTest                              0x0000000102cbf6d8 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 179
2021-04-30T23:47:20.1105100Z 	27  XCTest                              0x0000000102c4bf5a __26-[XCTestCase performTest:]_block_invoke.362 + 86
2021-04-30T23:47:20.1106160Z 	28  XCTest                              0x0000000102cd0b9f +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
2021-04-30T23:47:20.1107470Z 	29  XCTest                              0x0000000102c4b7c7 -[XCTestCase performTest:] + 695
2021-04-30T23:47:20.1108440Z 	30  XCTest                              0x0000000102c9d6da -[XCTest runTest] + 57
2021-04-30T23:47:20.1109480Z 	31  XCTest                              0x0000000102c45035 __27-[XCTestSuite performTest:]_block_invoke + 329
2021-04-30T23:47:20.1111260Z 	32  XCTest                              0x0000000102c44856 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
2021-04-30T23:47:20.1112470Z 	33  XCTest                              0x0000000102cd0b9f +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
2021-04-30T23:47:20.1113470Z 	34  XCTest                              0x0000000102cd0ab0 +[XCTContext runInContextForTestCase:block:] + 52
2021-04-30T23:47:20.1114910Z 	35  XCTest                              0x0000000102c4480d -[XCTestSuite _performProtectedSectionForTest:testSection:] + 148
2021-04-30T23:47:20.1116210Z 	36  XCTest                              0x0000000102c44b11 -[XCTestSuite performTest:] + 290
2021-04-30T23:47:20.1117190Z 	37  XCTest                              0x0000000102c9d6da -[XCTest runTest] + 57
2021-04-30T23:47:20.1118230Z 	38  XCTest                              0x0000000102c45035 __27-[XCTestSuite performTest:]_block_invoke + 329
2021-04-30T23:47:20.1119630Z 	39  XCTest                              0x0000000102c44856 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
2021-04-30T23:47:20.1120840Z 	40  XCTest                              0x0000000102cd0b9f +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
2021-04-30T23:47:20.1121850Z 	41  XCTest                              0x0000000102cd0ab0 +[XCTContext runInContextForTestCase:block:] + 52
2021-04-30T23:47:20.1123270Z 	42  XCTest                              0x0000000102c4480d -[XCTestSuite _performProtectedSectionForTest:testSection:] + 148
2021-04-30T23:47:20.1124570Z 	43  XCTest                              0x0000000102c44b11 -[XCTestSuite performTest:] + 290
2021-04-30T23:47:20.1125550Z 	44  XCTest                              0x0000000102c9d6da -[XCTest runTest] + 57
2021-04-30T23:47:20.1126920Z 	45  XCTest                              0x0000000102c45035 __27-[XCTestSuite performTest:]_block_invoke + 329
2021-04-30T23:47:20.1128330Z 	46  XCTest                              0x0000000102c44856 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
2021-04-30T23:47:20.1129540Z 	47  XCTest                              0x0000000102cd0b9f +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
2021-04-30T23:47:20.1130540Z 	48  XCTest                              0x0000000102cd0ab0 +[XCTContext runInContextForTestCase:block:] + 52
2021-04-30T23:47:20.1131960Z 	49  XCTest                              0x0000000102c4480d -[XCTestSuite _performProtectedSectionForTest:testSection:] + 148
2021-04-30T23:47:20.1133270Z 	50  XCTest                              0x0000000102c44b11 -[XCTestSuite performTest:] + 290
2021-04-30T23:47:20.1134540Z 	51  XCTest                              0x0000000102c9d6da -[XCTest runTest] + 57
2021-04-30T23:47:20.1135740Z 	52  XCTest                              0x0000000102ced8b5 __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke_2 + 148
2021-04-30T23:47:20.1136850Z 	53  XCTest                              0x0000000102cd0b9f +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
2021-04-30T23:47:20.1137860Z 	54  XCTest                              0x0000000102cd0ab0 +[XCTContext runInContextForTestCase:block:] + 52
2021-04-30T23:47:20.1139240Z 	55  XCTest                              0x0000000102ced81a __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke + 111
2021-04-30T23:47:20.1140700Z 	56  XCTest                              0x0000000102ced99b __44-[XCTTestRunSession runTestsAndReturnError:]_block_invoke.95 + 96
2021-04-30T23:47:20.1142250Z 	57  XCTest                              0x0000000102c6bcb8 -[XCTestObservationCenter _observeTestExecutionForBlock:] + 325
2021-04-30T23:47:20.1143760Z 	58  XCTest                              0x0000000102ced5e0 -[XCTTestRunSession runTestsAndReturnError:] + 615
2021-04-30T23:47:20.1144930Z 	59  XCTest                              0x0000000102c28a7e -[XCTestDriver _runTests] + 466
2021-04-30T23:47:20.1145520Z 	60  XCTest                              0x0000000102cccb82 _XCTestMain + 108
2021-04-30T23:47:20.1146240Z 	61  xctest                              0x0000000102a13f07 main + 210
2021-04-30T23:47:20.1146730Z 	62  libdyld.dylib                       0x00007fff70a53cc9 start + 1
```
 #### Summary of Changes
 * Use a `NSData` to hold the value until it is dispatched