### PR TITLE
[Darwin] Schedule Mdns callbacks on the main framework dispatch queue

### DIFF
--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -297,6 +297,9 @@ CHIP_ERROR Register(uint32_t interfaceId, const char * type, const char * name, 
 
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
+    err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
+    VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
+
     return MdnsContexts::GetInstance().Add(sdCtx, sdRef);
 }
 
@@ -364,6 +367,9 @@ CHIP_ERROR Browse(void * context, MdnsBrowseCallback callback, uint32_t interfac
     err   = DNSServiceBrowse(&sdRef, 0 /* flags */, interfaceId, type, kLocalDomain, OnBrowse, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
+    err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
+    VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
+
     return MdnsContexts::GetInstance().Add(sdCtx, sdRef);
 }
 
@@ -415,6 +421,9 @@ CHIP_ERROR GetAddrInfo(void * context, MdnsResolveCallback callback, uint32_t in
     err = DNSServiceGetAddrInfo(&sdRef, 0 /* flags */, interfaceId, kDNSServiceProtocol_IPv4, hostname, OnGetAddrInfo, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
 
+    err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
+    VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
+
     return MdnsContexts::GetInstance().Add(sdCtx, sdRef);
 }
 
@@ -438,6 +447,9 @@ CHIP_ERROR Resolve(void * context, MdnsResolveCallback callback, uint32_t interf
     sdCtx = chip::Platform::New<ResolveContext>(context, callback, name);
     err   = DNSServiceResolve(&sdRef, 0 /* flags */, interfaceId, name, type, kLocalDomain, OnResolve, sdCtx);
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
+
+    err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
+    VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
 
     return MdnsContexts::GetInstance().Add(sdCtx, sdRef);
 }


### PR DESCRIPTION
 #### Problem

The Mdns callbacks are not called on the main framework dispatch queue.

 #### Summary of Changes
 * Uses the main framework dispatch queue