### PR TITLE
* Fix 64-bit prints mDNS code for nano libprintf

### DIFF
--- a/src/app/server/Mdns.cpp
+++ b/src/app/server/Mdns.cpp
@@ -49,8 +49,9 @@ NodeId GetCurrentNodeId()
     auto pairing = GetGlobalAdminPairingTable().cbegin();
     if (pairing != GetGlobalAdminPairingTable().cend())
     {
-        ChipLogProgress(Discovery, "Found admin paring for admin %" PRIX16 ", node %" PRIX64, pairing->GetAdminId(),
-                        pairing->GetNodeId());
+        ChipLogProgress(Discovery, "Found admin paring for admin %" PRIX16 ", node 0x%08" PRIx32 "%08" PRIx32,
+                        pairing->GetAdminId(), static_cast<uint32_t>(pairing->GetNodeId() >> 32),
+                        static_cast<uint32_t>(pairing->GetNodeId()));
         return pairing->GetNodeId();
     }
 
@@ -105,8 +106,11 @@ CHIP_ERROR AdvertiseOperational()
 
     auto & mdnsAdvertiser = chip::Mdns::ServiceAdvertiser::Instance();
 
-    ChipLogProgress(Discovery, "Advertise operational node %" PRIX64 "-%" PRIX64, advertiseParameters.GetPeerId().GetFabricId(),
-                    advertiseParameters.GetPeerId().GetNodeId());
+    ChipLogProgress(Discovery, "Advertise operational node 0x%08" PRIx32 "%08" PRIx32 "-0x%08" PRIx32 "%08" PRIx32,
+                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetFabricId() >> 32),
+                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetFabricId()),
+                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetNodeId() >> 32),
+                    static_cast<uint32_t>(advertiseParameters.GetPeerId().GetNodeId()));
     return mdnsAdvertiser.Advertise(advertiseParameters);
 }
 

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -160,7 +160,8 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
 
     ReturnErrorOnFailure(SetupHostname(params.GetMac()));
 
-    snprintf(service.mName, sizeof(service.mName), "%016" PRIX64, mCommissionInstanceName);
+    snprintf(service.mName, sizeof(service.mName), "%08" PRIX32 "%08" PRIX32, static_cast<uint32_t>(mCommissionInstanceName >> 32),
+             static_cast<uint32_t>(mCommissionInstanceName));
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissioning)
     {
         strncpy(service.mType, "_chipc", sizeof(service.mType));
@@ -374,7 +375,8 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, MdnsService * re
     nodeData.mAddress     = result->mAddress.ValueOr({});
     nodeData.mPort        = result->mPort;
 
-    ChipLogProgress(Discovery, "Node ID resolved for %" PRIX64, nodeData.mPeerId.GetNodeId());
+    ChipLogProgress(Discovery, "Node ID resolved for 0x08%" PRIX32 "08%" PRIX32,
+                    static_cast<uint32_t>(nodeData.mPeerId.GetNodeId() >> 32), static_cast<uint32_t>(nodeData.mPeerId.GetNodeId()));
     mgr->mResolverDelegate->OnNodeIdResolved(nodeData);
 }
 


### PR DESCRIPTION
 #### Problem
Node and fabric ID prints are not printed correctly due to the use of PRIX64 format specifiers

 #### Summary of Changes
Reworked 64-bit PRIX64 into PRIX32 combinations, supported by nano printf.
