### PR TITLE
Fix restyle URL for downloading script

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -33,7 +33,7 @@ set -e
 CHIP_ROOT=$(cd "$here/../.." && pwd)
 
 restyle-paths() {
-    url=https://github.com/restyled-io/restyler/raw/master/bin/restyle-path
+    url=https://github.com/restyled-io/restyler/raw/main/bin/restyle-path
 
     sh <(curl --location --proto "=https" --tlsv1.2 "$url" -sSf) "$@"
 }


### PR DESCRIPTION
 #### Problem
CHIP's restyle helper script is failing to download the restyler from GitHub.

 #### Summary of Changes
Restyle project seems to have renamed the master branch to main branch. Updating the helper script to download the restyler from the updated path.