### PR TITLE
Zap remove ember af maximum aps payload length

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -742,18 +742,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -3173,15 +3173,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/bridge-app/bridge-common/gen/callback-stub.cpp
+++ b/examples/bridge-app/bridge-common/gen/callback-stub.cpp
@@ -590,18 +590,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/bridge-app/bridge-common/gen/callback.h
+++ b/examples/bridge-app/bridge-common/gen/callback.h
@@ -1093,15 +1093,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/chip-tool/gen/callback-stub.cpp
+++ b/examples/chip-tool/gen/callback-stub.cpp
@@ -798,18 +798,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/chip-tool/gen/callback.h
+++ b/examples/chip-tool/gen/callback.h
@@ -3495,15 +3495,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -590,18 +590,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -1093,15 +1093,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -582,18 +582,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -940,15 +940,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -582,18 +582,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -925,15 +925,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/tv-app/tv-common/gen/callback-stub.cpp
+++ b/examples/tv-app/tv-common/gen/callback-stub.cpp
@@ -758,18 +758,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/tv-app/tv-common/gen/callback.h
+++ b/examples/tv-app/tv-common/gen/callback.h
@@ -3152,15 +3152,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/window-app/common/gen/callback-stub.cpp
+++ b/examples/window-app/common/gen/callback-stub.cpp
@@ -558,18 +558,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/examples/window-app/common/gen/callback.h
+++ b/examples/window-app/common/gen/callback.h
@@ -620,15 +620,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -204,7 +204,8 @@ void emberAfPluginReportingTickEventHandler(void)
     // reportSize needs to be able to fit a sum of dataSize and some other stuff
     // without overflowing.
     uint32_t reportSize;
-    uint8_t index, currentPayloadMaxLength = 0, smallestPayloadMaxLength = 0;
+    uint8_t index;
+    uint16_t currentPayloadMaxLength = 0, smallestPayloadMaxLength = 0;
 
     for (i = 0; i < REPORT_TABLE_SIZE; i++)
     {
@@ -292,8 +293,7 @@ void emberAfPluginReportingTickEventHandler(void)
                 if (status == (EmberAfStatus) EMBER_SUCCESS && bindingEntry.local == entry.endpoint &&
                     bindingEntry.clusterId == entry.clusterId)
                 {
-                    currentPayloadMaxLength =
-                        emberAfMaximumApsPayloadLength(bindingEntry.type, bindingEntry.networkIndex, apsFrame);
+                    currentPayloadMaxLength = EMBER_AF_RESPONSE_BUFFER_LEN;
                     if (currentPayloadMaxLength < smallestPayloadMaxLength)
                     {
                         smallestPayloadMaxLength = currentPayloadMaxLength;

--- a/src/app/util/af-main-common.cpp
+++ b/src/app/util/af-main-common.cpp
@@ -283,16 +283,9 @@ static EmberStatus send(EmberOutgoingMessageType type, uint64_t indexOrDestinati
     emAfApplyDisableDefaultResponse(&message[0]);
     emAfApplyRetryOverride(&apsFrame->options);
 
-    if (messageLength <= emberAfMaximumApsPayloadLength(type, indexOrDestination, apsFrame))
+    if (messageLength <= EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH)
     {
         status = emAfSend(type, indexOrDestination, apsFrame, (uint8_t) messageLength, message, &messageTag, alias, sequence);
-#ifdef EMBER_AF_PLUGIN_FRAGMENTATION
-    }
-    else if (!broadcast)
-    {
-        status = emAfFragmentationSendUnicast(type, indexOrDestination, apsFrame, message, messageLength, &messageTag);
-        emberAfDebugPrintln("%pstart:len=%d.", "Fragmentation:", messageLength);
-#endif
     }
     else
     {

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -1475,24 +1475,6 @@ EmberStatus emberAfSendImmediateDefaultResponse(EmberAfStatus status);
 EmberStatus emberAfSendImmediateDefaultResponseWithCallback(EmberAfStatus status, EmberAfMessageSentFunction callback);
 
 /**
- * @brief Returns the maximum size of the payload that the Application
- * Support sub-layer will accept for the given message type, destination, and
- * APS frame.
- *
- * The size depends on multiple factors, including the security level in use
- * and additional information added to the message to support the various
- * options.
- *
- * @param type The outgoing message type.
- * @param indexOrDestination Depending on the message type, this is either the
- *  EmberNodeId of the destination, an index into the address table, an index
- *  into the binding table, the multicast identifier, or a broadcast address.
- * @param apsFrame The APS frame for the message.
- * @return The maximum APS payload length for the given message.
- */
-uint8_t emberAfMaximumApsPayloadLength(EmberOutgoingMessageType type, uint64_t indexOrDestination, EmberApsFrame * apsFrame);
-
-/**
  * @brief Access to client API APS frame.
  */
 EmberApsFrame * emberAfGetCommandApsFrame(void);

--- a/src/app/util/config.h
+++ b/src/app/util/config.h
@@ -125,15 +125,6 @@
 #define ZA_MAX_HOPS 12
 #endif
 
-#ifndef EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH
-#define EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH 0
-#endif
-
-// The maximum APS payload, not including any APS options.  This value is also
-// available from emberMaximumApsPayloadLength() or ezspMaximumPayloadLength().
-// See http://portal.ember.com/faq/payload for more information.
-#define EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH 82 - EMBER_AF_SOURCE_ROUTING_RESERVED_PAYLOAD_LENGTH
-
 // Max PHY size = 128
 //   -1 byte for PHY length
 //   -2 bytes for MAC CRC
@@ -157,14 +148,8 @@
 // affects the payloads generated from the CLI and the payloads generated
 // as responses.
 // Maximum payload length.
-// If fragmenation is enabled, and fragmentation length is bigger than default, then use that
-#if defined(EMBER_AF_PLUGIN_FRAGMENTATION) && (EMBER_AF_PLUGIN_FRAGMENTATION_BUFFER_SIZE > EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH)
-#define EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH EMBER_AF_PLUGIN_FRAGMENTATION_BUFFER_SIZE
-#define EMBER_AF_INCOMING_BUFFER_LENGTH EMBER_AF_PLUGIN_FRAGMENTATION_BUFFER_SIZE
-#else
-#define EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH
-#define EMBER_AF_INCOMING_BUFFER_LENGTH EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH
-#endif
+#define EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH 1024
+#define EMBER_AF_INCOMING_BUFFER_LENGTH 1024
 
 // *******************************************************************
 // Application configuration of Flash

--- a/src/app/util/process-global-message.cpp
+++ b/src/app/util/process-global-message.cpp
@@ -73,13 +73,13 @@ bool emAfSyncingTime = false;
 #endif
 
 #define DISC_ATTR_RSP_MAX_ATTRIBUTES                                                                                               \
-    (((EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH - EMBER_AF_ZCL_MANUFACTURER_SPECIFIC_OVERHEAD /* max ZCL header size */                 \
-       - 1)                                                                              /* discovery is complete boolean */       \
+    (((EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH - EMBER_AF_ZCL_MANUFACTURER_SPECIFIC_OVERHEAD /* max ZCL header size */                \
+       - 1)                                                                               /* discovery is complete boolean */      \
       / 3)        /* size of one discover attributes response entry */                                                             \
      % UINT8_MAX) /* make count fit in an 8 bit integer */
 #define DISC_ATTR_EXT_RSP_MAX_ATTRIBUTES                                                                                           \
-    (((EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH - EMBER_AF_ZCL_MANUFACTURER_SPECIFIC_OVERHEAD /* max ZCL header size */                 \
-       - 1)                                                                              /* discovery is complete boolean */       \
+    (((EMBER_AF_MAXIMUM_SEND_PAYLOAD_LENGTH - EMBER_AF_ZCL_MANUFACTURER_SPECIFIC_OVERHEAD /* max ZCL header size */                \
+       - 1)                                                                               /* discovery is complete boolean */      \
       / 4)        /* size of one discover attributes extended response entry */                                                    \
      % UINT8_MAX) /* make count fit in an 8 bit integer */
 

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -851,52 +851,6 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
     return emberAfSendDefaultResponseWithCallback(cmd, status, NULL);
 }
 
-uint8_t emberAfMaximumApsPayloadLength(EmberOutgoingMessageType type, uint64_t indexOrDestination, EmberApsFrame * apsFrame)
-{
-    NodeId destination = EMBER_UNKNOWN_NODE_ID;
-    uint8_t max        = EMBER_AF_MAXIMUM_APS_PAYLOAD_LENGTH;
-
-    if ((apsFrame->options & EMBER_APS_OPTION_SOURCE_EUI64) != 0U)
-    {
-        max = static_cast<uint8_t>(max - EUI64_SIZE);
-    }
-    if ((apsFrame->options & EMBER_APS_OPTION_DESTINATION_EUI64) != 0U)
-    {
-        max = static_cast<uint8_t>(max - EUI64_SIZE);
-    }
-    if ((apsFrame->options & EMBER_APS_OPTION_FRAGMENT) != 0U)
-    {
-        max = static_cast<uint8_t>(max - EMBER_AF_APS_FRAGMENTATION_OVERHEAD);
-    }
-
-    switch (type)
-    {
-    case EMBER_OUTGOING_DIRECT:
-        destination = indexOrDestination;
-        break;
-    case EMBER_OUTGOING_VIA_ADDRESS_TABLE:
-        // destination = emberGetAddressTableRemoteNodeId(indexOrDestination);
-        break;
-    case EMBER_OUTGOING_VIA_BINDING:
-        // destination = emberGetBindingRemoteNodeId(indexOrDestination);
-        break;
-    case EMBER_OUTGOING_MULTICAST:
-        // APS multicast messages include the two-byte group id and exclude the
-        // one-byte destination endpoint, for a net loss of an extra byte.
-        max--;
-        break;
-    case EMBER_OUTGOING_BROADCAST:
-        break;
-    default:
-        // MISRA requires default case.
-        break;
-    }
-
-    max = static_cast<uint8_t>(max - emberAfGetSourceRouteOverheadCallback(destination));
-
-    return max;
-}
-
 void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
 {
     data[index]     = (uint8_t)(((x)) & 0xFF);

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -564,18 +564,6 @@ bool __attribute__((weak)) emberAfGetEndpointInfoCallback(
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -578,15 +578,6 @@ uint32_t emberAfGetCurrentTimeCallback();
  */
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex, EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/controller/python/gen/callback-stub.cpp
+++ b/src/controller/python/gen/callback-stub.cpp
@@ -806,18 +806,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/controller/python/gen/callback.h
+++ b/src/controller/python/gen/callback.h
@@ -3548,15 +3548,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/darwin/Framework/CHIP/gen/callback-stub.cpp
+++ b/src/darwin/Framework/CHIP/gen/callback-stub.cpp
@@ -718,18 +718,6 @@ emberAfGetEndpointInfoCallback(EndpointId endpoint, uint8_t * returnNetworkIndex
     return false;
 }
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t __attribute__((weak)) emberAfGetSourceRouteOverheadCallback(chip::NodeId destination)
-{
-    return 0;
-}
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration

--- a/src/darwin/Framework/CHIP/gen/callback.h
+++ b/src/darwin/Framework/CHIP/gen/callback.h
@@ -2552,15 +2552,6 @@ uint32_t emberAfGetCurrentTimeCallback();
 bool emberAfGetEndpointInfoCallback(chip::EndpointId endpoint, uint8_t * returnNetworkIndex,
                                     EmberAfEndpointInfoStruct * returnEndpointInfo);
 
-/** @brief Get Source Route Overhead
- *
- * This function is called by the framework to determine the overhead required
- * in the network frame for source routing to a particular destination.
- *
- * @param destination The node id of the destination  Ver.: always
- */
-uint8_t emberAfGetSourceRouteOverheadCallback(chip::NodeId destination);
-
 /** @brief Registration Abort
  *
  * This callback is called when the device should abort the registration


### PR DESCRIPTION
#### Problem
 Ember has a limit on the actual message payload. Currently this limit is `82` and it starts to be
 too small for reading `List` attributes.
 Futhermore, there is a method named `emberAfMaximumApsPayloadLength` use to calculate the size
 of the payload depending on some routing parameters as far as I can tell. It is unclear to me
 that CHIP will ever use those.

 #### Summary of changes
 * Remove `emberAfMaximumApsPayloadLength` and some dependencies
 * Upgrade the maximum payload size from `82` to `1024`
