### PR TITLE
Zap use byte span in struct

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/bridge-app/bridge-common/gen/af-structs.h
+++ b/examples/bridge-app/bridge-common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/chip-tool/gen/CHIPClientCallbacks.cpp
+++ b/examples/chip-tool/gen/CHIPClientCallbacks.cpp
@@ -458,7 +458,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].GroupKeyIndex = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].GroupKeyRoot = emberAfGetString(message, 0, messageLen);
+                            data[i].GroupKeyRoot = chip::ByteSpan(message, 16);
                             message += 16;
                             CHECK_MESSAGE_LENGTH(16);
                             data[i].GroupKeyEpochStartTime = emberAfGetInt64u(message, 0, messageLen);
@@ -490,7 +490,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].VendorId = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].Label = emberAfGetString(message, 0, messageLen);
+                            data[i].Label = chip::ByteSpan(message, 32);
                             message += 32;
                             CHECK_MESSAGE_LENGTH(32);
                             data[i].NodeId = emberAfGetInt64u(message, 0, messageLen);

--- a/examples/chip-tool/gen/CHIPClustersObjc.mm
+++ b/examples/chip-tool/gen/CHIPClustersObjc.mm
@@ -2696,10 +2696,9 @@ public:
                 values[i] = [[NSDictionary alloc]
                     initWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
                     [NSNumber numberWithUnsignedShort:entries[i].GroupKeyIndex], @"GroupKeyIndex",
-                    [NSData dataWithBytes:entries[i].GroupKeyRoot + 1u length:emberAfStringLength(entries[i].GroupKeyRoot)],
-                    @"GroupKeyRoot", [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime],
-                    @"GroupKeyEpochStartTime", [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy],
-                    @"GroupKeySecurityPolicy", nil];
+                    [NSData dataWithBytes:entries[i].GroupKeyRoot.data() length:entries[i].GroupKeyRoot.size()], @"GroupKeyRoot",
+                    [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime], @"GroupKeyEpochStartTime",
+                    [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy], @"GroupKeySecurityPolicy", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -2738,8 +2737,8 @@ public:
                 values[i] =
                     [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                           @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
-                                          [NSData dataWithBytes:entries[i].Label + 1u length:emberAfStringLength(entries[i].Label)],
-                                          @"Label", [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
+                                          [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()], @"Label",
+                                          [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];

--- a/examples/chip-tool/gen/af-structs.h
+++ b/examples/chip-tool/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/lighting-app/lighting-common/gen/af-structs.h
+++ b/examples/lighting-app/lighting-common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/lock-app/lock-common/gen/af-structs.h
+++ b/examples/lock-app/lock-common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/tv-app/tv-common/gen/af-structs.h
+++ b/examples/tv-app/tv-common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/examples/window-app/common/gen/af-structs.h
+++ b/examples/window-app/common/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClientCallbacks-src.zapt
@@ -348,12 +348,20 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             {
                                 {{#if isStruct}}
                                 {{#chip_attribute_list_entryTypes}}
+                                {{#if (isOctetString type)}}
+                                data[i].{{name}} = chip::ByteSpan(message, {{size}});
+                                {{else}}
                                 data[i].{{name}} = emberAfGet{{asReadType type}}(message, 0, messageLen);
+                                {{/if}}
                                 message += {{size}};
                                 CHECK_MESSAGE_LENGTH({{size}});
                                 {{/chip_attribute_list_entryTypes}}
                                 {{else}}
+                                {{#if (isOctetString type)}}
+                                data[i] = chip::ByteSpan(message, {{size}});
+                                {{else}}
                                 data[i] = emberAfGet{{asReadType type}}(message, 0, messageLen);
+                                {{/if}}
                                 message += {{size}};
                                 CHECK_MESSAGE_LENGTH({{size}});
                                 {{/if}}

--- a/src/app/zap-templates/templates/app/CHIPClustersObjc-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClustersObjc-src.zapt
@@ -423,7 +423,7 @@ public:
                 {{#chip_attribute_list_entryTypes}}
                     {{#if (isString type)}}
                     {{#if (isOctetString type)}}
-                    [NSData dataWithBytes:entries[i].{{name}}+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i].{{name}})],
+                    [NSData dataWithBytes:entries[i].{{name}}.data() length:entries[i].{{name}}.size()],
                     {{else}}
                     [[NSString alloc] initWithBytes:entries[i].{{name}}+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i].{{name}}) encoding:NSUTF8StringEncoding],
                     {{/if}}
@@ -434,7 +434,15 @@ public:
                 {{/chip_attribute_list_entryTypes}}
                 nil];
                 {{else}}
+                {{#if (isString type)}}
+                {{#if (isOctetString type)}}
+                values[i] = [NSData dataWithBytes:entries[i].data() length:entries[i].size()];
+                {{else}}
+                values[i] = [[NSString alloc] initWithBytes:entries[i]+{{asReadTypeLength type}} length:emberAf{{asReadType type}}Length(entries[i]) encoding:NSUTF8StringEncoding];
+                {{/if}}
+                {{else}}
                 values[i] = [NSNumber numberWith{{asObjectiveCNumberType label type}}:entries[i]];
+                {{/if}}
                 {{/if}}
             }
 

--- a/src/app/zap-templates/templates/app/af-structs.zapt
+++ b/src/app/zap-templates/templates/app/af-structs.zapt
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 #include <app/util/basic-types.h>
+#include <support/Span.h>
 #include "enums.h"
 
 {{#zcl_structs}}

--- a/src/app/zap-templates/templates/app/helper.js
+++ b/src/app/zap-templates/templates/app/helper.js
@@ -181,6 +181,8 @@ function asChipUnderlyingType(label, type)
     return 'chip::GroupId';
   } else if (zclHelper.isStrEqual(label, "commandId")) {
     return 'chip::CommandId';
+  } else if (type == 'OCTET_STRING') {
+    return 'chip::ByteSpan';
   } else {
     const options = { 'hash' : {} };
     return zclHelper.asUnderlyingZclType.call(this, type, options);

--- a/src/controller/python/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/python/gen/CHIPClientCallbacks.cpp
@@ -458,7 +458,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].GroupKeyIndex = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].GroupKeyRoot = emberAfGetString(message, 0, messageLen);
+                            data[i].GroupKeyRoot = chip::ByteSpan(message, 16);
                             message += 16;
                             CHECK_MESSAGE_LENGTH(16);
                             data[i].GroupKeyEpochStartTime = emberAfGetInt64u(message, 0, messageLen);
@@ -490,7 +490,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].VendorId = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].Label = emberAfGetString(message, 0, messageLen);
+                            data[i].Label = chip::ByteSpan(message, 32);
                             message += 32;
                             CHECK_MESSAGE_LENGTH(32);
                             data[i].NodeId = emberAfGetInt64u(message, 0, messageLen);

--- a/src/controller/python/gen/CHIPClustersObjc.mm
+++ b/src/controller/python/gen/CHIPClustersObjc.mm
@@ -2622,10 +2622,9 @@ public:
                 values[i] = [[NSDictionary alloc]
                     initWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
                     [NSNumber numberWithUnsignedShort:entries[i].GroupKeyIndex], @"GroupKeyIndex",
-                    [NSData dataWithBytes:entries[i].GroupKeyRoot + 1u length:emberAfStringLength(entries[i].GroupKeyRoot)],
-                    @"GroupKeyRoot", [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime],
-                    @"GroupKeyEpochStartTime", [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy],
-                    @"GroupKeySecurityPolicy", nil];
+                    [NSData dataWithBytes:entries[i].GroupKeyRoot.data() length:entries[i].GroupKeyRoot.size()], @"GroupKeyRoot",
+                    [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime], @"GroupKeyEpochStartTime",
+                    [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy], @"GroupKeySecurityPolicy", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -2664,8 +2663,8 @@ public:
                 values[i] =
                     [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                           @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
-                                          [NSData dataWithBytes:entries[i].Label + 1u length:emberAfStringLength(entries[i].Label)],
-                                          @"Label", [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
+                                          [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()], @"Label",
+                                          [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];

--- a/src/controller/python/gen/af-structs.h
+++ b/src/controller/python/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;

--- a/src/darwin/Framework/CHIP/gen/CHIPClientCallbacks.cpp
+++ b/src/darwin/Framework/CHIP/gen/CHIPClientCallbacks.cpp
@@ -458,7 +458,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].GroupKeyIndex = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].GroupKeyRoot = emberAfGetString(message, 0, messageLen);
+                            data[i].GroupKeyRoot = chip::ByteSpan(message, 16);
                             message += 16;
                             CHECK_MESSAGE_LENGTH(16);
                             data[i].GroupKeyEpochStartTime = emberAfGetInt64u(message, 0, messageLen);
@@ -490,7 +490,7 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             data[i].VendorId = emberAfGetInt16u(message, 0, messageLen);
                             message += 2;
                             CHECK_MESSAGE_LENGTH(2);
-                            data[i].Label = emberAfGetString(message, 0, messageLen);
+                            data[i].Label = chip::ByteSpan(message, 32);
                             message += 32;
                             CHECK_MESSAGE_LENGTH(32);
                             data[i].NodeId = emberAfGetInt64u(message, 0, messageLen);

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -2045,10 +2045,9 @@ public:
                 values[i] = [[NSDictionary alloc]
                     initWithObjectsAndKeys:[NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
                     [NSNumber numberWithUnsignedShort:entries[i].GroupKeyIndex], @"GroupKeyIndex",
-                    [NSData dataWithBytes:entries[i].GroupKeyRoot + 1u length:emberAfStringLength(entries[i].GroupKeyRoot)],
-                    @"GroupKeyRoot", [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime],
-                    @"GroupKeyEpochStartTime", [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy],
-                    @"GroupKeySecurityPolicy", nil];
+                    [NSData dataWithBytes:entries[i].GroupKeyRoot.data() length:entries[i].GroupKeyRoot.size()], @"GroupKeyRoot",
+                    [NSNumber numberWithUnsignedLongLong:entries[i].GroupKeyEpochStartTime], @"GroupKeyEpochStartTime",
+                    [NSNumber numberWithUnsignedChar:entries[i].GroupKeySecurityPolicy], @"GroupKeySecurityPolicy", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];
@@ -2087,8 +2086,8 @@ public:
                 values[i] =
                     [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                           @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
-                                          [NSData dataWithBytes:entries[i].Label + 1u length:emberAfStringLength(entries[i].Label)],
-                                          @"Label", [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
+                                          [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()], @"Label",
+                                          [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];

--- a/src/darwin/Framework/CHIP/gen/af-structs.h
+++ b/src/darwin/Framework/CHIP/gen/af-structs.h
@@ -23,6 +23,7 @@
 #include "enums.h"
 #include <app/util/basic-types.h>
 #include <stdint.h>
+#include <support/Span.h>
 
 // Struct for ApplicationLauncherApp
 typedef struct _ApplicationLauncherApp
@@ -201,7 +202,7 @@ typedef struct _EventLogPayload
     uint8_t logId;
     uint16_t eventId;
     uint32_t eventTime;
-    uint8_t * eventData;
+    chip::ByteSpan eventData;
 } EmberAfEventLogPayload;
 
 // Struct for ExtendedDiscoverAttributesInfoRecord
@@ -217,7 +218,7 @@ typedef struct _FabricDescriptor
 {
     chip::FabricId FabricId;
     uint16_t VendorId;
-    uint8_t * Label;
+    chip::ByteSpan Label;
     chip::NodeId NodeId;
 } EmberAfFabricDescriptor;
 
@@ -237,8 +238,8 @@ typedef struct _GpTranslationTableUpdateTranslation
     uint16_t profile;
     uint16_t cluster;
     uint8_t zigbeeCommandId;
-    uint8_t * zigbeeCommandPayload;
-    uint8_t * additionalInfoBlock;
+    chip::ByteSpan zigbeeCommandPayload;
+    chip::ByteSpan additionalInfoBlock;
 } EmberAfGpTranslationTableUpdateTranslation;
 
 // Struct for GroupInformationRecord
@@ -253,7 +254,7 @@ typedef struct _GroupKey
 {
     uint16_t VendorId;
     uint16_t GroupKeyIndex;
-    uint8_t * GroupKeyRoot;
+    chip::ByteSpan GroupKeyRoot;
     uint64_t GroupKeyEpochStartTime;
     uint8_t GroupKeySecurityPolicy;
 } EmberAfGroupKey;
@@ -487,20 +488,20 @@ typedef struct _SpecialDay
 // Struct for ThreadInterfaceScanResult
 typedef struct _ThreadInterfaceScanResult
 {
-    uint8_t * DiscoveryResponse;
+    chip::ByteSpan DiscoveryResponse;
 } EmberAfThreadInterfaceScanResult;
 
 // Struct for TierLabelsPayload
 typedef struct _TierLabelsPayload
 {
     uint8_t tierId;
-    uint8_t * tierLabel;
+    chip::ByteSpan tierLabel;
 } EmberAfTierLabelsPayload;
 
 // Struct for TopUpPayload
 typedef struct _TopUpPayload
 {
-    uint8_t * topUpCode;
+    chip::ByteSpan topUpCode;
     int32_t topUpAmount;
     uint32_t topUpTime;
 } EmberAfTopUpPayload;
@@ -539,8 +540,8 @@ typedef struct _TvChannelLineupInfo
 typedef struct _WiFiInterfaceScanResult
 {
     uint8_t Security;
-    uint8_t * SSID;
-    uint8_t * BSSID;
+    chip::ByteSpan SSID;
+    chip::ByteSpan BSSID;
     uint8_t Channel;
     uint32_t FrequencyBand;
 } EmberAfWiFiInterfaceScanResult;


### PR DESCRIPTION
 #### Problem

The generated structs emit `uint8_t *` for `OCTET_STRING`. This starts to be used fairly often, so this PR emit `chip::ByteSpan` instead.

 #### Summary of Changes
 * Replace `uint8_t *` in generated structs by `chip::ByteSpan`
 * Update the templates where the code assumes `uint8_t *` and do funny things