### PR TITLE
Fix race condition during CRMP sendMessage

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -34,7 +34,9 @@ OT_SIMULATION_CACHE="$CIRQUE_CACHE_PATH/ot-simulation.tgz"
 
 # Append test name here to add more tests for run_all_tests
 CIRQUE_TESTS=(
+    "EchoTest"
     "MobileDeviceTest"
+    "InteractionModel"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -187,7 +187,8 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
-        encryptedMsg = msgBuf.Retain();
+        encryptedMsg        = msgBuf.Retain();
+        (*bufferRetainSlot) = std::move(encryptedMsg);
     }
 
     ChipLogProgress(Inet,
@@ -208,11 +209,6 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     }
     ChipLogProgress(Inet, "Secure msg send status %s", ErrorStr(err));
     SuccessOrExit(err);
-
-    if (bufferRetainSlot != nullptr)
-    {
-        (*bufferRetainSlot) = std::move(encryptedMsg);
-    }
 
 exit:
     if (!msgBuf.IsNull())

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -149,13 +149,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
 
     Transport::AdminPairingInfo * admin = nullptr;
 
-    // Hold the reference to encrypted message in stack variable.
-    // In case of any failures, the reference is not returned, and this stack variable
-    // will automatically free the reference on returning from the function.
-    EncryptedPacketBufferHandle encryptedMsg;
-
     VerifyOrExit(mState == State::kInitialized, err = CHIP_ERROR_INCORRECT_STATE);
-
     VerifyOrExit(!msgBuf.IsNull(), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(!msgBuf->HasChainedBuffer(), err = CHIP_ERROR_INVALID_MESSAGE_LENGTH);
 
@@ -187,8 +181,7 @@ CHIP_ERROR SecureSessionMgr::SendMessage(SecureSessionHandle session, PayloadHea
     // Retain the packet buffer in case it's needed for retransmissions.
     if (bufferRetainSlot != nullptr)
     {
-        encryptedMsg        = msgBuf.Retain();
-        (*bufferRetainSlot) = std::move(encryptedMsg);
+        (*bufferRetainSlot) = msgBuf.Retain();
     }
 
     ChipLogProgress(Inet,


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, we see the cirque is flaky with random crash if we enable IM and Echo test. The crash log shows we have race condition during CRMP sendMessage.

Now we need to first send the message and cache the message during CRMP since the packetHeader is encoded at TransportLayer during send. If we receive ack response before we cache the sent message, we will try to remove an non-exist buffer from retransTable and crash.

With #6333, packetHeader encoding and decoding is moved to SecureSessionMgr, we can cache the outgoing message first and send later to prevent this race condition.


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Fix race condition during CRMP sendMessage 
2. Enable EchoTest in Cirque
3. Enable InteractionModel Test in Cirque

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6155

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
