### PR TITLE
[Darwin] Do not push the DNSServiceRegister onto the main dispatch queue

### DIFF
--- a/src/platform/Darwin/MdnsImpl.cpp
+++ b/src/platform/Darwin/MdnsImpl.cpp
@@ -297,9 +297,6 @@ CHIP_ERROR Register(uint32_t interfaceId, const char * type, const char * name, 
 
     VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err), CHIP_ERROR_INTERNAL);
 
-    err = DNSServiceSetDispatchQueue(sdRef, chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue());
-    VerifyOrReturnError(CheckForSuccess(sdCtx, __func__, err, true), CHIP_ERROR_INTERNAL);
-
     return MdnsContexts::GetInstance().Add(sdCtx, sdRef);
 }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Pairing is working randomly with this change. I'm not sure why yet but it creates random failures into the darwin CI and prevent local testing.

