### PR TITLE
* Add # of SRP service configuration + tailor SRP RAM useage

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -628,6 +628,15 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT 0
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES
+ *
+ * Amount of services available for advertising using SRP.
+ */
+#ifndef CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES
+#define CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES 3
+#endif
+
 // -------------------- Thread Configuration --------------------
 
 /**

--- a/src/lib/mdns/Advertiser.h
+++ b/src/lib/mdns/Advertiser.h
@@ -76,6 +76,11 @@ private:
 class OperationalAdvertisingParameters : public BaseAdvertisingParams<OperationalAdvertisingParameters>
 {
 public:
+    // Amount of mDNS text entries required for this advertising type
+    static constexpr uint8_t kNumAdvertisingTxtEntries = 2;
+    static constexpr uint8_t kTxtMaxKeySize            = 3 + 1; // "CRI"/"CRA" as possible keys
+    static constexpr uint8_t kTxtMaxValueSize          = 7 + 1; // Max for text representation of the 32-bit CRMP intervals
+
     OperationalAdvertisingParameters & SetPeerId(const PeerId & peerId)
     {
         mPeerId = peerId;
@@ -104,6 +109,11 @@ private:
 class CommissionAdvertisingParameters : public BaseAdvertisingParams<CommissionAdvertisingParameters>
 {
 public:
+    // Amount of mDNS text entries required for this advertising type
+    static constexpr uint8_t kNumAdvertisingTxtEntries = 8;     // Min 1 - Max 8
+    static constexpr uint8_t kTxtMaxKeySize            = 2 + 1; // "D"/"VP"/"CM"/"DT"/"DN"/"RI"/"PI"/"PH" as possible keys
+    static constexpr uint8_t kTxtMaxValueSize          = 128;   // Max from PI - Pairing Instruction
+
     CommissionAdvertisingParameters & SetShortDiscriminator(uint8_t discriminator)
     {
         mShortDiscriminator = discriminator;

--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -141,7 +141,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
     char discriminatorBuf[6];
     char vendorProductBuf[12];
     char pairingInstrBuf[128];
-    TextEntry textEntries[4];
+    TextEntry textEntries[CommissionAdvertisingParameters::kNumAdvertisingTxtEntries];
     size_t textEntrySize = 0;
     char shortDiscriminatorSubtype[6];
     char longDiscriminatorSubtype[8];
@@ -210,6 +210,8 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const CommissionAdvertisingParameter
                                          strnlen(pairingInstrBuf, sizeof(pairingInstrBuf)) };
     }
 
+    // TODO: Add missing "CM" / "DT" / "DN" keys + split "P" into "PH"/"PI" to be spec-compliant
+
     snprintf(shortDiscriminatorSubtype, sizeof(shortDiscriminatorSubtype), "_S%03u", params.GetShortDiscriminator());
     subTypes[subTypeSize++] = shortDiscriminatorSubtype;
     snprintf(longDiscriminatorSubtype, sizeof(longDiscriminatorSubtype), "_L%04u", params.GetLongDiscriminator());
@@ -250,7 +252,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     constexpr uint8_t kMaxCRMPRetryBufferSize = 7 + 1;
     char crmpRetryIntervalIdleBuf[kMaxCRMPRetryBufferSize];
     char crmpRetryIntervalActiveBuf[kMaxCRMPRetryBufferSize];
-    TextEntry crmpRetryIntervalEntries[2];
+    TextEntry crmpRetryIntervalEntries[OperationalAdvertisingParameters::kNumAdvertisingTxtEntries];
     size_t textEntrySize = 0;
     uint32_t crmpRetryIntervalIdle, crmpRetryIntervalActive;
     int writtenCharactersNumber;

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -37,7 +37,7 @@ namespace Mdns {
 
 static constexpr uint8_t kMdnsNameMaxSize         = 33;    // [Node]-[Fabric] ID in hex - 16+1+16
 static constexpr uint8_t kMdnsProtocolTextMaxSize = 4 + 1; // "_tcp" or "_udp"
-static constexpr uint8_t kMdnsTypeMaxSize         = 6 + 1; // "_chip", "_chipc" or "_chipd"
+static constexpr uint8_t kMdnsTypeMaxSize         = 10;    // "_chip", "_chipc" or "_chipd"
 static constexpr uint16_t kMdnsTextMaxSize        = 64;
 
 enum class MdnsServiceProtocol : uint8_t

--- a/src/lib/mdns/platform/Mdns.h
+++ b/src/lib/mdns/platform/Mdns.h
@@ -35,9 +35,9 @@
 namespace chip {
 namespace Mdns {
 
-static constexpr uint8_t kMdnsNameMaxSize         = 33;
-static constexpr uint8_t kMdnsProtocolTextMaxSize = 8;
-static constexpr uint8_t kMdnsTypeMaxSize         = 32;
+static constexpr uint8_t kMdnsNameMaxSize         = 33;    // [Node]-[Fabric] ID in hex - 16+1+16
+static constexpr uint8_t kMdnsProtocolTextMaxSize = 4 + 1; // "_tcp" or "_udp"
+static constexpr uint8_t kMdnsTypeMaxSize         = 6 + 1; // "_chip", "_chipc" or "_chipd"
 static constexpr uint16_t kMdnsTextMaxSize        = 64;
 
 enum class MdnsServiceProtocol : uint8_t

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -32,6 +32,7 @@
 #include <openthread/srp_client.h>
 #endif
 
+#include <lib/mdns/Advertiser.h>
 #include <lib/mdns/platform/Mdns.h>
 
 namespace chip {
@@ -119,16 +120,14 @@ private:
 
     struct SrpClient
     {
-        static constexpr uint8_t kServiceId           = 0x5d;
         static constexpr uint8_t kMaxServicesNumber   = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
         static constexpr uint8_t kMaxInstanceNameSize = chip::Mdns::kMdnsNameMaxSize;
         static constexpr uint8_t kMaxNameSize         = chip::Mdns::kMdnsTypeMaxSize + chip::Mdns::kMdnsProtocolTextMaxSize + 1;
         static constexpr uint8_t kMaxHostNameSize     = 32;
-        // Thread only supports operational discovery currently, increase when commissionable discovery would get added
-        // see GH issue:#5351
-        static constexpr uint8_t kMaxTxtEntriesNumber = 2;     // Based on operational discovery - 2 records required
-        static constexpr uint8_t kMaxTxtValueSize     = 16;    // Based on operational discovery - 32-bit numbers filled in
-        static constexpr uint8_t kMaxTxtKeySize       = 3 + 1; // Based on operational discovery - CRI/CRA
+        // Thread only supports operational discovery
+        static constexpr uint8_t kMaxTxtEntriesNumber = chip::Mdns::OperationalAdvertisingParameters::kNumAdvertisingTxtEntries;
+        static constexpr uint8_t kMaxTxtValueSize     = chip::Mdns::OperationalAdvertisingParameters::kTxtMaxValueSize;
+        static constexpr uint8_t kMaxTxtKeySize       = chip::Mdns::OperationalAdvertisingParameters::kTxtMaxKeySize;
 
         struct Service
         {

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -120,13 +120,15 @@ private:
     struct SrpClient
     {
         static constexpr uint8_t kServiceId           = 0x5d;
-        static constexpr uint8_t kMaxServicesNumber   = 3;
-        static constexpr uint8_t kMaxInstanceNameSize = 64;
-        static constexpr uint8_t kMaxNameSize         = 16;
+        static constexpr uint8_t kMaxServicesNumber   = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
+        static constexpr uint8_t kMaxInstanceNameSize = chip::Mdns::kMdnsNameMaxSize;
+        static constexpr uint8_t kMaxNameSize         = chip::Mdns::kMdnsTypeMaxSize + chip::Mdns::kMdnsProtocolTextMaxSize + 1;
         static constexpr uint8_t kMaxHostNameSize     = 32;
-        static constexpr uint8_t kMaxTxtEntriesNumber = 4;
-        static constexpr uint8_t kMaxTxtValueSize     = 255;
-        static constexpr uint8_t kMaxTxtKeySize       = 16;
+        // Thread only supports operational discovery currently, increase when commissionable discovery would get added
+        // see GH issue:#5351
+        static constexpr uint8_t kMaxTxtEntriesNumber = 2;     // Based on operational discovery - 2 records required
+        static constexpr uint8_t kMaxTxtValueSize     = 16;    // Based on operational discovery - 32-bit numbers filled in
+        static constexpr uint8_t kMaxTxtKeySize       = 3 + 1; // Based on operational discovery - CRI/CRA
 
         struct Service
         {


### PR DESCRIPTION
 #### Problem
The SRP feature for Thread devices adds a 3kB increase of RAM for the current default configuration.
The code is currently over-dimensioned in terms of buffer allocations.

 #### Summary of Changes
* Added CHIPDeviceConfig.h flag to select amount of services - default 3 now
* Tailored down default RAM numbers to current Thread use-case - operational advertising only
* Updated mDNS max size defines given the current state of the protocol

Fixes #6320
