### PR TITLE
Tweaks in efr32 thread examples

### DIFF
--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -66,7 +66,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(10 * 1024)",
+    "SL_HEAP_SIZE=(12 * 1024)",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -59,7 +59,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(10 * 1024)",
+    "SL_HEAP_SIZE=(12 * 1024)",
   ]
 }
 

--- a/examples/platform/efr32/uart.h
+++ b/examples/platform/efr32/uart.h
@@ -29,8 +29,11 @@ int16_t uartConsoleWrite(const char * Buf, uint16_t BufLength);
 int16_t uartConsoleRead(char * Buf, uint16_t NbBytesToRead);
 
 // Implemented by in openthread code
+#ifndef PW_RPC_ENABLED
 extern void otPlatUartReceived(const uint8_t * aBuf, uint16_t aBufLength);
 extern void otPlatUartSendDone(void);
+extern void otSysEventSignalPending(void);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -60,7 +60,7 @@ efr32_sdk("sdk") {
   defines = [
     "BOARD_ID=${efr32_board}",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
-    "SL_HEAP_SIZE=(10 * 1024)",
+    "SL_HEAP_SIZE=(12 * 1024)",
   ]
 }
 

--- a/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
+++ b/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
@@ -79,10 +79,6 @@ private:
     inline ImplClass * Impl() { return static_cast<ImplClass *>(this); }
 
     static void ThreadTaskMain(void * arg);
-    static void OnJoinerTimer(TimerHandle_t xTimer);
-
-    portTickType mJoinerExpire;
-    bool mJoinerStartPending = false;
 
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_TASK) && CHIP_CONFIG_FREERTOS_USE_STATIC_TASK
     StackType_t mThreadStack[CHIP_DEVICE_CONFIG_THREAD_TASK_STACK_SIZE / sizeof(StackType_t)];


### PR DESCRIPTION
Increase heap size for examples using thread, as srp host setup was sometimes failing with error: insuffisant buffers available.
Remove The thread joinerStart on a periodic timer. This isn't used or needed by EFR32 platform, but I am not 100% sure for other manufactures using THREAD and FreeRTOS.
Add a UART IRQ to wakeup the thread process on OT CLI inputs.