### PR TITLE
Move Internal APIs to an Internal Header

### DIFF
--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		991DC0842475F45400C13860 /* CHIPDeviceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC0822475F45400C13860 /* CHIPDeviceController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		991DC0892475F47D00C13860 /* CHIPDeviceController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 991DC0872475F47D00C13860 /* CHIPDeviceController.mm */; };
 		991DC08B247704DC00C13860 /* CHIPLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 991DC08A247704DC00C13860 /* CHIPLogging.h */; };
+		9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9956064326420367000C28DE /* CHIPSetupPayload_Internal.h */; };
 		B20252972459E34F00F97062 /* CHIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* CHIP.framework */; };
 		B289D4212639C0D300D4E314 /* CHIPOnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* CHIPOnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B289D4222639C0D300D4E314 /* CHIPOnboardingPayloadParser.m in Sources */ = {isa = PBXBuildFile; fileRef = B289D4202639C0D300D4E314 /* CHIPOnboardingPayloadParser.m */; };
@@ -110,6 +111,7 @@
 		991DC0822475F45400C13860 /* CHIPDeviceController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceController.h; sourceTree = "<group>"; };
 		991DC0872475F47D00C13860 /* CHIPDeviceController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceController.mm; sourceTree = "<group>"; };
 		991DC08A247704DC00C13860 /* CHIPLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPLogging.h; sourceTree = "<group>"; };
+		9956064326420367000C28DE /* CHIPSetupPayload_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPSetupPayload_Internal.h; sourceTree = "<group>"; };
 		B202528D2459E34F00F97062 /* CHIP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CHIP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B20252912459E34F00F97062 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B20252962459E34F00F97062 /* CHIPTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CHIPTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -235,6 +237,7 @@
 				B2E0D7AC245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h */,
 				B2E0D7AE245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.mm */,
 				B2E0D7AF245B0B5C003C5B48 /* CHIPSetupPayload.h */,
+				9956064326420367000C28DE /* CHIPSetupPayload_Internal.h */,
 				B2E0D7B0245B0B5C003C5B48 /* CHIPSetupPayload.mm */,
 				991DC0822475F45400C13860 /* CHIPDeviceController.h */,
 				991DC0872475F47D00C13860 /* CHIPDeviceController.mm */,
@@ -277,6 +280,7 @@
 				B2E0D7B2245B0B5C003C5B48 /* CHIPManualSetupPayloadParser.h in Headers */,
 				B2E0D7B1245B0B5C003C5B48 /* CHIP.h in Headers */,
 				B2E0D7B8245B0B5C003C5B48 /* CHIPSetupPayload.h in Headers */,
+				9956064426420367000C28DE /* CHIPSetupPayload_Internal.h in Headers */,
 				2C8C8FC1253E0C2100797F05 /* CHIPPersistentStorageDelegate.h in Headers */,
 				B2E0D7B5245B0B5C003C5B48 /* CHIPQRCodeSetupPayloadParser.h in Headers */,
 				1EC4CE6425CC276600D7304F /* CHIPClustersObjc.h in Headers */,

--- a/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPManualSetupPayloadParser.mm
@@ -18,7 +18,7 @@
 
 #import "CHIPError.h"
 #import "CHIPLogging.h"
-#import "CHIPSetupPayload.h"
+#import "CHIPSetupPayload_Internal.h"
 
 #import <setup_payload/ManualSetupPayloadParser.h>
 #import <setup_payload/SetupPayload.h>

--- a/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/CHIPQRCodeSetupPayloadParser.mm
@@ -18,7 +18,7 @@
 #import "CHIPQRCodeSetupPayloadParser.h"
 #import "CHIPError.h"
 #import "CHIPLogging.h"
-#import "CHIPSetupPayload.h"
+#import "CHIPSetupPayload_Internal.h"
 
 #import <setup_payload/QRCodeSetupPayloadParser.h>
 #import <setup_payload/SetupPayload.h>

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.h
@@ -17,13 +17,9 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef __cplusplus
-#import <setup_payload/SetupPayload.h>
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, RendezvousInformationFlags) {
+typedef NS_ENUM(NSUInteger, CHIPRendezvousInformationFlags) {
     kRendezvousInformationNone = 0, // Device does not support any method for rendezvous
     kRendezvousInformationSoftAP = 1 << 0, // Device supports WiFi softAP
     kRendezvousInformationBLE = 1 << 1, // Device supports BLE
@@ -32,7 +28,7 @@ typedef NS_ENUM(NSUInteger, RendezvousInformationFlags) {
     kRendezvousInformationAllMask = kRendezvousInformationSoftAP | kRendezvousInformationBLE | kRendezvousInformationOnNetwork,
 };
 
-typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
+typedef NS_ENUM(NSUInteger, CHIPOptionalQRCodeInfoType) {
     kOptionalQRCodeInfoTypeUnknown,
     kOptionalQRCodeInfoTypeString,
     kOptionalQRCodeInfoTypeInt32
@@ -51,17 +47,12 @@ typedef NS_ENUM(NSUInteger, OptionalQRCodeInfoType) {
 @property (nonatomic, strong) NSNumber * vendorID;
 @property (nonatomic, strong) NSNumber * productID;
 @property (nonatomic, assign) BOOL requiresCustomFlow;
-@property (nonatomic, assign) RendezvousInformationFlags rendezvousInformation;
+@property (nonatomic, assign) CHIPRendezvousInformationFlags rendezvousInformation;
 @property (nonatomic, strong) NSNumber * discriminator;
 @property (nonatomic, strong) NSNumber * setUpPINCode;
 
 @property (nonatomic, strong) NSString * serialNumber;
 - (NSArray<CHIPOptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
-
-#ifdef __cplusplus
-- (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-- (RendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value;
-#endif
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "CHIPSetupPayload.h"
+#import "CHIPSetupPayload_Internal.h"
 #import "CHIPError.h"
 #import <setup_payload/SetupPayload.h>
 
@@ -26,7 +26,7 @@
     chip::SetupPayload _chipSetupPayload;
 }
 
-- (RendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value
+- (CHIPRendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value
 {
     if (value.Has(chip::RendezvousInformationFlag::kBLE)) {
         return kRendezvousInformationBLE;

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload.mm
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-#import "CHIPSetupPayload_Internal.h"
 #import "CHIPError.h"
+#import "CHIPSetupPayload_Internal.h"
 #import <setup_payload/SetupPayload.h>
 
 @implementation CHIPOptionalQRCodeInfo

--- a/src/darwin/Framework/CHIP/CHIPSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPSetupPayload_Internal.h
@@ -1,0 +1,23 @@
+//
+//  CHIPSetupPayload_Internal.h
+//  CHIP
+//
+//  Copyright © 2021 CHIP. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CHIPSetupPayload.h"
+
+#ifdef __cplusplus
+#import <setup_payload/SetupPayload.h>
+#endif
+
+@interface CHIPSetupPayload ()
+
+#ifdef __cplusplus
+- (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
+- (CHIPRendezvousInformationFlags)valueOf:(chip::RendezvousInformationFlags)value;
+#endif
+
+@end


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
CHIPSetupPayload has APIs that don't need to be public. The class meant to be a container that is only initialized by the Manual or QRCode payload parsers. 

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Moved the internal only APIs to `CHIPSetupPayload_Internal.h`
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
