### PR TITLE
ESP32: Fix compilation of temperature-measurement-app and lock-app

### DIFF
--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -26,7 +26,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "nvs_flash.h"
-#include <app/server/DataModelHandler.h>
 #include <app/server/Server.h>
 
 #include <cmath>

--- a/examples/temperature-measurement-app/esp32/main/main.cpp
+++ b/examples/temperature-measurement-app/esp32/main/main.cpp
@@ -26,7 +26,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "nvs_flash.h"
-#include <app/server/DataModelHandler.h>
 #include <app/server/Server.h>
 
 #include <cmath>


### PR DESCRIPTION
Remove inclusion of unwanted header file DataModelHandler.h.

The compilation fails as this file is now moved to "src/app/util"
