### PR TITLE
Add CHIPOnboardingPayloadParser.m to the list of files built by chip-…

### DIFF
--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -44,6 +44,7 @@ static_library("framework") {
     "CHIPLogging.h",
     "CHIPManualSetupPayloadParser.h",
     "CHIPManualSetupPayloadParser.mm",
+    "CHIPOnboardingPayloadParser.m",
     "CHIPPersistentStorageDelegate.h",
     "CHIPPersistentStorageDelegateBridge.h",
     "CHIPPersistentStorageDelegateBridge.mm",


### PR DESCRIPTION
…tool-darwin


 #### Problem

`CHIPOnboardingPayloadParser.m `is not built and it ends up into a linkage issue:
```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_CHIPOnboardingPayloadParser", referenced from:
      objc-class-ref in framework.a(framework.CHIPDeviceController.mm.o)
```

 #### Summary of Changes
  * Add `CHIPOnboardingPayloadParser.m`