### PR TITLE
Fix crash when CRMP resend fails.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -341,8 +341,15 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 {
     CHIP_ERROR err              = CHIP_NO_ERROR;
     ReliableMessageContext * rc = entry->rc;
+    uint32_t msgId              = 0; // Not actually used unless we reach the
+                                     // line that initializes it properly.
 
     VerifyOrReturnError(rc != nullptr, err);
+
+    // Now that we know this is a valid entry, grab the message id from the
+    // retained buffer.  We need to do that now, because we're about to hand it
+    // over to someone else, and on failure it will no longer be available.
+    msgId = entry->retainedBuf.GetMsgId();
 
     const ExchangeMessageDispatch * dispatcher = rc->GetExchangeContext()->GetMessageDispatch();
     VerifyOrExit(dispatcher != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
@@ -358,8 +365,8 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         // Remove from table
-        ChipLogError(ExchangeManager, "Crit-err %ld when sending CHIP MsgId:%08" PRIX32 ", send tries: %d", long(err),
-                     entry->retainedBuf.GetMsgId(), entry->sendCount);
+        ChipLogError(ExchangeManager, "Crit-err %ld when sending CHIP MsgId:%08" PRIX32 ", send tries: %d", long(err), msgId,
+                     entry->sendCount);
 
         ClearRetransTable(*entry);
     }


### PR DESCRIPTION
If CRMP resend fails, the attempt to log the failure ends up
dereferencing null in the moved-out-of retained buffer object, in an
attempt to get the message id.

The fix is to grab the message id up front.
