### PR TITLE
Remove the storage delegate's queue from the storage bridge

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -65,14 +65,12 @@ void CHIPSetNextAvailableDeviceID(uint64_t id)
 
 CHIPDeviceController * InitializeCHIP(void)
 {
-    static dispatch_queue_t callbackQueue;
     static CHIPToolPersistentStorageDelegate * storage = nil;
     static dispatch_once_t onceToken;
     CHIPDeviceController * controller = [CHIPDeviceController sharedController];
     dispatch_once(&onceToken, ^{
         storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        callbackQueue = dispatch_queue_create("com.chip.persistentstorage.callback", DISPATCH_QUEUE_SERIAL);
-        [controller startup:storage queue:callbackQueue];
+        [controller startup:storage];
     });
 
     return controller;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -89,10 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
  * check if the stack needs to be started up.
  *
  * @param[in] storageDelegate The delegate for persistent storage
- *
- * @param[in] queue The queue on which the storage callbacks will be delivered
  */
-- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate queue:(_Nullable dispatch_queue_t)queue;
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate;
 
 /**
  * Shutdown the CHIP Stack. Repeated calls to shutdown without calls to startup in between are NO-OPs.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -122,7 +122,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
     return YES;
 }
 
-- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate queue:(_Nullable dispatch_queue_t)queue
+- (BOOL)startup:(_Nullable id<CHIPPersistentStorageDelegate>)storageDelegate
 {
     __block BOOL commissionerInitialized = NO;
     dispatch_sync(_chipWorkQueue, ^{
@@ -133,7 +133,7 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 
         CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
 
-        _persistentStorageDelegateBridge->setFrameworkDelegate(storageDelegate, queue);
+        _persistentStorageDelegateBridge->setFrameworkDelegate(storageDelegate);
         // initialize NodeID if needed
         [self _getControllerNodeId];
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -28,7 +28,7 @@ public:
     CHIPPersistentStorageDelegateBridge();
     ~CHIPPersistentStorageDelegateBridge();
 
-    void setFrameworkDelegate(_Nullable id<CHIPPersistentStorageDelegate> delegate, _Nullable dispatch_queue_t queue);
+    void setFrameworkDelegate(_Nullable id<CHIPPersistentStorageDelegate> delegate);
 
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -60,8 +60,7 @@ CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(void)
 
 CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}
 
-void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(
-    _Nullable id<CHIPPersistentStorageDelegate> delegate)
+void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(_Nullable id<CHIPPersistentStorageDelegate> delegate)
 {
     dispatch_async(mWorkQueue, ^{
         if (delegate) {
@@ -124,7 +123,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncSetKeyValue(const char * key
 
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate) {
-                [strongDelegate CHIPSetKeyValue:keyString value:valueString];
+            [strongDelegate CHIPSetKeyValue:keyString value:valueString];
         } else {
             [mDefaultPersistentStorage setObject:valueString forKey:keyString];
         }
@@ -145,7 +144,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncDeleteKeyValue(const char * 
 
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
         if (strongDelegate) {
-                [strongDelegate CHIPDeleteKeyValue:keyString];
+            [strongDelegate CHIPDeleteKeyValue:keyString];
         } else {
             [mDefaultPersistentStorage removeObjectForKey:keyString];
         }

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -61,15 +61,13 @@ CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(void)
 CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) {}
 
 void CHIPPersistentStorageDelegateBridge::setFrameworkDelegate(
-    _Nullable id<CHIPPersistentStorageDelegate> delegate, _Nullable dispatch_queue_t queue)
+    _Nullable id<CHIPPersistentStorageDelegate> delegate)
 {
     dispatch_async(mWorkQueue, ^{
-        if (delegate && queue) {
+        if (delegate) {
             mDelegate = delegate;
-            mQueue = queue;
         } else {
             mDelegate = nil;
-            mQueue = nil;
         }
     });
 }
@@ -125,10 +123,8 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncSetKeyValue(const char * key
         NSLog(@"PersistentStorageDelegate Set Key %@", keyString);
 
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-        if (strongDelegate && mQueue) {
-            dispatch_sync(mQueue, ^{
+        if (strongDelegate) {
                 [strongDelegate CHIPSetKeyValue:keyString value:valueString];
-            });
         } else {
             [mDefaultPersistentStorage setObject:valueString forKey:keyString];
         }
@@ -148,10 +144,8 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncDeleteKeyValue(const char * 
         NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
 
         id<CHIPPersistentStorageDelegate> strongDelegate = mDelegate;
-        if (strongDelegate && mQueue) {
-            dispatch_sync(mQueue, ^{
+        if (strongDelegate) {
                 [strongDelegate CHIPDeleteKeyValue:keyString];
-            });
         } else {
             [mDefaultPersistentStorage removeObjectForKey:keyString];
         }

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -95,7 +95,7 @@ CHIPDevice * GetPairedDevice(uint64_t deviceId)
     [controller setListenPort:kLocalPort];
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    BOOL started = [controller startup:nil queue:nil];
+    BOOL started = [controller startup:nil];
     XCTAssertTrue(started);
 
     NSError * error;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
The storage delegate bridge is using the delegate queue only for writes. 
Since the Storage APIs are all sync right now, there's no use of this queue. 
In the future if we reintroduce Async APIs, we it's perfectly acceptable to require the Delegate to make their implementation thread safe rather than promising to call them back on a queue they supplied. 
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Removed the delegate queue passed into the storage delegate bridge. 
Now the delegate bridge directly calls into the delegate's APIs and it's upto the delegate to ensure thread safety.
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
