### PR TITLE
Fix reading controller node ID from storage

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -187,8 +187,6 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
 
         _persistentStorageDelegateBridge->SyncSetKeyValue(CHIP_COMMISSIONER_DEVICE_ID_KEY, &_localDeviceId, sizeof(_localDeviceId));
     } else {
-        NSScanner * scanner = [NSScanner scannerWithString:[NSString stringWithFormat:@"%lld", _localDeviceId]];
-        [scanner scanHexLongLong:&_localDeviceId];
         CHIP_LOG_ERROR("Found %llx node ID for the controller", _localDeviceId);
     }
     return [NSNumber numberWithUnsignedLongLong:_localDeviceId];


### PR DESCRIPTION
 #### Problem
The CHIP iOS framework is not reading correct controller node ID from the storage.

 #### Summary of Changes
The controller is passing node ID as integer to storage API, but on read it's trying to parse as a string.
This PR removes the code that parses the ID as string.
