### PR TITLE
Update mobile-device-test.py endpoint to 0 instead of 1 and use const…

### DIFF
--- a/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/esp32/main/CHIPDeviceManager.cpp
@@ -96,7 +96,7 @@ exit:
 } // namespace chip
 
 void emberAfPostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();

--- a/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceCallbacks.cpp
@@ -77,7 +77,7 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
 }
 
 void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                                  uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
              endpointId, attributeId);

--- a/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPDeviceManager.h
@@ -73,7 +73,7 @@ public:
      * @param value              pointer to the new value
      */
     virtual void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
     {}
     virtual ~CHIPDeviceManagerCallbacks() {}
 };

--- a/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/esp32/main/include/DeviceCallbacks.h
@@ -35,7 +35,7 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     virtual void PostAttributeChangeCallback(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -43,7 +43,7 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {}
 
 bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -45,7 +45,7 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lighting-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/efr32/src/ZclCallbacks.cpp
@@ -31,7 +31,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lighting-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/k32w/main/ZclCallbacks.cpp
@@ -29,7 +29,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -42,7 +42,7 @@ using namespace chip;
 using namespace chip::DeviceLayer;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lighting-app/nrfconnect/main/LightingManager.cpp
+++ b/examples/lighting-app/nrfconnect/main/LightingManager.cpp
@@ -54,7 +54,7 @@ void LightingManager::SetCallbacks(LightingCallback_fn aActionInitiated_CB, Ligh
     mActionCompleted_CB = aActionCompleted_CB;
 }
 
-bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value)
+bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint16_t size, uint8_t * value)
 {
     // TODO: this function is called InitiateAction because we want to implement some features such as ramping up here.
     bool action_initiated = false;

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 using namespace chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     ChipLogProgress(Zcl, "Cluster callback: %d", clusterId);
 

--- a/examples/lighting-app/nrfconnect/main/include/LightingManager.h
+++ b/examples/lighting-app/nrfconnect/main/include/LightingManager.h
@@ -46,7 +46,7 @@ public:
     int Init(const device * pwmDevice, uint32_t pwmChannel);
     bool IsTurnedOn() const { return mState == kState_On; }
     uint8_t GetLevel() const { return mLevel; }
-    bool InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value);
+    bool InitiateAction(Action_t aAction, int32_t aActor, uint16_t size, uint8_t * value);
     void SetCallbacks(LightingCallback_fn aActionInitiated_CB, LightingCallback_fn aActionCompleted_CB);
 
 private:

--- a/examples/lighting-app/qpg6100/include/LightingManager.h
+++ b/examples/lighting-app/qpg6100/include/LightingManager.h
@@ -48,7 +48,7 @@ public:
     int Init();
     bool IsTurnedOn();
     uint8_t GetLevel();
-    bool InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value);
+    bool InitiateAction(Action_t aAction, int32_t aActor, uint16_t size, uint8_t * value);
 
     using LightingCallback_fn = std::function<void(Action_t)>;
 

--- a/examples/lighting-app/qpg6100/src/LightingManager.cpp
+++ b/examples/lighting-app/qpg6100/src/LightingManager.cpp
@@ -46,7 +46,7 @@ void LightingManager::SetCallbacks(LightingCallback_fn aActionInitiated_CB, Ligh
     mActionCompleted_CB = aActionCompleted_CB;
 }
 
-bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint8_t size, uint8_t * value)
+bool LightingManager::InitiateAction(Action_t aAction, int32_t aActor, uint16_t size, uint8_t * value)
 {
     // TODO: this function is called InitiateAction because we want to implement some features such as ramping up here.
     bool action_initiated = false;

--- a/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
@@ -33,7 +33,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId == ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/lock-app/esp32/main/CHIPDeviceManager.cpp
@@ -93,7 +93,7 @@ exit:
 } // namespace chip
 
 void emberAfPostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();

--- a/examples/lock-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lock-app/esp32/main/DeviceCallbacks.cpp
@@ -54,7 +54,7 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
     ESP_LOGI(TAG, "Current free heap: %d\n", heap_caps_get_free_size(MALLOC_CAP_8BIT));
 }
 void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                                  uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
              endpointId, attributeId);

--- a/examples/lock-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/lock-app/esp32/main/include/CHIPDeviceManager.h
@@ -73,7 +73,7 @@ public:
      * @param value              pointer to the new value
      */
     virtual void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
     {}
     virtual ~CHIPDeviceManagerCallbacks() {}
 };

--- a/examples/lock-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/lock-app/esp32/main/include/DeviceCallbacks.h
@@ -35,7 +35,7 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     virtual void PostAttributeChangeCallback(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);

--- a/examples/lock-app/k32w/main/ZclCallbacks.cpp
+++ b/examples/lock-app/k32w/main/ZclCallbacks.cpp
@@ -29,7 +29,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg6100/src/ZclCallbacks.cpp
@@ -32,7 +32,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_ON_OFF_CLUSTER_ID)
     {

--- a/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
+++ b/examples/temperature-measurement-app/esp32/main/CHIPDeviceManager.cpp
@@ -96,7 +96,7 @@ exit:
 } // namespace chip
 
 void emberAfPostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();

--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -54,7 +54,7 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
 }
 
 void DeviceCallbacks::PostAttributeChangeCallback(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                                  uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                                  uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     ESP_LOGI(TAG, "PostAttributeChangeCallback - Cluster ID: '0x%04x', EndPoint ID: '0x%02x', Attribute ID: '0x%04x'", clusterId,
              endpointId, attributeId);

--- a/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
+++ b/examples/temperature-measurement-app/esp32/main/include/CHIPDeviceManager.h
@@ -74,7 +74,7 @@ public:
      * @param value              pointer to the new value
      */
     virtual void PostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
     {}
     virtual ~CHIPDeviceManagerCallbacks() {}
 };

--- a/examples/temperature-measurement-app/esp32/main/include/DeviceCallbacks.h
+++ b/examples/temperature-measurement-app/esp32/main/include/DeviceCallbacks.h
@@ -35,7 +35,7 @@ class DeviceCallbacks : public chip::DeviceManager::CHIPDeviceManagerCallbacks
 public:
     virtual void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     virtual void PostAttributeChangeCallback(chip::EndpointId endpointId, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value);
+                                             uint8_t mask, uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);

--- a/examples/tv-app/linux/include/cluster-change-attribute.cpp
+++ b/examples/tv-app/linux/include/cluster-change-attribute.cpp
@@ -45,7 +45,7 @@ void runTvCommand(TvCommand command)
 }
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId == ZCL_ON_OFF_CLUSTER_ID && attributeId == ZCL_ON_OFF_ATTRIBUTE_ID)
     {

--- a/examples/window-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/window-app/efr32/src/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 using namespace ::chip;
 
 void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t mask,
-                                        uint16_t manufacturerCode, uint8_t type, uint8_t size, uint8_t * value)
+                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
 {
     if (clusterId != ZCL_WINDOW_COVERING_CLUSTER_ID)
     {

--- a/src/controller/python/test/mobile-device-test.py
+++ b/src/controller/python/test/mobile-device-test.py
@@ -32,6 +32,9 @@ TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
 # Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
 TEST_THREAD_NETWORK_ID = "fedcba9876543210"
 
+ENDPOINT_ID = 0
+GROUP_ID = 0
+
 
 def TestFail(message):
     logger.fatal("Testfail: {}".format(message))
@@ -86,7 +89,7 @@ class MobileDeviceTests():
     def TestNetworkCommissioning(self, nodeid: int):
         self.logger.info("Commissioning network to device {}".format(nodeid))
         try:
-            self.devCtrl.ZCLSend("NetworkCommissioning", "AddThreadNetwork", nodeid, 1, 0, {
+            self.devCtrl.ZCLSend("NetworkCommissioning", "AddThreadNetwork", nodeid, ENDPOINT_ID, GROUP_ID, {
                 "operationalDataset": bytes.fromhex(TEST_THREAD_NETWORK_DATASET_TLV),
                 "breadcrumb": 0,
                 "timeoutMs": 1000})
@@ -95,7 +98,7 @@ class MobileDeviceTests():
             return False
         self.logger.info("Send EnableNetwork command to device {}".format(nodeid))
         try:
-            self.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", nodeid, 1, 0, {
+            self.devCtrl.ZCLSend("NetworkCommissioning", "EnableNetwork", nodeid, ENDPOINT_ID, GROUP_ID, {
                 "networkID": bytes.fromhex(TEST_THREAD_NETWORK_ID),
                 "breadcrumb": 0,
                 "timeoutMs": 1000})
@@ -107,12 +110,12 @@ class MobileDeviceTests():
     def TestOnOffCluster(self, nodeid: int):
         self.logger.info("Sending On/Off commands to device {}".format(nodeid))
         try:
-            self.devCtrl.ZCLSend("OnOff", "On", nodeid, 1, 0, {})
+            self.devCtrl.ZCLSend("OnOff", "On", nodeid, ENDPOINT_ID, GROUP_ID, {})
         except Exception as ex:
             self.logger.exception("Failed to send On command")
             return False
         try:
-            self.devCtrl.ZCLSend("OnOff", "Off", nodeid, 1, 0, {})
+            self.devCtrl.ZCLSend("OnOff", "Off", nodeid, ENDPOINT_ID, GROUP_ID, {})
         except Exception as ex:
             self.logger.exception("Failed to send Off command")
             return False


### PR DESCRIPTION
…ants instead of raw numbers

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

When the endpoint of the lighting-app has been moved from endpoint 1 to 0 in #6487, the `Cirque` tests were disabled so I missed to change `mobile-device-test.py`.

This PR update the endpoint of the tests.


 #### Summary of Changes
 * Update endpoint of `mobile-device-tests.py` from 1 to 0 and use constants to make it easier to locate