### PR TITLE
Write null termination at the end of the device list string

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -944,7 +944,7 @@ void DeviceCommissioner::PersistDeviceList()
             {
                 // TODO: no need to base64 again the value
                 PERSISTENT_KEY_OP(static_cast<uint64_t>(0), kPairedDeviceListKeyPrefix, key,
-                                  mStorageDelegate->SyncSetKeyValue(key, value, static_cast<uint16_t>(strlen(value))));
+                                  mStorageDelegate->SyncSetKeyValue(key, value, requiredSize));
                 mPairedDevicesUpdated = false;
             }
             chip::Platform::MemoryFree(serialized);


### PR DESCRIPTION
 #### Problem
Sometimes the storage is returning corrupted device list.
e.g.
```
AQAAAAAAAAA=\M^?\M^?\M^?\M^?\M-oͫ\M^I\M^?\M^?\M^?\M^?\M^@\M^PX
```
instead of
```
AQAAAAAAAAA=
```

 #### Summary of Changes
The code is using `strlen` to figure out how many bytes to write to the storage. This omits the null termination character.
This PR uses the length returned by serialize operation (that includes the null) to write to the storage.