### PR TITLE
Fixing compile issue on Mac

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -105,7 +105,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
                 } else {
                     error = CHIP_ERROR_NO_MEMORY;
                 }
-                size = decoded.length();
+                size = static_cast<uint16_t>(decoded.length());
             }
         } else {
             error = CHIP_ERROR_KEY_NOT_FOUND;


### PR DESCRIPTION
#### Problem
The error of implicit conversion loses integer precision appears in compile time

#### Summary of Changes
- Updated the CHIPPersistentStorageDelegateBridge.mm file

#### Test
- Used the `./gn_build.sh ` to verify the building is successful 