### PR TITLE
Fix bug where removed admin can continue messaging accessory and is a…

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -427,7 +427,9 @@ CHIP_ERROR OpenDefaultPairingWindow(ResetAdmins resetAdmins, chip::PairingWindow
         uint16_t nextKeyId = gRendezvousServer.GetNextKeyId();
         EraseAllAdminPairingsUpTo(gNextAvailableAdminId);
         EraseAllSessionsUpTo(nextKeyId);
-        gNextAvailableAdminId = 0;
+        // Only resetting gNextAvailableAdminId at reboot otherwise previously paired device with adminID 0
+        // can continue sending messages to accessory as next available admin will also be 0.
+        // This logic is not up to spec, will be implemented up to spec once AddOptCert is implemented.
         gAdminPairings.Reset();
     }
 


### PR DESCRIPTION
The bug is as followed (all this logic is temporary logic, not up to spec until AddOptCert is implemented):

When OpenDefaultPairingWindow is called with ResetAdmins::kYes, it removes all admins and sets the next available admin back to 0. On an incoming secure message from a commissioner, accessory checks whether the incoming admin id matches one in the admin pairing table.

Intial pairing flow for first admin:
1) Pairing window is open, next available admin ID is 0, admin pairing table contains one unintialized admin with adminId 0
2) Upon pairing, a secure message is received from admin (admin ID 0), at that point since admin 0 matches an initialised admin 0, that admin is populated with information of new admin. (NOT up to spec, a fabric will not be created this way in the future but via AddOptCert.)
3) Admin table now has an initialised admin 0 and next available admin is 1
4) If another commissioner tries to message accessory, message is dropped since that admin Id does not match one in the admin pairing table

If, OpenDefaultPairingWindow( ResetAdmins::kYes) is then called via RemoveAllFabrics, the following flow happens:
1) Admin pairing table initially has one initialized admin ( admin 0) and that admin calls RemoveAllFabrics to reset device.
2) OpenDefaultPairingWindow( ResetAdmins::kYes)  is called (all admins removed,  next available admin 0, uninitialised admin 0 is added to admin pairing table), pairing window is reopened.
3) We now have an admin pairing table with uninitialised admin 0 and the pairing window is open
4) If previously paired Admin 0 now tries to send a command to accessory, their message should be rejected since all admins were removed. However, when message is sent, since this is all not up to spec and they can still securely message the accessory, message will be received and initial pairing flow (above) starting step #2 will be triggered causing this previously unpaired admin to silently repair to device without going through pairing flow
Result: Any previously paired admin can pair silently to accessory by simply sending a command

Fix: do not reset next available id back to 0 when RemoveAllFabrics is called (Factory reset does the right thing and it is set back to 0). Then when previously paired admin tries to pair (adminID 0), it will not match the unitiliazed admin in the pairing table.