### PR TITLE
Revert "[Python dev ctrl] ChipStack is initialized twice on Darwin (#…

### DIFF
--- a/src/controller/python/chip/native/StackInit.cpp
+++ b/src/controller/python/chip/native/StackInit.cpp
@@ -72,13 +72,11 @@ void pychip_native_init()
     }
 #endif // CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
-#ifndef CONFIG_DEVICE_LAYER
     err = chip::DeviceLayer::PlatformMgr().InitChipStack();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
     }
-#endif
     int result   = pthread_create(&sPlatformMainThread, nullptr, PlatformMainLoop, nullptr);
     int tmpErrno = errno;
 

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -95,6 +95,7 @@ public:
     CHIP_ERROR Shutdown();
 
 private:
+    bool mInitialized = false;
     // ===== Members for internal use by the following friends.
 
     friend class PlatformManagerImpl;
@@ -181,7 +182,14 @@ namespace DeviceLayer {
 
 inline CHIP_ERROR PlatformManager::InitChipStack()
 {
-    return static_cast<ImplClass *>(this)->_InitChipStack();
+    if (mInitialized)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR err = static_cast<ImplClass *>(this)->_InitChipStack();
+    mInitialized   = (err == CHIP_NO_ERROR);
+    return err;
 }
 
 inline CHIP_ERROR PlatformManager::AddEventHandler(EventHandlerFunct handler, intptr_t arg)

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -182,6 +182,13 @@ namespace DeviceLayer {
 
 inline CHIP_ERROR PlatformManager::InitChipStack()
 {
+    // NOTE: this is NOT thread safe and cannot be as the chip stack lock is prepared by
+    // InitChipStack itself on many platforms.
+    //
+    // In the future, this could be moved into specific platform code (where it can
+    // be made thread safe) or we could use std::atomic. In general however, init twice
+    // is likely a logic error and we may want to avoid that path anyway. Likely to
+    // be done once code stabilizes a bit more.
     if (mInitialized)
     {
         return CHIP_NO_ERROR;

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -186,7 +186,7 @@ inline CHIP_ERROR PlatformManager::InitChipStack()
     // InitChipStack itself on many platforms.
     //
     // In the future, this could be moved into specific platform code (where it can
-    // be made thread safe) or we could use std::atomic. In general however, init twice
+    // be made thread safe). In general however, init twice
     // is likely a logic error and we may want to avoid that path anyway. Likely to
     // be done once code stabilizes a bit more.
     if (mInitialized)


### PR DESCRIPTION
This fixes having the system layer initialized for chip-repl. Without it the repl hangs because system layer is not initialized.