### PR TITLE
Update secure session key derivation to follow CHIP spec

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -202,8 +202,8 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
-                                     SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
+    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, SecureSession::SessionRole::kInitiator,
+                                     gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -205,8 +205,8 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
-                                     SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
+    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, SecureSession::SessionRole::kInitiator,
+                                     gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/RendezvousServer.cpp
+++ b/src/app/server/RendezvousServer.cpp
@@ -115,7 +115,7 @@ void RendezvousServer::OnSessionEstablished()
     CHIP_ERROR err =
         mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
                                 mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
-                                SecureSessionMgr::PairingDirection::kResponder, mAdmin->GetAdminId(), nullptr);
+                                SecureSession::SessionRole::kResponder, mAdmin->GetAdminId(), nullptr);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -170,8 +170,8 @@ static CHIP_ERROR RestoreAllSessionsFromKVS(SecureSessionMgr & sessionMgr, Rende
                             static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId() >> 32),
                             static_cast<uint32_t>(session->PeerConnection().GetPeerNodeId()));
             sessionMgr.NewPairing(Optional<Transport::PeerAddress>::Value(session->PeerConnection().GetPeerAddress()),
-                                  session->PeerConnection().GetPeerNodeId(), session,
-                                  SecureSessionMgr::PairingDirection::kResponder, connection.GetAdminId(), nullptr);
+                                  session->PeerConnection().GetPeerNodeId(), session, SecureSession::SessionRole::kResponder,
+                                  connection.GetAdminId(), nullptr);
             session->Clear();
         }
     }
@@ -593,7 +593,7 @@ CHIP_ERROR AddTestPairing()
     testSession = chip::Platform::New<PASESession>();
     testSession->FromSerializable(serializedTestSession);
     SuccessOrExit(err = gSessions.NewPairing(Optional<PeerAddress>{ PeerAddress::Uninitialized() }, chip::kTestControllerNodeId,
-                                             testSession, SecureSessionMgr::PairingDirection::kResponder, gNextAvailableAdminId));
+                                             testSession, SecureSession::SessionRole::kResponder, gNextAvailableAdminId));
     ++gNextAvailableAdminId;
 
 exit:

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -159,8 +159,8 @@ CHIP_ERROR EstablishSecureSession()
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(chip::Optional<chip::Transport::PeerAddress>::Value(
                                          chip::Transport::PeerAddress::UDP(gDestAddr, CHIP_PORT, INET_NULL_INTERFACEID)),
-                                     chip::kTestDeviceNodeId, testSecurePairingSecret,
-                                     chip::SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
+                                     chip::kTestDeviceNodeId, testSecurePairingSecret, chip::SecureSession::SessionRole::kInitiator,
+                                     gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -173,8 +173,8 @@ int main(int argc, char * argv[])
 
     InitializeEventLogging(&gExchangeManager);
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
-                                     chip::SecureSessionMgr::PairingDirection::kResponder, gAdminId);
+    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
+                                     gAdminId);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -366,7 +366,7 @@ CHIP_ERROR Device::LoadSecureSessionParameters(ResetTransport resetNeeded)
     }
 
     err = mSessionManager->NewPairing(Optional<Transport::PeerAddress>::Value(mDeviceAddress), mDeviceId, &pairingSession,
-                                      SecureSessionMgr::PairingDirection::kInitiator, mAdminId);
+                                      SecureSession::SessionRole::kInitiator, mAdminId);
     SuccessOrExit(err);
 
 exit:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -906,7 +906,7 @@ void DeviceCommissioner::OnSessionEstablished()
     CHIP_ERROR err =
         mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
                                 mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
-                                SecureSessionMgr::PairingDirection::kInitiator, mAdminId, nullptr);
+                                SecureSession::SessionRole::kInitiator, mAdminId, nullptr);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -40,10 +40,10 @@ CHIP_ERROR MessagingContext::Init(nlTestSuite * suite, TransportMgrBase * transp
     ReturnErrorOnFailure(mExchangeManager.Init(&mSecureSessionMgr));
 
     ReturnErrorOnFailure(mSecureSessionMgr.NewPairing(mPeer, GetDestinationNodeId(), &mPairingLocalToPeer,
-                                                      SecureSessionMgr::PairingDirection::kInitiator, mSrcAdminId));
+                                                      SecureSession::SessionRole::kInitiator, mSrcAdminId));
 
-    return mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal,
-                                        SecureSessionMgr::PairingDirection::kResponder, mDestAdminId);
+    return mSecureSessionMgr.NewPairing(mPeer, GetSourceNodeId(), &mPairingPeerToLocal, SecureSession::SessionRole::kResponder,
+                                        mDestAdminId);
 }
 
 // Shutdown all layers, finalize operations

--- a/src/messaging/tests/TestMessageCounterSyncMgr.cpp
+++ b/src/messaging/tests/TestMessageCounterSyncMgr.cpp
@@ -193,13 +193,13 @@ void CheckSendMsgCounterSyncReq(nlTestSuite * inSuite, void * inContext)
     SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer,
-                                                   SecureSessionMgr::PairingDirection::kInitiator, 0);
+                                                   SecureSession::SessionRole::kInitiator, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
 
-    err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal,
-                                                   SecureSessionMgr::PairingDirection::kResponder, 1);
+    err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal, SecureSession::SessionRole::kResponder,
+                                                   1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle session(kDestinationNodeId, 0x4000, 0);
@@ -239,13 +239,13 @@ void CheckReceiveMsgCounterSyncReq(nlTestSuite * inSuite, void * inContext)
     SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
 
     err = ctx.GetSecureSessionManager().NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer,
-                                                   SecureSessionMgr::PairingDirection::kInitiator, 0);
+                                                   SecureSession::SessionRole::kInitiator, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
 
-    err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal,
-                                                   SecureSessionMgr::PairingDirection::kResponder, 1);
+    err = ctx.GetSecureSessionManager().NewPairing(peer, kSourceNodeId, &pairingPeerToLocal, SecureSession::SessionRole::kResponder,
+                                                   1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle session(kDestinationNodeId, 0x4000, 0);
@@ -334,12 +334,11 @@ void CheckReceiveMessage(nlTestSuite * inSuite, void * inContext)
 
     SecurePairingUsingTestSecret pairingPeerToLocal(kTestLocalGroupKeyId, kTestPeerGroupKeyId);
 
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairingPeerToLocal, SecureSessionMgr::PairingDirection::kInitiator, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairingPeerToLocal, SecureSession::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairingLocalToPeer(kTestPeerGroupKeyId, kTestLocalGroupKeyId);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer, SecureSessionMgr::PairingDirection::kResponder,
-                                      0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairingLocalToPeer, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR EstablishSecureSession()
 
     // Attempt to connect to the peer.
     err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
-                                     chip::SecureSessionMgr::PairingDirection::kInitiator, gAdminId);
+                                     chip::SecureSession::SessionRole::kInitiator, gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -117,8 +117,8 @@ int main(int argc, char * argv[])
         SuccessOrExit(err);
     }
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
-                                     chip::SecureSessionMgr::PairingDirection::kResponder, gAdminId);
+    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
+                                     gAdminId);
     SuccessOrExit(err);
 
     if (!disableEcho)

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -258,7 +258,7 @@ void CASESession::OnResponseTimeout(ExchangeContext * ec)
     Clear();
 }
 
-CHIP_ERROR CASESession::DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session)
+CHIP_ERROR CASESession::DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role)
 {
     System::PacketBufferHandle msg_salt;
     uint16_t saltlen;
@@ -266,8 +266,6 @@ CHIP_ERROR CASESession::DeriveSecureSession(const uint8_t * info, size_t info_le
     (void) kKDFSEInfo;
     (void) kKDFSEInfoLength;
 
-    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info_len > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mPairingComplete, CHIP_ERROR_INCORRECT_STATE);
 
     // Generate Salt for Encryption keys
@@ -283,7 +281,9 @@ CHIP_ERROR CASESession::DeriveSecureSession(const uint8_t * info, size_t info_le
         VerifyOrReturnError(bbuf.Fit(), CHIP_ERROR_NO_MEMORY);
     }
 
-    ReturnErrorOnFailure(session.InitFromSecret(mSharedSecret, mSharedSecret.Length(), msg_salt->Start(), saltlen, info, info_len));
+    ReturnErrorOnFailure(session.InitFromSecret(ByteSpan(mSharedSecret, mSharedSecret.Length()),
+                                                ByteSpan(msg_salt->Start(), saltlen),
+                                                SecureSession::SessionInfoType::kSessionEstablishment, role));
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -116,13 +116,12 @@ public:
      *   Derive a secure session from the established session. The API will return error
      *   if called before session is established.
      *
-     * @param info        Information string used for key derivation
-     * @param info_len    Length of info string
      * @param session     Reference to the secure session that will be
      *                    initialized once session establishment is complete
+     * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session) override;
+    virtual CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
     /**
      * @brief

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -332,13 +332,11 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
     mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
-CHIP_ERROR PASESession::DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session)
+CHIP_ERROR PASESession::DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role)
 {
-    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info_len > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mPairingComplete, CHIP_ERROR_INCORRECT_STATE);
-
-    return session.InitFromSecret(mKe, mKeLen, nullptr, 0, info, info_len);
+    return session.InitFromSecret(ByteSpan(mKe, mKeLen), ByteSpan(nullptr, 0),
+                                  SecureSession::SessionInfoType::kSessionEstablishment, role);
 }
 
 CHIP_ERROR PASESession::SendPBKDFParamRequest()

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -85,7 +85,7 @@ public:
      *
      * @param mySetUpPINCode  Setup PIN code of the local device
      * @param pbkdf2IterCount Iteration count for PBKDF2 function
-     * @param salt            Salt to be used for SPAKE2P opertation
+     * @param salt            Salt to be used for SPAKE2P operation
      * @param saltLen         Length of salt
      * @param myKeyId         Key ID to be assigned to the secure session on the peer node
      * @param delegate        Callback object
@@ -142,13 +142,12 @@ public:
      *   Derive a secure session from the paired session. The API will return error
      *   if called before pairing is established.
      *
-     * @param info        Information string used for key derivation
-     * @param info_len    Length of info string
-     * @param session     Referene to the sescure session that will be
+     * @param session     Referene to the secure session that will be
      *                    initialized once pairing is complete
+     * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session) override;
+    CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override;
 
     /**
      * @brief
@@ -327,14 +326,11 @@ public:
 
     SecurePairingUsingTestSecret(uint16_t peerKeyId, uint16_t localKeyId) : mPeerKeyID(peerKeyId), mLocalKeyID(localKeyId) {}
 
-    CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session) override
+    CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) override
     {
-        VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(info_len > 0, CHIP_ERROR_INVALID_ARGUMENT);
-
         size_t secretLen = strlen(kTestSecret);
-
-        return session.InitFromSecret(reinterpret_cast<const uint8_t *>(kTestSecret), secretLen, nullptr, 0, info, info_len);
+        return session.InitFromSecret(ByteSpan(reinterpret_cast<const uint8_t *>(kTestSecret), secretLen), ByteSpan(nullptr, 0),
+                                      SecureSession::SessionInfoType::kSessionEstablishment, role);
     }
 
     CHIP_ERROR ToSerializable(PASESessionSerializable & serializable)

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -228,7 +228,7 @@ void CASE_SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
         SecureSession session1;
 
         NL_TEST_ASSERT(inSuite,
-                       testPairingSession1->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session1) == CHIP_NO_ERROR);
+                       testPairingSession1->DeriveSecureSession(session1, SecureSession::SessionRole::kInitiator) == CHIP_NO_ERROR);
 
         NL_TEST_ASSERT(inSuite, session1.Encrypt(plain_text, sizeof(plain_text), encrypted, header, mac) == CHIP_NO_ERROR);
     }
@@ -236,7 +236,7 @@ void CASE_SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     {
         SecureSession session2;
         NL_TEST_ASSERT(inSuite,
-                       testPairingSession2->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session2) == CHIP_NO_ERROR);
+                       testPairingSession2->DeriveSecureSession(session2, SecureSession::SessionRole::kResponder) == CHIP_NO_ERROR);
 
         uint8_t decrypted[64];
         NL_TEST_ASSERT(inSuite, session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, mac) == CHIP_NO_ERROR);

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -201,7 +201,7 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     {
         SecureSession session1;
 
-        CHIP_ERROR err = testPairingSession1->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session1);
+        CHIP_ERROR err = testPairingSession1->DeriveSecureSession(session1, SecureSession::SessionRole::kInitiator);
 
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
@@ -212,7 +212,7 @@ void SecurePairingSerializeTest(nlTestSuite * inSuite, void * inContext)
     {
         SecureSession session2;
         NL_TEST_ASSERT(inSuite,
-                       testPairingSession2->DeriveSecureSession(Uint8::from_const_char("abc"), 3, session2) == CHIP_NO_ERROR);
+                       testPairingSession2->DeriveSecureSession(session2, SecureSession::SessionRole::kResponder) == CHIP_NO_ERROR);
 
         uint8_t decrypted[64];
         NL_TEST_ASSERT(inSuite, session2.Decrypt(encrypted, sizeof(plain_text), decrypted, header, mac) == CHIP_NO_ERROR);

--- a/src/transport/PairingSession.h
+++ b/src/transport/PairingSession.h
@@ -41,13 +41,12 @@ public:
      *   Derive a secure session from the paired session. The API will return error
      *   if called before pairing is established.
      *
-     * @param info        Information string used for key derivation
-     * @param info_len    Length of info string
      * @param session     Referene to the secure session that will be
      *                    initialized once pairing is complete
+     * @param role        Role of the new session (initiator or responder)
      * @return CHIP_ERROR The result of session derivation
      */
-    virtual CHIP_ERROR DeriveSecureSession(const uint8_t * info, size_t info_len, SecureSession & session) = 0;
+    virtual CHIP_ERROR DeriveSecureSession(SecureSession & session, SecureSession::SessionRole role) = 0;
 
     /**
      * @brief

--- a/src/transport/PeerConnectionState.h
+++ b/src/transport/PeerConnectionState.h
@@ -82,8 +82,7 @@ public:
     uint64_t GetLastActivityTimeMs() const { return mLastActivityTimeMs; }
     void SetLastActivityTimeMs(uint64_t value) { mLastActivityTimeMs = value; }
 
-    SecureSession & GetSenderSecureSession() { return mSenderSecureSession; }
-    SecureSession & GetReceiverSecureSession() { return mReceiverSecureSession; }
+    SecureSession & GetSecureSession() { return mSecureSession; }
 
     Transport::AdminId GetAdminId() const { return mAdmin; }
     void SetAdminId(Transport::AdminId admin) { mAdmin = admin; }
@@ -110,21 +109,20 @@ public:
         mPeerNodeId         = kUndefinedNodeId;
         mSendMessageIndex   = 0;
         mLastActivityTimeMs = 0;
-        mSenderSecureSession.Reset();
-        mReceiverSecureSession.Reset();
+        mSecureSession.Reset();
         mMsgCounterSynStatus = MsgCounterSyncStatus::NotSync;
     }
 
     CHIP_ERROR EncryptBeforeSend(const uint8_t * input, size_t input_length, uint8_t * output, PacketHeader & header,
                                  MessageAuthenticationCode & mac) const
     {
-        return mSenderSecureSession.Encrypt(input, input_length, output, header, mac);
+        return mSecureSession.Encrypt(input, input_length, output, header, mac);
     }
 
     CHIP_ERROR DecryptOnReceive(const uint8_t * input, size_t input_length, uint8_t * output, const PacketHeader & header,
                                 const MessageAuthenticationCode & mac) const
     {
-        return mReceiverSecureSession.Decrypt(input, input_length, output, header, mac);
+        return mSecureSession.Decrypt(input, input_length, output, header, mac);
     }
 
 private:
@@ -143,8 +141,7 @@ private:
     uint16_t mLocalKeyID         = UINT16_MAX;
     uint64_t mLastActivityTimeMs = 0;
     Transport::Base * mTransport = nullptr;
-    SecureSession mSenderSecureSession;
-    SecureSession mReceiverSecureSession;
+    SecureSession mSecureSession;
     Transport::AdminId mAdmin = kUndefinedAdminId;
 };
 

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -37,49 +37,61 @@ namespace {
 constexpr size_t kAESCCMIVLen = 12;
 constexpr size_t kMaxAADLen   = 128;
 
+/* Session Establish Key Info */
+constexpr uint8_t SEKeysInfo[] = { 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x4b, 0x65, 0x79, 0x73 };
+
+/* Session Resumption Key Info */
+constexpr uint8_t RSEKeysInfo[] = { 0x53, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x75,
+                                    0x6d, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x4b, 0x65, 0x79, 0x73 };
+
 } // namespace
 
 using namespace Crypto;
 
 SecureSession::SecureSession() : mKeyAvailable(false) {}
 
-CHIP_ERROR SecureSession::InitFromSecret(const uint8_t * secret, const size_t secret_length, const uint8_t * salt,
-                                         const size_t salt_length, const uint8_t * info, const size_t info_length)
+CHIP_ERROR SecureSession::InitFromSecret(const ByteSpan & secret, const ByteSpan & salt, SessionInfoType infoType, SessionRole role)
 {
 
     VerifyOrReturnError(mKeyAvailable == false, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(secret != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(secret_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError((salt_length == 0) || (salt != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(secret.data() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(secret.size() > 0, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError((salt.size() == 0) || (salt.data() != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(HKDF_SHA256(secret, secret_length, salt, salt_length, info, info_length, mKey, sizeof(mKey)));
+    const uint8_t * info = SEKeysInfo;
+    size_t infoLen       = sizeof(SEKeysInfo);
+
+    if (infoType == SessionInfoType::kSessionResumption)
+    {
+        info    = RSEKeysInfo;
+        infoLen = sizeof(RSEKeysInfo);
+    }
+
+    ReturnErrorOnFailure(
+        HKDF_SHA256(secret.data(), secret.size(), salt.data(), salt.size(), info, infoLen, &mKeys[0][0], sizeof(mKeys)));
 
     mKeyAvailable = true;
+    mSessionRole  = role;
 
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SecureSession::Init(const Crypto::P256Keypair & local_keypair, const Crypto::P256PublicKey & remote_public_key,
-                               const uint8_t * salt, const size_t salt_length, const uint8_t * info, const size_t info_length)
+                               const ByteSpan & salt, SessionInfoType infoType, SessionRole role)
 {
 
     VerifyOrReturnError(mKeyAvailable == false, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError((salt_length == 0) || (salt != nullptr), CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(info != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     P256ECDHDerivedSecret secret;
     ReturnErrorOnFailure(local_keypair.ECDH_derive_secret(remote_public_key, secret));
 
-    return InitFromSecret(secret, secret.Length(), salt, salt_length, info, info_length);
+    return InitFromSecret(ByteSpan(secret, secret.Length()), salt, infoType, role);
 }
 
 void SecureSession::Reset()
 {
     mKeyAvailable = false;
-    memset(mKey, 0, sizeof(mKey));
+    memset(mKeys, 0, sizeof(mKeys));
 }
 
 CHIP_ERROR SecureSession::GetIV(const PacketHeader & header, uint8_t * iv, size_t len)
@@ -132,8 +144,19 @@ CHIP_ERROR SecureSession::Encrypt(const uint8_t * input, size_t input_length, ui
 
     ReturnErrorOnFailure(GetIV(header, IV, sizeof(IV)));
     ReturnErrorOnFailure(GetAdditionalAuthData(header, AAD, aadLen));
-    ReturnErrorOnFailure(
-        AES_CCM_encrypt(input, input_length, AAD, aadLen, mKey, sizeof(mKey), IV, sizeof(IV), output, tag, taglen));
+
+    KeyUsage usage = kR2IKey;
+
+    // Message is encrypted before sending. If the secure session was created by session
+    // initiator, we'll use I2R key to encrypt the message that's being transmittted.
+    // Otherwise, we'll use R2I key, as the responder is sending the message.
+    if (mSessionRole == SessionRole::kInitiator)
+    {
+        usage = kI2RKey;
+    }
+
+    ReturnErrorOnFailure(AES_CCM_encrypt(input, input_length, AAD, aadLen, mKeys[usage], kAES_CCM128_Key_Length, IV, sizeof(IV),
+                                         output, tag, taglen));
 
     mac.SetTag(&header, encType, tag, taglen);
 
@@ -157,7 +180,18 @@ CHIP_ERROR SecureSession::Decrypt(const uint8_t * input, size_t input_length, ui
     ReturnErrorOnFailure(GetIV(header, IV, sizeof(IV)));
     ReturnErrorOnFailure(GetAdditionalAuthData(header, AAD, aadLen));
 
-    return AES_CCM_decrypt(input, input_length, AAD, aadLen, tag, taglen, mKey, sizeof(mKey), IV, sizeof(IV), output);
+    KeyUsage usage = kI2RKey;
+
+    // Message is decrypted on receive. If the secure session was created by session
+    // initiator, we'll use R2I key to decrypt the message (as it was sent by responder).
+    // Otherwise, we'll use I2R key, as the responder is sending the message.
+    if (mSessionRole == SessionRole::kInitiator)
+    {
+        usage = kR2IKey;
+    }
+
+    return AES_CCM_decrypt(input, input_length, AAD, aadLen, tag, taglen, mKeys[usage], kAES_CCM128_Key_Length, IV, sizeof(IV),
+                           output);
 }
 
 } // namespace chip

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -218,7 +218,7 @@ exit:
 }
 
 CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId,
-                                        PairingSession * pairing, PairingDirection direction, Transport::AdminId admin,
+                                        PairingSession * pairing, SecureSession::SessionRole direction, Transport::AdminId admin,
                                         Transport::Base * transport)
 {
     uint16_t peerKeyId          = pairing->GetPeerKeyId();
@@ -237,6 +237,7 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
     state = nullptr;
     ReturnErrorOnFailure(
         mPeerConnections.CreateNewPeerConnectionState(Optional<NodeId>::Value(peerNodeId), peerKeyId, localKeyId, &state));
+    ReturnErrorCodeIf(state == nullptr, CHIP_ERROR_NO_MEMORY);
 
     state->SetAdminId(admin);
     state->SetTransport(transport);
@@ -256,38 +257,11 @@ CHIP_ERROR SecureSessionMgr::NewPairing(const Optional<Transport::PeerAddress> &
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (state != nullptr)
+    ReturnErrorOnFailure(pairing->DeriveSecureSession(state->GetSecureSession(), direction));
+
+    if (mCB != nullptr)
     {
-        switch (direction)
-        {
-        case PairingDirection::kInitiator: {
-            const char * i2rInfo = pairing->GetI2RSessionInfo();
-            ReturnErrorOnFailure(pairing->DeriveSecureSession(reinterpret_cast<const uint8_t *>(i2rInfo), strlen(i2rInfo),
-                                                              state->GetSenderSecureSession()));
-
-            const char * r2iInfo = pairing->GetR2ISessionInfo();
-            ReturnErrorOnFailure(pairing->DeriveSecureSession(reinterpret_cast<const uint8_t *>(r2iInfo), strlen(r2iInfo),
-                                                              state->GetReceiverSecureSession()));
-        }
-        break;
-        case PairingDirection::kResponder: {
-            const char * i2rInfo = pairing->GetR2ISessionInfo();
-            ReturnErrorOnFailure(pairing->DeriveSecureSession(reinterpret_cast<const uint8_t *>(i2rInfo), strlen(i2rInfo),
-                                                              state->GetSenderSecureSession()));
-
-            const char * r2iInfo = pairing->GetI2RSessionInfo();
-            ReturnErrorOnFailure(pairing->DeriveSecureSession(reinterpret_cast<const uint8_t *>(r2iInfo), strlen(r2iInfo),
-                                                              state->GetReceiverSecureSession()));
-        }
-        break;
-        default:
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        };
-
-        if (mCB != nullptr)
-        {
-            mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), admin }, this);
-        }
+        mCB->OnNewConnection({ state->GetPeerNodeId(), state->GetPeerKeyID(), admin }, this);
     }
 
     return CHIP_NO_ERROR;

--- a/src/transport/SecureSessionMgr.h
+++ b/src/transport/SecureSessionMgr.h
@@ -212,15 +212,6 @@ public:
     ~SecureSessionMgr() override;
 
     /**
-     *    Whether the current node initiated the pairing, or it is responding to a pairing request.
-     */
-    enum class PairingDirection
-    {
-        kInitiator, /**< We initiated the pairing request. */
-        kResponder, /**< We are responding to the pairing request. */
-    };
-
-    /**
      * @brief
      *   Send a message to a currently connected peer.
      *
@@ -255,7 +246,7 @@ public:
      *   peer node.
      */
     CHIP_ERROR NewPairing(const Optional<Transport::PeerAddress> & peerAddr, NodeId peerNodeId, PairingSession * pairing,
-                          PairingDirection direction, Transport::AdminId admin, Transport::Base * transport = nullptr);
+                          SecureSession::SessionRole direction, Transport::AdminId admin, Transport::Base * transport = nullptr);
 
     /**
      * @brief

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -195,11 +195,11 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
@@ -287,11 +287,11 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;
@@ -363,11 +363,11 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, admin != nullptr);
 
     SecurePairingUsingTestSecret pairing1(1, 2);
-    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSessionMgr::PairingDirection::kInitiator, 1);
+    err = secureSessionMgr.NewPairing(peer, kSourceNodeId, &pairing1, SecureSession::SessionRole::kInitiator, 1);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecurePairingUsingTestSecret pairing2(2, 1);
-    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSessionMgr::PairingDirection::kResponder, 0);
+    err = secureSessionMgr.NewPairing(peer, kDestinationNodeId, &pairing2, SecureSession::SessionRole::kResponder, 0);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     SecureSessionHandle localToRemoteSession = callback.mLocalToRemoteSession;


### PR DESCRIPTION
 #### Problem
The current code is not using correct info strings/byte array to device secure session keys. 
Issue #6167 describes it more details.

 #### Summary of Changes
Updated the code to follow the spec. One secure session object will carry the bidirectional key, and will use the correct key for encrypting/decrypting based on how the session was established.

 Fixes #6167
