### PR TITLE
Fix exchange leak issue in IM Read Interaction test in Cirque

### DIFF
--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -365,6 +365,7 @@ int main(int argc, char * argv[])
     }
 
     gpCommandSender->Shutdown();
+    gpReadClient->Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     ShutdownChip();
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Detect exchange leak during IM Read Interaction test 

sg send status No Error CHIP:EM: Flushed pending ack for MsgId:00000005 CHIP:DMG: Client[0] moving to [INIT] Read Response: 3/3(100.00%) time=0.006ms CHIP:DMG: ICR moving to [Uninitiali] CHIP:DMG: Client[0] moving to [UNINIT] CHIP:DMG: IM RH moving to [Uninitialized] chip-im-initiator: ../../../../../src/messaging/ExchangeMgr.cpp:108: CHIP_ERROR chip::Messaging::ExchangeManager::Shutdown(): Assertion `ec.GetReferenceCount() == 0' failed. Thread 1 "chip-im-initiat" received signal SIGABRT, Aborted. 0x00007ffff756118b in raise () from /lib/x86_64-linux-gnu/libc.so.6 #0 0x00007ffff756118b in raise () at /lib/x86_64-linux-gnu/libc.so.6 #1 0x00007ffff7540859 in abort () at /lib/x86_64-linux-gnu/libc.so.6 #2 0x00007ffff7540729 in () at /lib/x86_64-linux-gnu/libc.so.6 #3 0x00007ffff7551f36 in () at /lib/x86_64-linux-gnu/libc.so.6 #4 0x000055555559aa45 in chip::Messaging::ExchangeManager::Shutdown() (this=0x5555555d8900 <gExchangeManager>) at ../../../../../src/messaging/ExchangeMgr.cpp:108 #5 0x00005555555672a4 in ShutdownChip() () at ../../../../../src/app/tests/integration/common.cpp:60 #6 0x0000555555565819 in main(int, char**) (argc=2, argv=0x7fffffffecf8) at ../../../../../src/app/tests/integration/chip_im_initiator.cpp:369 (gdb) quit A debugging session is active. Inferior 1 [process 123] will be killed.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Hard close the exchange in ReadClient during shutdown process to prevent exchange leak.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
