### PR TITLE
Fix for System Layer event handler crash

### DIFF
--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -144,11 +144,7 @@ static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clu
 
 EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t delayMs)
 {
-    if (delayMs == 0)
-    {
-        emberEventControlSetActive(control);
-    }
-    else if (delayMs <= EMBER_MAX_EVENT_CONTROL_DELAY_MS)
+    if (delayMs <= EMBER_MAX_EVENT_CONTROL_DELAY_MS)
     {
         control->status = EMBER_EVENT_MS_TIME;
         chip::DeviceLayer::SystemLayer.StartTimer(delayMs, EventControlHandler, control);


### PR DESCRIPTION
 #### Problem
System Layer Handler crash when level change commands are sent in quick succession.

 #### Summary of Changes
For 0 delay `StartTimer( )` invokes the handler immediately, which collides with the handler invoked by `emberEventControlSetActive`.

 Fixes #5678 