### PR TITLE
Fixing compile issue on Mac

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.h
@@ -38,7 +38,6 @@ public:
 
 private:
     id<CHIPPersistentStorageDelegate> mDelegate;
-    dispatch_queue_t mQueue;
 
     NSUserDefaults * mDefaultPersistentStorage;
     dispatch_queue_t mWorkQueue;


### PR DESCRIPTION
#### Problem
Compiler complains about unused variable

#### Summary of Changes
- Updated the CHIPPersistentStorageDelegateBridge.h file

#### Test
- Used the `./gn_build.sh ` to verify the building is successful 
