### PR TITLE
Example operational credentials issuer for tests and tools

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -33,9 +33,10 @@ CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, Node
 
     chip::Controller::CommissionerInitParams params;
 
-    params.storageDelegate              = &storage;
-    params.mDeviceAddressUpdateDelegate = this;
-    params.pairingDelegate              = this;
+    params.storageDelegate                = &storage;
+    params.mDeviceAddressUpdateDelegate   = this;
+    params.pairingDelegate                = this;
+    params.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -23,6 +23,8 @@
 #include "gen/CHIPClientCallbacks.h"
 #include "gen/CHIPClusters.h"
 
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+
 enum class PairingMode
 {
     None,
@@ -91,6 +93,7 @@ public:
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             break;
         }
+        mOpCredsIssuer.Initialize();
     }
 
     /////////// Command Interface /////////
@@ -144,4 +147,5 @@ private:
     ChipDevice * mDevice;
     chip::Controller::NetworkCommissioningCluster mCluster;
     chip::EndpointId mEndpointId = 0;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -27,6 +27,8 @@ static_library("controller") {
     "CHIPDeviceController.h",
     "DeviceAddressUpdateDelegate.h",
     "EmptyDataModelHandler.cpp",
+    "ExampleOperationalCredentialsIssuer.cpp",
+    "ExampleOperationalCredentialsIssuer.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -643,6 +643,8 @@ DeviceCommissioner::DeviceCommissioner()
 
 CHIP_ERROR DeviceCommissioner::Init(NodeId localDeviceId, CommissionerInitParams params)
 {
+    VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
     ReturnErrorOnFailure(DeviceController::Init(localDeviceId, params));
 
     uint16_t size    = sizeof(mNextKeyId);
@@ -960,7 +962,7 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(N
 
 CHIP_ERROR DeviceCommissioner::OnOperationalCertificateSigningRequest(NodeId node, const ByteSpan & csr)
 {
-    ReturnErrorCodeIf(mOperationalCredentialsDelegate == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> opCert;
     ReturnErrorCodeIf(!opCert.Alloc(kMaxCHIPOpCertLength), CHIP_ERROR_NO_MEMORY);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -305,7 +305,7 @@ public:
     ~DeviceCommissioner() {}
 
     /**
-     * Commisioner-specific initialization, includes parameters such as the pairing delegate.
+     * Commissioner-specific initialization, includes parameters such as the pairing delegate.
      */
     CHIP_ERROR Init(NodeId localDeviceId, CommissionerInitParams params);
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <credentials/CHIPCert.h>
+
+namespace chip {
+namespace Controller {
+
+using namespace Credentials;
+using namespace Crypto;
+
+CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNodeOperationalCertificate(const PeerId & peerId, const ByteSpan & csr,
+                                                                                   int64_t serialNumber, uint8_t * certBuf,
+                                                                                   uint32_t certBufSize, uint32_t & outCertLen)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
+    X509CertRequestParams request = { serialNumber, mIssuerId,         mNow, mNow + mValidity, true, peerId.GetFabricId(),
+                                      true,         peerId.GetNodeId() };
+
+    P256PublicKey pubkey;
+    ReturnErrorOnFailure(VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));
+    return NewNodeOperationalX509Cert(request, CertificateIssuerLevel::kIssuerIsRootCA, pubkey, mIssuer, certBuf, certBufSize,
+                                      outCertLen);
+}
+
+CHIP_ERROR ExampleOperationalCredentialsIssuer::GetRootCACertificate(FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize,
+                                                                     uint32_t & outCertLen)
+{
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
+    X509CertRequestParams request = { 0, mIssuerId, mNow, mNow + mValidity, true, fabricId, false, 0 };
+    return NewRootX509Cert(request, mIssuer, certBuf, certBufSize, outCertLen);
+}
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *    This file contains class definition of an example operational certificate
+ *    issuer for CHIP devices. The class can be used as a guideline on how to
+ *    construct your own certificate issuer. It can also be used in tests and tools
+ *    if a specific signing authority is not required.
+ */
+
+#pragma once
+
+#include <controller/OperationalCredentialsDelegate.h>
+#include <core/CHIPError.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <support/CodeUtils.h>
+
+namespace chip {
+namespace Controller {
+
+class DLL_EXPORT ExampleOperationalCredentialsIssuer : public OperationalCredentialsDelegate
+{
+public:
+    virtual ~ExampleOperationalCredentialsIssuer() {}
+
+    CHIP_ERROR GenerateNodeOperationalCertificate(const PeerId & peerId, const ByteSpan & csr, int64_t serialNumber,
+                                                  uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+
+    CHIP_ERROR GetRootCACertificate(FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
+
+    /**
+     * @brief Serialize the issuer's keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Serialize(Crypto::P256SerializedKeypair & issuer)
+    {
+        VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
+        return mIssuer.Serialize(issuer);
+    }
+
+    /**
+     * @brief Deserialize the keypair as issuer's keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Deserialize(Crypto::P256SerializedKeypair & issuer)
+    {
+        ReturnErrorOnFailure(mIssuer.Deserialize(issuer));
+        mInitialized = true;
+        return CHIP_NO_ERROR;
+    }
+
+    /**
+     * @brief Initialize the issuer with a new keypair.
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Initialize()
+    {
+        ReturnErrorOnFailure(mIssuer.Initialize());
+        mInitialized = true;
+        return CHIP_NO_ERROR;
+    }
+
+    void SetIssuerId(uint32_t id) { mIssuerId = id; }
+
+    void SetCurrentEpoch(uint32_t epoch) { mNow = epoch; }
+
+    void SetCertificateValidityPeriod(uint32_t validity) { mValidity = validity; }
+
+private:
+    Crypto::P256Keypair mIssuer;
+    bool mInitialized  = false;
+    uint32_t mIssuerId = 0;
+    uint32_t mNow      = 0;
+
+    // By default, let's set validity to 10 years
+    uint32_t mValidity = 365 * 24 * 60 * 60 * 10;
+};
+
+} // namespace Controller
+} // namespace chip

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -143,6 +143,14 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     initParams.inetLayer       = inetLayer;
     initParams.bleLayer        = GetJNIBleLayer();
 
+    *errInfoOnFailure = mOpCredsIssuer.Initialize();
+    if (*errInfoOnFailure != CHIP_NO_ERROR)
+    {
+        return nullptr;
+    }
+
+    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
+
     *errInfoOnFailure = wrapper->Controller()->Init(nodeId, initParams);
 
     if (*errInfoOnFailure != CHIP_NO_ERROR)

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -143,13 +143,13 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     initParams.inetLayer       = inetLayer;
     initParams.bleLayer        = GetJNIBleLayer();
 
-    *errInfoOnFailure = mOpCredsIssuer.Initialize();
+    *errInfoOnFailure = wrapper->OpCredsIssuer().Initialize();
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {
         return nullptr;
     }
 
-    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
+    initParams.operationalCredentialsDelegate = &wrapper->OpCredsIssuer();
 
     *errInfoOnFailure = wrapper->Controller()->Init(nodeId, initParams);
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -39,6 +39,7 @@ public:
     ~AndroidDeviceControllerWrapper();
 
     chip::Controller::DeviceCommissioner * Controller() { return mController.get(); }
+    chip::Controller::ExampleOperationalCredentialsIssuer & OpCredsIssuer() { return mOpCredsIssuer; }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
 
     // DevicePairingDelegate implementation

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -22,6 +22,7 @@
 #include <jni.h>
 
 #include <controller/CHIPDeviceController.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
 /**
@@ -75,6 +76,7 @@ private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
 
     ChipDeviceControllerPtr mController;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 
     JavaVM * mJavaVM       = nullptr;
     jobject mJavaObjectRef = nullptr;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -49,6 +49,7 @@
 #include <app/InteractionModelEngine.h>
 #include <controller/CHIPDevice.h>
 #include <controller/CHIPDeviceController.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <mdns/Resolver.h>
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
@@ -68,6 +69,7 @@ namespace {
 chip::Controller::PythonPersistentStorageDelegate sStorageDelegate;
 chip::Controller::ScriptDevicePairingDelegate sPairingDelegate;
 chip::Controller::ScriptDeviceAddressUpdateDelegate sDeviceAddressUpdateDelegate;
+chip::Controller::ExampleOperationalCredentialsIssuer sOperationalCredentialsIssuer;
 } // namespace
 
 // NOTE: Remote device ID is in sync with the echo server device id
@@ -132,9 +134,13 @@ CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceC
         localDeviceId = kDefaultLocalDeviceId;
     }
 
+    ReturnErrorOnFailure(sOperationalCredentialsIssuer.Initialize());
+
     initParams.storageDelegate              = &sStorageDelegate;
     initParams.mDeviceAddressUpdateDelegate = &sDeviceAddressUpdateDelegate;
     initParams.pairingDelegate              = &sPairingDelegate;
+
+    initParams.operationalCredentialsDelegate = &sOperationalCredentialsIssuer;
 
 #if CHIP_ENABLE_INTERACTION_MODEL
     initParams.imDelegate = &PythonInteractionModelDelegate::Instance();

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include <controller/CHIPDeviceController.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
 #include <support/CodeUtils.h>
@@ -73,6 +74,7 @@ private:
 
 ServerStorageDelegate gServerStorage;
 ScriptDevicePairingDelegate gPairingDelegate;
+chip::Controller::ExampleOperationalCredentialsIssuer gOperationalCredentialsIssuer;
 
 } // namespace
 
@@ -99,7 +101,18 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         params.inetLayer       = &chip::DeviceLayer::InetLayer;
         params.pairingDelegate = &gPairingDelegate;
 
-        err = result->Init(localDeviceId, params);
+        err = gOperationalCredentialsIssuer.Initialize();
+
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Controller, "Operational credentials issuer initialization failed: %s", chip::ErrorStr(err));
+        }
+        else
+        {
+            params.operationalCredentialsDelegate = &gOperationalCredentialsIssuer;
+
+            err = result->Init(localDeviceId, params);
+        }
     });
 
     if (err != CHIP_NO_ERROR)

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -169,6 +169,8 @@ static NSString * const kInfoStackShutdown = @"Shutting down the CHIP Stack";
         params.mDeviceAddressUpdateDelegate = _pairingDelegateBridge;
         params.pairingDelegate = _pairingDelegateBridge;
 
+        params.operationalCredentialsDelegate = _operationalCredentialsDelegate;
+
         errorCode = _cppCommissioner->Init(_localDeviceId, params);
         if ([self checkForStartError:(CHIP_NO_ERROR == errorCode) logMsg:kErrorCommissionerInit]) {
             return;


### PR DESCRIPTION
 #### Problem
Need a sample operational certificate issuer for test apps and tools. Without it, once OpCreds is integrated to commissioning flow, the commissioner apps such as chip-tool, Python tool and other apps will stop working. 

 #### Summary of Changes
Implemented an example certificate issuer and integrated to tools in CHIP project.
Also, added a check in `DeviceCommissioner` which makes it mandatory to have an operational certificate issuer.