### PR TITLE
Followup for #6599. discover/clusters/reporting commands of chip-tool…

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -18,6 +18,7 @@
 
 #include "ModelCommand.h"
 
+#include <app/InteractionModelEngine.h>
 #include <inttypes.h>
 
 using namespace ::chip;
@@ -29,9 +30,12 @@ constexpr uint16_t kWaitDurationInSeconds = 10;
 CHIP_ERROR ModelCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Controller::CommissionerInitParams initParams;
 
-    initParams.storageDelegate = &storage;
+    mOpCredsIssuer.Initialize();
+
+    chip::Controller::CommissionerInitParams initParams;
+    initParams.storageDelegate                = &storage;
+    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -21,6 +21,7 @@
 #include "../../config/PersistentStorage.h"
 #include "../common/Command.h"
 #include <app/chip-zcl-zpro-codec.h>
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <core/CHIPEncoding.h>
 
 // Limits on endpoint values.
@@ -42,5 +43,6 @@ public:
 private:
     ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
     uint8_t mEndPointId;
 };

--- a/examples/chip-tool/commands/discover/DiscoverCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.cpp
@@ -24,8 +24,9 @@ CHIP_ERROR DiscoverCommand::Run(PersistentStorage & storage, NodeId localId, Nod
 {
     chip::Controller::CommissionerInitParams params;
 
-    params.storageDelegate              = &storage;
-    params.mDeviceAddressUpdateDelegate = this;
+    params.storageDelegate                = &storage;
+    params.mDeviceAddressUpdateDelegate   = this;
+    params.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     ReturnErrorOnFailure(mCommissioner.SetUdpListenPort(storage.GetListenPort()));
     ReturnErrorOnFailure(mCommissioner.Init(localId, params));

--- a/examples/chip-tool/commands/discover/DiscoverCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommand.h
@@ -20,6 +20,7 @@
 
 #include "../../config/PersistentStorage.h"
 #include "../common/Command.h"
+#include <controller/ExampleOperationalCredentialsIssuer.h>
 
 class DiscoverCommand : public Command, public chip::Controller::DeviceAddressUpdateDelegate
 {
@@ -44,4 +45,5 @@ protected:
 private:
     chip::NodeId mNodeId;
     uint64_t mFabricId;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -31,8 +31,9 @@ CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, Node
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Controller::CommissionerInitParams params;
+    mOpCredsIssuer.Initialize();
 
+    chip::Controller::CommissionerInitParams params;
     params.storageDelegate                = &storage;
     params.mDeviceAddressUpdateDelegate   = this;
     params.pairingDelegate                = this;

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -31,10 +31,14 @@ constexpr uint16_t kWaitDurationInSeconds = UINT16_MAX;
 CHIP_ERROR ReportingCommand::Run(PersistentStorage & storage, NodeId localId, NodeId remoteId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+
+    mOpCredsIssuer.Initialize();
+
     chip::Controller::BasicCluster cluster;
     chip::Controller::CommissionerInitParams initParams;
 
-    initParams.storageDelegate = &storage;
+    initParams.storageDelegate                = &storage;
+    initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Commissioner: %s", ErrorStr(err)));

--- a/examples/chip-tool/commands/reporting/ReportingCommand.h
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.h
@@ -21,6 +21,8 @@
 #include "../../config/PersistentStorage.h"
 #include "../common/Command.h"
 
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+
 // Limits on endpoint values.
 #define CHIP_ZCL_ENDPOINT_MIN 0x00
 #define CHIP_ZCL_ENDPOINT_MAX 0xF0
@@ -43,4 +45,5 @@ private:
 
     ChipDeviceCommissioner mCommissioner;
     ChipDevice * mDevice;
+    chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -45,6 +45,7 @@ static_library("framework") {
     "CHIPManualSetupPayloadParser.h",
     "CHIPManualSetupPayloadParser.mm",
     "CHIPOnboardingPayloadParser.m",
+    "CHIPOperationalCredentialsDelegate.mm",
     "CHIPPersistentStorageDelegate.h",
     "CHIPPersistentStorageDelegateBridge.h",
     "CHIPPersistentStorageDelegateBridge.mm",
@@ -63,6 +64,8 @@ static_library("framework") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]
+
+  frameworks = [ "Security.framework" ]
 
   public_configs = [ ":darwin_config" ]
 }

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -237,6 +237,11 @@ bool CHIPOperationalCredentialsDelegate::ToChipEpochTime(uint32_t offset, uint32
     NSCalendar * calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents * components = [calendar components:units fromDate:date];
 
-    return chip::CalendarToChipEpochTime([components year], [components month], [components day], [components hour],
-        [components minute], [components second], epoch);
+    uint16_t year = static_cast<uint16_t>([components year]);
+    uint8_t month = static_cast<uint8_t>([components month]);
+    uint8_t day = static_cast<uint8_t>([components day]);
+    uint8_t hour = static_cast<uint8_t>([components hour]);
+    uint8_t minute = static_cast<uint8_t>([components minute]);
+    uint8_t second = static_cast<uint8_t>([components second]);
+    return chip::CalendarToChipEpochTime(year, month, day, hour, minute, second, epoch);
 }


### PR DESCRIPTION
… fails during commissioner init

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Most `chip-tool`  commands does not work anymore after #6599 because of a missing param.
Also `chip-tool-darwin` does not compile properly if you add some code in it.

 #### Summary of Changes
 * Add the `ExampleOperationalCredentialsIssuer` param
 * Fix Darwin `BUILD.gn` and some conversions.