### PR TITLE
Fix failure to start operational advertising

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -120,7 +120,7 @@ private:
     struct SrpClient
     {
         static constexpr uint8_t kMaxServicesNumber   = CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES;
-        static constexpr uint8_t kMaxInstanceNameSize = chip::Mdns::kMdnsNameMaxSize;
+        static constexpr uint8_t kMaxInstanceNameSize = chip::Mdns::kMdnsNameMaxSize + 1;
         static constexpr uint8_t kMaxNameSize         = chip::Mdns::kMdnsTypeMaxSize + chip::Mdns::kMdnsProtocolTextMaxSize + 1;
         static constexpr uint8_t kMaxHostNameSize     = 32;
         // Thread only supports operational discovery


### PR DESCRIPTION
 #### Problem
Starting an Advertise operational node fails with 
`[SVR] Failed to start operational advertising: CHIP Error 4000030 (0x003D091E): Invalid string length`

SrpClient::kMaxInstanceNameSize = 33 ([Node]-[Fabric] ID in hex - 16+1+16)
Srp client service mInstanceName is declared `char mInstanceName[kMaxInstanceNameSize];` so it is missing a space for the NULL Character.

_AddSrpService or _RemoveSrpService fails on
`VerifyOrExit(strlen(aInstanceName) < SrpClient::kMaxInstanceNameSize, error = CHIP_ERROR_INVALID_STRING_LENGTH);` as it verifies < 33

 #### Summary of Changes
Add +1 for Null character. Without the Null character the srp server would fail to parse the service.
With this `VerifyOrExit(strlen(aInstanceName) < SrpClient::kMaxInstanceNameSize, error = CHIP_ERROR_INVALID_STRING_LENGTH);` now accepts the full srp instance name ([Node]-[Fabric] ID in hex - 16+1+16)

