### PR TITLE
Add Label to FabricDescriptorStruct and hook up logic with UpdateFabricLabel

### DIFF
--- a/config/nrfconnect/app/enable-gnu-std.cmake
+++ b/config/nrfconnect/app/enable-gnu-std.cmake
@@ -1,0 +1,4 @@
+add_library(gnu14 INTERFACE)
+target_compile_options(gnu14 INTERFACE -std=gnu++14 -D_SYS__PTHREADTYPES_H_)
+target_link_libraries(app PRIVATE gnu14)
+

--- a/config/nrfconnect/app/enable-gnu-std.cmake
+++ b/config/nrfconnect/app/enable-gnu-std.cmake
@@ -1,4 +1,3 @@
-add_library(gnu14 INTERFACE)
-target_compile_options(gnu14 INTERFACE -std=gnu++14 -D_SYS__PTHREADTYPES_H_)
-target_link_libraries(app PRIVATE gnu14)
-
+add_library(gnu17 INTERFACE)
+target_compile_options(gnu17 INTERFACE -std=gnu++17 -D_SYS__PTHREADTYPES_H_)
+target_link_libraries(app PRIVATE gnu17)

--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -420,7 +420,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -434,7 +434,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -858,7 +866,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -879,6 +879,7 @@ static void OnOperationalCredentialsFabricsListListAttributeResponse(void * cont
         ChipLogProgress(chipTool, "  FabricId: %" PRIu64 "", entries[i].FabricId);
         ChipLogProgress(chipTool, "  VendorId: %" PRIu16 "", entries[i].VendorId);
         ChipLogProgress(chipTool, "  NodeId: %" PRIu64 "", entries[i].NodeId);
+        ChipLogProgress(Zcl, "  Label: %zu", entries[i].Label.size());
     }
 
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);

--- a/examples/lighting-app/lighting-common/gen/attribute-size.cpp
+++ b/examples/lighting-app/lighting-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,7 +140,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -334,7 +342,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -34,6 +34,8 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrfconnect-lighting-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_compile_options(app PRIVATE -Werror)
 
 target_include_directories(app PRIVATE

--- a/examples/lock-app/lock-common/gen/attribute-size.cpp
+++ b/examples/lock-app/lock-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,7 +140,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -334,7 +342,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -36,6 +36,8 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-lock-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_include_directories(app PRIVATE 
                            main/include 
                            ${LOCK_COMMON} 

--- a/examples/pigweed-app/nrfconnect/CMakeLists.txt
+++ b/examples/pigweed-app/nrfconnect/CMakeLists.txt
@@ -31,6 +31,8 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrf52840-pigweed-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_compile_options(app PRIVATE -Werror)
 
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -30,6 +30,8 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-pump-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_include_directories(app PRIVATE 
                            main/include 
                            ${PUMP_COMMON} 

--- a/examples/pump-app/pump-common/gen/attribute-size.cpp
+++ b/examples/pump-app/pump-common/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,7 +140,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -334,7 +342,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -30,6 +30,8 @@ target_compile_options(app PRIVATE -Werror)
 
 project(chip-nrfconnect-pump-controller-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_include_directories(app PRIVATE 
                            main/include 
                            ${PUMPC_COMMON} 

--- a/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/attribute-size.cpp
@@ -85,7 +85,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -99,7 +99,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -284,7 +292,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/shell/nrfconnect/CMakeLists.txt
+++ b/examples/shell/nrfconnect/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrfconnect-shell-example)
 
+include(${CHIP_ROOT}/config/nrfconnect/app/enable-gnu-std.cmake)
+
 target_compile_options(app PRIVATE -Werror)
 
 target_include_directories(app PRIVATE

--- a/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/attribute-size.cpp
@@ -126,7 +126,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -140,7 +140,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -179,7 +187,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/examples/tv-app/tv-common/gen/attribute-size.cpp
+++ b/examples/tv-app/tv-common/gen/attribute-size.cpp
@@ -324,7 +324,7 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
         {
         case 0x0001: // fabrics list
         {
-            entryLength = 18;
+            entryLength = 52;
             if (((index - 1) * entryLength) > (am->size - entryLength))
             {
                 ChipLogError(Zcl, "Index %l is invalid.", index);
@@ -338,7 +338,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
             copyListMember(write ? dest : (uint8_t *) &entry->VendorId, write ? (uint8_t *) &entry->VendorId : src, write,
                            &entryOffset, sizeof(entry->VendorId)); // INT16U
             copyListMember(write ? dest : (uint8_t *) &entry->NodeId, write ? (uint8_t *) &entry->NodeId : src, write, &entryOffset,
-                           sizeof(entry->NodeId)); // NODE_ID
+                           sizeof(entry->NodeId));      // NODE_ID
+            chip::ByteSpan * LabelSpan = &entry->Label; // OCTET_STRING
+            if (CHIP_NO_ERROR !=
+                (write ? WriteByteSpan(dest + entryOffset, 34, LabelSpan) : ReadByteSpan(src + entryOffset, 34, LabelSpan)))
+            {
+                ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
+                return 0;
+            }
+            entryOffset = static_cast<uint16_t>(entryOffset + 34);
             break;
         }
         }
@@ -674,7 +682,7 @@ uint16_t emberAfAttributeValueListSize(ClusterId clusterId, AttributeId attribut
         {
         case 0x0001: // fabrics list
             // Struct _FabricDescriptor
-            entryLength = 18;
+            entryLength = 52;
             break;
         }
         break;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -87,12 +87,12 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, c
     fabricDescriptor.FabricId = fabricId;
     fabricDescriptor.NodeId   = nodeId;
     fabricDescriptor.VendorId = vendorId;
-    if (fabricLabel != nullptr) 
+    if (fabricLabel != nullptr)
     {
         size_t lengthToStore = strnlen(Uint8::to_const_char(fabricLabel), kFabricLabelMaxLengthInBytes);
         fabricDescriptor.Label = ByteSpan(fabricLabel, lengthToStore);
     }
-    
+
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                    "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -29,14 +29,14 @@
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <app/util/attribute-storage.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/PeerId.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <string.h>
 #include <support/CodeUtils.h>
 #include <support/ScopedBuffer.h>
 #include <support/logging/CHIPLogging.h>
 #include <transport/AdminPairingTable.h>
-#include <lib/core/CHIPSafeCasts.h>
-#include <string.h>
 
 using namespace chip;
 using namespace ::chip::DeviceLayer;
@@ -93,7 +93,6 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, c
         fabricDescriptor.Label = ByteSpan(fabricLabel, lengthToStore);
     }
 
-
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                    "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64
                    ", nodeId 0x" ChipLogFormatX64 " vendorId 0x%04" PRIX16,
@@ -111,9 +110,9 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
     uint32_t fabricIndex = 0;
     for (auto & pairing : GetGlobalAdminPairingTable())
     {
-        NodeId nodeId     = pairing.GetNodeId();
-        uint64_t fabricId = pairing.GetFabricId();
-        uint16_t vendorId = pairing.GetVendorId();
+        NodeId nodeId               = pairing.GetNodeId();
+        uint64_t fabricId           = pairing.GetFabricId();
+        uint16_t vendorId           = pairing.GetVendorId();
         const uint8_t * fabricLabel = pairing.GetFabricLabel();
 
         // Skip over uninitialized admins
@@ -301,7 +300,7 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Co
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: UpdateFabricLabel");
 
-    EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     CHIP_ERROR err;
 
     // Fetch current fabric

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -89,7 +89,7 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, c
     fabricDescriptor.VendorId = vendorId;
     if (fabricLabel != nullptr)
     {
-        size_t lengthToStore = strnlen(Uint8::to_const_char(fabricLabel), kFabricLabelMaxLengthInBytes);
+        size_t lengthToStore   = strnlen(Uint8::to_const_char(fabricLabel), kFabricLabelMaxLengthInBytes);
         fabricDescriptor.Label = ByteSpan(fabricLabel, lengthToStore);
     }
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -35,6 +35,8 @@
 #include <support/ScopedBuffer.h>
 #include <support/logging/CHIPLogging.h>
 #include <transport/AdminPairingTable.h>
+#include <lib/core/CHIPSafeCasts.h>
+#include <string.h>
 
 using namespace chip;
 using namespace ::chip::DeviceLayer;
@@ -77,7 +79,7 @@ EmberAfStatus writeFabricAttribute(uint8_t * buffer, int32_t index = -1)
                                     index + 1);
 }
 
-EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, int32_t index)
+EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, const uint8_t * fabricLabel, int32_t index)
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -85,6 +87,12 @@ EmberAfStatus writeFabric(FabricId fabricId, NodeId nodeId, uint16_t vendorId, i
     fabricDescriptor.FabricId = fabricId;
     fabricDescriptor.NodeId   = nodeId;
     fabricDescriptor.VendorId = vendorId;
+    if (fabricLabel != nullptr) 
+    {
+        size_t lengthToStore = strnlen(Uint8::to_const_char(fabricLabel), kFabricLabelMaxLengthInBytes);
+        fabricDescriptor.Label = ByteSpan(fabricLabel, lengthToStore);
+    }
+    
 
     emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                    "OpCreds: Writing admin into attribute store at index %d: fabricId 0x" ChipLogFormatX64
@@ -106,6 +114,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
         NodeId nodeId     = pairing.GetNodeId();
         uint64_t fabricId = pairing.GetFabricId();
         uint16_t vendorId = pairing.GetVendorId();
+        const uint8_t * fabricLabel = pairing.GetFabricLabel();
 
         // Skip over uninitialized admins
         if (nodeId == kUndefinedNodeId || fabricId == kUndefinedFabricId || vendorId == kUndefinedVendorId)
@@ -116,7 +125,7 @@ CHIP_ERROR writeAdminsIntoFabricsListAttribute()
                            ChipLogValueX64(fabricId), ChipLogValueX64(nodeId), vendorId);
             continue;
         }
-        else if (writeFabric(fabricId, nodeId, vendorId, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
+        else if (writeFabric(fabricId, nodeId, vendorId, fabricLabel, fabricIndex) != EMBER_ZCL_STATUS_SUCCESS)
         {
             emberAfPrintln(EMBER_AF_PRINT_DEBUG,
                            "OpCreds: Failed to write admin with fabricId 0x" ChipLogFormatX64 " in fabrics list",
@@ -292,7 +301,23 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Co
 {
     emberAfPrintln(EMBER_AF_PRINT_DEBUG, "OpCreds: UpdateFabricLabel");
 
-    EmberAfStatus status = EMBER_ZCL_STATUS_FAILURE;
+    EmberAfStatus status   = EMBER_ZCL_STATUS_SUCCESS;
+    CHIP_ERROR err;
+
+    // Fetch current fabric
+    AdminPairingInfo * admin = retrieveCurrentAdmin();
+    VerifyOrExit(admin != nullptr, status = EMBER_ZCL_STATUS_FAILURE);
+
+    // Set Label on fabric
+    err = admin->SetFabricLabel(Label);
+    VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+
+    // Persist updated fabric
+    err = GetGlobalAdminPairingTable().Store(admin->GetAdminId());
+    VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+
+exit:
+    writeAdminsIntoFabricsListAttribute();
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/app/common/gen/af-structs.h
+++ b/src/app/common/gen/af-structs.h
@@ -219,6 +219,7 @@ typedef struct _FabricDescriptor
     chip::FabricId FabricId;
     uint16_t VendorId;
     chip::NodeId NodeId;
+    chip::ByteSpan Label;
 } EmberAfFabricDescriptor;
 
 // Struct for GpPairingConfigurationGroupList

--- a/src/app/zap-templates/zcl/custom-types.xml
+++ b/src/app/zap-templates/zcl/custom-types.xml
@@ -58,7 +58,7 @@ limitations under the License.
      <item name="FabricId" type="FABRIC_ID"/>
      <item name="VendorId" type="INT16U"/> // Change INT16U to new type VendorID #2395
      <item name="NodeId" type="NODE_ID"/>
-     // TODO: Add Label once CHAR_STRING or OCTET_STRING works
+     <item name="Label" type="OCTET_STRING" length="32"/>// TODO: Add Label once CHAR_STRING or OCTET_STRING works
    </struct>
    <struct name="TestListStructOctet">
      <item name="fabricIndex" type="INT64U"/>

--- a/src/controller/data_model/gen/CHIPClientCallbacks.cpp
+++ b/src/controller/data_model/gen/CHIPClientCallbacks.cpp
@@ -730,6 +730,9 @@ bool emberAfReadAttributesResponseCallback(ClusterId clusterId, uint8_t * messag
                             CHECK_MESSAGE_LENGTH(8);
                             data[i].NodeId = emberAfGetInt64u(message, 0, 8);
                             message += 8;
+                            CHECK_STATUS(ReadByteSpan(message, 34, &data[i].Label));
+                            messageLen -= 34;
+                            message += 34;
                         }
 
                         Callback::Callback<OperationalCredentialsFabricsListListAttributeCallback> * cb =

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Fabric/FabricUIViewController.m
@@ -244,6 +244,7 @@
 - (IBAction)removeAllFabricsButtonPressed:(id)sender
 {
     NSLog(@"Request to Remove All Fabrics.");
+    [self.removeFabricTextField resignFirstResponder];
     UIAlertController * alert =
         [UIAlertController alertControllerWithTitle:@"Remove All Fabrics?"
                                             message:@"Are you sure you want to remove all fabrics, this will remove all fabrics on "
@@ -280,6 +281,7 @@
 {
     NSString * label = _updateFabricLabelTextField.text;
     NSLog(@"Request to updateFabricLabel %@", label);
+    [self.updateFabricLabelTextField resignFirstResponder];
     [self updateResult:[NSString stringWithFormat:@"updateFabricLabel command sent."] isError:NO];
     [self.cluster
         updateFabricLabel:label
@@ -287,18 +289,20 @@
               dispatch_async(dispatch_get_main_queue(), ^{
                   if (error) {
                       NSLog(@"Got back error trying to updateFabricLabel %@", error);
-                      self->_updateFabricLabelTextField.text = @"";
                       dispatch_async(dispatch_get_main_queue(), ^{
+                          self->_updateFabricLabelTextField.text = @"";
                           [self updateResult:[NSString stringWithFormat:@"Command updateFabricLabel failed with error %@", error]
                                      isError:YES];
                       });
                   } else {
                       NSLog(@"Successfully updated the label: %@", values);
                       dispatch_async(dispatch_get_main_queue(), ^{
+                          self->_updateFabricLabelTextField.text = @"";
                           [self
                               updateResult:[NSString
                                                stringWithFormat:@"Command updateFabricLabel succeeded to update label to %@", label]
                                    isError:NO];
+                          [self fetchFabricsList];
                       });
                   }
               });

--- a/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
+++ b/src/darwin/Framework/CHIP/gen/CHIPClustersObjc.mm
@@ -3096,7 +3096,9 @@ public:
             for (uint16_t i = 0; i < count; i++) {
                 values[i] = [[NSDictionary alloc] initWithObjectsAndKeys:[NSNumber numberWithUnsignedLongLong:entries[i].FabricId],
                                                   @"FabricId", [NSNumber numberWithUnsignedShort:entries[i].VendorId], @"VendorId",
-                                                  [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId", nil];
+                                                  [NSNumber numberWithUnsignedLongLong:entries[i].NodeId], @"NodeId",
+                                                  [NSData dataWithBytes:entries[i].Label.data() length:entries[i].Label.size()],
+                                                  @"Label", nil];
             }
 
             id array = [NSArray arrayWithObjects:values count:count];

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -33,7 +33,7 @@ namespace Transport {
 CHIP_ERROR AdminPairingInfo::SetFabricLabel(const uint8_t * fabricLabel)
 {
     const char * charFabricLabel = Uint8::to_const_char(fabricLabel);
-    size_t stringLength = strnlen(charFabricLabel, kFabricLabelMaxLengthInBytes);
+    size_t stringLength          = strnlen(charFabricLabel, kFabricLabelMaxLengthInBytes);
     memcpy(mFabricLabel, charFabricLabel, stringLength);
     mFabricLabel[stringLength] = '\0'; // Set null terminator
 
@@ -42,59 +42,59 @@ CHIP_ERROR AdminPairingInfo::SetFabricLabel(const uint8_t * fabricLabel)
 
 CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
 {
-        CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
-        char key[KeySize()];
-        ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
+    char key[KeySize()];
+    ReturnErrorOnFailure(GenerateKey(mAdmin, key, sizeof(key)));
 
-        StorableAdminPairingInfo * info = chip::Platform::New<StorableAdminPairingInfo>();
-        ReturnErrorCodeIf(info == nullptr, CHIP_ERROR_NO_MEMORY);
+    StorableAdminPairingInfo * info = chip::Platform::New<StorableAdminPairingInfo>();
+    ReturnErrorCodeIf(info == nullptr, CHIP_ERROR_NO_MEMORY);
 
-        info->mNodeId   = Encoding::LittleEndian::HostSwap64(mNodeId);
-        info->mAdmin    = Encoding::LittleEndian::HostSwap16(mAdmin);
-        info->mFabricId = Encoding::LittleEndian::HostSwap64(mFabricId);
-        info->mVendorId = Encoding::LittleEndian::HostSwap16(mVendorId);
+    info->mNodeId   = Encoding::LittleEndian::HostSwap64(mNodeId);
+    info->mAdmin    = Encoding::LittleEndian::HostSwap16(mAdmin);
+    info->mFabricId = Encoding::LittleEndian::HostSwap64(mFabricId);
+    info->mVendorId = Encoding::LittleEndian::HostSwap16(mVendorId);
 
-        size_t stringLength = strnlen(mFabricLabel, kFabricLabelMaxLengthInBytes);
-        memcpy(info->mFabricLabel, mFabricLabel , stringLength);
-        info->mFabricLabel[stringLength] = '\0'; // Set null terminator
+    size_t stringLength = strnlen(mFabricLabel, kFabricLabelMaxLengthInBytes);
+    memcpy(info->mFabricLabel, mFabricLabel, stringLength);
+    info->mFabricLabel[stringLength] = '\0'; // Set null terminator
 
-        if (mOperationalKey != nullptr)
-        {
-            SuccessOrExit(err = mOperationalKey->Serialize(info->mOperationalKey));
-        }
-        else
-        {
-            P256Keypair keypair;
-            SuccessOrExit(err = keypair.Initialize());
-            SuccessOrExit(err = keypair.Serialize(info->mOperationalKey));
-        }
+    if (mOperationalKey != nullptr)
+    {
+        SuccessOrExit(err = mOperationalKey->Serialize(info->mOperationalKey));
+    }
+    else
+    {
+        P256Keypair keypair;
+        SuccessOrExit(err = keypair.Initialize());
+        SuccessOrExit(err = keypair.Serialize(info->mOperationalKey));
+    }
 
-        if (mRootCert == nullptr || mRootCertLen == 0)
-        {
-            info->mRootCertLen = 0;
-        }
-        else
-        {
-            info->mRootCertLen = Encoding::LittleEndian::HostSwap16(mRootCertLen);
-            memcpy(info->mRootCert, mRootCert, mRootCertLen);
-        }
+    if (mRootCert == nullptr || mRootCertLen == 0)
+    {
+        info->mRootCertLen = 0;
+    }
+    else
+    {
+        info->mRootCertLen = Encoding::LittleEndian::HostSwap16(mRootCertLen);
+        memcpy(info->mRootCert, mRootCert, mRootCertLen);
+    }
 
-        if (mOperationalCert == nullptr || mOpCertLen == 0)
-        {
-            info->mOpCertLen = 0;
-        }
-        else
-        {
-            info->mOpCertLen = Encoding::LittleEndian::HostSwap16(mOpCertLen);
-            memcpy(info->mOperationalCert, mOperationalCert, mOpCertLen);
-        }
+    if (mOperationalCert == nullptr || mOpCertLen == 0)
+    {
+        info->mOpCertLen = 0;
+    }
+    else
+    {
+        info->mOpCertLen = Encoding::LittleEndian::HostSwap16(mOpCertLen);
+        memcpy(info->mOperationalCert, mOperationalCert, mOpCertLen);
+    }
 
-        err = kvs->SyncSetKeyValue(key, info, sizeof(StorableAdminPairingInfo));
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue: %s", chip::ErrorStr(err));
-        }
+    err = kvs->SyncSetKeyValue(key, info, sizeof(StorableAdminPairingInfo));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue: %s", chip::ErrorStr(err));
+    }
 
 exit:
     if (info != nullptr)

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -29,12 +29,14 @@
 #include <support/DLLUtil.h>
 #include <support/Span.h>
 #include <transport/raw/MessageHeader.h>
+#include <lib/core/CHIPSafeCasts.h>
 
 namespace chip {
 namespace Transport {
 
 typedef uint16_t AdminId;
 static constexpr AdminId kUndefinedAdminId = UINT16_MAX;
+static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 
 // KVS store is sensitive to length of key strings, based on the underlying
 // platform. Keeping them short.
@@ -65,6 +67,12 @@ class DLL_EXPORT AdminPairingInfo
 {
 public:
     AdminPairingInfo() { Reset(); }
+    
+    // Returns a pointer to a null terminated char array
+    const uint8_t * GetFabricLabel() const { return Uint8::from_const_char(mFabricLabel); };
+
+    // Expects a pointer to a null terminated char array
+    CHIP_ERROR SetFabricLabel(const uint8_t * fabricLabel);
 
     ~AdminPairingInfo()
     {
@@ -133,6 +141,7 @@ public:
         mAdmin    = kUndefinedAdminId;
         mFabricId = kUndefinedFabricId;
         mVendorId = kUndefinedVendorId;
+        mFabricLabel[0] = '\0';
 
         if (mOperationalKey != nullptr)
         {
@@ -149,6 +158,7 @@ private:
     FabricId mFabricId = kUndefinedFabricId;
     AdminId mAdmin     = kUndefinedAdminId;
     uint16_t mVendorId = kUndefinedVendorId;
+    char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = {'\0'};
 
     AccessControlList mACL;
 
@@ -178,6 +188,8 @@ private:
         uint64_t mNodeId;   /* This field is serialized in LittleEndian byte order */
         uint64_t mFabricId; /* This field is serialized in LittleEndian byte order */
         uint16_t mVendorId; /* This field is serialized in LittleEndian byte order */
+
+        char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = {'\0'};
 
         uint16_t mRootCertLen; /* This field is serialized in LittleEndian byte order */
         uint16_t mOpCertLen;   /* This field is serialized in LittleEndian byte order */

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -25,17 +25,17 @@
 #include <core/CHIPPersistentStorageDelegate.h>
 #include <credentials/CHIPOperationalCredentials.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <support/CHIPMem.h>
 #include <support/DLLUtil.h>
 #include <support/Span.h>
 #include <transport/raw/MessageHeader.h>
-#include <lib/core/CHIPSafeCasts.h>
 
 namespace chip {
 namespace Transport {
 
 typedef uint16_t AdminId;
-static constexpr AdminId kUndefinedAdminId = UINT16_MAX;
+static constexpr AdminId kUndefinedAdminId            = UINT16_MAX;
 static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 
 // KVS store is sensitive to length of key strings, based on the underlying
@@ -137,10 +137,10 @@ public:
      */
     void Reset()
     {
-        mNodeId   = kUndefinedNodeId;
-        mAdmin    = kUndefinedAdminId;
-        mFabricId = kUndefinedFabricId;
-        mVendorId = kUndefinedVendorId;
+        mNodeId         = kUndefinedNodeId;
+        mAdmin          = kUndefinedAdminId;
+        mFabricId       = kUndefinedFabricId;
+        mVendorId       = kUndefinedVendorId;
         mFabricLabel[0] = '\0';
 
         if (mOperationalKey != nullptr)
@@ -154,11 +154,11 @@ public:
     friend class AdminPairingTable;
 
 private:
-    NodeId mNodeId     = kUndefinedNodeId;
-    FabricId mFabricId = kUndefinedFabricId;
-    AdminId mAdmin     = kUndefinedAdminId;
-    uint16_t mVendorId = kUndefinedVendorId;
-    char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = {'\0'};
+    NodeId mNodeId                                      = kUndefinedNodeId;
+    FabricId mFabricId                                  = kUndefinedFabricId;
+    AdminId mAdmin                                      = kUndefinedAdminId;
+    uint16_t mVendorId                                  = kUndefinedVendorId;
+    char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
 
     AccessControlList mACL;
 
@@ -189,7 +189,7 @@ private:
         uint64_t mFabricId; /* This field is serialized in LittleEndian byte order */
         uint16_t mVendorId; /* This field is serialized in LittleEndian byte order */
 
-        char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = {'\0'};
+        char mFabricLabel[kFabricLabelMaxLengthInBytes + 1] = { '\0' };
 
         uint16_t mRootCertLen; /* This field is serialized in LittleEndian byte order */
         uint16_t mOpCertLen;   /* This field is serialized in LittleEndian byte order */

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -67,7 +67,7 @@ class DLL_EXPORT AdminPairingInfo
 {
 public:
     AdminPairingInfo() { Reset(); }
-    
+
     // Returns a pointer to a null terminated char array
     const uint8_t * GetFabricLabel() const { return Uint8::from_const_char(mFabricLabel); };
 


### PR DESCRIPTION
Once  #6596 goes in, there will be OCTET_STRING support in lists. This means we can add support for Label in the Fabric Descriptor Struct. This PR:

- Adds Label to FabricDescriptor struct + regens files
- Adds fabric label to AdminPairingInfo with persistence support
- Hooks up UpdateFabricLabel to SetFabricLabel and writes the fabric label into the attribute list upon changes.

Added commit message:
Adds Label to the FabricDescriptorStruct and adopts it everywhere
    
    How was this tested? (at least one bullet point required)
    - Added UI in chiptool ios to test this and tested that the label can be modifiled, nulled out and persists after m5stack reboots