### PR TITLE
Add commissioning complete callback and timer.

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -197,6 +197,11 @@ enum PublicEventTypes
      * wifi/ethernet interface.
      */
     kInterfaceIpAddressChanged,
+
+    /**
+     * Commissioning has completed either through timer expiry or by a call to the general commissioning cluster command.
+     */
+    kCommissioningComplete,
 };
 
 /**
@@ -401,6 +406,11 @@ struct ChipDeviceEvent final
         {
             InterfaceIpChangeType Type;
         } InterfaceIpAddressChanged;
+
+        struct
+        {
+            CHIP_ERROR status;
+        } CommissioningComplete;
     };
 
     void Clear() { memset(this, 0, sizeof(*this)); }

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -49,6 +49,7 @@ class TraitManager;
 class ThreadStackManagerImpl;
 class TimeSyncManager;
 namespace Internal {
+class DeviceControlServer;
 class FabricProvisioningServer;
 class ServiceProvisioningServer;
 class BLEManagerImpl;
@@ -104,6 +105,7 @@ private:
     friend class TraitManager;
     friend class ThreadStackManagerImpl;
     friend class TimeSyncManager;
+    friend class Internal::DeviceControlServer;
     friend class Internal::FabricProvisioningServer;
     friend class Internal::ServiceProvisioningServer;
     friend class Internal::BLEManagerImpl;

--- a/src/include/platform/internal/DeviceControlServer.h
+++ b/src/include/platform/internal/DeviceControlServer.h
@@ -43,6 +43,8 @@ public:
 private:
     // ===== Members for internal use by the following friends.
     static DeviceControlServer sInstance;
+    friend void CommissioningTimerFunction(System::Layer * layer, void * aAppState, System::Error aError);
+    void CommissioningFailedTimerComplete(System::Error aErrror);
 
     // ===== Private members reserved for use by this class only.
 


### PR DESCRIPTION
Adds a timer to the arm failsafe call, and generates a device event
(kCommissioningComplete) when the commissioning complete call happens
or when the failsafe timer is triggered.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Arm failsafe and commissioning complete commands don't currently do anything.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Adds a timer to the arm failsafe call, and generates a device event
(kCommissioningComplete) when the commissioning complete call happens
or when the failsafe timer is triggered

 Fixes #6672
<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
