### PR TITLE
[Darwin] Add kSecAttrApplicationTag

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -55,6 +55,7 @@ private:
 
     const uint32_t kCertificateValiditySecs = 365 * 24 * 60 * 60;
     const NSString * kCHIPCAKeyLabel = @"chip.nodeopcerts.CA:0";
+    const NSData * kCHIPCAKeyTag = [@"com.zigbee.chip.commissioner.ca.issuer.id" dataUsingEncoding:NSUTF8StringEncoding];
 
     id mKeyType = (id) kSecAttrKeyTypeECSECPrimeRandom;
     id mKeySize = @256;

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -106,6 +106,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::LoadKeysFromKeyChain()
         (id) kSecAttrKeyType : mKeyType,
         (id) kSecAttrKeySizeInBits : mKeySize,
         (id) kSecAttrLabel : kCHIPCAKeyLabel,
+        (id) kSecAttrApplicationTag : kCHIPCAKeyTag,
         (id) kSecReturnRef : (id) kCFBooleanTrue
     };
 
@@ -131,6 +132,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
         (id) kSecAttrKeyType : mKeyType,
         (id) kSecAttrKeySizeInBits : mKeySize,
         (id) kSecAttrLabel : kCHIPCAKeyLabel,
+        (id) kSecAttrApplicationTag : kCHIPCAKeyTag,
     };
 
     status = SecKeyGeneratePair((__bridge CFDictionaryRef) keygenParams, &publicKey, &privateKey);
@@ -144,6 +146,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateKeys()
         (id) kSecAttrKeyType : mKeyType,
         (id) kSecAttrKeySizeInBits : mKeySize,
         (id) kSecAttrLabel : kCHIPCAKeyLabel,
+        (id) kSecAttrApplicationTag : kCHIPCAKeyTag,
         (id) kSecValueRef : (__bridge id) privateKey,
     };
 
@@ -168,6 +171,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::DeleteKeys()
         (id) kSecAttrKeyType : mKeyType,
         (id) kSecAttrKeySizeInBits : mKeySize,
         (id) kSecAttrLabel : kCHIPCAKeyLabel,
+        (id) kSecAttrApplicationTag : kCHIPCAKeyTag,
     };
 
     status = SecItemDelete((__bridge CFDictionaryRef) deleteParams);


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Without `kSecAttrApplicationTag`,  `SecItemDelete` fails to properly retrieve the key to delete on macOS.


 #### Summary of Changes
 * Add `kSecAttrApplicationTag`
