### PR TITLE
Fix rendezvous bypass mode

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -848,7 +848,31 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
 
     device->Serialize(serialized);
 
-    OnSessionEstablished();
+    err = mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(peerAddress), device->GetDeviceId(),
+                                  testSecurePairingSecret, SecureSession::SessionRole::kInitiator, mAdminId, nullptr);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        OnSessionEstablishmentError(err);
+    }
+    SuccessOrExit(err);
+
+    mPairedDevices.Insert(device->GetDeviceId());
+    mPairedDevicesUpdated = true;
+
+    // Note - This assumes storage is synchronous, the device must be in storage before we can cleanup
+    // the rendezvous session and mark pairing success
+    PersistDevice(device);
+    // Also persist the device list at this time
+    // This makes sure that a newly added device is immediately available
+    PersistDeviceList();
+
+    if (mPairingDelegate != nullptr)
+    {
+        mPairingDelegate->OnStatusUpdate(DevicePairingDelegate::SecurePairingSuccess);
+    }
+
+    RendezvousCleanup(CHIP_NO_ERROR);
 
 exit:
     if (testSecurePairingSecret != nullptr)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -829,6 +829,7 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
 
     SecurePairingUsingTestSecret * testSecurePairingSecret = nullptr;
 
+    // Check that the caller has provided an IP address (instead of a BLE peer address)
     VerifyOrExit(peerAddress.GetTransportType() == Transport::Type::kUdp, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(remoteDeviceId != kUndefinedNodeId && remoteDeviceId != kAnyNodeId, err = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -852,7 +853,7 @@ CHIP_ERROR DeviceCommissioner::PairTestDeviceWithoutSecurity(NodeId remoteDevice
                                   testSecurePairingSecret, SecureSession::SessionRole::kInitiator, mAdminId, nullptr);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
         OnSessionEstablishmentError(err);
     }
     SuccessOrExit(err);
@@ -991,7 +992,7 @@ void DeviceCommissioner::OnSessionEstablished()
                                 SecureSession::SessionRole::kInitiator, mAdminId, nullptr);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
         OnSessionEstablishmentError(err);
         return;
     }
@@ -1002,7 +1003,7 @@ void DeviceCommissioner::OnSessionEstablished()
     err = SendOperationalCertificateSigningRequestCommand(device->GetDeviceId());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Ble, "Failed in sending opcsr request command to the device: err %s", ErrorStr(err));
+        ChipLogError(Controller, "Failed in sending opcsr request command to the device: err %s", ErrorStr(err));
         OnSessionEstablishmentError(err);
         return;
     }


### PR DESCRIPTION
#### Problem
Rendezvous bypass mode is not working. It's failing in establishing the secure session.

 #### Summary of Changes
Recent controller changes mixed using test secret with non-test pairing. This change makes sure that the test secret is used for establishing the secure session when bypass mode is being used.

Fixes #6578
