### PR TITLE
Revert "[chip-tool] fix Thread operational dataset (#6627)" because it hand-edited generated files.

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -25,8 +25,6 @@
 #include "gen/CHIPClientCallbacks.h"
 #include "gen/CHIPClusters.h"
 #include <lib/core/CHIPSafeCasts.h>
-#include <lib/support/CHIPArgParser.hpp>
-#include <lib/support/ThreadOperationalDataset.h>
 
 static void OnDefaultSuccessResponse(void * context)
 {
@@ -9831,7 +9829,7 @@ class NetworkCommissioningAddThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningAddThreadNetwork() : ModelCommand("add-thread-network")
     {
-        AddArgument("operationalDataset", &mThreadOpDatasetArg);
+        AddArgument("operationalDataset", &mOperationalDataset);
         AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
         AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
@@ -9844,18 +9842,13 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        uint8_t opDataset[chip::Thread::kSizeOperationalDataset];
-        uint32_t opDatasetLen;
-
         ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x06) on endpoint %" PRIu16, endpointId);
-
-        chip::ArgParser::ParseHexString(mThreadOpDatasetArg, static_cast<uint32_t>(strlen(mThreadOpDatasetArg)), opDataset,
-                                        static_cast<uint32_t>(sizeof(opDataset)), opDatasetLen);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
         return cluster.AddThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                        chip::ByteSpan(opDataset, opDatasetLen), mBreadcrumb, mTimeoutMs);
+                                        chip::ByteSpan(chip::Uint8::from_char(mOperationalDataset), strlen(mOperationalDataset)),
+                                        mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -9864,7 +9857,7 @@ private:
             OnNetworkCommissioningClusterAddThreadNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mThreadOpDatasetArg;
+    char * mOperationalDataset;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };
@@ -10117,7 +10110,7 @@ class NetworkCommissioningUpdateThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningUpdateThreadNetwork() : ModelCommand("update-thread-network")
     {
-        AddArgument("operationalDataset", &mThreadOpDatasetArg);
+        AddArgument("operationalDataset", &mOperationalDataset);
         AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
         AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
@@ -10130,17 +10123,13 @@ public:
 
     CHIP_ERROR SendCommand(ChipDevice * device, uint8_t endpointId) override
     {
-        uint8_t opDataset[chip::Thread::kSizeOperationalDataset];
-        uint32_t opDatasetLen;
-
         ChipLogProgress(chipTool, "Sending cluster (0x0031) command (0x08) on endpoint %" PRIu16, endpointId);
 
         chip::Controller::NetworkCommissioningCluster cluster;
         cluster.Associate(device, endpointId);
-        chip::ArgParser::ParseHexString(mThreadOpDatasetArg, static_cast<uint32_t>(strlen(mThreadOpDatasetArg)), opDataset,
-                                        static_cast<uint32_t>(sizeof(opDataset)), opDatasetLen);
         return cluster.UpdateThreadNetwork(onSuccessCallback->Cancel(), onFailureCallback->Cancel(),
-                                           chip::ByteSpan(opDataset, opDatasetLen), mBreadcrumb, mTimeoutMs);
+                                           chip::ByteSpan(chip::Uint8::from_char(mOperationalDataset), strlen(mOperationalDataset)),
+                                           mBreadcrumb, mTimeoutMs);
     }
 
 private:
@@ -10149,7 +10138,7 @@ private:
             OnNetworkCommissioningClusterUpdateThreadNetworkResponse, this);
     chip::Callback::Callback<DefaultFailureCallback> * onFailureCallback =
         new chip::Callback::Callback<DefaultFailureCallback>(OnDefaultFailureResponse, this);
-    char * mThreadOpDatasetArg;
+    char * mOperationalDataset;
     uint64_t mBreadcrumb;
     uint32_t mTimeoutMs;
 };

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -22,7 +22,6 @@
 #include "../common/Command.h"
 #include "gen/CHIPClientCallbacks.h"
 #include "gen/CHIPClusters.h"
-#include <lib/support/ThreadOperationalDataset.h>
 
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 
@@ -62,7 +61,7 @@ public:
             AddArgument("password", &mPassword);
             break;
         case PairingNetworkType::Thread:
-            AddArgument("operationalDataset", &mThreadOpDatasetArg);
+            AddArgument("operationalDataset", &mOperationalDataset);
             break;
         }
 
@@ -136,8 +135,7 @@ private:
     uint64_t mFabricId;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
-    char * mThreadOpDatasetArg;
-    chip::Thread::OperationalDataset mThreadOpDataset;
+    char * mOperationalDataset;
     char * mSSID;
     char * mPassword;
 


### PR DESCRIPTION
This reverts commit 06d66a343b5daeed6419d4e199eab38b66221b38.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
https://github.com/project-chip/connectedhomeip/pull/6627 hand-edited generated files, so now whenever someone else changes ZAP anything and reruns codegen some (but not all) of the changes from that PR get reverted.  This is causing a bunch of friction for people trying to work on all sorts of things.

The right fix here is to change either the template or the non-generated code surrounding the generated bits or both (e.g. introduce a concept of "hex-encoded byte arg" explicitly as an arg type).

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Revert https://github.com/project-chip/connectedhomeip/pull/6627 for now.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
