### PR TITLE
ChipDeviceController: ERROR: AddressSanitizer: heap-buffer-overflow

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -565,7 +565,7 @@ CHIP_ERROR DeviceController::InitializePairedDeviceList()
     if (!mPairedDevicesInitialized)
     {
         constexpr uint16_t max_size = CHIP_MAX_SERIALIZED_SIZE_U64(kNumMaxPairedDevices);
-        buffer                      = static_cast<char *>(chip::Platform::MemoryAlloc(max_size));
+        buffer                      = static_cast<char *>(chip::Platform::MemoryCalloc(max_size, 1));
         uint16_t size               = max_size;
 
         VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
 #### Problem
```
==51543==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61a000000bd9 at pc 0x000108218634 bp 0x7ffee8389640 sp 0x7ffee8388e00
READ of size 1370 at 0x61a000000bd9 thread T0
    #0 0x108218633 in wrap_strlen+0x183 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1a633)
    #1 0x107ac73e3 in chip::Controller::DeviceController::SetPairedDeviceList(char const*) CHIPDeviceController.cpp:603
    #2 0x107ac4ade in chip::Controller::DeviceController::InitializePairedDeviceList() CHIPDeviceController.cpp:581
    #3 0x107ac3dfd in chip::Controller::DeviceController::GetDevice(unsigned long long, chip::Controller::Device**) CHIPDeviceController.cpp:347
    #4 0x10799c933 in Update::RunCommand(unsigned long long, unsigned long long) Commands.h:69
    #5 0x10789aeb8 in DiscoverCommand::Run(PersistentStorage&, unsigned long long, unsigned long long) DiscoverCommand.cpp:35
    #6 0x10788ac10 in Commands::RunCommand(PersistentStorage&, unsigned long long, unsigned long long, int, char**) Commands.cpp:128
    #7 0x107889aed in Commands::Run(unsigned long long, unsigned long long, int, char**) Commands.cpp:59
    #8 0x1078fbe9b in main main.cpp:41
    #9 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

0x61a000000bd9 is located 0 bytes to the right of 1369-byte region [0x61a000000680,0x61a000000bd9)
allocated by thread T0 here:
    #0 0x10824717d in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4917d)
    #1 0x107b193f0 in chip::Platform::MemoryAlloc(unsigned long) CHIPMem-Malloc.cpp:106
    #2 0x107ac483c in chip::Controller::DeviceController::InitializePairedDeviceList() CHIPDeviceController.cpp:568
    #3 0x107ac3dfd in chip::Controller::DeviceController::GetDevice(unsigned long long, chip::Controller::Device**) CHIPDeviceController.cpp:347
    #4 0x10799c933 in Update::RunCommand(unsigned long long, unsigned long long) Commands.h:69
    #5 0x10789aeb8 in DiscoverCommand::Run(PersistentStorage&, unsigned long long, unsigned long long) DiscoverCommand.cpp:35
    #6 0x10788ac10 in Commands::RunCommand(PersistentStorage&, unsigned long long, unsigned long long, int, char**) Commands.cpp:128
    #7 0x107889aed in Commands::Run(unsigned long long, unsigned long long, int, char**) Commands.cpp:59
    #8 0x1078fbe9b in main main.cpp:41
    #9 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x1a633) in wrap_strlen+0x183
Shadow bytes around the buggy address:
  0x1c3400000120: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400000130: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400000140: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400000150: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400000160: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x1c3400000170: 00 00 00 00 00 00 00 00 00 00 00[01]fa fa fa fa
  0x1c3400000180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400000190: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c34000001a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c34000001b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c34000001c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==51543==ABORTING
[5]    51543 abort      ./out/debug/standalone/chip-tool discover update 0 0
```


 #### Summary of Changes
 * Use `MemoryCalloc` instead `MemoryAlloc`