### PR TITLE
MdnsImpl.cpp: ERROR: AddressSanitizer: SEGV on unknown address

### DIFF
--- a/src/lib/mdns/Discovery_ImplPlatform.cpp
+++ b/src/lib/mdns/Discovery_ImplPlatform.cpp
@@ -379,6 +379,7 @@ CHIP_ERROR DiscoveryImplPlatform::Advertise(const OperationalAdvertisingParamete
     service.mTextEntrySize = textEntrySize;
     service.mInterface     = INET_NULL_INTERFACEID;
     service.mAddressType   = Inet::kIPAddressType_Any;
+    service.mSubTypeSize   = 0;
     error                  = ChipMdnsPublishService(&service);
 
     if (error == CHIP_NO_ERROR)


### PR DESCRIPTION

 #### Problem
 ```
[1620820107849] [0xdd513] CHIP: [DIS] Advertise operational node 0x0000000000000000-0x0000000000000000
[1620820107849] [0xdd513] CHIP: [ZCL] Type: _chip
[1620820107849] [0xdd513] CHIP: [ZCL] subtypeSize: 105965433134048
AddressSanitizer:DEADLYSIGNAL
=================================================================
==68006==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x000102a7e0fe bp 0x7ffeed295c50 sp 0x7ffeed2959e0 T0)
==68006==The signal is caused by a READ memory access.
==68006==Hint: this fault was caused by a dereference of a high value address (see register values below).  Dissassemble the provided pc to learn which register was used.
    #0 0x102a7e0fe in (anonymous namespace)::GetFullTypeWithSubTypes(char const*, chip::Mdns::MdnsServiceProtocol, char const**, unsigned long) MdnsImpl.cpp:67
    #1 0x102a7db5f in chip::Mdns::ChipMdnsPublishService(chip::Mdns::MdnsService const*) MdnsImpl.cpp:508
    #2 0x102a4cdb4 in chip::Mdns::DiscoveryImplPlatform::Advertise(chip::Mdns::OperationalAdvertisingParameters const&) Discovery_ImplPlatform.cpp:383
    #3 0x102acde83 in chip::app::Mdns::AdvertiseOperational() Mdns.cpp:115
    #4 0x102ad3f79 in chip::app::Mdns::StartServer() Mdns.cpp:253
    #5 0x102ae8fb0 in InitServer(AppDelegate*) Server.cpp:551
    #6 0x1029ee9cc in ChipLinuxAppMainLoop() AppMain.cpp:114
    #7 0x10296dfb8 in main main.cpp:58
    #8 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

==68006==Register values:
rax = 0x0100000102b4fc00  rbx = 0x00007ffeed295b60  rcx = 0x0000000000000000  rdx = 0x0020100020569f80  
rdi = 0x00001fffdda52a80  rsi = 0x0000100000000000  rbp = 0x00007ffeed295c50  rsp = 0x00007ffeed2959e0  
 r8 = 0x00000000000130a8   r9 = 0x0000000000000000  r10 = 0x00007fff932a5c38  r11 = 0x0000000000000000  
r12 = 0x00001fffdda52bd0  r13 = 0x0000000102b4d780  r14 = 0x00007ffeed295c80  r15 = 0x00007ffeed296090  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV MdnsImpl.cpp:67 in (anonymous namespace)::GetFullTypeWithSubTypes(char const*, chip::Mdns::MdnsServiceProtocol, char const**, unsigned long)
==68006==ABORTING
```

 #### Summary of Changes
  * Initialize `mSubTypeSize` to `0`