### PR TITLE
Build is failing on Darwin

### DIFF
--- a/src/include/platform/LockTracker.h
+++ b/src/include/platform/LockTracker.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#if CHIP_HAVE_CONFIG_H
 #include <platform/CHIPDeviceBuildConfig.h>
+#endif
 
 /// Defines support for asserting that the chip stack is locked by the current thread via
 /// the macro:


### PR DESCRIPTION
#### Problem
The gn_build.sh is failing on Mac OS

#### Summary of Changes
- Updated the CHIPClustersObjc.mm file
- Updated the LockTracker.h file

#### Test
- Used the `./gn_build.sh ` to verify the building is successful 
