### PR TITLE
CHIPDevice: ERROR: AddressSanitizer: heap-use-after-free

### DIFF
--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -324,6 +324,14 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = nullptr;
 #endif
+        if (mExchangeMgr)
+        {
+            // Ensure that any exchange contexts we have open get closed now,
+            // because we don't want them to call back in to us after this
+            // point.
+            mExchangeMgr->CloseAllContextsForDelegate(this);
+        }
+        mExchangeMgr = nullptr;
     }
 
     NodeId GetDeviceId() const { return mDeviceId; }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -262,6 +262,8 @@ CHIP_ERROR DeviceController::Shutdown()
     mInetLayer       = nullptr;
     mStorageDelegate = nullptr;
 
+    ReleaseAllDevices();
+
     if (mMessageCounterManager != nullptr)
     {
         chip::Platform::Delete(mMessageCounterManager);
@@ -302,7 +304,6 @@ CHIP_ERROR DeviceController::Shutdown()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_MDNS
 
-    ReleaseAllDevices();
     return CHIP_NO_ERROR;
 }
 
@@ -735,6 +736,8 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogDetail(Controller, "Shutting down the commissioner");
+
+    mPairingSession.Clear();
 
     PersistDeviceList();
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

```
==82183==ERROR: AddressSanitizer: heap-use-after-free on address 0x61a00000029c at pc 0x000104aa0abd bp 0x7ffeeb416ee0 sp 0x7ffeeb416ed8
READ of size 4 at 0x61a00000029c thread T0
    #0 0x104aa0abc in chip::ReferenceCounted<chip::Messaging::ExchangeContext, chip::Messaging::ExchangeContextDeletor, 0>::GetReferenceCount() const ReferenceCounted.h:77
    #1 0x104aaa7bb in chip::Messaging::ExchangeManager::CloseAllContextsForDelegate(chip::Messaging::ExchangeDelegateBase const*) ExchangeMgr.cpp:396
    #2 0x104811913 in chip::Controller::Device::~Device() CHIPDevice.h:93
    #3 0x1048117b4 in chip::Controller::Device::~Device() CHIPDevice.h:87
    #4 0x104811706 in chip::Controller::DeviceController::~DeviceController() CHIPDeviceController.h:161
    #5 0x104870524 in chip::Controller::DeviceController::~DeviceController() CHIPDeviceController.h:161
    #6 0x1048704da in ModelCommand::~ModelCommand() ModelCommand.h:31
    #7 0x1048dcd12 in OnOffOn::~OnOffOn() Commands.h:10334
    #8 0x1048dc934 in OnOffOn::~OnOffOn() Commands.h:10331
    #9 0x1048dc95b in OnOffOn::~OnOffOn() Commands.h:10331
    #10 0x104802cc5 in std::__1::default_delete<Command>::operator()(Command*) const memory:2368
    #11 0x104802c1e in std::__1::unique_ptr<Command, std::__1::default_delete<Command> >::reset(Command*) memory:2623
    #12 0x104802b58 in std::__1::unique_ptr<Command, std::__1::default_delete<Command> >::~unique_ptr() memory:2577
    #13 0x1047fb164 in std::__1::unique_ptr<Command, std::__1::default_delete<Command> >::~unique_ptr() memory:2577
    #14 0x104807388 in std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > >::destroy(std::__1::unique_ptr<Command, std::__1::default_delete<Command> >*) memory:1936
    #15 0x10480735c in void std::__1::allocator_traits<std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::__destroy<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > >(std::__1::integral_constant<bool, true>, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > >&, std::__1::unique_ptr<Command, std::__1::default_delete<Command> >*) memory:1798
    #16 0x1048072c8 in void std::__1::allocator_traits<std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::destroy<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > >(std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > >&, std::__1::unique_ptr<Command, std::__1::default_delete<Command> >*) memory:1635
    #17 0x104807196 in std::__1::__vector_base<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::__destruct_at_end(std::__1::unique_ptr<Command, std::__1::default_delete<Command> >*) vector:426
    #18 0x10480708a in std::__1::__vector_base<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::clear() vector:369
    #19 0x104806d62 in std::__1::__vector_base<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::~__vector_base() vector:463
    #20 0x104806c47 in std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::~vector() vector:555
    #21 0x104806c14 in std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >::~vector() vector:550
    #22 0x104806be5 in std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >::~pair() utility:297
    #23 0x104806bb4 in std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >::~pair() utility:297
    #24 0x10486e8f8 in void std::__1::allocator_traits<std::__1::allocator<std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*> > >::__destroy<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > >(std::__1::integral_constant<bool, false>, std::__1::allocator<std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*> >&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >*) memory:1803
    #25 0x10486e7d8 in void std::__1::allocator_traits<std::__1::allocator<std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*> > >::destroy<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > >(std::__1::allocator<std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*> >&, std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >*) memory:1635
    #26 0x10486e651 in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1836
    #27 0x10486e61e in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1834
    #28 0x10486e61e in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1834
    #29 0x10486e5d5 in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1833
    #30 0x10486e61e in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1834
    #31 0x10486e61e in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::destroy(std::__1::__tree_node<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, void*>*) __tree:1834
    #32 0x10486e567 in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::~__tree() __tree:1824
    #33 0x10486e534 in std::__1::__tree<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::__map_value_compare<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, true>, std::__1::allocator<std::__1::__value_type<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::~__tree() __tree:1821
    #34 0x10486e514 in std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::~map() map:1090
    #35 0x10486e4f4 in std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > >, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::vector<std::__1::unique_ptr<Command, std::__1::default_delete<Command> >, std::__1::allocator<std::__1::unique_ptr<Command, std::__1::default_delete<Command> > > > > > >::~map() map:1088
    #36 0x10486e4d4 in Commands::~Commands() Commands.h:25
    #37 0x10486d834 in Commands::~Commands() Commands.h:25
    #38 0x10486d767 in main main.cpp:42
    #39 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

0x61a00000029c is located 540 bytes inside of 1360-byte region [0x61a000000080,0x61a0000005d0)
freed by thread T0 here:
    #0 0x1051fb2c6 in wrap_free+0xa6 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x492c6)
    #1 0x104a9e50e in chip::Platform::MemoryFree(void*) CHIPMem-Malloc.cpp:126
    #2 0x104a46a32 in void chip::Platform::Delete<chip::Messaging::ExchangeManager>(chip::Messaging::ExchangeManager*) CHIPMem.h:163
    #3 0x104a464b6 in chip::Controller::DeviceController::Shutdown() CHIPDeviceController.cpp:254
    #4 0x1047eb722 in ModelCommand::Run(PersistentStorage&, unsigned long long, unsigned long long) ModelCommand.cpp:71
    #5 0x1047fc4b0 in Commands::RunCommand(PersistentStorage&, unsigned long long, unsigned long long, int, char**) Commands.cpp:128
    #6 0x1047fb38d in Commands::Run(unsigned long long, unsigned long long, int, char**) Commands.cpp:59
    #7 0x10486d75b in main main.cpp:41
    #8 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

previously allocated by thread T0 here:
    #0 0x1051fb17d in wrap_malloc+0x9d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0x4917d)
    #1 0x104a9e390 in chip::Platform::MemoryAlloc(unsigned long) CHIPMem-Malloc.cpp:106
    #2 0x104a45da1 in chip::Messaging::ExchangeManager* chip::Platform::New<chip::Messaging::ExchangeManager>() CHIPMem.h:144
    #3 0x104a44c22 in chip::Controller::DeviceController::Init(unsigned long long, chip::Controller::ControllerInitParams) CHIPDeviceController.cpp:167
    #4 0x1047eb375 in ModelCommand::Run(PersistentStorage&, unsigned long long, unsigned long long) ModelCommand.cpp:53
    #5 0x1047fc4b0 in Commands::RunCommand(PersistentStorage&, unsigned long long, unsigned long long, int, char**) Commands.cpp:128
    #6 0x1047fb38d in Commands::Run(unsigned long long, unsigned long long, int, char**) Commands.cpp:59
    #7 0x10486d75b in main main.cpp:41
    #8 0x7fff6c7eecc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)

SUMMARY: AddressSanitizer: heap-use-after-free ReferenceCounted.h:77 in chip::ReferenceCounted<chip::Messaging::ExchangeContext, chip::Messaging::ExchangeContextDeletor, 0>::GetReferenceCount() const
Shadow bytes around the buggy address:
  0x1c3400000000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400000010: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000020: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000030: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000040: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x1c3400000050: fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000060: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000070: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c3400000090: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x1c34000000a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==82183==ABORTING
[8]    82183 abort      ./out/debug/standalone/chip-tool onoff on 1
```
 