### PR TITLE
[QPG6100] Enabling SRP support

### DIFF
--- a/examples/platform/qpg6100/project_include/OpenThreadConfig.h
+++ b/examples/platform/qpg6100/project_include/OpenThreadConfig.h
@@ -43,6 +43,9 @@
 #define OPENTHREAD_CONFIG_NCP_UART_ENABLE 1
 #define OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE 1
 
+#define OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE 1
+#define OPENTHREAD_CONFIG_ECDSA_ENABLE 1
+
 // Use the Qorvo-supplied default platform configuration for remainder
 // of OpenThread config options.
 //

--- a/src/platform/qpg6100/CHIPDevicePlatformConfig.h
+++ b/src/platform/qpg6100/CHIPDevicePlatformConfig.h
@@ -41,6 +41,10 @@
 #define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_INFO_EIDC_KEY 4
 #define CHIP_DEVICE_CONFIG_PERSISTED_STORAGE_DEBUG_EIDC_KEY 5
 
+#define CHIP_DEVICE_CONFIG_ENABLE_MDNS 1
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT 1
+#define CHIP_DEVICE_CONFIG_THREAD_SRP_MAX_SERVICES 1
+
 // ========== Platform-specific Configuration =========
 
 // These are configuration options that are unique to the platform.

--- a/src/platform/qpg6100/args.gni
+++ b/src/platform/qpg6100/args.gni
@@ -21,6 +21,7 @@ arm_platform_config = "${qpg6100_sdk_build_root}/qpg6100_arm.gni"
 mbedtls_target = "${qpg6100_sdk_build_root}:qpg6100_sdk"
 
 chip_device_platform = "qpg6100"
+chip_mdns = "platform"
 
 lwip_platform = "qpg6100"
 lwip_ipv6 = true


### PR DESCRIPTION
 #### Problem
SRP support required for DNS with Thread devices was not enabled yet in master for QPG6100.

 #### Summary of Changes
* Enable flags to add SRP support
* Update submodule to 
** add required OT SRP glue code + foresee NVM area
** add mbedTLS ECDSA support
