### PR TITLE
Fix potential deadlock in TestMdns

### DIFF
--- a/src/platform/tests/TestMdns.cpp
+++ b/src/platform/tests/TestMdns.cpp
@@ -137,7 +137,7 @@ int TestMdns()
             chip::DeviceLayer::SystemLayer.WakeSelect();
             chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-            // TODO: the above does not seem to actually reliably shut down the chip
+            // TODO: the above does not seem to actually reliably shut down the chip stack.
             // Program will abort with core because chip thread will still run.
             doneCondition.wait_for(lock, std::chrono::seconds(1));
             if (!done)


### PR DESCRIPTION
 #### Problem
if testmdns fails (e.g. avahi not running), the test will deadlock forever:
  - wait_for requires that lock is aquired when exiting
  - lock was set for the entire 'run main loop' which never finishes

 #### Summary of Changes
 
Narrow down the scope of the loops.
Add a start and done condition as separate tasks.
Attempt to cleanly shut down the chip stack on error (this does NOT work, however I was unable to debug as to why ... this test has logic flaws in terms of how the chip main loop is handled)