### PR TITLE
ESP32 - Fix compilation of temperature-measurement-app with automake

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/component.mk
+++ b/examples/temperature-measurement-app/esp32/main/component.mk
@@ -29,6 +29,7 @@ COMPONENT_SRCDIRS :=                                                            
   ../third_party/connectedhomeip/src/app/reporting                                \
   ../third_party/connectedhomeip/src/app/clusters/basic                           \
   ../third_party/connectedhomeip/src/app/clusters/bindings                        \
+  ../third_party/connectedhomeip/src/app/clusters/general-commissioning-server    \
   ../third_party/connectedhomeip/src/app/clusters/network-commissioning           \
   ../third_party/connectedhomeip/src/app/clusters/temperature-measurement-server  \
 


### PR DESCRIPTION

 #### Problem
temperature-measurement-app fails on ESP32 using automake

 #### Summary of Changes
Add entry of `general-commissioning-server` to example `component.mk` file