### PR TITLE
Refactor exchange usage in IM to improve cirque stability

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -36,7 +36,7 @@ OT_SIMULATION_CACHE="$CIRQUE_CACHE_PATH/ot-simulation.tgz"
 CIRQUE_TESTS=(
     "EchoTest"
     "MobileDeviceTest"
-    "InteractionModel"
+    "InteractionModelTest"
 )
 
 BOLD_GREEN_TEXT="\033[1;32m"

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR Command::Reset()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandList::Builder commandListBuilder;
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
 
     if (mCommandMessageBuf.IsNull())
     {
@@ -132,7 +132,7 @@ void Command::Shutdown()
     mCommandMessageWriter.Reset();
     mCommandMessageBuf = nullptr;
 
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
 
     mpExchangeMgr = nullptr;
     mpDelegate    = nullptr;
@@ -212,7 +212,7 @@ CHIP_ERROR Command::ConstructCommandPath(const CommandPathParams & aCommandPathP
     return commandPath.GetError();
 }
 
-CHIP_ERROR Command::ClearExistingExchangeContext()
+CHIP_ERROR Command::AbortExistingExchangeContext()
 {
     // Discard any existing exchange context. Effectively we can only have one Echo exchange with
     // a single node at any one time.

--- a/src/app/Command.cpp
+++ b/src/app/Command.cpp
@@ -37,7 +37,6 @@ CHIP_ERROR Command::Init(Messaging::ExchangeManager * apExchangeMgr, Interaction
     // Error if already initialized.
     VerifyOrExit(apExchangeMgr != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mpExchangeMgr == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mpExchangeCtx == nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     mpExchangeMgr = apExchangeMgr;
     mpDelegate    = apDelegate;

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -119,7 +119,7 @@ public:
     virtual CHIP_ERROR ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement) = 0;
 
 protected:
-    CHIP_ERROR ClearExistingExchangeContext();
+    CHIP_ERROR AbortExistingExchangeContext();
     void MoveToState(const CommandState aTargetState);
     CHIP_ERROR ProcessCommandMessage(System::PacketBufferHandle && payload, CommandRoleId aCommandRoleId);
     CHIP_ERROR ConstructCommandPath(const CommandPathParams & aCommandPathParams, CommandDataElement::Builder aCommandDataElement);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -83,7 +83,8 @@ void CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExchangeCon
 exit:
     ChipLogFunctError(err);
 
-    // We shall close the exchange instead of abort to allow the ExchangeMgr complete ack if there is any.
+    // Close the exchange cleanly so that the ExchangeManager will send an ack for the message we just received.
+    // This needs to be done before the Reset() call, because Reset() aborts mpExchangeCtx if its not null.
     mpExchangeCtx->Close();
     mpExchangeCtx = nullptr;
     Reset();

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
 
     // Discard any existing exchange context. Effectively we can only have one exchange per CommandSender
     // at any one time.
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
 
     // Create a new exchange context.
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
@@ -61,7 +61,7 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ClearExistingExchangeContext();
+        AbortExistingExchangeContext();
     }
     ChipLogFunctError(err);
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -39,7 +39,7 @@ CHIP_ERROR ReadClient::Init(Messaging::ExchangeManager * apExchangeMgr, Interact
     mpDelegate    = apDelegate;
     mState        = ClientState::Initialized;
 
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
 
 exit:
     ChipLogFunctError(err);
@@ -48,7 +48,7 @@ exit:
 
 void ReadClient::Shutdown()
 {
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
     mpExchangeMgr = nullptr;
     mpDelegate    = nullptr;
     MoveToState(ClientState::Uninitialized);
@@ -91,7 +91,7 @@ CHIP_ERROR ReadClient::SendReadRequest(NodeId aNodeId, Transport::AdminId aAdmin
 
     // Discard any existing exchange context. Effectively we can only have one exchange per ReadClient
     // at any one time.
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
 
     {
         System::PacketBufferTLVWriter writer;
@@ -181,7 +181,7 @@ exit:
 
     if (err != CHIP_NO_ERROR)
     {
-        ClearExistingExchangeContext();
+        AbortExistingExchangeContext();
     }
 
     return err;
@@ -220,7 +220,7 @@ exit:
     return;
 }
 
-CHIP_ERROR ReadClient::ClearExistingExchangeContext()
+CHIP_ERROR ReadClient::AbortExistingExchangeContext()
 {
     if (mpExchangeCtx != nullptr)
     {
@@ -315,7 +315,7 @@ void ReadClient::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContex
 {
     ChipLogProgress(DataManagement, "Time out! failed to receive report data from Exchange: %d",
                     apExchangeContext->GetExchangeId());
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
     MoveToState(ClientState::Initialized);
     if (nullptr != mpDelegate)
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -200,7 +200,7 @@ void ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchangeContex
 exit:
     ChipLogFunctError(err);
 
-    // We shall close the exchange instead of abort to allow the ExchangeMgr complete ack if there is any.
+    // Close the exchange cleanly so that the ExchangeManager will send an ack for the message we just received.
     mpExchangeCtx->Close();
     mpExchangeCtx = nullptr;
     MoveToState(ClientState::Initialized);

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -115,7 +115,7 @@ private:
 
     void MoveToState(const ClientState aTargetState);
     CHIP_ERROR ProcessReportData(System::PacketBufferHandle aPayload);
-    CHIP_ERROR ClearExistingExchangeContext();
+    CHIP_ERROR AbortExistingExchangeContext();
     const char * GetStateStr() const;
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -52,7 +52,7 @@ void ReadHandler::Shutdown()
 {
     InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpAttributeClusterInfoList);
     InteractionModelEngine::GetInstance()->ReleaseClusterInfoList(mpEventClusterInfoList);
-    ClearExistingExchangeContext();
+    AbortExistingExchangeContext();
     MoveToState(HandlerState::Uninitialized);
     mpDelegate                 = nullptr;
     mpAttributeClusterInfoList = nullptr;
@@ -60,7 +60,7 @@ void ReadHandler::Shutdown()
     mCurrentPriority           = PriorityLevel::Invalid;
 }
 
-CHIP_ERROR ReadHandler::ClearExistingExchangeContext()
+CHIP_ERROR ReadHandler::AbortExistingExchangeContext()
 {
     if (mpExchangeCtx != nullptr)
     {

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -128,7 +128,7 @@ private:
     void MoveToState(const HandlerState aTargetState);
 
     const char * GetStateStr() const;
-    CHIP_ERROR ClearExistingExchangeContext();
+    CHIP_ERROR AbortExistingExchangeContext();
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     InteractionModelDelegate * mpDelegate      = nullptr;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Currently, Interaction Model does not use exchange properly to send/receive CHIP messages, this is one of reasons which cause Cirque CI flaky.

Exchange is used to represent a conversation defined in each protocol, it's life cycle is defined within protocol, Each protocol should specify the begin and end of each conversation represented by an exchange.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Discard any existing exchange context at the beginning of sending IM request message. This is the start of IM conversation, we should create an new exchange for this conversation.

2. We should abort the exchange if failed to send IM request message.

3. We should use close instead of abort after receiving the IM response message, which the ExchangeMgr to handle the remaining CRMP activities if there is any.

4. ReadClient/CommandSender should only have one exchange for one conversation at any time, we should create another  ReadClient/CommandSender instance if we want to send another IM command in parallel.   

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
