### PR TITLE
Enable -Werror in Darwin CI

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -46,7 +46,23 @@ jobs:
               run: xcodebuild clean
               working-directory: src/darwin/Framework
             - name: Run macOS Build
-              run: xcodebuild -target "CHIP" -sdk macosx
+              # Enable -Werror by hand here, because the Xcode config can't
+              # enable it for various reasons.  Keep whatever Xcode settings
+              # for OTHER_CFLAGS exist by using ${inherited}.
+              #
+              # Disable -Wdocumentation because so much of our doxygen is so
+              # broken.  See https://github.com/project-chip/connectedhomeip/issues/6734
+              #
+              # Disable -Wconditional-uninitialized because the generated IM TLV
+              # code hits this all over the place.
+              #
+              # Disable -Wmacro-redefined because CHIP_DEVICE_CONFIG_ENABLE_MDNS
+              # seems to be unconditionally defined in CHIPDeviceBuildConfig.h,
+              # which is apparently being included after CHIPDeviceConfig.h.
+              #
+              # Disable -Wdeprecated-declarations because we use deprecated
+              # things like PairTestDeviceWithoutSecurity.
+              run: xcodebuild -target "CHIP" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wno-documentation -Wno-conditional-uninitialized -Wno-macro-redefined -Wno-deprecated-declarations'
               working-directory: src/darwin/Framework
             - name: Clean Build
               run: xcodebuild clean


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Darwin CI does not use `-Werror`

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Enable it.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
