### PR TITLE
Fix darwin warnings due to invalid doxygen syntax

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback-stub.cpp
@@ -528,7 +528,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/all-clusters-app/all-clusters-common/gen/callback.h
+++ b/examples/all-clusters-app/all-clusters-common/gen/callback.h
@@ -2168,7 +2168,6 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief Barrier Control Cluster BarrierControlGoToPercent Command callback
- * @param percentOpen
  */
 
 bool emberAfBarrierControlClusterBarrierControlGoToPercentCallback(chip::app::Command * commandObj, uint8_t percentOpen);
@@ -2187,10 +2186,6 @@ bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::Command * commandObj)
 
 /**
  * @brief Binding Cluster Bind Command callback
- * @param nodeId
- * @param groupId
- * @param endpointId
- * @param clusterId
  */
 
 bool emberAfBindingClusterBindCallback(chip::app::Command * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
@@ -2198,10 +2193,6 @@ bool emberAfBindingClusterBindCallback(chip::app::Command * commandObj, chip::No
 
 /**
  * @brief Binding Cluster Unbind Command callback
- * @param nodeId
- * @param groupId
- * @param endpointId
- * @param clusterId
  */
 
 bool emberAfBindingClusterUnbindCallback(chip::app::Command * commandObj, chip::NodeId nodeId, chip::GroupId groupId,
@@ -2209,10 +2200,6 @@ bool emberAfBindingClusterUnbindCallback(chip::app::Command * commandObj, chip::
 
 /**
  * @brief Color Control Cluster MoveColor Command callback
- * @param rateX
- * @param rateY
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveColorCallback(chip::app::Command * commandObj, int16_t rateX, int16_t rateY, uint8_t optionsMask,
@@ -2220,12 +2207,6 @@ bool emberAfColorControlClusterMoveColorCallback(chip::app::Command * commandObj
 
 /**
  * @brief Color Control Cluster MoveColorTemperature Command callback
- * @param moveMode
- * @param rate
- * @param colorTemperatureMinimum
- * @param colorTemperatureMaximum
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::Command * commandObj, uint8_t moveMode, uint16_t rate,
@@ -2234,10 +2215,6 @@ bool emberAfColorControlClusterMoveColorTemperatureCallback(chip::app::Command *
 
 /**
  * @brief Color Control Cluster MoveHue Command callback
- * @param moveMode
- * @param rate
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveHueCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
@@ -2245,10 +2222,6 @@ bool emberAfColorControlClusterMoveHueCallback(chip::app::Command * commandObj, 
 
 /**
  * @brief Color Control Cluster MoveSaturation Command callback
- * @param moveMode
- * @param rate
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveSaturationCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate,
@@ -2256,11 +2229,6 @@ bool emberAfColorControlClusterMoveSaturationCallback(chip::app::Command * comma
 
 /**
  * @brief Color Control Cluster MoveToColor Command callback
- * @param colorX
- * @param colorY
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveToColorCallback(chip::app::Command * commandObj, uint16_t colorX, uint16_t colorY,
@@ -2268,10 +2236,6 @@ bool emberAfColorControlClusterMoveToColorCallback(chip::app::Command * commandO
 
 /**
  * @brief Color Control Cluster MoveToColorTemperature Command callback
- * @param colorTemperature
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::Command * commandObj, uint16_t colorTemperature,
@@ -2280,11 +2244,6 @@ bool emberAfColorControlClusterMoveToColorTemperatureCallback(chip::app::Command
 
 /**
  * @brief Color Control Cluster MoveToHue Command callback
- * @param hue
- * @param direction
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveToHueCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t direction,
@@ -2292,11 +2251,6 @@ bool emberAfColorControlClusterMoveToHueCallback(chip::app::Command * commandObj
 
 /**
  * @brief Color Control Cluster MoveToHueAndSaturation Command callback
- * @param hue
- * @param saturation
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::Command * commandObj, uint8_t hue, uint8_t saturation,
@@ -2305,10 +2259,6 @@ bool emberAfColorControlClusterMoveToHueAndSaturationCallback(chip::app::Command
 
 /**
  * @brief Color Control Cluster MoveToSaturation Command callback
- * @param saturation
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::Command * commandObj, uint8_t saturation,
@@ -2316,11 +2266,6 @@ bool emberAfColorControlClusterMoveToSaturationCallback(chip::app::Command * com
 
 /**
  * @brief Color Control Cluster StepColor Command callback
- * @param stepX
- * @param stepY
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterStepColorCallback(chip::app::Command * commandObj, int16_t stepX, int16_t stepY,
@@ -2328,13 +2273,6 @@ bool emberAfColorControlClusterStepColorCallback(chip::app::Command * commandObj
 
 /**
  * @brief Color Control Cluster StepColorTemperature Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param colorTemperatureMinimum
- * @param colorTemperatureMaximum
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::Command * commandObj, uint8_t stepMode, uint16_t stepSize,
@@ -2344,11 +2282,6 @@ bool emberAfColorControlClusterStepColorTemperatureCallback(chip::app::Command *
 
 /**
  * @brief Color Control Cluster StepHue Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterStepHueCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -2356,11 +2289,6 @@ bool emberAfColorControlClusterStepHueCallback(chip::app::Command * commandObj, 
 
 /**
  * @brief Color Control Cluster StepSaturation Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterStepSaturationCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -2368,8 +2296,6 @@ bool emberAfColorControlClusterStepSaturationCallback(chip::app::Command * comma
 
 /**
  * @brief Color Control Cluster StopMoveStep Command callback
- * @param optionsMask
- * @param optionsOverride
  */
 
 bool emberAfColorControlClusterStopMoveStepCallback(chip::app::Command * commandObj, uint8_t optionsMask, uint8_t optionsOverride);
@@ -2388,105 +2314,84 @@ bool emberAfDoorLockClusterClearAllRfidsCallback(chip::app::Command * commandObj
 
 /**
  * @brief Door Lock Cluster ClearHolidaySchedule Command callback
- * @param scheduleId
  */
 
 bool emberAfDoorLockClusterClearHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId);
 
 /**
  * @brief Door Lock Cluster ClearPin Command callback
- * @param userId
  */
 
 bool emberAfDoorLockClusterClearPinCallback(chip::app::Command * commandObj, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster ClearRfid Command callback
- * @param userId
  */
 
 bool emberAfDoorLockClusterClearRfidCallback(chip::app::Command * commandObj, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster ClearWeekdaySchedule Command callback
- * @param scheduleId
- * @param userId
  */
 
 bool emberAfDoorLockClusterClearWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster ClearYeardaySchedule Command callback
- * @param scheduleId
- * @param userId
  */
 
 bool emberAfDoorLockClusterClearYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster GetHolidaySchedule Command callback
- * @param scheduleId
  */
 
 bool emberAfDoorLockClusterGetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId);
 
 /**
  * @brief Door Lock Cluster GetLogRecord Command callback
- * @param logIndex
  */
 
 bool emberAfDoorLockClusterGetLogRecordCallback(chip::app::Command * commandObj, uint16_t logIndex);
 
 /**
  * @brief Door Lock Cluster GetPin Command callback
- * @param userId
  */
 
 bool emberAfDoorLockClusterGetPinCallback(chip::app::Command * commandObj, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster GetRfid Command callback
- * @param userId
  */
 
 bool emberAfDoorLockClusterGetRfidCallback(chip::app::Command * commandObj, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster GetUserType Command callback
- * @param userId
  */
 
 bool emberAfDoorLockClusterGetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster GetWeekdaySchedule Command callback
- * @param scheduleId
- * @param userId
  */
 
 bool emberAfDoorLockClusterGetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster GetYeardaySchedule Command callback
- * @param scheduleId
- * @param userId
  */
 
 bool emberAfDoorLockClusterGetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId);
 
 /**
  * @brief Door Lock Cluster LockDoor Command callback
- * @param pin
  */
 
 bool emberAfDoorLockClusterLockDoorCallback(chip::app::Command * commandObj, uint8_t * PIN);
 
 /**
  * @brief Door Lock Cluster SetHolidaySchedule Command callback
- * @param scheduleId
- * @param localStartTime
- * @param localEndTime
- * @param operatingModeDuringHoliday
  */
 
 bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint32_t localStartTime,
@@ -2494,10 +2399,6 @@ bool emberAfDoorLockClusterSetHolidayScheduleCallback(chip::app::Command * comma
 
 /**
  * @brief Door Lock Cluster SetPin Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param pin
  */
 
 bool emberAfDoorLockClusterSetPinCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
@@ -2505,10 +2406,6 @@ bool emberAfDoorLockClusterSetPinCallback(chip::app::Command * commandObj, uint1
 
 /**
  * @brief Door Lock Cluster SetRfid Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param id
  */
 
 bool emberAfDoorLockClusterSetRfidCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus, uint8_t userType,
@@ -2516,21 +2413,12 @@ bool emberAfDoorLockClusterSetRfidCallback(chip::app::Command * commandObj, uint
 
 /**
  * @brief Door Lock Cluster SetUserType Command callback
- * @param userId
- * @param userType
  */
 
 bool emberAfDoorLockClusterSetUserTypeCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
 
 /**
  * @brief Door Lock Cluster SetWeekdaySchedule Command callback
- * @param scheduleId
- * @param userId
- * @param daysMask
- * @param startHour
- * @param startMinute
- * @param endHour
- * @param endMinute
  */
 
 bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2539,10 +2427,6 @@ bool emberAfDoorLockClusterSetWeekdayScheduleCallback(chip::app::Command * comma
 
 /**
  * @brief Door Lock Cluster SetYeardaySchedule Command callback
- * @param scheduleId
- * @param userId
- * @param localStartTime
- * @param localEndTime
  */
 
 bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2550,24 +2434,18 @@ bool emberAfDoorLockClusterSetYeardayScheduleCallback(chip::app::Command * comma
 
 /**
  * @brief Door Lock Cluster UnlockDoor Command callback
- * @param pin
  */
 
 bool emberAfDoorLockClusterUnlockDoorCallback(chip::app::Command * commandObj, uint8_t * PIN);
 
 /**
  * @brief Door Lock Cluster UnlockWithTimeout Command callback
- * @param timeoutInSeconds
- * @param pin
  */
 
 bool emberAfDoorLockClusterUnlockWithTimeoutCallback(chip::app::Command * commandObj, uint16_t timeoutInSeconds, uint8_t * pin);
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -2581,10 +2459,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -2592,24 +2466,18 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Groups Cluster AddGroup Command callback
- * @param groupId
- * @param groupName
  */
 
 bool emberAfGroupsClusterAddGroupCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t * groupName);
 
 /**
  * @brief Groups Cluster AddGroupIfIdentifying Command callback
- * @param groupId
- * @param groupName
  */
 
 bool emberAfGroupsClusterAddGroupIfIdentifyingCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t * groupName);
 
 /**
  * @brief Groups Cluster GetGroupMembership Command callback
- * @param groupCount
- * @param groupList
  */
 
 bool emberAfGroupsClusterGetGroupMembershipCallback(chip::app::Command * commandObj, uint8_t groupCount,
@@ -2623,29 +2491,24 @@ bool emberAfGroupsClusterRemoveAllGroupsCallback(chip::app::Command * commandObj
 
 /**
  * @brief Groups Cluster RemoveGroup Command callback
- * @param groupId
  */
 
 bool emberAfGroupsClusterRemoveGroupCallback(chip::app::Command * commandObj, uint16_t groupId);
 
 /**
  * @brief Groups Cluster ViewGroup Command callback
- * @param groupId
  */
 
 bool emberAfGroupsClusterViewGroupCallback(chip::app::Command * commandObj, uint16_t groupId);
 
 /**
  * @brief IAS Zone Cluster ZoneEnrollResponse Command callback
- * @param enrollResponseCode
- * @param zoneId
  */
 
 bool emberAfIasZoneClusterZoneEnrollResponseCallback(chip::app::Command * commandObj, uint8_t enrollResponseCode, uint8_t zoneId);
 
 /**
  * @brief Identify Cluster Identify Command callback
- * @param identifyTime
  */
 
 bool emberAfIdentifyClusterIdentifyCallback(chip::app::Command * commandObj, uint16_t identifyTime);
@@ -2658,10 +2521,6 @@ bool emberAfIdentifyClusterIdentifyQueryCallback(chip::app::Command * commandObj
 
 /**
  * @brief Level Control Cluster Move Command callback
- * @param moveMode
- * @param rate
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
@@ -2669,10 +2528,6 @@ bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster MoveToLevel Command callback
- * @param level
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
@@ -2680,8 +2535,6 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandO
 
 /**
  * @brief Level Control Cluster MoveToLevelWithOnOff Command callback
- * @param level
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level,
@@ -2689,19 +2542,12 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command *
 
 /**
  * @brief Level Control Cluster MoveWithOnOff Command callback
- * @param moveMode
- * @param rate
  */
 
 bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate);
 
 /**
  * @brief Level Control Cluster Step Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -2709,9 +2555,6 @@ bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster StepWithOnOff Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -2719,8 +2562,6 @@ bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Level Control Cluster Stop Command callback
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride);
@@ -2739,9 +2580,6 @@ bool emberAfLowPowerClusterSleepCallback(chip::app::Command * commandObj);
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -2749,10 +2587,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -2760,9 +2594,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -2770,9 +2601,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -2780,7 +2608,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -2788,9 +2615,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -2798,9 +2622,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -2808,9 +2629,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -2819,10 +2637,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -2831,8 +2645,6 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Comm
 
 /**
  * @brief OTA Software Update Server Cluster ApplyUpdateRequest Command callback
- * @param updateToken
- * @param newVersion
  */
 
 bool emberAfOtaSoftwareUpdateServerClusterApplyUpdateRequestCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
@@ -2840,8 +2652,6 @@ bool emberAfOtaSoftwareUpdateServerClusterApplyUpdateRequestCallback(chip::app::
 
 /**
  * @brief OTA Software Update Server Cluster NotifyUpdateApplied Command callback
- * @param updateToken
- * @param currentVersion
  */
 
 bool emberAfOtaSoftwareUpdateServerClusterNotifyUpdateAppliedCallback(chip::app::Command * commandObj, chip::ByteSpan updateToken,
@@ -2849,15 +2659,6 @@ bool emberAfOtaSoftwareUpdateServerClusterNotifyUpdateAppliedCallback(chip::app:
 
 /**
  * @brief OTA Software Update Server Cluster QueryImage Command callback
- * @param vendorId
- * @param productId
- * @param imageType
- * @param hardwareVersion
- * @param currentVersion
- * @param protocolsSupported
- * @param location
- * @param clientCanConsent
- * @param metadataForServer
  */
 
 bool emberAfOtaSoftwareUpdateServerClusterQueryImageCallback(
@@ -2885,11 +2686,6 @@ bool emberAfOnOffClusterToggleCallback(chip::app::Command * commandObj);
 
 /**
  * @brief Operational Credentials Cluster AddOpCert Command callback
- * @param noc
- * @param iCACertificate
- * @param iPKValue
- * @param caseAdminNode
- * @param adminVendorId
  */
 
 bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::Command * commandObj, chip::ByteSpan NOC,
@@ -2898,7 +2694,6 @@ bool emberAfOperationalCredentialsClusterAddOpCertCallback(chip::app::Command * 
 
 /**
  * @brief Operational Credentials Cluster OpCSRRequest Command callback
- * @param cSRNonce
  */
 
 bool emberAfOperationalCredentialsClusterOpCSRRequestCallback(chip::app::Command * commandObj, chip::ByteSpan CSRNonce);
@@ -2911,9 +2706,6 @@ bool emberAfOperationalCredentialsClusterRemoveAllFabricsCallback(chip::app::Com
 
 /**
  * @brief Operational Credentials Cluster RemoveFabric Command callback
- * @param fabricId
- * @param nodeId
- * @param vendorId
  */
 
 bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::Command * commandObj, chip::FabricId FabricId,
@@ -2921,25 +2713,18 @@ bool emberAfOperationalCredentialsClusterRemoveFabricCallback(chip::app::Command
 
 /**
  * @brief Operational Credentials Cluster SetFabric Command callback
- * @param vendorId
  */
 
 bool emberAfOperationalCredentialsClusterSetFabricCallback(chip::app::Command * commandObj, uint16_t VendorId);
 
 /**
  * @brief Operational Credentials Cluster UpdateFabricLabel Command callback
- * @param label
  */
 
 bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(chip::app::Command * commandObj, uint8_t * Label);
 
 /**
  * @brief Scenes Cluster AddScene Command callback
- * @param groupId
- * @param sceneId
- * @param transitionTime
- * @param sceneName
- * @param extensionFieldSets
  */
 
 bool emberAfScenesClusterAddSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
@@ -2948,16 +2733,12 @@ bool emberAfScenesClusterAddSceneCallback(chip::app::Command * commandObj, uint1
 
 /**
  * @brief Scenes Cluster GetSceneMembership Command callback
- * @param groupId
  */
 
 bool emberAfScenesClusterGetSceneMembershipCallback(chip::app::Command * commandObj, uint16_t groupId);
 
 /**
  * @brief Scenes Cluster RecallScene Command callback
- * @param groupId
- * @param sceneId
- * @param transitionTime
  */
 
 bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId,
@@ -2965,31 +2746,24 @@ bool emberAfScenesClusterRecallSceneCallback(chip::app::Command * commandObj, ui
 
 /**
  * @brief Scenes Cluster RemoveAllScenes Command callback
- * @param groupId
  */
 
 bool emberAfScenesClusterRemoveAllScenesCallback(chip::app::Command * commandObj, uint16_t groupId);
 
 /**
  * @brief Scenes Cluster RemoveScene Command callback
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterRemoveSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
 
 /**
  * @brief Scenes Cluster StoreScene Command callback
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterStoreSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
 
 /**
  * @brief Scenes Cluster ViewScene Command callback
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterViewSceneCallback(chip::app::Command * commandObj, uint16_t groupId, uint8_t sceneId);
@@ -3014,7 +2788,6 @@ bool emberAfTestClusterClusterTestSpecificCallback(chip::app::Command * commandO
 
 /**
  * @brief Trusted Root Certificates Cluster AddTrustedRootCertificate Command callback
- * @param rootCertificate
  */
 
 bool emberAfTrustedRootCertificatesClusterAddTrustedRootCertificateCallback(chip::app::Command * commandObj,
@@ -3022,7 +2795,6 @@ bool emberAfTrustedRootCertificatesClusterAddTrustedRootCertificateCallback(chip
 
 /**
  * @brief Trusted Root Certificates Cluster RemoveTrustedRootCertificate Command callback
- * @param trustedRootIdentifier
  */
 
 bool emberAfTrustedRootCertificatesClusterRemoveTrustedRootCertificateCallback(chip::app::Command * commandObj,

--- a/examples/bridge-app/bridge-common/gen/callback-stub.cpp
+++ b/examples/bridge-app/bridge-common/gen/callback-stub.cpp
@@ -360,7 +360,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/bridge-app/bridge-common/gen/callback.h
+++ b/examples/bridge-app/bridge-common/gen/callback.h
@@ -514,9 +514,6 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -530,10 +527,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -541,10 +534,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Level Control Cluster Move Command callback
- * @param moveMode
- * @param rate
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
@@ -552,10 +541,6 @@ bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster MoveToLevel Command callback
- * @param level
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
@@ -563,8 +548,6 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandO
 
 /**
  * @brief Level Control Cluster MoveToLevelWithOnOff Command callback
- * @param level
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level,
@@ -572,19 +555,12 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command *
 
 /**
  * @brief Level Control Cluster MoveWithOnOff Command callback
- * @param moveMode
- * @param rate
  */
 
 bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate);
 
 /**
  * @brief Level Control Cluster Step Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -592,9 +568,6 @@ bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster StepWithOnOff Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -602,8 +575,6 @@ bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Level Control Cluster Stop Command callback
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride);
@@ -616,9 +587,6 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -626,10 +594,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -637,9 +601,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -647,9 +608,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -657,7 +615,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -665,9 +622,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -675,9 +629,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -685,9 +636,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -696,10 +644,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/chip-tool/gen/callback-stub.cpp
+++ b/examples/chip-tool/gen/callback-stub.cpp
@@ -568,7 +568,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/chip-tool/gen/callback.h
+++ b/examples/chip-tool/gen/callback.h
@@ -2552,23 +2552,18 @@ void emberAfWakeOnLanClusterClientTickCallback(chip::EndpointId endpoint);
 
 /**
  * @brief Account Login Cluster GetSetupPINResponse Command callback
- * @param setupPIN
  */
 
 bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::Command * commandObj, uint8_t * setupPIN);
 
 /**
  * @brief Application Launcher Cluster LaunchAppResponse Command callback
- * @param status
- * @param data
  */
 
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
 
 /**
  * @brief Content Launch Cluster LaunchContentResponse Command callback
- * @param data
- * @param contentLaunchStatus
  */
 
 bool emberAfContentLaunchClusterLaunchContentResponseCallback(chip::app::Command * commandObj, uint8_t * data,
@@ -2576,8 +2571,6 @@ bool emberAfContentLaunchClusterLaunchContentResponseCallback(chip::app::Command
 
 /**
  * @brief Content Launch Cluster LaunchURLResponse Command callback
- * @param data
- * @param contentLaunchStatus
  */
 
 bool emberAfContentLaunchClusterLaunchURLResponseCallback(chip::app::Command * commandObj, uint8_t * data,
@@ -2585,60 +2578,48 @@ bool emberAfContentLaunchClusterLaunchURLResponseCallback(chip::app::Command * c
 
 /**
  * @brief Door Lock Cluster ClearAllPinsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearAllRfidsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster GetHolidayScheduleResponse Command callback
- * @param scheduleId
- * @param status
- * @param localStartTime
- * @param localEndTime
- * @param operatingModeDuringHoliday
  */
 
 bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint8_t status,
@@ -2647,13 +2628,6 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetLogRecordResponse Command callback
- * @param logEntryId
- * @param timestamp
- * @param eventType
- * @param source
- * @param eventIdOrAlarmCode
- * @param userId
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * commandObj, uint16_t logEntryId, uint32_t timestamp,
@@ -2662,10 +2636,6 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * com
 
 /**
  * @brief Door Lock Cluster GetPinResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -2673,10 +2643,6 @@ bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Door Lock Cluster GetRfidResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param rfid
  */
 
 bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -2684,22 +2650,12 @@ bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Door Lock Cluster GetUserTypeResponse Command callback
- * @param userId
- * @param userType
  */
 
 bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
 
 /**
  * @brief Door Lock Cluster GetWeekdayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param daysMask
- * @param startHour
- * @param startMinute
- * @param endHour
- * @param endMinute
  */
 
 bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2708,11 +2664,6 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetYeardayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param localStartTime
- * @param localEndTime
  */
 
 bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2720,71 +2671,60 @@ bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster LockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetUserTypeResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockWithTimeoutResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief General Commissioning Cluster ArmFailSafeResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2792,8 +2732,6 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Co
 
 /**
  * @brief General Commissioning Cluster CommissioningCompleteResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2801,8 +2739,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chi
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfigResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2810,17 +2746,12 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip:
 
 /**
  * @brief Groups Cluster AddGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster GetGroupMembershipResponse Command callback
- * @param capacity
- * @param groupCount
- * @param groupList
  */
 
 bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
@@ -2828,17 +2759,12 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Groups Cluster RemoveGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster ViewGroupResponse Command callback
- * @param status
- * @param groupId
- * @param groupName
  */
 
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2846,99 +2772,84 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Identify Cluster IdentifyQueryResponse Command callback
- * @param timeout
  */
 
 bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout);
 
 /**
  * @brief Keypad Input Cluster SendKeyResponse Command callback
- * @param status
  */
 
 bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Media Playback Cluster MediaFastForwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaNextResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPauseResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPlayResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPreviousResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaRewindResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipBackwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipForwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipSeekResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipSeekResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaStartOverResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaStopResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2946,8 +2857,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::ap
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2955,8 +2864,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster DisableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2964,8 +2871,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster EnableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2973,8 +2878,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster RemoveNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2982,10 +2885,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster ScanNetworksResponse Command callback
- * @param errorCode
- * @param debugText
- * @param wifiScanResults
- * @param threadScanResults
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
@@ -2995,8 +2894,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3004,8 +2901,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip:
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3013,16 +2908,12 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::a
 
 /**
  * @brief Operational Credentials Cluster SetFabricResponse Command callback
- * @param fabricId
  */
 
 bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Command * commandObj, chip::FabricId FabricId);
 
 /**
  * @brief Scenes Cluster AddSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3030,11 +2921,6 @@ bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Scenes Cluster GetSceneMembershipResponse Command callback
- * @param status
- * @param capacity
- * @param groupId
- * @param sceneCount
- * @param sceneList
  */
 
 bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
@@ -3043,17 +2929,12 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Scenes Cluster RemoveAllScenesResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Scenes Cluster RemoveSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3061,9 +2942,6 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * comman
 
 /**
  * @brief Scenes Cluster StoreSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3071,12 +2949,6 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * command
 
 /**
  * @brief Scenes Cluster ViewSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
- * @param transitionTime
- * @param sceneName
- * @param extensionFieldSets
  */
 
 bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3085,8 +2957,6 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief TV Channel Cluster ChangeChannelResponse Command callback
- * @param channelMatch
- * @param errorType
  */
 
 bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * commandObj,
@@ -3095,25 +2965,18 @@ bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * c
 
 /**
  * @brief Target Navigator Cluster NavigateTargetResponse Command callback
- * @param status
- * @param data
  */
 
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
 
 /**
  * @brief Test Cluster Cluster TestSpecificResponse Command callback
- * @param returnValue
  */
 
 bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::Command * commandObj, uint8_t returnValue);
 
 /**
  * @brief Thermostat Cluster CurrentWeeklySchedule Command callback
- * @param numberOfTransitionsForSequence
- * @param dayOfWeekForSequence
- * @param modeForSequence
- * @param payload
  */
 
 bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(chip::app::Command * commandObj, uint8_t numberOfTransitionsForSequence,
@@ -3122,12 +2985,6 @@ bool emberAfThermostatClusterCurrentWeeklyScheduleCallback(chip::app::Command * 
 
 /**
  * @brief Thermostat Cluster RelayStatusLog Command callback
- * @param timeOfDay
- * @param relayStatus
- * @param localTemperature
- * @param humidityInPercentage
- * @param setpoint
- * @param unreadEntries
  */
 
 bool emberAfThermostatClusterRelayStatusLogCallback(chip::app::Command * commandObj, uint16_t timeOfDay, uint16_t relayStatus,

--- a/examples/lighting-app/lighting-common/gen/callback-stub.cpp
+++ b/examples/lighting-app/lighting-common/gen/callback-stub.cpp
@@ -360,7 +360,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/lighting-app/lighting-common/gen/callback.h
+++ b/examples/lighting-app/lighting-common/gen/callback.h
@@ -514,9 +514,6 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -530,10 +527,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -541,10 +534,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Level Control Cluster Move Command callback
- * @param moveMode
- * @param rate
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
@@ -552,10 +541,6 @@ bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster MoveToLevel Command callback
- * @param level
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
@@ -563,8 +548,6 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandO
 
 /**
  * @brief Level Control Cluster MoveToLevelWithOnOff Command callback
- * @param level
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level,
@@ -572,19 +555,12 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command *
 
 /**
  * @brief Level Control Cluster MoveWithOnOff Command callback
- * @param moveMode
- * @param rate
  */
 
 bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate);
 
 /**
  * @brief Level Control Cluster Step Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -592,9 +568,6 @@ bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster StepWithOnOff Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -602,8 +575,6 @@ bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Level Control Cluster Stop Command callback
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride);
@@ -616,9 +587,6 @@ bool emberAfLevelControlClusterStopWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -626,10 +594,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -637,9 +601,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -647,9 +608,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -657,7 +615,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -665,9 +622,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -675,9 +629,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -685,9 +636,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -696,10 +644,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/lock-app/lock-common/gen/callback-stub.cpp
+++ b/examples/lock-app/lock-common/gen/callback-stub.cpp
@@ -352,7 +352,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/lock-app/lock-common/gen/callback.h
+++ b/examples/lock-app/lock-common/gen/callback.h
@@ -436,9 +436,6 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -452,10 +449,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -463,9 +456,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -473,10 +463,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -484,9 +470,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -494,9 +477,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -504,7 +484,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -512,9 +491,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -522,9 +498,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -532,9 +505,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -543,10 +513,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/pump-app/pump-common/gen/callback-stub.cpp
+++ b/examples/pump-app/pump-common/gen/callback-stub.cpp
@@ -352,7 +352,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/pump-app/pump-common/gen/callback.h
+++ b/examples/pump-app/pump-common/gen/callback.h
@@ -437,9 +437,6 @@ void emberAfPumpConfigurationAndControlClusterServerTickCallback(chip::EndpointI
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -453,10 +450,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -464,9 +457,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -474,10 +464,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -485,9 +471,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -495,9 +478,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -505,7 +485,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -513,9 +492,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -523,9 +499,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -533,9 +506,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -544,10 +514,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/pump-controller-app/pump-controller-common/gen/callback-stub.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/callback-stub.cpp
@@ -352,7 +352,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/pump-controller-app/pump-controller-common/gen/callback.h
+++ b/examples/pump-controller-app/pump-controller-common/gen/callback.h
@@ -437,9 +437,6 @@ void emberAfPumpConfigurationAndControlClusterClientTickCallback(chip::EndpointI
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -453,10 +450,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -464,9 +457,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -474,10 +464,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -485,9 +471,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -495,9 +478,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -505,7 +485,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -513,9 +492,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -523,9 +499,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -533,9 +506,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -544,10 +514,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback-stub.cpp
@@ -352,7 +352,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/temperature-measurement-app/esp32/main/gen/callback.h
+++ b/examples/temperature-measurement-app/esp32/main/gen/callback.h
@@ -440,9 +440,6 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -456,10 +453,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -467,9 +460,6 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -477,10 +467,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -488,9 +474,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -498,9 +481,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -508,7 +488,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -516,9 +495,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -526,9 +502,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -536,9 +509,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -547,10 +517,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,

--- a/examples/tv-app/tv-common/gen/callback-stub.cpp
+++ b/examples/tv-app/tv-common/gen/callback-stub.cpp
@@ -448,7 +448,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/tv-app/tv-common/gen/callback.h
+++ b/examples/tv-app/tv-common/gen/callback.h
@@ -1376,23 +1376,18 @@ void emberAfWiFiNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId end
 
 /**
  * @brief Account Login Cluster GetSetupPIN Command callback
- * @param tempAccountIdentifier
  */
 
 bool emberAfAccountLoginClusterGetSetupPINCallback(chip::app::Command * commandObj, uint8_t * tempAccountIdentifier);
 
 /**
  * @brief Account Login Cluster Login Command callback
- * @param tempAccountIdentifier
- * @param setupPIN
  */
 
 bool emberAfAccountLoginClusterLoginCallback(chip::app::Command * commandObj, uint8_t * tempAccountIdentifier, uint8_t * setupPIN);
 
 /**
  * @brief Application Launcher Cluster LaunchApp Command callback
- * @param data
- * @param application
  */
 
 bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::Command * commandObj, uint8_t * data,
@@ -1400,40 +1395,30 @@ bool emberAfApplicationLauncherClusterLaunchAppCallback(chip::app::Command * com
 
 /**
  * @brief Audio Output Cluster RenameOutput Command callback
- * @param index
- * @param name
  */
 
 bool emberAfAudioOutputClusterRenameOutputCallback(chip::app::Command * commandObj, uint8_t index, uint8_t * name);
 
 /**
  * @brief Audio Output Cluster SelectOutput Command callback
- * @param index
  */
 
 bool emberAfAudioOutputClusterSelectOutputCallback(chip::app::Command * commandObj, uint8_t index);
 
 /**
  * @brief Content Launch Cluster LaunchContent Command callback
- * @param autoPlay
- * @param data
  */
 
 bool emberAfContentLaunchClusterLaunchContentCallback(chip::app::Command * commandObj, uint8_t autoPlay, uint8_t * data);
 
 /**
  * @brief Content Launch Cluster LaunchURL Command callback
- * @param contentURL
- * @param displayString
  */
 
 bool emberAfContentLaunchClusterLaunchURLCallback(chip::app::Command * commandObj, uint8_t * contentURL, uint8_t * displayString);
 
 /**
  * @brief General Commissioning Cluster ArmFailSafe Command callback
- * @param expiryLengthSeconds
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeCallback(chip::app::Command * commandObj, uint16_t expiryLengthSeconds,
@@ -1447,10 +1432,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteCallback(chip::app::
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfig Command callback
- * @param location
- * @param countryCode
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Command * commandObj, uint8_t location,
@@ -1458,17 +1439,12 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigCallback(chip::app::Co
 
 /**
  * @brief Keypad Input Cluster SendKey Command callback
- * @param keyCode
  */
 
 bool emberAfKeypadInputClusterSendKeyCallback(chip::app::Command * commandObj, uint8_t keyCode);
 
 /**
  * @brief Level Control Cluster Move Command callback
- * @param moveMode
- * @param rate
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
@@ -1476,10 +1452,6 @@ bool emberAfLevelControlClusterMoveCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster MoveToLevel Command callback
- * @param level
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandObj, uint8_t level, uint16_t transitionTime,
@@ -1487,8 +1459,6 @@ bool emberAfLevelControlClusterMoveToLevelCallback(chip::app::Command * commandO
 
 /**
  * @brief Level Control Cluster MoveToLevelWithOnOff Command callback
- * @param level
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command * commandObj, uint8_t level,
@@ -1496,19 +1466,12 @@ bool emberAfLevelControlClusterMoveToLevelWithOnOffCallback(chip::app::Command *
 
 /**
  * @brief Level Control Cluster MoveWithOnOff Command callback
- * @param moveMode
- * @param rate
  */
 
 bool emberAfLevelControlClusterMoveWithOnOffCallback(chip::app::Command * commandObj, uint8_t moveMode, uint8_t rate);
 
 /**
  * @brief Level Control Cluster Step Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -1516,9 +1479,6 @@ bool emberAfLevelControlClusterStepCallback(chip::app::Command * commandObj, uin
 
 /**
  * @brief Level Control Cluster StepWithOnOff Command callback
- * @param stepMode
- * @param stepSize
- * @param transitionTime
  */
 
 bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * commandObj, uint8_t stepMode, uint8_t stepSize,
@@ -1526,8 +1486,6 @@ bool emberAfLevelControlClusterStepWithOnOffCallback(chip::app::Command * comman
 
 /**
  * @brief Level Control Cluster Stop Command callback
- * @param optionMask
- * @param optionOverride
  */
 
 bool emberAfLevelControlClusterStopCallback(chip::app::Command * commandObj, uint8_t optionMask, uint8_t optionOverride);
@@ -1552,15 +1510,12 @@ bool emberAfMediaInputClusterHideInputStatusCallback(chip::app::Command * comman
 
 /**
  * @brief Media Input Cluster RenameInput Command callback
- * @param index
- * @param name
  */
 
 bool emberAfMediaInputClusterRenameInputCallback(chip::app::Command * commandObj, uint8_t index, uint8_t * name);
 
 /**
  * @brief Media Input Cluster SelectInput Command callback
- * @param index
  */
 
 bool emberAfMediaInputClusterSelectInputCallback(chip::app::Command * commandObj, uint8_t index);
@@ -1609,21 +1564,18 @@ bool emberAfMediaPlaybackClusterMediaRewindCallback(chip::app::Command * command
 
 /**
  * @brief Media Playback Cluster MediaSkipBackward Command callback
- * @param deltaPositionMilliseconds
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipBackwardCallback(chip::app::Command * commandObj, uint64_t deltaPositionMilliseconds);
 
 /**
  * @brief Media Playback Cluster MediaSkipForward Command callback
- * @param deltaPositionMilliseconds
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipForwardCallback(chip::app::Command * commandObj, uint64_t deltaPositionMilliseconds);
 
 /**
  * @brief Media Playback Cluster MediaSkipSeek Command callback
- * @param position
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipSeekCallback(chip::app::Command * commandObj, uint64_t position);
@@ -1660,15 +1612,12 @@ bool emberAfOnOffClusterToggleCallback(chip::app::Command * commandObj);
 
 /**
  * @brief TV Channel Cluster ChangeChannel Command callback
- * @param match
  */
 
 bool emberAfTvChannelClusterChangeChannelCallback(chip::app::Command * commandObj, uint8_t * match);
 
 /**
  * @brief TV Channel Cluster ChangeChannelByNumber Command callback
- * @param majorNumber
- * @param minorNumber
  */
 
 bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::Command * commandObj, uint16_t majorNumber,
@@ -1676,15 +1625,12 @@ bool emberAfTvChannelClusterChangeChannelByNumberCallback(chip::app::Command * c
 
 /**
  * @brief TV Channel Cluster SkipChannel Command callback
- * @param count
  */
 
 bool emberAfTvChannelClusterSkipChannelCallback(chip::app::Command * commandObj, uint16_t Count);
 
 /**
  * @brief Target Navigator Cluster NavigateTarget Command callback
- * @param target
- * @param data
  */
 
 bool emberAfTargetNavigatorClusterNavigateTargetCallback(chip::app::Command * commandObj, uint8_t target, uint8_t * data);

--- a/examples/window-app/common/gen/callback-stub.cpp
+++ b/examples/window-app/common/gen/callback-stub.cpp
@@ -336,7 +336,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/examples/window-app/common/gen/callback.h
+++ b/examples/window-app/common/gen/callback.h
@@ -280,9 +280,6 @@ void emberAfWindowCoveringClusterServerTickCallback(chip::EndpointId endpoint);
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan operationalDataset,
@@ -290,10 +287,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Comma
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -301,9 +294,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster DisableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -311,9 +301,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkCallback(chip::app::Command
 
 /**
  * @brief Network Commissioning Cluster EnableNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan networkID,
@@ -321,7 +308,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster GetLastNetworkCommissioningResult Command callback
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback(chip::app::Command * commandObj,
@@ -329,9 +315,6 @@ bool emberAfNetworkCommissioningClusterGetLastNetworkCommissioningResultCallback
 
 /**
  * @brief Network Commissioning Cluster RemoveNetwork Command callback
- * @param networkID
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan NetworkID,
@@ -339,9 +322,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkCallback(chip::app::Command 
 
 /**
  * @brief Network Commissioning Cluster ScanNetworks Command callback
- * @param ssid
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -349,9 +329,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksCallback(chip::app::Command *
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetwork Command callback
- * @param operationalDataset
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Command * commandObj,
@@ -360,10 +337,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkCallback(chip::app::Co
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetwork Command callback
- * @param ssid
- * @param credentials
- * @param breadcrumb
- * @param timeoutMs
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkCallback(chip::app::Command * commandObj, chip::ByteSpan ssid,
@@ -378,7 +351,6 @@ bool emberAfWindowCoveringClusterWindowCoveringDownCloseCallback(chip::app::Comm
 
 /**
  * @brief Window Covering Cluster WindowCoveringGoToLiftPercentage Command callback
- * @param percentageLiftValue
  */
 
 bool emberAfWindowCoveringClusterWindowCoveringGoToLiftPercentageCallback(chip::app::Command * commandObj,
@@ -386,14 +358,12 @@ bool emberAfWindowCoveringClusterWindowCoveringGoToLiftPercentageCallback(chip::
 
 /**
  * @brief Window Covering Cluster WindowCoveringGoToLiftValue Command callback
- * @param liftValue
  */
 
 bool emberAfWindowCoveringClusterWindowCoveringGoToLiftValueCallback(chip::app::Command * commandObj, uint16_t liftValue);
 
 /**
  * @brief Window Covering Cluster WindowCoveringGoToTiltPercentage Command callback
- * @param percentageTiltValue
  */
 
 bool emberAfWindowCoveringClusterWindowCoveringGoToTiltPercentageCallback(chip::app::Command * commandObj,
@@ -401,7 +371,6 @@ bool emberAfWindowCoveringClusterWindowCoveringGoToTiltPercentageCallback(chip::
 
 /**
  * @brief Window Covering Cluster WindowCoveringGoToTiltValue Command callback
- * @param tiltValue
  */
 
 bool emberAfWindowCoveringClusterWindowCoveringGoToTiltValueCallback(chip::app::Command * commandObj, uint16_t tiltValue);

--- a/src/app/Command.h
+++ b/src/app/Command.h
@@ -55,10 +55,10 @@ public:
 
     enum class CommandState
     {
-        Uninitialized = 0, //< The invoke command message has not been initialized
-        Initialized,       //< The invoke command message has been initialized and is ready
-        AddCommand,        //< The invoke command message has added Command
-        Sending,           //< The invoke command message  has sent out the invoke command
+        Uninitialized = 0, ///< The invoke command message has not been initialized
+        Initialized,       ///< The invoke command message has been initialized and is ready
+        AddCommand,        ///< The invoke command message has added Command
+        Sending,           ///< The invoke command message has sent out the invoke command
     };
 
     /**

--- a/src/app/EventLoggingDelegate.h
+++ b/src/app/EventLoggingDelegate.h
@@ -56,7 +56,7 @@ public:
      *  be structured using context tags.
      *
      *
-     *  @param[inout] aWriter A reference to the chip::TLV::TLVWriter object to be
+     *  @param[in,out] aWriter A reference to the chip::TLV::TLVWriter object to be
      *                         used for event data serialization.
      *
      *  @retval #CHIP_NO_ERROR  On success.

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -71,7 +71,7 @@ public:
      * @param[in] apNext         The pointer to CircularEventBuffer storing
      *                           events of greater priority.
      *
-     * @param[in] apNext         CircularEventBuffer prioty level
+     * @param[in] aPriorityLevel CircularEventBuffer priority level
      */
     void Init(uint8_t * apBuffer, uint32_t aBufferLength, CircularEventBuffer * apPrev, CircularEventBuffer * apNext,
               PriorityLevel aPriorityLevel);
@@ -144,12 +144,11 @@ public:
     virtual ~CircularEventBuffer() = default;
 
 private:
-    CircularEventBuffer * mpPrev = nullptr; //< A pointer CircularEventBuffer storing events less important events
-    CircularEventBuffer * mpNext = nullptr; //< A pointer CircularEventBuffer storing events more important events
+    CircularEventBuffer * mpPrev = nullptr; ///< A pointer CircularEventBuffer storing events less important events
+    CircularEventBuffer * mpNext = nullptr; ///< A pointer CircularEventBuffer storing events more important events
 
-    PriorityLevel mPriority =
-        PriorityLevel::Invalid; //< The buffer is the final bucket for events of this priority.  Events of lesser priority are
-    //< dropped when they get bumped out of this buffer
+    PriorityLevel mPriority = PriorityLevel::Invalid; ///< The buffer is the final bucket for events of this priority.  Events of
+                                                      ///< lesser priority are dropped when they get bumped out of this buffer
 
     // The counter we're going to actually use.
     MonotonicallyIncreasingCounter * mpEventNumberCounter = nullptr;
@@ -157,11 +156,11 @@ private:
     // The backup counter to use if no counter is provided for us.
     MonotonicallyIncreasingCounter mNonPersistedCounter;
 
-    size_t mRequiredSpaceForEvicted = 0;  //< Required space for previous buffer to evict event to new buffer
-    EventNumber mFirstEventNumber   = 0;  //< First event Number stored in the logging subsystem for this priority
-    EventNumber mLastEventNumber    = 0;  //< Last event Number vended for this priority
-    Timestamp mFirstEventSystemTimestamp; //< The timestamp of the first event in this buffer
-    Timestamp mLastEventSystemTimestamp;  //< The timestamp of the last event in this buffer
+    size_t mRequiredSpaceForEvicted = 0;  ///< Required space for previous buffer to evict event to new buffer
+    EventNumber mFirstEventNumber   = 0;  ///< First event Number stored in the logging subsystem for this priority
+    EventNumber mLastEventNumber    = 0;  ///< Last event Number vended for this priority
+    Timestamp mFirstEventSystemTimestamp; ///< The timestamp of the first event in this buffer
+    Timestamp mLastEventSystemTimestamp;  ///< The timestamp of the last event in this buffer
 };
 
 class CircularEventReader;
@@ -184,9 +183,9 @@ private:
 
 enum class EventManagementStates
 {
-    Idle       = 1, //< No log offload in progress, log offload can begin without any constraints
-    InProgress = 2, //< Log offload in progress
-    Shutdown   = 3  //< Not capable of performing any logging operation
+    Idle       = 1, // No log offload in progress, log offload can begin without any constraints
+    InProgress = 2, // Log offload in progress
+    Shutdown   = 3  // Not capable of performing any logging operation
 };
 
 /**
@@ -206,7 +205,7 @@ struct LogStorageResources
     uint8_t * mpBuffer =
         nullptr; // Buffer to be used as a storage at the particular priority level and shared with more important events.
                  // Must not be nullptr.  Must be large enough to accommodate the largest event emitted by the system.
-    uint32_t mBufferSize = 0; //< The size, in bytes, of the `mBuffer`.
+    uint32_t mBufferSize = 0; ///< The size, in bytes, of the `mBuffer`.
     Platform::PersistedStorage::Key * mCounterKey =
         nullptr;                // Name of the key naming persistent counter for events of this priority.  When NULL, the persistent
                                 // counters will not be used for this priority level.
@@ -268,9 +267,6 @@ public:
     /**
      * @brief
      *   EventManagement default constructor. Provided primarily to make the compiler happy.
-     *
-
-     * @return EventManagement
      */
     EventManagement(){};
 
@@ -344,7 +340,7 @@ public:
      * @brief
      *   A helper method to get tlv reader along with buffer has data from particular priority
      *
-     * @param[inout] aReader A reference to the reader that will be
+     * @param[in,out] aReader A reference to the reader that will be
      *                        initialized with the backing storage from
      *                        the event log
      *
@@ -374,10 +370,10 @@ public:
      * will terminate the event writing on event boundary.
      *
      * @param[in] aWriter     The writer to use for event storage
-     * @param[in] apEventClusterInfolist  the interested cluster info list with event path inside
+     * @param[in] apClusterInfolist the interested cluster info list with event path inside
      * @param[in] aPriority The priority of events to be fetched
      *
-     * @param[inout] aEventNumber On input, the Event number immediately
+     * @param[in,out] aEventNumber On input, the Event number immediately
      *                         prior to the one we're fetching.  On
      *                         completion, the event number of the last event
      *                         fetched.
@@ -468,7 +464,7 @@ private:
      * @brief Helper function for writing event header and data according to event
      *   logging protocol.
      *
-     * @param[inout] apContext   EventLoadOutContext, initialized with stateful
+     * @param[in,out] apContext EventLoadOutContext, initialized with stateful
      *                          information for the buffer. State is updated
      *                          and preserved by ConstructEvent using this context.
      *

--- a/src/app/MessageDef/CommandPath.h
+++ b/src/app/MessageDef/CommandPath.h
@@ -96,7 +96,7 @@ public:
     /**
      *  @brief Get a TLVReader for the ClusterId. Next() must be called before accessing them.
      *
-     *  @param [in] apEndpointId    A pointer to ClusterId
+     *  @param [in] apClusterId    A pointer to ClusterId
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
@@ -107,7 +107,7 @@ public:
     /**
      *  @brief Get a TLVReader for the CommandId. Next() must be called before accessing them.
      *
-     *  @param [in] apEndpointId    A pointer to CommandId
+     *  @param [in] apCommandId    A pointer to CommandId
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types

--- a/src/app/MessageDef/EventDataElement.h
+++ b/src/app/MessageDef/EventDataElement.h
@@ -135,7 +135,7 @@ public:
     /**
      *  @brief Get a TLVReader for the DeltaUTCTimestamp. Next() must be called before accessing them.
      *
-     *  @param [in] apDeltaUTCTimestampstamp   A pointer to apDeltaUTCTimestamp
+     *  @param [in] apDeltaUTCTimestamp   A pointer to apDeltaUTCTimestamp
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_ERROR_WRONG_TLV_TYPE if there is such element but it's not any of the defined unsigned integer types
@@ -245,7 +245,7 @@ public:
      *  This field is present if delta encoding of the System timestamp relative to a prior event is desired for compression
      * reasons. When this field is present, the System Timestamp field SHALL be omitted.
      *
-     *  @param [in] DeltaSystemTimestamp The uint64_t variable to reflect DeltaSystemTimestamp
+     *  @param [in] aDeltaSystemTimestamp The uint64_t variable to reflect DeltaSystemTimestamp
      *
      *  @return A reference to *this
      */

--- a/src/app/MessageDef/InvokeCommand.h
+++ b/src/app/MessageDef/InvokeCommand.h
@@ -72,9 +72,9 @@ public:
 #endif
 
     /**
-     *  @brief Get a TLVReader for the CommandList. Next() must be called before accessing them.
+     *  @brief Get a parser for a CommandList.
      *
-     *  @param [in] apWriter    A pointer to TLVWriter
+     *  @param [in] apCommandList    A pointer to the command list parser.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element

--- a/src/app/MessageDef/Parser.h
+++ b/src/app/MessageDef/Parser.h
@@ -57,7 +57,7 @@ public:
     /**
      *  @brief Get the TLV Reader
      *
-     *  @param [in] aReader A pointer to a TLVReader
+     *  @param [in] apReader A pointer to a TLVReader
      *
      */
     void GetReader(chip::TLV::TLVReader * const apReader);

--- a/src/app/MessageDef/ReadRequest.h
+++ b/src/app/MessageDef/ReadRequest.h
@@ -77,7 +77,7 @@ public:
     /**
      *  @brief Get a TLVReader for the AttributePathList. Next() must be called before accessing them.
      *
-     *  @param [in] apAttributePath    A pointer to apAttributePath
+     *  @param [in] apAttributePathList    A pointer to an attribute path list parser.
      *
      *  @return #CHIP_NO_ERROR on success
      *          #CHIP_END_OF_TLV if there is no such element

--- a/src/app/MessageDef/StatusElement.h
+++ b/src/app/MessageDef/StatusElement.h
@@ -79,7 +79,6 @@ public:
      * @param[out]   apGeneralCode     Pointer to the storage for the GeneralCode
      * @param[out]   apProtocolId     Pointer to the storage for the ProtocolId
      * @param[out]   apProtocolCode   Pointer to the storage for the ProtocolCode
-     * @param[out]   apClusterId     Pointer to the storage for the ClusterId
      *
      * @return       CHIP_ERROR codes returned by chip::TLV objects. CHIP_END_OF_TLV if either
      *               element is missing. CHIP_ERROR_WRONG_TLV_TYPE if the elements are of the wrong

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -79,9 +79,9 @@ private:
 
     enum class ClientState
     {
-        Uninitialized = 0, //< The client has not been initialized
-        Initialized,       //< The client has been initialized and is ready for a SendReadRequest
-        AwaitingResponse,  //< The client has sent out the read request message
+        Uninitialized = 0, ///< The client has not been initialized
+        Initialized,       ///< The client has been initialized and is ready for a SendReadRequest
+        AwaitingResponse,  ///< The client has sent out the read request message
     };
 
     /**

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -117,9 +117,9 @@ public:
 private:
     enum class HandlerState
     {
-        Uninitialized = 0, //< The handler has not been initialized
-        Initialized,       //< The handler has been initialized and is ready
-        Reportable,        //< The handler has received read request and is waiting for the data to send to be available
+        Uninitialized = 0, ///< The handler has not been initialized
+        Initialized,       ///< The handler has been initialized and is ready
+        Reportable,        ///< The handler has received read request and is waiting for the data to send to be available
     };
 
     CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle aPayload);

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -723,9 +723,9 @@ typedef enum
 typedef enum
 {
     EMBER_AF_OK_TO_SLEEP,
-    /** @deprecated. */
+    /** deprecated. */
     EMBER_AF_OK_TO_HIBERNATE = EMBER_AF_OK_TO_SLEEP,
-    /** @deprecated. */
+    /** deprecated. */
     EMBER_AF_OK_TO_NAP,
     EMBER_AF_STAY_AWAKE,
 } EmberAfEventSleepControl;

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -82,8 +82,8 @@
  * or NULL if attribute was not found.
  *
  * @param endpoint Zigbee endpoint number.
- * @param cluster Cluster ID of the sought cluster.
- * @param attribute Attribute ID of the sought attribute.
+ * @param clusterId Cluster ID of the sought cluster.
+ * @param attributeId Attribute ID of the sought attribute.
  * @param mask CLUSTER_MASK_SERVER or CLUSTER_MASK_CLIENT
  *
  * @return Returns pointer to the attribute metadata location.
@@ -261,9 +261,9 @@ EmberAfStatus emberAfWriteManufacturerSpecificClientAttribute(chip::EndpointId e
  *
  * @param endpoint Zigbee endpoint number
  * @param cluster Cluster ID of the sought cluster.
- * @param attribute Attribute ID of the sought attribute.
+ * @param attributeID Attribute ID of the sought attribute.
  * @param mask CLUSTER_MASK_SERVER or CLUSTER_MASK_CLIENT
- * @param buffer Location where attribute will be written from.
+ * @param dataPtr Location where attribute will be written from.
  * @param dataType ZCL attribute type.
  */
 EmberAfStatus emberAfVerifyAttributeWrite(chip::EndpointId endpoint, chip::ClusterId cluster, chip::AttributeId attributeID,
@@ -1162,8 +1162,8 @@ EmberStatus emberAfEndpointEventControlSetDelayMinutes(EmberEventControl * contr
  * @brief A function used to retrieve the number of milliseconds until
  * the next event scheduled in the application framework's event
  * mechanism.
- * @param maxMs, the maximum number of milliseconds until the next
- *        event.
+ * @param maxMs the maximum number of milliseconds until the next
+ *              event.
  * @return The number of milliseconds until the next event or
  * maxMs if no event is scheduled before then.
  */

--- a/src/app/util/time-util.h
+++ b/src/app/util/time-util.h
@@ -117,8 +117,8 @@ void emberAfPrintDateln(const EmberAfDate * date);
  * which will update the time. Otherwise the emberAfSetTimeCallback
  * is called, which in the case of the stub does nothing.
  *
- * @param utcTime: A ZigBee time, the number of seconds since the
- *                 year 2000.
+ * @param utcTime A ZigBee time, the number of seconds since the
+ *                year 2000.
  */
 void emberAfSetTime(uint32_t utcTime);
 
@@ -145,8 +145,8 @@ uint32_t emberAfGetCurrentTime(void);
  * a human readable time from the passed value. If not, this
  * function will print nothing.
  *
- * @param utcTime: A ZigBee time, the number of seconds since the
- *                 year 2000.
+ * @param utcTime A ZigBee time, the number of seconds since the
+ *                year 2000.
  */
 void emberAfPrintTime(uint32_t utcTime);
 
@@ -154,7 +154,7 @@ void emberAfPrintTime(uint32_t utcTime);
  * @brief Prints the time in ISO 8601 format
  * yyyy-mm-dd hh:mm:ss
  *
- * @param utcTime: A ZigBee time, the number of seconds since the
- *                 year 2000.
+ * @param utcTime A ZigBee time, the number of seconds since the
+ *                year 2000.
  */
 void emberAfPrintTimeIsoFormat(uint32_t utcTime);

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -1199,31 +1199,13 @@ enum
     /**
      * @brief Drop frame.
      */
-    EMBER_DROP_FRAME = 0x79,
-    /**
-     * @brief
-     */
+    EMBER_DROP_FRAME       = 0x79,
     EMBER_PASS_UNPROCESSED = 0x7A,
-    /**
-     * @brief
-     */
-    EMBER_TX_THEN_DROP = 0x7B,
-    /**
-     * @brief
-     */
-    EMBER_NO_SECURITY = 0x7C,
-    /**
-     * @brief
-     */
-    EMBER_COUNTER_FAILURE = 0x7D,
-    /**
-     * @brief
-     */
-    EMBER_AUTH_FAILURE = 0x7E,
-    /**
-     * @brief
-     */
-    EMBER_UNPROCESSED = 0x7F,
+    EMBER_TX_THEN_DROP     = 0x7B,
+    EMBER_NO_SECURITY      = 0x7C,
+    EMBER_COUNTER_FAILURE  = 0x7D,
+    EMBER_AUTH_FAILURE     = 0x7E,
+    EMBER_UNPROCESSED      = 0x7F,
 
     //@}
     //

--- a/src/app/zap-templates/templates/app/callback-stub-src.zapt
+++ b/src/app/zap-templates/templates/app/callback-stub-src.zapt
@@ -316,7 +316,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/src/app/zap-templates/templates/app/callback.zapt
+++ b/src/app/zap-templates/templates/app/callback.zapt
@@ -113,11 +113,6 @@ void emberAf{{asCamelCased name false}}Cluster{{asCamelCased side false}}TickCal
 {{#if (isCommandAvailable parent.side incoming outgoing commandSource)}}
 /**
 * @brief {{parent.name}} Cluster {{name}} Command callback
-{{#if (zcl_command_arguments_count this.id)}}
-{{#zcl_command_arguments}}
-* @param {{asCamelCased label}}
-{{/zcl_command_arguments}}
-{{/if}}
 */
 
 bool emberAf{{asCamelCased parent.name false}}Cluster{{asCamelCased name false}}Callback(chip::app::Command * commandObj{{#zcl_command_arguments}}, {{#if (isOctetString type)}}chip::ByteSpan{{else}}{{asUnderlyingZclType type}}{{/if}} {{asSymbol label}}{{/zcl_command_arguments}});

--- a/src/controller/python/gen/callback-stub.cpp
+++ b/src/controller/python/gen/callback-stub.cpp
@@ -584,7 +584,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/src/controller/python/gen/callback.h
+++ b/src/controller/python/gen/callback.h
@@ -2711,23 +2711,18 @@ void emberAfWindowCoveringClusterClientTickCallback(chip::EndpointId endpoint);
 
 /**
  * @brief Account Login Cluster GetSetupPINResponse Command callback
- * @param setupPIN
  */
 
 bool emberAfAccountLoginClusterGetSetupPINResponseCallback(chip::app::Command * commandObj, uint8_t * setupPIN);
 
 /**
  * @brief Application Launcher Cluster LaunchAppResponse Command callback
- * @param status
- * @param data
  */
 
 bool emberAfApplicationLauncherClusterLaunchAppResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
 
 /**
  * @brief Content Launch Cluster LaunchContentResponse Command callback
- * @param data
- * @param contentLaunchStatus
  */
 
 bool emberAfContentLaunchClusterLaunchContentResponseCallback(chip::app::Command * commandObj, uint8_t * data,
@@ -2735,8 +2730,6 @@ bool emberAfContentLaunchClusterLaunchContentResponseCallback(chip::app::Command
 
 /**
  * @brief Content Launch Cluster LaunchURLResponse Command callback
- * @param data
- * @param contentLaunchStatus
  */
 
 bool emberAfContentLaunchClusterLaunchURLResponseCallback(chip::app::Command * commandObj, uint8_t * data,
@@ -2744,60 +2737,48 @@ bool emberAfContentLaunchClusterLaunchURLResponseCallback(chip::app::Command * c
 
 /**
  * @brief Door Lock Cluster ClearAllPinsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearAllRfidsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster GetHolidayScheduleResponse Command callback
- * @param scheduleId
- * @param status
- * @param localStartTime
- * @param localEndTime
- * @param operatingModeDuringHoliday
  */
 
 bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint8_t status,
@@ -2806,13 +2787,6 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetLogRecordResponse Command callback
- * @param logEntryId
- * @param timestamp
- * @param eventType
- * @param source
- * @param eventIdOrAlarmCode
- * @param userId
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * commandObj, uint16_t logEntryId, uint32_t timestamp,
@@ -2821,10 +2795,6 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * com
 
 /**
  * @brief Door Lock Cluster GetPinResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -2832,10 +2802,6 @@ bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Door Lock Cluster GetRfidResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param rfid
  */
 
 bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -2843,22 +2809,12 @@ bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Door Lock Cluster GetUserTypeResponse Command callback
- * @param userId
- * @param userType
  */
 
 bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
 
 /**
  * @brief Door Lock Cluster GetWeekdayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param daysMask
- * @param startHour
- * @param startMinute
- * @param endHour
- * @param endMinute
  */
 
 bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2867,11 +2823,6 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetYeardayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param localStartTime
- * @param localEndTime
  */
 
 bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -2879,71 +2830,60 @@ bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster LockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetUserTypeResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockWithTimeoutResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief General Commissioning Cluster ArmFailSafeResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2951,8 +2891,6 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Co
 
 /**
  * @brief General Commissioning Cluster CommissioningCompleteResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2960,8 +2898,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chi
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfigResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2969,17 +2905,12 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip:
 
 /**
  * @brief Groups Cluster AddGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster GetGroupMembershipResponse Command callback
- * @param capacity
- * @param groupCount
- * @param groupList
  */
 
 bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
@@ -2987,17 +2918,12 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Groups Cluster RemoveGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster ViewGroupResponse Command callback
- * @param status
- * @param groupId
- * @param groupName
  */
 
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3005,99 +2931,84 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Identify Cluster IdentifyQueryResponse Command callback
- * @param timeout
  */
 
 bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout);
 
 /**
  * @brief Keypad Input Cluster SendKeyResponse Command callback
- * @param status
  */
 
 bool emberAfKeypadInputClusterSendKeyResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Media Playback Cluster MediaFastForwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaFastForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaNextResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaNextResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPauseResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPauseResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPlayResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPlayResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaPreviousResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaPreviousResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaRewindResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaRewindResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipBackwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipBackwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipForwardResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipForwardResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaSkipSeekResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaSkipSeekResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaStartOverResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaStartOverResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Media Playback Cluster MediaStopResponse Command callback
- * @param mediaPlaybackStatus
  */
 
 bool emberAfMediaPlaybackClusterMediaStopResponseCallback(chip::app::Command * commandObj, uint8_t mediaPlaybackStatus);
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3105,8 +3016,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::ap
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3114,8 +3023,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster DisableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3123,8 +3030,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster EnableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3132,8 +3037,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster RemoveNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3141,10 +3044,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster ScanNetworksResponse Command callback
- * @param errorCode
- * @param debugText
- * @param wifiScanResults
- * @param threadScanResults
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
@@ -3154,8 +3053,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3163,8 +3060,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip:
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -3172,12 +3067,6 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::a
 
 /**
  * @brief Operational Credentials Cluster OpCSRResponse Command callback
- * @param csr
- * @param cSRNonce
- * @param vendorReserved1
- * @param vendorReserved2
- * @param vendorReserved3
- * @param signature
  */
 
 bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Command * commandObj, chip::ByteSpan CSR,
@@ -3187,9 +3076,6 @@ bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Comman
 
 /**
  * @brief Operational Credentials Cluster OpCertResponse Command callback
- * @param statusCode
- * @param fabricIndex
- * @param debugText
  */
 
 bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Command * commandObj, uint8_t StatusCode,
@@ -3197,16 +3083,12 @@ bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Comma
 
 /**
  * @brief Operational Credentials Cluster SetFabricResponse Command callback
- * @param fabricId
  */
 
 bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Command * commandObj, chip::FabricId FabricId);
 
 /**
  * @brief Scenes Cluster AddSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3214,11 +3096,6 @@ bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Scenes Cluster GetSceneMembershipResponse Command callback
- * @param status
- * @param capacity
- * @param groupId
- * @param sceneCount
- * @param sceneList
  */
 
 bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
@@ -3227,17 +3104,12 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Scenes Cluster RemoveAllScenesResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Scenes Cluster RemoveSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3245,9 +3117,6 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * comman
 
 /**
  * @brief Scenes Cluster StoreSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3255,12 +3124,6 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * command
 
 /**
  * @brief Scenes Cluster ViewSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
- * @param transitionTime
- * @param sceneName
- * @param extensionFieldSets
  */
 
 bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -3269,8 +3132,6 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief TV Channel Cluster ChangeChannelResponse Command callback
- * @param channelMatch
- * @param errorType
  */
 
 bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * commandObj,
@@ -3279,15 +3140,12 @@ bool emberAfTvChannelClusterChangeChannelResponseCallback(chip::app::Command * c
 
 /**
  * @brief Target Navigator Cluster NavigateTargetResponse Command callback
- * @param status
- * @param data
  */
 
 bool emberAfTargetNavigatorClusterNavigateTargetResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t * data);
 
 /**
  * @brief Test Cluster Cluster TestSpecificResponse Command callback
- * @param returnValue
  */
 
 bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::Command * commandObj, uint8_t returnValue);

--- a/src/darwin/Framework/CHIP/gen/callback-stub.cpp
+++ b/src/darwin/Framework/CHIP/gen/callback-stub.cpp
@@ -496,7 +496,7 @@ bool __attribute__((weak)) emberAfPreMessageSendCallback(EmberAfMessageStruct * 
  * be handled by the application framework.
  *
  * @param type   Ver.: always
- * @param indexOrDestination   Ver.: always
+ * @param destination   Ver.: always
  * @param apsFrame   Ver.: always
  * @param msgLen   Ver.: always
  * @param message   Ver.: always

--- a/src/darwin/Framework/CHIP/gen/callback.h
+++ b/src/darwin/Framework/CHIP/gen/callback.h
@@ -1850,60 +1850,48 @@ void emberAfTrustedRootCertificatesClusterClientTickCallback(chip::EndpointId en
 
 /**
  * @brief Door Lock Cluster ClearAllPinsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllPinsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearAllRfidsResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearAllRfidsResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster ClearYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterClearYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster GetHolidayScheduleResponse Command callback
- * @param scheduleId
- * @param status
- * @param localStartTime
- * @param localEndTime
- * @param operatingModeDuringHoliday
  */
 
 bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint8_t status,
@@ -1912,13 +1900,6 @@ bool emberAfDoorLockClusterGetHolidayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetLogRecordResponse Command callback
- * @param logEntryId
- * @param timestamp
- * @param eventType
- * @param source
- * @param eventIdOrAlarmCode
- * @param userId
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * commandObj, uint16_t logEntryId, uint32_t timestamp,
@@ -1927,10 +1908,6 @@ bool emberAfDoorLockClusterGetLogRecordResponseCallback(chip::app::Command * com
 
 /**
  * @brief Door Lock Cluster GetPinResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param pin
  */
 
 bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -1938,10 +1915,6 @@ bool emberAfDoorLockClusterGetPinResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Door Lock Cluster GetRfidResponse Command callback
- * @param userId
- * @param userStatus
- * @param userType
- * @param rfid
  */
 
 bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userStatus,
@@ -1949,22 +1922,12 @@ bool emberAfDoorLockClusterGetRfidResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Door Lock Cluster GetUserTypeResponse Command callback
- * @param userId
- * @param userType
  */
 
 bool emberAfDoorLockClusterGetUserTypeResponseCallback(chip::app::Command * commandObj, uint16_t userId, uint8_t userType);
 
 /**
  * @brief Door Lock Cluster GetWeekdayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param daysMask
- * @param startHour
- * @param startMinute
- * @param endHour
- * @param endMinute
  */
 
 bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -1973,11 +1936,6 @@ bool emberAfDoorLockClusterGetWeekdayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster GetYeardayScheduleResponse Command callback
- * @param scheduleId
- * @param userId
- * @param status
- * @param localStartTime
- * @param localEndTime
  */
 
 bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t scheduleId, uint16_t userId,
@@ -1985,71 +1943,60 @@ bool emberAfDoorLockClusterGetYeardayScheduleResponseCallback(chip::app::Command
 
 /**
  * @brief Door Lock Cluster LockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterLockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetHolidayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetHolidayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetPinResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetPinResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetRfidResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetRfidResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetUserTypeResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetUserTypeResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetWeekdayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetWeekdayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster SetYeardayScheduleResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterSetYeardayScheduleResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockDoorResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockDoorResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief Door Lock Cluster UnlockWithTimeoutResponse Command callback
- * @param status
  */
 
 bool emberAfDoorLockClusterUnlockWithTimeoutResponseCallback(chip::app::Command * commandObj, uint8_t status);
 
 /**
  * @brief General Commissioning Cluster ArmFailSafeResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2057,8 +2004,6 @@ bool emberAfGeneralCommissioningClusterArmFailSafeResponseCallback(chip::app::Co
 
 /**
  * @brief General Commissioning Cluster CommissioningCompleteResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2066,8 +2011,6 @@ bool emberAfGeneralCommissioningClusterCommissioningCompleteResponseCallback(chi
 
 /**
  * @brief General Commissioning Cluster SetRegulatoryConfigResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2075,17 +2018,12 @@ bool emberAfGeneralCommissioningClusterSetRegulatoryConfigResponseCallback(chip:
 
 /**
  * @brief Groups Cluster AddGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterAddGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster GetGroupMembershipResponse Command callback
- * @param capacity
- * @param groupCount
- * @param groupList
  */
 
 bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command * commandObj, uint8_t capacity, uint8_t groupCount,
@@ -2093,17 +2031,12 @@ bool emberAfGroupsClusterGetGroupMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Groups Cluster RemoveGroupResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfGroupsClusterRemoveGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Groups Cluster ViewGroupResponse Command callback
- * @param status
- * @param groupId
- * @param groupName
  */
 
 bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2111,15 +2044,12 @@ bool emberAfGroupsClusterViewGroupResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Identify Cluster IdentifyQueryResponse Command callback
- * @param timeout
  */
 
 bool emberAfIdentifyClusterIdentifyQueryResponseCallback(chip::app::Command * commandObj, uint16_t timeout);
 
 /**
  * @brief Network Commissioning Cluster AddThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2127,8 +2057,6 @@ bool emberAfNetworkCommissioningClusterAddThreadNetworkResponseCallback(chip::ap
 
 /**
  * @brief Network Commissioning Cluster AddWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2136,8 +2064,6 @@ bool emberAfNetworkCommissioningClusterAddWiFiNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster DisableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2145,8 +2071,6 @@ bool emberAfNetworkCommissioningClusterDisableNetworkResponseCallback(chip::app:
 
 /**
  * @brief Network Commissioning Cluster EnableNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2154,8 +2078,6 @@ bool emberAfNetworkCommissioningClusterEnableNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster RemoveNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2163,10 +2085,6 @@ bool emberAfNetworkCommissioningClusterRemoveNetworkResponseCallback(chip::app::
 
 /**
  * @brief Network Commissioning Cluster ScanNetworksResponse Command callback
- * @param errorCode
- * @param debugText
- * @param wifiScanResults
- * @param threadScanResults
  */
 
 bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
@@ -2176,8 +2094,6 @@ bool emberAfNetworkCommissioningClusterScanNetworksResponseCallback(
 
 /**
  * @brief Network Commissioning Cluster UpdateThreadNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2185,8 +2101,6 @@ bool emberAfNetworkCommissioningClusterUpdateThreadNetworkResponseCallback(chip:
 
 /**
  * @brief Network Commissioning Cluster UpdateWiFiNetworkResponse Command callback
- * @param errorCode
- * @param debugText
  */
 
 bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::app::Command * commandObj, uint8_t errorCode,
@@ -2194,12 +2108,6 @@ bool emberAfNetworkCommissioningClusterUpdateWiFiNetworkResponseCallback(chip::a
 
 /**
  * @brief Operational Credentials Cluster OpCSRResponse Command callback
- * @param csr
- * @param cSRNonce
- * @param vendorReserved1
- * @param vendorReserved2
- * @param vendorReserved3
- * @param signature
  */
 
 bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Command * commandObj, chip::ByteSpan CSR,
@@ -2209,9 +2117,6 @@ bool emberAfOperationalCredentialsClusterOpCSRResponseCallback(chip::app::Comman
 
 /**
  * @brief Operational Credentials Cluster OpCertResponse Command callback
- * @param statusCode
- * @param fabricIndex
- * @param debugText
  */
 
 bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Command * commandObj, uint8_t StatusCode,
@@ -2219,16 +2124,12 @@ bool emberAfOperationalCredentialsClusterOpCertResponseCallback(chip::app::Comma
 
 /**
  * @brief Operational Credentials Cluster SetFabricResponse Command callback
- * @param fabricId
  */
 
 bool emberAfOperationalCredentialsClusterSetFabricResponseCallback(chip::app::Command * commandObj, chip::FabricId FabricId);
 
 /**
  * @brief Scenes Cluster AddSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2236,11 +2137,6 @@ bool emberAfScenesClusterAddSceneResponseCallback(chip::app::Command * commandOb
 
 /**
  * @brief Scenes Cluster GetSceneMembershipResponse Command callback
- * @param status
- * @param capacity
- * @param groupId
- * @param sceneCount
- * @param sceneList
  */
 
 bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command * commandObj, uint8_t status, uint8_t capacity,
@@ -2249,17 +2145,12 @@ bool emberAfScenesClusterGetSceneMembershipResponseCallback(chip::app::Command *
 
 /**
  * @brief Scenes Cluster RemoveAllScenesResponse Command callback
- * @param status
- * @param groupId
  */
 
 bool emberAfScenesClusterRemoveAllScenesResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId);
 
 /**
  * @brief Scenes Cluster RemoveSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2267,9 +2158,6 @@ bool emberAfScenesClusterRemoveSceneResponseCallback(chip::app::Command * comman
 
 /**
  * @brief Scenes Cluster StoreSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
  */
 
 bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2277,12 +2165,6 @@ bool emberAfScenesClusterStoreSceneResponseCallback(chip::app::Command * command
 
 /**
  * @brief Scenes Cluster ViewSceneResponse Command callback
- * @param status
- * @param groupId
- * @param sceneId
- * @param transitionTime
- * @param sceneName
- * @param extensionFieldSets
  */
 
 bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandObj, uint8_t status, uint16_t groupId,
@@ -2291,7 +2173,6 @@ bool emberAfScenesClusterViewSceneResponseCallback(chip::app::Command * commandO
 
 /**
  * @brief Test Cluster Cluster TestSpecificResponse Command callback
- * @param returnValue
  */
 
 bool emberAfTestClusterClusterTestSpecificResponseCallback(chip::app::Command * commandObj, uint8_t returnValue);

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -89,9 +89,11 @@ public:
     /**
      *  Creates a new ExchangeContext with a given peer CHIP node specified by the peer node identifier.
      *
-     *  @param[in]    peerNodeId    The node identifier of the peer with which the ExchangeContext is being set up.
+     *  @param[in]    session    The identifier of the secure session (possibly
+     *                           the empty session for a non-secure exchange)
+     *                           for which the ExchangeContext is being set up.
      *
-     *  @param[in]    delegate      A pointer to ExchangeDelegate.
+     *  @param[in]    delegate   A pointer to ExchangeDelegate.
      *
      *  @return   A pointer to the created ExchangeContext object On success. Otherwise NULL if no object
      *            can be allocated or is available.
@@ -103,8 +105,6 @@ public:
      *  invoked for all messages of the given protocol.
      *
      *  @param[in]    protocolId      The protocol identifier of the received message.
-     *
-     *  @param[in]    handler         The unsolicited message handler.
      *
      *  @param[in]    delegate        A pointer to ExchangeDelegate.
      *

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -184,11 +184,10 @@ public:
     bool IsOccupied() const;
 
     /**
-     *  Set if an acknowledgment needs to be sent back to the peer on this exchange.
+     *  Set whether there is an acknowledgment panding to be send to the peer on
+     *  this exchange.
      *
-     *  @param[in]  inAckPending A Boolean indicating whether (true) or not
-     *                          (false) an acknowledgment should be sent back
-     *                          in response to a received message.
+     *  @param[in]  inOccupied Whether there is a pending acknowledgment.
      */
     void SetOccupied(bool inOccupied);
 

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -75,7 +75,7 @@ public:
     /**
      * Return a tick counter value given a time period.
      *
-     * @param[in]  newTime        Timestamp value of in milliseconds.
+     * @param[in]  period        Timestamp value of in milliseconds.
      *
      * @return Tick count for the time period.
      */
@@ -137,9 +137,9 @@ public:
     void PauseRetransmision(ReliableMessageContext * rc, uint32_t PauseTimeMillis);
 
     /**
-     *  Re-start retranmisttion of cached encryped packet for current entry.
+     *  Re-start retranmisttion of cached encryped packets for the given ReliableMessageContext.
      *
-     *  @param[in]   entry    A pointer to a retransmission table entry added into the table.
+     *  @param[in] rc The ReliableMessageContext to resume retransmission for.
      *
      *  @retval  #CHIP_NO_ERROR On success.
      */


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
We have invalid doxygen syntax that leads to tons of warnings on Darwin

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Fix the various doxygen bits.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes https://github.com/project-chip/connectedhomeip/issues/6734

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Review note: Just review the manual changeset, not the second one that generates all the generated bits.