### PR TITLE
Add dependency on platform_buildconfig header to the system library

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -151,6 +151,7 @@ static_library("system") {
 
   public_deps = [
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform:platform_buildconfig",
     "${nlassert_root}:nlassert",
   ]
 


### PR DESCRIPTION
 #### Problem
Build seems racy: system checks for 'chip stack is locked' however lock header requires the generated platform configuration header.


 #### Summary of Changes
 Add a configuration header dependency in the system library
