### PR TITLE
CHIPDeviceController::StopPairing does not stop pairing

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1044,6 +1044,10 @@ CHIP_ERROR DeviceCommissioner::UnpairDevice(NodeId remoteDeviceId)
 
 void DeviceCommissioner::FreeRendezvousSession()
 {
+    mPairingSession.Clear();
+#if CONFIG_NETWORK_LAYER_BLE
+    mBleLayer->CancelBleIncompleteConnection();
+#endif
     PersistNextKeyId();
 }
 


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 
`ChipDeviceController::StopPairing` does not stop pairing anymore. Likely a regression from the shift to the `Network Provisioning` cluster.
