### PR TITLE
Allow sending IM commands to different peer key id

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -34,7 +34,8 @@ using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 namespace chip {
 namespace app {
 
-CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId)
+CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId,
+                                             chip::Messaging::ExchangeContext * exchangeContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -46,8 +47,15 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     // Create a new exchange context.
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
     // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
-    mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
-    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    if (exchangeContext == nullptr)
+    {
+        mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
+        VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
+    }
+    else
+    {
+        mpExchangeCtx = exchangeContext;
+    }
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -34,8 +34,7 @@ using GeneralStatusCode = chip::Protocols::SecureChannel::GeneralStatusCode;
 namespace chip {
 namespace app {
 
-CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId,
-                                             chip::Messaging::ExchangeContext * exchangeContext)
+CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -47,15 +46,15 @@ CHIP_ERROR CommandSender::SendCommandRequest(NodeId aNodeId, Transport::AdminId 
     // Create a new exchange context.
     // TODO: temprary create a SecureSessionHandle from node id, will be fix in PR 3602
     // TODO: Hard code keyID to 0 to unblock IM end-to-end test. Complete solution is tracked in issue:4451
-    if (exchangeContext == nullptr)
+    if (secureSession == nullptr)
     {
         mpExchangeCtx = mpExchangeMgr->NewContext({ aNodeId, 0, aAdminId }, this);
-        VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     }
     else
     {
-        mpExchangeCtx = exchangeContext;
+        mpExchangeCtx = mpExchangeMgr->NewContext(*secureSession, this);
     }
+    VerifyOrExit(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeoutMsec);
 
     err = mpExchangeCtx->SendMessage(

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -45,8 +45,8 @@ namespace app {
 class CommandSender : public Command, public Messaging::ExchangeDelegate
 {
 public:
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId,
-                                  Messaging::ExchangeContext * exchangeContext = nullptr);
+    // TODO: issue #6792 - the secure session parameter should be made non-optional and passed by reference.
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId, SecureSessionHandle * secureSession = nullptr);
 
     void OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                            const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload) override;

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -45,7 +45,8 @@ namespace app {
 class CommandSender : public Command, public Messaging::ExchangeDelegate
 {
 public:
-    CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId);
+    CHIP_ERROR SendCommandRequest(NodeId aNodeId, Transport::AdminId aAdminId,
+                                  Messaging::ExchangeContext * exchangeContext = nullptr);
 
     void OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PacketHeader & aPacketHeader,
                            const PayloadHeader & aPayloadHeader, System::PacketBufferHandle aPayload) override;

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -145,9 +145,7 @@ CHIP_ERROR Device::SendCommands()
     bool loadedSecureSession = false;
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
     VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    Messaging::ExchangeContext * exchange = mExchangeMgr->NewContext(mSecureSession, mCommandSender);
-    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_NO_MEMORY);
-    return mCommandSender->SendCommandRequest(mDeviceId, mAdminId, exchange);
+    return mCommandSender->SendCommandRequest(mDeviceId, mAdminId, &mSecureSession);
 }
 
 CHIP_ERROR Device::Serialize(SerializedDevice & output)

--- a/src/controller/CHIPDevice.cpp
+++ b/src/controller/CHIPDevice.cpp
@@ -145,7 +145,9 @@ CHIP_ERROR Device::SendCommands()
     bool loadedSecureSession = false;
     ReturnErrorOnFailure(LoadSecureSessionParametersIfNeeded(loadedSecureSession));
     VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    return mCommandSender->SendCommandRequest(mDeviceId, mAdminId);
+    Messaging::ExchangeContext * exchange = mExchangeMgr->NewContext(mSecureSession, mCommandSender);
+    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_NO_MEMORY);
+    return mCommandSender->SendCommandRequest(mDeviceId, mAdminId, exchange);
 }
 
 CHIP_ERROR Device::Serialize(SerializedDevice & output)


### PR DESCRIPTION
Chip device has a session open with a device, and that device may
or may not have a key id of 0. The IM command sender assumes a key
of 0 and creates a new exchange using that key. It then fails to
find that peer session becuase the keys don't match. Instead,
allow chip device to pass in its own exchange context. Function
defaults to null, which will create the exchange context with key
0 as normal for other use cases.

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
IM command sender assumes the peer has a key id of 0. This is not always the case and the device has proper information about the peer's key.

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Adds a function parameter to the SendCommand function so the device can pass along its exchange context with the proper values set. Nullptr default will cause a new exchange context with a key of 0 to be created.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6767

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
