### PR TITLE
Implemented CASEServer to fetch credentials, and wait for SigmaR1

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -33,6 +33,7 @@
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
+#include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <setup_payload/SetupPayload.h>
 #include <support/CodeUtils.h>
@@ -285,6 +286,7 @@ private:
 DemoTransportMgr gTransports;
 SecureSessionMgr gSessions;
 RendezvousServer gRendezvousServer;
+CASEServer gCASEServer;
 Messaging::ExchangeManager gExchangeMgr;
 ServerRendezvousAdvertisementDelegate gAdvDelegate;
 
@@ -566,6 +568,9 @@ void InitServer(AppDelegate * delegate)
     // Register to receive unsolicited Service Provisioning messages from the exchange manager.
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::ServiceProvisioning::Id, &gCallbacks);
     VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER);
+
+    err = gCASEServer.WaitForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable());
+    SuccessOrExit(err);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -569,7 +569,7 @@ void InitServer(AppDelegate * delegate)
     err = gExchangeMgr.RegisterUnsolicitedMessageHandlerForProtocol(Protocols::ServiceProvisioning::Id, &gCallbacks);
     VerifyOrExit(err == CHIP_NO_ERROR, err = CHIP_ERROR_NO_UNSOLICITED_MESSAGE_HANDLER);
 
-    err = gCASEServer.WaitForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable());
+    err = gCASEServer.ListenForSessionEstablishment(&gExchangeMgr, &gTransports, &gSessions, &GetGlobalAdminPairingTable());
     SuccessOrExit(err);
 
 exit:

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -4,6 +4,8 @@ static_library("secure_channel") {
   output_name = "libSecureChannel"
 
   sources = [
+    "CASEServer.cpp",
+    "CASEServer.h",
     "CASESession.cpp",
     "CASESession.h",
     "PASESession.cpp",

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -27,8 +27,8 @@ using namespace ::chip::Transport;
 
 namespace chip {
 
-CHIP_ERROR CASEServer::WaitForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                                   SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins)
+CHIP_ERROR CASEServer::ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
+                                                     SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins)
 {
     VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -65,7 +65,7 @@ CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
     ReturnErrorOnFailure(mCredentials.Init(&mCertificates, mCertificates.GetCertCount()));
 
     // Setup CASE state machine using the credentials for the current admin.
-    ReturnErrorOnFailure(mPairingSession.WaitForSessionEstablishment(&mCredentials, mNextKeyId++, this));
+    ReturnErrorOnFailure(mPairingSession.ListenForSessionEstablishment(&mCredentials, mNextKeyId++, this));
 
     // Hand over the exchange context to the CASE session.
     ec->SetDelegate(&mPairingSession);

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -1,0 +1,119 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <protocols/secure_channel/CASEServer.h>
+
+#include <core/CHIPError.h>
+#include <support/CodeUtils.h>
+#include <support/SafeInt.h>
+#include <transport/SecureSessionMgr.h>
+
+using namespace ::chip::Inet;
+using namespace ::chip::Transport;
+
+namespace chip {
+
+CHIP_ERROR CASEServer::WaitForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
+                                                   SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins)
+{
+    VerifyOrReturnError(transportMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(sessionMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(admins != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mSessionMgr      = sessionMgr;
+    mAdmins          = admins;
+    mExchangeManager = exchangeManager;
+
+    ReturnErrorOnFailure(mPairingSession.MessageDispatch().Init(transportMgr));
+
+    ReturnErrorOnFailure(
+        mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1, this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CASEServer::InitCASEHandshake(Messaging::ExchangeContext * ec)
+{
+    ReturnErrorCodeIf(ec == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Lookup the admin that corresponds to the CASE session setup request.
+    // Each admin provisions their own credentials on the device. So it's essential to
+    // use the correct operational certificates for CASE session setup.
+    mAdminId = ec->GetSecureSession().GetAdminId();
+    ReturnErrorCodeIf(mAdminId == Transport::kUndefinedAdminId, CHIP_ERROR_INVALID_ARGUMENT);
+
+    Transport::AdminPairingInfo * admin = mAdmins->FindAdminWithId(mAdminId);
+    ReturnErrorCodeIf(admin == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    ReturnErrorOnFailure(admin->GetOperationalCertificateSet(mCertificates));
+
+    mCredentials.Release();
+    ReturnErrorOnFailure(mCredentials.Init(&mCertificates, mCertificates.GetCertCount()));
+
+    // Setup CASE state machine using the credentials for the current admin.
+    ReturnErrorOnFailure(mPairingSession.WaitForSessionEstablishment(&mCredentials, mNextKeyId++, this));
+
+    // Hand over the exchange context to the CASE session.
+    ec->SetDelegate(&mPairingSession);
+
+    return CHIP_NO_ERROR;
+}
+
+void CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader,
+                                   const PayloadHeader & payloadHeader, System::PacketBufferHandle payload)
+{
+    ReturnOnFailure(InitCASEHandshake(ec));
+    mPairingSession.OnMessageReceived(ec, packetHeader, payloadHeader, std::move(payload));
+
+    // TODO - Enable multiple concurrent CASE session establishment
+    // This will prevent CASEServer to process another CASE session establishment request until the current
+    // one completes (successfully or failed)
+    mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1);
+}
+
+void CASEServer::Cleanup()
+{
+    // Let's re-register for CASE SigmaR1 message, so that the next CASE session setup request can be processed.
+    mExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1, this);
+    mAdminId = Transport::kUndefinedAdminId;
+    mCredentials.Release();
+}
+
+void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
+{
+    ChipLogProgress(AppServer, "CASE Session establishment failed: %s", ErrorStr(err));
+    Cleanup();
+}
+
+void CASEServer::OnSessionEstablished()
+{
+    ChipLogProgress(AppServer, "CASE Session established. Setting up the secure channel.");
+    CHIP_ERROR err =
+        mSessionMgr->NewPairing(Optional<Transport::PeerAddress>::Value(mPairingSession.PeerConnection().GetPeerAddress()),
+                                mPairingSession.PeerConnection().GetPeerNodeId(), &mPairingSession,
+                                SecureSession::SessionRole::kResponder, mAdminId, nullptr);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Ble, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        OnSessionEstablishmentError(err);
+        return;
+    }
+
+    ChipLogProgress(AppServer, "CASE secure channel is available now.");
+    Cleanup();
+}
+} // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -44,11 +44,6 @@ public:
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
     void OnSessionEstablished() override;
 
-    void Cleanup();
-
-    uint16_t GetNextKeyId() const { return mNextKeyId; }
-    void SetNextKeyId(uint16_t id) { mNextKeyId = id; }
-
     //// ExchangeDelegate Implementation ////
     void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
                            System::PacketBufferHandle payload) override;
@@ -73,6 +68,7 @@ private:
     OperationalCredentialSet mCredentials;
 
     CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
+    void Cleanup();
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -37,8 +37,8 @@ public:
         mCredentials.Release();
     }
 
-    CHIP_ERROR WaitForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
-                                           SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins);
+    CHIP_ERROR ListenForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
+                                             SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins);
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablishmentError(CHIP_ERROR error) override;

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <messaging/ExchangeDelegate.h>
+#include <messaging/ExchangeMgr.h>
+#include <protocols/secure_channel/CASESession.h>
+
+namespace chip {
+
+class CASEServer : public SessionEstablishmentDelegate, public Messaging::ExchangeDelegateBase
+{
+public:
+    CASEServer() {}
+    ~CASEServer()
+    {
+        if (mExchangeManager != nullptr)
+        {
+            mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_SigmaR1);
+        }
+
+        mCredentials.Release();
+    }
+
+    CHIP_ERROR WaitForSessionEstablishment(Messaging::ExchangeManager * exchangeManager, TransportMgrBase * transportMgr,
+                                           SecureSessionMgr * sessionMgr, Transport::AdminPairingTable * admins);
+
+    //////////// SessionEstablishmentDelegate Implementation ///////////////
+    void OnSessionEstablishmentError(CHIP_ERROR error) override;
+    void OnSessionEstablished() override;
+
+    void Cleanup();
+
+    uint16_t GetNextKeyId() const { return mNextKeyId; }
+    void SetNextKeyId(uint16_t id) { mNextKeyId = id; }
+
+    //// ExchangeDelegate Implementation ////
+    void OnMessageReceived(Messaging::ExchangeContext * ec, const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                           System::PacketBufferHandle payload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * ec) override {}
+    Messaging::ExchangeMessageDispatch * GetMessageDispatch(Messaging::ReliableMessageMgr * reliableMessageManager,
+                                                            SecureSessionMgr * sessionMgr) override
+    {
+        return mPairingSession.GetMessageDispatch(reliableMessageManager, sessionMgr);
+    }
+
+private:
+    Messaging::ExchangeManager * mExchangeManager = nullptr;
+
+    CASESession mPairingSession;
+    uint16_t mNextKeyId            = 0;
+    SecureSessionMgr * mSessionMgr = nullptr;
+
+    Transport::AdminId mAdminId = Transport::kUndefinedAdminId;
+
+    Transport::AdminPairingTable * mAdmins = nullptr;
+    ChipCertificateSet mCertificates;
+    OperationalCredentialSet mCredentials;
+
+    CHIP_ERROR InitCASEHandshake(Messaging::ExchangeContext * ec);
+};
+
+} // namespace chip

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -211,8 +211,8 @@ CHIP_ERROR CASESession::Init(OperationalCredentialSet * operationalCredentialSet
 }
 
 CHIP_ERROR
-CASESession::WaitForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId,
-                                         SessionEstablishmentDelegate * delegate)
+CASESession::ListenForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId,
+                                           SessionEstablishmentDelegate * delegate)
 {
     ReturnErrorOnFailure(Init(operationalCredentialSet, myKeyId, delegate));
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -93,8 +93,8 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR WaitForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId,
-                                           SessionEstablishmentDelegate * delegate);
+    CHIP_ERROR ListenForSessionEstablishment(OperationalCredentialSet * operationalCredentialSet, uint16_t myKeyId,
+                                             SessionEstablishmentDelegate * delegate);
 
     /**
      * @brief

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -108,8 +108,8 @@ void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
     TestCASESecurePairingDelegate delegate;
     CASESession pairing;
 
-    NL_TEST_ASSERT(inSuite, pairing.WaitForSessionEstablishment(&accessoryDevOpCred, 0, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, pairing.WaitForSessionEstablishment(&accessoryDevOpCred, 0, &delegate) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(&accessoryDevOpCred, 0, nullptr) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, pairing.ListenForSessionEstablishment(&accessoryDevOpCred, 0, &delegate) == CHIP_NO_ERROR);
 }
 
 void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
@@ -169,7 +169,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     ExchangeContext * contextCommissioner = ctx.NewExchangeToLocal(&pairingCommissioner);
 
     NL_TEST_ASSERT(inSuite,
-                   pairingAccessory.WaitForSessionEstablishment(&accessoryDevOpCred, 0, &delegateAccessory) == CHIP_NO_ERROR);
+                   pairingAccessory.ListenForSessionEstablishment(&accessoryDevOpCred, 0, &delegateAccessory) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite,
                    pairingCommissioner.EstablishSession(Transport::PeerAddress(Transport::Type::kBle), &commissionerDevOpCred, 1, 0,
                                                         contextCommissioner, &delegateCommissioner) == CHIP_NO_ERROR);

--- a/src/transport/AdminPairingTable.h
+++ b/src/transport/AdminPairingTable.h
@@ -23,6 +23,7 @@
 
 #include <app/util/basic-types.h>
 #include <core/CHIPPersistentStorageDelegate.h>
+#include <credentials/CHIPCert.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <support/CHIPMem.h>
 #include <support/DLLUtil.h>
@@ -41,11 +42,6 @@ constexpr char kAdminTableKeyPrefix[] = "CHIPAdmin";
 constexpr char kAdminTableCountKey[]  = "CHIPAdminNextId";
 
 constexpr uint16_t kMaxChipCertSize = 600;
-
-struct OperationalCredentials
-{
-    uint32_t placeholder;
-};
 
 struct AccessControlList
 {
@@ -100,9 +96,7 @@ public:
     CHIP_ERROR SetOperationalCert(const chip::ByteSpan & cert);
     CHIP_ERROR SetRootCert(const chip::ByteSpan & cert);
 
-    const OperationalCredentials & GetOperationalCreds() const { return mOpCred; }
-    OperationalCredentials & GetOperationalCreds() { return mOpCred; }
-    void SetOperationalCreds(const OperationalCredentials & creds) { mOpCred = creds; }
+    CHIP_ERROR GetOperationalCertificateSet(Credentials::ChipCertificateSet & certSet);
 
     const AccessControlList & GetACL() const { return mACL; }
     AccessControlList & GetACL() { return mACL; }
@@ -131,12 +125,11 @@ public:
     friend class AdminPairingTable;
 
 private:
-    AdminId mAdmin     = kUndefinedAdminId;
     NodeId mNodeId     = kUndefinedNodeId;
     FabricId mFabricId = kUndefinedFabricId;
+    AdminId mAdmin     = kUndefinedAdminId;
     uint16_t mVendorId = kUndefinedVendorId;
 
-    OperationalCredentials mOpCred;
     AccessControlList mACL;
 
     Crypto::P256Keypair * mOperationalKey = nullptr;


### PR DESCRIPTION
 #### Problem
Need mechanism to
1. Wait for first CASE message from peer to start handshake
2. Fetch operational credentials provisioned by the commissioner for which the CASE session is being established.

 #### Summary of Changes
This PR adds a new class `CASEServer`, that'll perform the actions mentioned in the problem.
The CASEServer will be available to device, as well as controllers.

This PR also optimizes the RAM usage for AdminPairingInfo.

 Fixes #6779
