### PR TITLE
[IM] Decouple CommandSender with CHIPDevice

### DIFF
--- a/examples/chip-tool/gen/CHIPClusters.cpp
+++ b/examples/chip-tool/gen/CHIPClusters.cpp
@@ -36,23 +36,26 @@ CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSetupPINCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // tempAccountIdentifier: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -60,25 +63,28 @@ CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLoginCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // tempAccountIdentifier: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier));
     // setupPIN: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), setupPIN));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // AccountLogin Cluster Attributes
@@ -176,13 +182,16 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchAppCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
@@ -191,12 +200,12 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
     // applicationId: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), applicationId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ApplicationLauncher Cluster Attributes
@@ -230,25 +239,28 @@ CHIP_ERROR AudioOutputCluster::RenameOutput(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRenameOutputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), name));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR AudioOutputCluster::SelectOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -256,23 +268,26 @@ CHIP_ERROR AudioOutputCluster::SelectOutput(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSelectOutputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // AudioOutput Cluster Attributes
@@ -305,23 +320,26 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // percentOpen: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), percentOpen));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSuccessCallback,
@@ -329,20 +347,23 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // BarrierControl Cluster Attributes
@@ -398,20 +419,23 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Basic Cluster Attributes
@@ -588,13 +612,16 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -605,12 +632,12 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -619,13 +646,16 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -636,12 +666,12 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Binding Cluster Attributes
@@ -665,13 +695,16 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rateX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rateX));
@@ -682,12 +715,12 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -697,13 +730,16 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -718,12 +754,12 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -731,13 +767,16 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -748,12 +787,12 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -761,13 +800,16 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: saturationMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -778,12 +820,12 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -792,13 +834,16 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorX: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorX));
@@ -811,12 +856,12 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -825,13 +870,16 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorTemperature: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorTemperature));
@@ -842,12 +890,12 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -856,13 +904,16 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -875,12 +926,12 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * onSuccessCallback,
@@ -889,13 +940,16 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -908,12 +962,12 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -922,13 +976,16 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // saturation: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), saturation));
@@ -939,12 +996,12 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -953,13 +1010,16 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepX));
@@ -972,12 +1032,12 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -987,13 +1047,16 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1010,12 +1073,12 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1024,13 +1087,16 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1043,12 +1109,12 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1057,13 +1123,16 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: saturationStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1076,12 +1145,12 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1089,25 +1158,28 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionsMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsMask));
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ColorControl Cluster Attributes
@@ -1719,25 +1791,28 @@ CHIP_ERROR ContentLaunchCluster::LaunchContent(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchContentCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // autoPlay: boolean
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), autoPlay));
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1745,25 +1820,28 @@ CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallb
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchURLCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // contentURL: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), contentURL));
     // displayString: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), displayString));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ContentLaunch Cluster Attributes
@@ -1851,40 +1929,46 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1892,23 +1976,26 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1916,23 +2003,26 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1940,23 +2030,26 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1964,25 +2057,28 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1990,25 +2086,28 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2016,23 +2115,26 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2040,23 +2142,26 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // logIndex: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), logIndex));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2064,23 +2169,26 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2088,23 +2196,26 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2112,23 +2223,26 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2136,25 +2250,28 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2162,25 +2279,28 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2188,23 +2308,26 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2213,13 +2336,16 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2230,12 +2356,12 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     // operatingModeDuringHoliday: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operatingModeDuringHoliday));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2243,13 +2369,16 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -2260,12 +2389,12 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2273,13 +2402,16 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -2290,12 +2422,12 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     // id: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), id));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2303,25 +2435,28 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
     // userType: doorLockUserType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userType));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2330,13 +2465,16 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2353,12 +2491,12 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     // endMinute: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), endMinute));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2366,13 +2504,16 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2383,12 +2524,12 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     // localEndTime: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), localEndTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2396,23 +2537,26 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2420,25 +2564,28 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutInSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutInSeconds));
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // DoorLock Cluster Attributes
@@ -2502,13 +2649,16 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // expiryLengthSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), expiryLengthSeconds));
@@ -2517,12 +2667,12 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelable * onSuccessCallback,
@@ -2530,20 +2680,23 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
@@ -2552,13 +2705,16 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRegulatoryConfigCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // location: regulatoryLocationType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), location));
@@ -2569,12 +2725,12 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // GeneralCommissioning Cluster Attributes
@@ -2689,25 +2845,28 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2715,25 +2874,28 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2741,45 +2903,51 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupCount: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupCount));
     // groupList: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupList));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2787,23 +2955,26 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2811,23 +2982,26 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Groups Cluster Attributes
@@ -2859,43 +3033,49 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // identifyTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), identifyTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Identify Cluster Attributes
@@ -2935,23 +3115,26 @@ CHIP_ERROR KeypadInputCluster::SendKey(Callback::Cancelable * onSuccessCallback,
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSendKeyCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // keyCode: keypadInputCecKeyCode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), keyCode));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // KeypadInput Cluster Attributes
@@ -2976,13 +3159,16 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -2993,12 +3179,12 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3006,13 +3192,16 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
@@ -3023,12 +3212,12 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSuccessCallback,
@@ -3037,25 +3226,28 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3063,25 +3255,28 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
     // rate: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3090,13 +3285,16 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -3109,12 +3307,12 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3122,13 +3320,16 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -3137,12 +3338,12 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3150,45 +3351,51 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionMask));
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LevelControl Cluster Attributes
@@ -3235,20 +3442,23 @@ CHIP_ERROR LowPowerCluster::Sleep(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSleepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LowPower Cluster Attributes
@@ -3271,20 +3481,23 @@ CHIP_ERROR MediaInputCluster::HideInputStatus(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kHideInputStatusCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3292,25 +3505,28 @@ CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRenameInputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), name));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::SelectInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3318,43 +3534,49 @@ CHIP_ERROR MediaInputCluster::SelectInput(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSelectInputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::ShowInputStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kShowInputStatusCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // MediaInput Cluster Attributes
@@ -3386,120 +3608,138 @@ CHIP_ERROR MediaPlaybackCluster::MediaFastForward(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaFastForwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaNext(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaNextCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPause(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPauseCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPlay(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPlayCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPrevious(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPreviousCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaRewind(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaRewindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipBackward(Callback::Cancelable * onSuccessCallback,
@@ -3507,23 +3747,26 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipBackward(Callback::Cancelable * onSucc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipBackwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // deltaPositionMilliseconds: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), deltaPositionMilliseconds));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipForward(Callback::Cancelable * onSuccessCallback,
@@ -3531,23 +3774,26 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipForward(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipForwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // deltaPositionMilliseconds: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), deltaPositionMilliseconds));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipSeek(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3555,63 +3801,72 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipSeek(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipSeekCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // position: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), position));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaStartOver(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaStartOverCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaStop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // MediaPlayback Cluster Attributes
@@ -3637,13 +3892,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -3652,12 +3910,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3666,13 +3924,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3683,12 +3944,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3697,13 +3958,16 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3712,12 +3976,12 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3726,13 +3990,16 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3741,12 +4008,12 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callback::Cancelable * onSuccessCallback,
@@ -3755,23 +4022,26 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3780,13 +4050,16 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3795,12 +4068,12 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSuccessCallback,
@@ -3809,13 +4082,16 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3824,12 +4100,12 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3839,13 +4115,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -3854,12 +4133,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3868,13 +4147,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3885,12 +4167,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // NetworkCommissioning Cluster Attributes
@@ -3914,60 +4196,69 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OnOff Cluster Attributes
@@ -4012,20 +4303,23 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveAllFabrics(Callback::Cancelable 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllFabricsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * onSuccessCallback,
@@ -4034,13 +4328,16 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // fabricId: fabricId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), fabricId));
@@ -4049,12 +4346,12 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuccessCallback,
@@ -4062,23 +4359,26 @@ CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
@@ -4086,23 +4386,26 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // label: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), label));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OperationalCredentials Cluster Attributes
@@ -4238,13 +4541,16 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -4261,12 +4567,12 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     // value: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), value));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4274,23 +4580,26 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4298,13 +4607,16 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -4313,12 +4625,12 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4326,23 +4638,26 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4350,25 +4665,28 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4376,25 +4694,28 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4402,25 +4723,28 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Scenes Cluster Attributes
@@ -4531,23 +4855,26 @@ CHIP_ERROR TvChannelCluster::ChangeChannel(Callback::Cancelable * onSuccessCallb
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kChangeChannelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // match: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), match));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TvChannelCluster::ChangeChannelByNumber(Callback::Cancelable * onSuccessCallback,
@@ -4556,25 +4883,28 @@ CHIP_ERROR TvChannelCluster::ChangeChannelByNumber(Callback::Cancelable * onSucc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kChangeChannelByNumberCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // majorNumber: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), majorNumber));
     // minorNumber: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), minorNumber));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TvChannelCluster::SkipChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4582,23 +4912,26 @@ CHIP_ERROR TvChannelCluster::SkipChannel(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipChannelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // count: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), count));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TvChannel Cluster Attributes
@@ -4646,25 +4979,28 @@ CHIP_ERROR TargetNavigatorCluster::NavigateTarget(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kNavigateTargetCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // target: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), target));
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TargetNavigator Cluster Attributes
@@ -4753,60 +5089,69 @@ CHIP_ERROR TestClusterCluster::Test(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestNotHandled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestNotHandledCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestSpecific(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestSpecificCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TestCluster Cluster Attributes
@@ -5111,40 +5456,46 @@ CHIP_ERROR ThermostatCluster::ClearWeeklySchedule(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetRelayStatusLog(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRelayStatusLogCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5152,25 +5503,28 @@ CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // daysToReturn: dayOfWeek
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), daysToReturn));
     // modeToReturn: modeForSequence
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), modeToReturn));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5179,13 +5533,16 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // numberOfTransitionsForSequence: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), numberOfTransitionsForSequence));
@@ -5196,12 +5553,12 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
     // payload: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), payload));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5209,25 +5566,28 @@ CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetpointRaiseLowerCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // mode: setpointAdjustMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), mode));
     // amount: int8s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), amount));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Thermostat Cluster Attributes

--- a/examples/pump-controller-app/pump-controller-common/gen/CHIPClusters.cpp
+++ b/examples/pump-controller-app/pump-controller-common/gen/CHIPClusters.cpp
@@ -35,60 +35,69 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OnOff Cluster Attributes

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -94,7 +94,6 @@ exit:
     // This needs to be done before the Reset() call, because Reset() aborts mpExchangeCtx if its not null.
     mpExchangeCtx->Close();
     mpExchangeCtx = nullptr;
-    Reset();
 
     if (mpDelegate != nullptr)
     {
@@ -107,18 +106,21 @@ exit:
             mpDelegate->CommandResponseProcessed(this);
         }
     }
+
+    Shutdown();
 }
 
 void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext)
 {
     ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Exchange: %d",
                     apExchangeContext->GetExchangeId());
-    Reset();
 
     if (mpDelegate != nullptr)
     {
         mpDelegate->CommandResponseError(this, CHIP_ERROR_TIMEOUT);
     }
+
+    Shutdown();
 }
 
 CHIP_ERROR CommandSender::ProcessCommandDataElement(CommandDataElement::Parser & aCommandElement)

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -47,8 +47,9 @@
 #include <app/reporting/Engine.h>
 #include <app/util/basic-types.h>
 
-#define CHIP_MAX_NUM_COMMAND_HANDLER 1
-#define CHIP_MAX_NUM_COMMAND_SENDER 1
+// TODO: Make number of command handler and command sender configurable
+#define CHIP_MAX_NUM_COMMAND_HANDLER 2
+#define CHIP_MAX_NUM_COMMAND_SENDER 2
 #define CHIP_MAX_NUM_READ_CLIENT 1
 #define CHIP_MAX_NUM_READ_HANDLER 1
 #define CHIP_MAX_REPORTS_IN_FLIGHT 1

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -48,8 +48,8 @@
 #include <app/util/basic-types.h>
 
 // TODO: Make number of command handler and command sender configurable
-#define CHIP_MAX_NUM_COMMAND_HANDLER 2
-#define CHIP_MAX_NUM_COMMAND_SENDER 2
+#define CHIP_MAX_NUM_COMMAND_HANDLER 4
+#define CHIP_MAX_NUM_COMMAND_SENDER 4
 #define CHIP_MAX_NUM_READ_CLIENT 1
 #define CHIP_MAX_NUM_READ_HANDLER 1
 #define CHIP_MAX_REPORTS_IN_FLIGHT 1

--- a/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
+++ b/src/app/zap-templates/templates/app/CHIPClusters-src.zapt
@@ -21,15 +21,18 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, k{{asCamelCased name false}}CommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
 {{#chip_server_cluster_command_arguments}}
 {{#first}}
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber = 0;
 {{/first}}
     // {{asCamelCased label}}: {{asCamelCased type}}
@@ -38,12 +41,12 @@ CHIP_ERROR {{asCamelCased clusterName false}}Cluster::{{asCamelCased name false}
     // Command takes no arguments.
 {{/chip_server_cluster_command_arguments}}
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 {{/chip_server_cluster_commands}}

--- a/src/controller/CHIPCluster.cpp
+++ b/src/controller/CHIPCluster.cpp
@@ -24,25 +24,30 @@
  *    the CHIP device.
  */
 
+#include <app/InteractionModelEngine.h>
 #include <controller/CHIPCluster.h>
 #include <protocols/temp_zcl/TempZCL.h>
+#include <support/CodeUtils.h>
 
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR ClusterBase::Associate(Device * device, EndpointId endpoint)
+CHIP_ERROR ClusterBase::Associate(Device * device, EndpointId endpoint, app::CommandSender * commandSender)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // TODO: Check if the device supports mCluster at the requested endpoint
 
-    mDevice   = device;
-    mEndpoint = endpoint;
+    mDevice         = device;
+    mEndpoint       = endpoint;
+    mpCommandSender = commandSender;
+
     return err;
 }
 
 void ClusterBase::Dissociate()
 {
-    mDevice = nullptr;
+    mDevice         = nullptr;
+    mpCommandSender = nullptr;
 }
 
 CHIP_ERROR ClusterBase::SendCommand(uint8_t seqNum, chip::System::PacketBufferHandle payload,

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -36,7 +36,7 @@ class DLL_EXPORT ClusterBase
 public:
     virtual ~ClusterBase() {}
 
-    CHIP_ERROR Associate(Device * device, EndpointId endpoint);
+    CHIP_ERROR Associate(Device * device, EndpointId endpoint, app::CommandSender * commandSender = nullptr);
 
     void Dissociate();
 
@@ -73,6 +73,7 @@ protected:
 
     const ClusterId mClusterId;
     Device * mDevice;
+    app::CommandSender * mpCommandSender = nullptr;
     EndpointId mEndpoint;
 };
 

--- a/src/controller/CHIPDevice.h
+++ b/src/controller/CHIPDevice.h
@@ -96,12 +96,6 @@ public:
             // point.
             mExchangeMgr->CloseAllContextsForDelegate(this);
         }
-
-        if (mCommandSender != nullptr)
-        {
-            mCommandSender->Shutdown();
-            mCommandSender = nullptr;
-        }
     }
 
     enum class PairingWindowOption
@@ -149,9 +143,7 @@ public:
      * @brief
      *   Send the command in internal command sender.
      */
-    CHIP_ERROR SendCommands();
-
-    app::CommandSender * GetCommandSender() { return mCommandSender; }
+    CHIP_ERROR SendCommands(app::CommandSender * commandObj);
 
     /**
      * @brief Get the IP address and port assigned to the device.
@@ -191,8 +183,6 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
-
-        InitCommandSender();
     }
 
     /**
@@ -356,8 +346,9 @@ public:
     // the app side instead of register callbacks here. The IM delegate can provide more infomation then callback and it is
     // type-safe.
     // TODO: Implement interaction model delegate in the application.
-    void AddIMResponseHandler(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback);
-    void CancelIMResponseHandler();
+    void AddIMResponseHandler(app::Command * commandObj, Callback::Cancelable * onSuccessCallback,
+                              Callback::Cancelable * onFailureCallback);
+    void CancelIMResponseHandler(app::Command * commandObj);
 
     void ProvisioningComplete(uint16_t caseKeyId)
     {
@@ -411,8 +402,6 @@ private:
 
     Messaging::ExchangeManager * mExchangeMgr = nullptr;
 
-    app::CommandSender * mCommandSender = nullptr;
-
     SecureSessionHandle mSecureSession = {};
 
     uint8_t mSequenceNumber = 0;
@@ -438,13 +427,6 @@ private:
      * @param[out] didLoad   Were the secure session params loaded by the call to this function.
      */
     CHIP_ERROR LoadSecureSessionParametersIfNeeded(bool & didLoad);
-
-    /**
-     * @brief
-     *   Initialize internal command sender, required for sending commands over interaction model.
-     *   It's safe to call InitCommandSender multiple times, but only one will be available.
-     */
-    void InitCommandSender();
 
     CHIP_ERROR EstablishCASESession();
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1221,8 +1221,6 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificate(Device * device, const
     Callback::Cancelable * successCallback = mOpCertResponseCallback.Cancel();
     Callback::Cancelable * failureCallback = mOnCertFailureCallback.Cancel();
 
-    device->GetCommandSender()->Reset();
-
     // TODO - Update ZAP to use 16 bit length for OCTET_STRING. This is a temporary hack, as OCTET_STRING only supports 8 bit
     // strings.
     if (opCertBuf.size() >= UINT8_MAX)
@@ -1271,7 +1269,6 @@ void DeviceCommissioner::OnOperationalCertificateAddResponse(void * context, uin
     VerifyOrExit(commissioner->mDeviceBeingPaired < kNumMaxActiveDevices, err = CHIP_ERROR_INCORRECT_STATE);
 
     device = &commissioner->mActiveDevices[commissioner->mDeviceBeingPaired];
-    device->GetCommandSender()->Reset();
 
     err = commissioner->SendTrustedRootCertificate(device);
 
@@ -1349,7 +1346,6 @@ CHIP_ERROR DeviceCommissioner::OnOperationalCredentialsProvisioningCompletion(De
 {
     ChipLogProgress(Controller, "Operational credentials provisioned on device %p", device);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    device->GetCommandSender()->Reset();
 
     mPairingSession.ToSerializable(device->GetPairing());
     mSystemLayer->CancelTimer(OnSessionEstablishmentTimeoutCallback, this);

--- a/src/controller/CHIPOperationalCredentialsProvisioner.cpp
+++ b/src/controller/CHIPOperationalCredentialsProvisioner.cpp
@@ -31,12 +31,14 @@ CHIP_ERROR OperationalCredentialsProvisioner::AddOpCert(Callback::Cancelable * o
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddOpCertCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->Reset());
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // noc: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), noc));
@@ -49,12 +51,12 @@ CHIP_ERROR OperationalCredentialsProvisioner::AddOpCert(Callback::Cancelable * o
     // adminVendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), adminVendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsProvisioner::OpCSRRequest(Callback::Cancelable * onSuccessCallback,
@@ -64,22 +66,24 @@ CHIP_ERROR OperationalCredentialsProvisioner::OpCSRRequest(Callback::Cancelable 
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOpCSRRequestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->Reset());
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // CSRNonce: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), CSRNonce));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsProvisioner::RemoveAllFabrics(Callback::Cancelable * onSuccessCallback,
@@ -89,18 +93,21 @@ CHIP_ERROR OperationalCredentialsProvisioner::RemoveAllFabrics(Callback::Cancela
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllFabricsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsProvisioner::RemoveFabric(Callback::Cancelable * onSuccessCallback,
@@ -111,11 +118,15 @@ CHIP_ERROR OperationalCredentialsProvisioner::RemoveFabric(Callback::Cancelable 
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
+
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // fabricId: fabricId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), fabricId));
@@ -124,12 +135,12 @@ CHIP_ERROR OperationalCredentialsProvisioner::RemoveFabric(Callback::Cancelable 
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsProvisioner::SetFabric(Callback::Cancelable * onSuccessCallback,
@@ -139,21 +150,25 @@ CHIP_ERROR OperationalCredentialsProvisioner::SetFabric(Callback::Cancelable * o
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
+
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsProvisioner::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
@@ -163,21 +178,24 @@ CHIP_ERROR OperationalCredentialsProvisioner::UpdateFabricLabel(Callback::Cancel
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // label: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), label));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OperationalCredentials Cluster Attributes
@@ -213,22 +231,24 @@ CHIP_ERROR TrustedRootCertificatesProvisioner::AddTrustedRootCertificate(Callbac
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->Reset());
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rootCertificate: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rootCertificate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TrustedRootCertificatesProvisioner::RemoveTrustedRootCertificate(Callback::Cancelable * onSuccessCallback,
@@ -239,22 +259,24 @@ CHIP_ERROR TrustedRootCertificatesProvisioner::RemoveTrustedRootCertificate(Call
 
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
 
-    ReturnErrorOnFailure(ZCLcommand->Reset());
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // trustedRootIdentifier: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), trustedRootIdentifier));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TrustedRootCertificates Cluster Attributes

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -37,7 +37,6 @@ chip_data_model("python_data_model") {
   zap_pregenerated_dir = "gen"
 
   use_default_client_callbacks = true
-  use_default_im_dispatch = false
 }
 
 shared_library("ChipDeviceCtrl") {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -359,8 +359,7 @@ CHIP_ERROR pychip_DeviceCommissioner_CloseBleConnection(chip::Controller::Device
 
 uint64_t pychip_GetCommandSenderHandle(chip::Controller::Device * device)
 {
-    chip::app::CommandSender * sender = device->GetCommandSender();
-    return sender == nullptr ? 0 : reinterpret_cast<uint64_t>(sender);
+    return 0;
 }
 
 void pychip_Stack_SetLogFunct(LogMessageFunct logFunct)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -212,10 +212,9 @@ class ChipDeviceController(object):
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
 
-        commandSenderHandle = self._dmLib.pychip_GetCommandSenderHandle(device)
-        im.ClearCommandStatus(commandSenderHandle)
+        commandSenderHandle = im.GetCommandSenderHandle()
         self._Cluster.SendCommand(
-            device, cluster, command, endpoint, groupid, args, commandSenderHandle != 0)
+            device, commandSenderHandle, cluster, command, endpoint, groupid, args, True)
         if blocking:
             # We only send 1 command by this function, so index is always 0
             return im.WaitCommandIndexStatus(commandSenderHandle, 1)

--- a/src/controller/python/chip/clusters/CHIPClusters.cpp
+++ b/src/controller/python/chip/clusters/CHIPClusters.cpp
@@ -90,23 +90,26 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 
 // Cluster AccountLogin
 
-CHIP_ERROR chip_ime_AppendCommand_AccountLogin_GetSetupPIN(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, const uint8_t * tempAccountIdentifier,
+CHIP_ERROR chip_ime_AppendCommand_AccountLogin_GetSetupPIN(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                           const uint8_t * tempAccountIdentifier,
                                                            uint32_t tempAccountIdentifier_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::AccountLoginCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetSetupPIN(nullptr, nullptr, chip::ByteSpan(tempAccountIdentifier, tempAccountIdentifier_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_AccountLogin_Login(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, const uint8_t * tempAccountIdentifier,
-                                                     uint32_t tempAccountIdentifier_Len, const uint8_t * setupPIN,
-                                                     uint32_t setupPIN_Len)
+CHIP_ERROR chip_ime_AppendCommand_AccountLogin_Login(chip::Controller::Device * device, uint64_t command,
+                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                     const uint8_t * tempAccountIdentifier, uint32_t tempAccountIdentifier_Len,
+                                                     const uint8_t * setupPIN, uint32_t setupPIN_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::AccountLoginCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Login(nullptr, nullptr, chip::ByteSpan(tempAccountIdentifier, tempAccountIdentifier_Len),
                          chip::ByteSpan(setupPIN, setupPIN_Len));
 }
@@ -198,14 +201,15 @@ CHIP_ERROR chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision(chip::Control
 // End of Cluster ApplicationBasic
 // Cluster ApplicationLauncher
 
-CHIP_ERROR chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, const uint8_t * data, uint32_t data_Len,
-                                                                uint16_t catalogVendorId, const uint8_t * applicationId,
-                                                                uint32_t applicationId_Len)
+CHIP_ERROR chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * data,
+                                                                uint32_t data_Len, uint16_t catalogVendorId,
+                                                                const uint8_t * applicationId, uint32_t applicationId_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ApplicationLauncherCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.LaunchApp(nullptr, nullptr, chip::ByteSpan(data, data_Len), catalogVendorId,
                              chip::ByteSpan(applicationId, applicationId_Len));
 }
@@ -233,20 +237,23 @@ CHIP_ERROR chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision(chip::Cont
 // End of Cluster ApplicationLauncher
 // Cluster AudioOutput
 
-CHIP_ERROR chip_ime_AppendCommand_AudioOutput_RenameOutput(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint8_t index, const uint8_t * name, uint32_t name_Len)
+CHIP_ERROR chip_ime_AppendCommand_AudioOutput_RenameOutput(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t index,
+                                                           const uint8_t * name, uint32_t name_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::AudioOutputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RenameOutput(nullptr, nullptr, index, chip::ByteSpan(name, name_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_AudioOutput_SelectOutput(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint8_t index)
+CHIP_ERROR chip_ime_AppendCommand_AudioOutput_SelectOutput(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t index)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::AudioOutputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SelectOutput(nullptr, nullptr, index);
 }
 
@@ -271,21 +278,23 @@ CHIP_ERROR chip_ime_ReadAttribute_AudioOutput_ClusterRevision(chip::Controller::
 // End of Cluster AudioOutput
 // Cluster BarrierControl
 
-CHIP_ERROR chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(chip::Controller::Device * device, uint64_t command,
                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                            uint8_t percentOpen)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::BarrierControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.BarrierControlGoToPercent(nullptr, nullptr, percentOpen);
 }
-CHIP_ERROR chip_ime_AppendCommand_BarrierControl_BarrierControlStop(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_BarrierControl_BarrierControlStop(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::BarrierControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.BarrierControlStop(nullptr, nullptr);
 }
 
@@ -337,12 +346,13 @@ CHIP_ERROR chip_ime_ReadAttribute_BarrierControl_ClusterRevision(chip::Controlle
 // End of Cluster BarrierControl
 // Cluster Basic
 
-CHIP_ERROR chip_ime_AppendCommand_Basic_MfgSpecificPing(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                        chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_Basic_MfgSpecificPing(chip::Controller::Device * device, uint64_t command,
+                                                        chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::BasicCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MfgSpecificPing(nullptr, nullptr);
 }
 
@@ -511,22 +521,24 @@ CHIP_ERROR chip_ime_ReadAttribute_Basic_ClusterRevision(chip::Controller::Device
 // End of Cluster Basic
 // Cluster Binding
 
-CHIP_ERROR chip_ime_AppendCommand_Binding_Bind(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                               chip::NodeId nodeId, chip::GroupId groupId, chip::EndpointId endpointId,
-                                               chip::ClusterId clusterId)
+CHIP_ERROR chip_ime_AppendCommand_Binding_Bind(chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId,
+                                               chip::GroupId, chip::NodeId nodeId, chip::GroupId groupId,
+                                               chip::EndpointId endpointId, chip::ClusterId clusterId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::BindingCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Bind(nullptr, nullptr, nodeId, groupId, endpointId, clusterId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Binding_Unbind(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                 chip::NodeId nodeId, chip::GroupId groupId, chip::EndpointId endpointId,
-                                                 chip::ClusterId clusterId)
+CHIP_ERROR chip_ime_AppendCommand_Binding_Unbind(chip::Controller::Device * device, uint64_t command,
+                                                 chip::EndpointId ZCLendpointId, chip::GroupId, chip::NodeId nodeId,
+                                                 chip::GroupId groupId, chip::EndpointId endpointId, chip::ClusterId clusterId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::BindingCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Unbind(nullptr, nullptr, nodeId, groupId, endpointId, clusterId);
 }
 
@@ -542,102 +554,116 @@ CHIP_ERROR chip_ime_ReadAttribute_Binding_ClusterRevision(chip::Controller::Devi
 // End of Cluster Binding
 // Cluster ColorControl
 
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveColor(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, int16_t rateX, int16_t rateY, uint8_t optionsMask,
-                                                         uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveColor(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, int16_t rateX,
+                                                         int16_t rateY, uint8_t optionsMask, uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveColor(nullptr, nullptr, rateX, rateY, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveColorTemperature(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveColorTemperature(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode,
                                                                     uint16_t rate, uint16_t colorTemperatureMinimum,
                                                                     uint16_t colorTemperatureMaximum, uint8_t optionsMask,
                                                                     uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveColorTemperature(nullptr, nullptr, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum,
                                         optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveHue(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                       chip::GroupId, uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                                       uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveHue(chip::Controller::Device * device, uint64_t command,
+                                                       chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode,
+                                                       uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveHue(nullptr, nullptr, moveMode, rate, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveSaturation(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t moveMode, uint8_t rate, uint8_t optionsMask,
-                                                              uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveSaturation(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode,
+                                                              uint8_t rate, uint8_t optionsMask, uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveSaturation(nullptr, nullptr, moveMode, rate, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToColor(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint16_t colorX, uint16_t colorY, uint16_t transitionTime,
-                                                           uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToColor(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t colorX,
+                                                           uint16_t colorY, uint16_t transitionTime, uint8_t optionsMask,
+                                                           uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToColor(nullptr, nullptr, colorX, colorY, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                       uint16_t colorTemperature, uint16_t transitionTime,
                                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToColorTemperature(nullptr, nullptr, colorTemperature, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToHue(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, uint8_t hue, uint8_t direction, uint16_t transitionTime,
-                                                         uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToHue(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t hue,
+                                                         uint8_t direction, uint16_t transitionTime, uint8_t optionsMask,
+                                                         uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToHue(nullptr, nullptr, hue, direction, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t hue,
                                                                       uint8_t saturation, uint16_t transitionTime,
                                                                       uint8_t optionsMask, uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToHueAndSaturation(nullptr, nullptr, hue, saturation, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToSaturation(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t saturation, uint16_t transitionTime,
-                                                                uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_MoveToSaturation(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t saturation,
+                                                                uint16_t transitionTime, uint8_t optionsMask,
+                                                                uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToSaturation(nullptr, nullptr, saturation, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepColor(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, int16_t stepX, int16_t stepY, uint16_t transitionTime,
-                                                         uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepColor(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, int16_t stepX,
+                                                         int16_t stepY, uint16_t transitionTime, uint8_t optionsMask,
+                                                         uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StepColor(nullptr, nullptr, stepX, stepY, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepColorTemperature(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepColorTemperature(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t stepMode,
                                                                     uint16_t stepSize, uint16_t transitionTime,
                                                                     uint16_t colorTemperatureMinimum,
@@ -645,35 +671,42 @@ CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepColorTemperature(chip::Contro
                                                                     uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StepColorTemperature(nullptr, nullptr, stepMode, stepSize, transitionTime, colorTemperatureMinimum,
                                         colorTemperatureMaximum, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepHue(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                       chip::GroupId, uint8_t stepMode, uint8_t stepSize, uint8_t transitionTime,
-                                                       uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepHue(chip::Controller::Device * device, uint64_t command,
+                                                       chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t stepMode,
+                                                       uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
+                                                       uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StepHue(nullptr, nullptr, stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepSaturation(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t stepMode, uint8_t stepSize,
-                                                              uint8_t transitionTime, uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_StepSaturation(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t stepMode,
+                                                              uint8_t stepSize, uint8_t transitionTime, uint8_t optionsMask,
+                                                              uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StepSaturation(nullptr, nullptr, stepMode, stepSize, transitionTime, optionsMask, optionsOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_ColorControl_StopMoveStep(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                            chip::GroupId, uint8_t optionsMask, uint8_t optionsOverride)
+CHIP_ERROR chip_ime_AppendCommand_ColorControl_StopMoveStep(chip::Controller::Device * device, uint64_t command,
+                                                            chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t optionsMask,
+                                                            uint8_t optionsOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ColorControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StopMoveStep(nullptr, nullptr, optionsMask, optionsOverride);
 }
 
@@ -1189,22 +1222,25 @@ CHIP_ERROR chip_ime_ReadAttribute_ColorControl_ClusterRevision(chip::Controller:
 // End of Cluster ColorControl
 // Cluster ContentLaunch
 
-CHIP_ERROR chip_ime_AppendCommand_ContentLaunch_LaunchContent(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t autoPlay, const uint8_t * data,
-                                                              uint32_t data_Len)
+CHIP_ERROR chip_ime_AppendCommand_ContentLaunch_LaunchContent(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t autoPlay,
+                                                              const uint8_t * data, uint32_t data_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ContentLaunchCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.LaunchContent(nullptr, nullptr, autoPlay, chip::ByteSpan(data, data_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_ContentLaunch_LaunchURL(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                          chip::GroupId, const uint8_t * contentURL, uint32_t contentURL_Len,
-                                                          const uint8_t * displayString, uint32_t displayString_Len)
+CHIP_ERROR chip_ime_AppendCommand_ContentLaunch_LaunchURL(chip::Controller::Device * device, uint64_t command,
+                                                          chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * contentURL,
+                                                          uint32_t contentURL_Len, const uint8_t * displayString,
+                                                          uint32_t displayString_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ContentLaunchCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.LaunchURL(nullptr, nullptr, chip::ByteSpan(contentURL, contentURL_Len),
                              chip::ByteSpan(displayString, displayString_Len));
 }
@@ -1252,195 +1288,226 @@ CHIP_ERROR chip_ime_ReadAttribute_Descriptor_ClusterRevision(chip::Controller::D
 // End of Cluster Descriptor
 // Cluster DoorLock
 
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearAllPins(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                        chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearAllPins(chip::Controller::Device * device, uint64_t command,
+                                                        chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearAllPins(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearAllRfids(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearAllRfids(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearAllRfids(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t scheduleId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearHolidaySchedule(nullptr, nullptr, scheduleId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearPin(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearPin(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearPin(nullptr, nullptr, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearRfid(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearRfid(chip::Controller::Device * device, uint64_t command,
+                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearRfid(nullptr, nullptr, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t scheduleId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                                uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearWeekdaySchedule(nullptr, nullptr, scheduleId, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t scheduleId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                                uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearYeardaySchedule(nullptr, nullptr, scheduleId, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetHolidaySchedule(nullptr, nullptr, scheduleId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetLogRecord(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                        chip::GroupId, uint16_t logIndex)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetLogRecord(chip::Controller::Device * device, uint64_t command,
+                                                        chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t logIndex)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetLogRecord(nullptr, nullptr, logIndex);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetPin(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                  uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetPin(chip::Controller::Device * device, uint64_t command,
+                                                  chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetPin(nullptr, nullptr, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetRfid(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                   uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetRfid(chip::Controller::Device * device, uint64_t command,
+                                                   chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetRfid(nullptr, nullptr, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetUserType(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                       chip::GroupId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetUserType(chip::Controller::Device * device, uint64_t command,
+                                                       chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetUserType(nullptr, nullptr, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                              uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetWeekdaySchedule(nullptr, nullptr, scheduleId, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId, uint16_t userId)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                              uint16_t userId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetYeardaySchedule(nullptr, nullptr, scheduleId, userId);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_LockDoor(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, const uint8_t * pin, uint32_t pin_Len)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_LockDoor(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * pin,
+                                                    uint32_t pin_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.LockDoor(nullptr, nullptr, chip::ByteSpan(pin, pin_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId, uint32_t localStartTime,
-                                                              uint32_t localEndTime, uint8_t operatingModeDuringHoliday)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                              uint32_t localStartTime, uint32_t localEndTime,
+                                                              uint8_t operatingModeDuringHoliday)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetHolidaySchedule(nullptr, nullptr, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetPin(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                  uint16_t userId, uint8_t userStatus, uint8_t userType, const uint8_t * pin,
-                                                  uint32_t pin_Len)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetPin(chip::Controller::Device * device, uint64_t command,
+                                                  chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId,
+                                                  uint8_t userStatus, uint8_t userType, const uint8_t * pin, uint32_t pin_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetPin(nullptr, nullptr, userId, userStatus, userType, chip::ByteSpan(pin, pin_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetRfid(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                   uint16_t userId, uint8_t userStatus, uint8_t userType, const uint8_t * id,
-                                                   uint32_t id_Len)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetRfid(chip::Controller::Device * device, uint64_t command,
+                                                   chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId,
+                                                   uint8_t userStatus, uint8_t userType, const uint8_t * id, uint32_t id_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetRfid(nullptr, nullptr, userId, userStatus, userType, chip::ByteSpan(id, id_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetUserType(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                       chip::GroupId, uint16_t userId, uint8_t userType)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetUserType(chip::Controller::Device * device, uint64_t command,
+                                                       chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t userId,
+                                                       uint8_t userType)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetUserType(nullptr, nullptr, userId, userType);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId, uint16_t userId, uint8_t daysMask,
-                                                              uint8_t startHour, uint8_t startMinute, uint8_t endHour,
-                                                              uint8_t endMinute)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                              uint16_t userId, uint8_t daysMask, uint8_t startHour,
+                                                              uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetWeekdaySchedule(nullptr, nullptr, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint8_t scheduleId, uint16_t userId,
-                                                              uint32_t localStartTime, uint32_t localEndTime)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t scheduleId,
+                                                              uint16_t userId, uint32_t localStartTime, uint32_t localEndTime)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetYeardaySchedule(nullptr, nullptr, scheduleId, userId, localStartTime, localEndTime);
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_UnlockDoor(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                      chip::GroupId, const uint8_t * pin, uint32_t pin_Len)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_UnlockDoor(chip::Controller::Device * device, uint64_t command,
+                                                      chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * pin,
+                                                      uint32_t pin_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.UnlockDoor(nullptr, nullptr, chip::ByteSpan(pin, pin_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId, uint16_t timeoutInSeconds, const uint8_t * pin,
-                                                             uint32_t pin_Len)
+CHIP_ERROR chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                             uint16_t timeoutInSeconds, const uint8_t * pin, uint32_t pin_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::DoorLockCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.UnlockWithTimeout(nullptr, nullptr, timeoutInSeconds, chip::ByteSpan(pin, pin_Len));
 }
 
@@ -1492,33 +1559,36 @@ CHIP_ERROR chip_ime_ReadAttribute_DoorLock_ClusterRevision(chip::Controller::Dev
 // End of Cluster DoorLock
 // Cluster GeneralCommissioning
 
-CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(chip::Controller::Device * device, uint64_t command,
                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                    uint16_t expiryLengthSeconds, uint64_t breadcrumb,
                                                                    uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ArmFailSafe(nullptr, nullptr, expiryLengthSeconds, breadcrumb, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(chip::Controller::Device * device, uint64_t command,
                                                                              chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.CommissioningComplete(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(chip::Controller::Device * device, uint64_t command,
                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                            uint8_t location, const uint8_t * countryCode,
                                                                            uint32_t countryCode_Len, uint64_t breadcrumb,
                                                                            uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GeneralCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetRegulatoryConfig(nullptr, nullptr, location, chip::ByteSpan(countryCode, countryCode_Len), breadcrumb,
                                        timeoutMs);
 }
@@ -1587,53 +1657,61 @@ CHIP_ERROR chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision(chip::Contr
 // End of Cluster GroupKeyManagement
 // Cluster Groups
 
-CHIP_ERROR chip_ime_AppendCommand_Groups_AddGroup(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                  uint16_t groupId, const uint8_t * groupName, uint32_t groupName_Len)
+CHIP_ERROR chip_ime_AppendCommand_Groups_AddGroup(chip::Controller::Device * device, uint64_t command,
+                                                  chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId,
+                                                  const uint8_t * groupName, uint32_t groupName_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddGroup(nullptr, nullptr, groupId, chip::ByteSpan(groupName, groupName_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                               chip::GroupId, uint16_t groupId, const uint8_t * groupName,
-                                                               uint32_t groupName_Len)
+CHIP_ERROR chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(chip::Controller::Device * device, uint64_t command,
+                                                               chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId,
+                                                               const uint8_t * groupName, uint32_t groupName_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddGroupIfIdentifying(nullptr, nullptr, groupId, chip::ByteSpan(groupName, groupName_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_Groups_GetGroupMembership(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                            chip::GroupId, uint8_t groupCount, uint16_t groupList)
+CHIP_ERROR chip_ime_AppendCommand_Groups_GetGroupMembership(chip::Controller::Device * device, uint64_t command,
+                                                            chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t groupCount,
+                                                            uint16_t groupList)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetGroupMembership(nullptr, nullptr, groupCount, groupList);
 }
-CHIP_ERROR chip_ime_AppendCommand_Groups_RemoveAllGroups(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_Groups_RemoveAllGroups(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveAllGroups(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_Groups_RemoveGroup(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, uint16_t groupId)
+CHIP_ERROR chip_ime_AppendCommand_Groups_RemoveGroup(chip::Controller::Device * device, uint64_t command,
+                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveGroup(nullptr, nullptr, groupId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Groups_ViewGroup(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                   uint16_t groupId)
+CHIP_ERROR chip_ime_AppendCommand_Groups_ViewGroup(chip::Controller::Device * device, uint64_t command,
+                                                   chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::GroupsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ViewGroup(nullptr, nullptr, groupId);
 }
 
@@ -1658,20 +1736,22 @@ CHIP_ERROR chip_ime_ReadAttribute_Groups_ClusterRevision(chip::Controller::Devic
 // End of Cluster Groups
 // Cluster Identify
 
-CHIP_ERROR chip_ime_AppendCommand_Identify_Identify(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint16_t identifyTime)
+CHIP_ERROR chip_ime_AppendCommand_Identify_Identify(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t identifyTime)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Identify(nullptr, nullptr, identifyTime);
 }
-CHIP_ERROR chip_ime_AppendCommand_Identify_IdentifyQuery(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_Identify_IdentifyQuery(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::IdentifyCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.IdentifyQuery(nullptr, nullptr);
 }
 
@@ -1696,12 +1776,13 @@ CHIP_ERROR chip_ime_ReadAttribute_Identify_ClusterRevision(chip::Controller::Dev
 // End of Cluster Identify
 // Cluster KeypadInput
 
-CHIP_ERROR chip_ime_AppendCommand_KeypadInput_SendKey(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                      chip::GroupId, uint8_t keyCode)
+CHIP_ERROR chip_ime_AppendCommand_KeypadInput_SendKey(chip::Controller::Device * device, uint64_t command,
+                                                      chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t keyCode)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::KeypadInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SendKey(nullptr, nullptr, keyCode);
 }
 
@@ -1717,73 +1798,84 @@ CHIP_ERROR chip_ime_ReadAttribute_KeypadInput_ClusterRevision(chip::Controller::
 // End of Cluster KeypadInput
 // Cluster LevelControl
 
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_Move(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint8_t moveMode, uint8_t rate, uint8_t optionMask,
-                                                    uint8_t optionOverride)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_Move(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode, uint8_t rate,
+                                                    uint8_t optionMask, uint8_t optionOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Move(nullptr, nullptr, moveMode, rate, optionMask, optionOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveToLevel(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId, uint8_t level, uint16_t transitionTime,
-                                                           uint8_t optionMask, uint8_t optionOverride)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveToLevel(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t level,
+                                                           uint16_t transitionTime, uint8_t optionMask, uint8_t optionOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToLevel(nullptr, nullptr, level, transitionTime, optionMask, optionOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t level,
                                                                     uint16_t transitionTime)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveToLevelWithOnOff(nullptr, nullptr, level, transitionTime);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveWithOnOff(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId, uint8_t moveMode, uint8_t rate)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_MoveWithOnOff(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t moveMode,
+                                                             uint8_t rate)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MoveWithOnOff(nullptr, nullptr, moveMode, rate);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_Step(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint8_t stepMode, uint8_t stepSize, uint16_t transitionTime,
-                                                    uint8_t optionMask, uint8_t optionOverride)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_Step(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t stepMode,
+                                                    uint8_t stepSize, uint16_t transitionTime, uint8_t optionMask,
+                                                    uint8_t optionOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Step(nullptr, nullptr, stepMode, stepSize, transitionTime, optionMask, optionOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_StepWithOnOff(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId, uint8_t stepMode, uint8_t stepSize,
-                                                             uint16_t transitionTime)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_StepWithOnOff(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t stepMode,
+                                                             uint8_t stepSize, uint16_t transitionTime)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StepWithOnOff(nullptr, nullptr, stepMode, stepSize, transitionTime);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_Stop(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint8_t optionMask, uint8_t optionOverride)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_Stop(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t optionMask,
+                                                    uint8_t optionOverride)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Stop(nullptr, nullptr, optionMask, optionOverride);
 }
-CHIP_ERROR chip_ime_AppendCommand_LevelControl_StopWithOnOff(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_LevelControl_StopWithOnOff(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LevelControlCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StopWithOnOff(nullptr, nullptr);
 }
 
@@ -1817,11 +1909,13 @@ CHIP_ERROR chip_ime_ReadAttribute_LevelControl_ClusterRevision(chip::Controller:
 // End of Cluster LevelControl
 // Cluster LowPower
 
-CHIP_ERROR chip_ime_AppendCommand_LowPower_Sleep(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_LowPower_Sleep(chip::Controller::Device * device, uint64_t command,
+                                                 chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::LowPowerCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Sleep(nullptr, nullptr);
 }
 
@@ -1837,36 +1931,41 @@ CHIP_ERROR chip_ime_ReadAttribute_LowPower_ClusterRevision(chip::Controller::Dev
 // End of Cluster LowPower
 // Cluster MediaInput
 
-CHIP_ERROR chip_ime_AppendCommand_MediaInput_HideInputStatus(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaInput_HideInputStatus(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.HideInputStatus(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaInput_RenameInput(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, uint8_t index, const uint8_t * name, uint32_t name_Len)
+CHIP_ERROR chip_ime_AppendCommand_MediaInput_RenameInput(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t index,
+                                                         const uint8_t * name, uint32_t name_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RenameInput(nullptr, nullptr, index, chip::ByteSpan(name, name_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaInput_SelectInput(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, uint8_t index)
+CHIP_ERROR chip_ime_AppendCommand_MediaInput_SelectInput(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t index)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SelectInput(nullptr, nullptr, index);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaInput_ShowInputStatus(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaInput_ShowInputStatus(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaInputCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ShowInputStatus(nullptr, nullptr);
 }
 
@@ -1891,92 +1990,105 @@ CHIP_ERROR chip_ime_ReadAttribute_MediaInput_ClusterRevision(chip::Controller::D
 // End of Cluster MediaInput
 // Cluster MediaPlayback
 
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaFastForward(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaFastForward(chip::Controller::Device * device, uint64_t command,
+                                                                 chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaFastForward(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaNext(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                          chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaNext(chip::Controller::Device * device, uint64_t command,
+                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaNext(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPause(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPause(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaPause(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPlay(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                          chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPlay(chip::Controller::Device * device, uint64_t command,
+                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaPlay(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPrevious(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaPrevious(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaPrevious(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaRewind(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                            chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaRewind(chip::Controller::Device * device, uint64_t command,
+                                                            chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaRewind(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                  chip::GroupId, uint64_t deltaPositionMilliseconds)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(chip::Controller::Device * device, uint64_t command,
+                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                                  uint64_t deltaPositionMilliseconds)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaSkipBackward(nullptr, nullptr, deltaPositionMilliseconds);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId, uint64_t deltaPositionMilliseconds)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(chip::Controller::Device * device, uint64_t command,
+                                                                 chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                                 uint64_t deltaPositionMilliseconds)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaSkipForward(nullptr, nullptr, deltaPositionMilliseconds);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                              chip::GroupId, uint64_t position)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek(chip::Controller::Device * device, uint64_t command,
+                                                              chip::EndpointId ZCLendpointId, chip::GroupId, uint64_t position)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaSkipSeek(nullptr, nullptr, position);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaStartOver(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                               chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaStartOver(chip::Controller::Device * device, uint64_t command,
+                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaStartOver(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaStop(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                          chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_MediaPlayback_MediaStop(chip::Controller::Device * device, uint64_t command,
+                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::MediaPlaybackCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.MediaStop(nullptr, nullptr);
 }
 
@@ -1992,100 +2104,110 @@ CHIP_ERROR chip_ime_ReadAttribute_MediaPlayback_ClusterRevision(chip::Controller
 // End of Cluster MediaPlayback
 // Cluster NetworkCommissioning
 
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(chip::Controller::Device * device, uint64_t command,
                                                                         chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                         const uint8_t * operationalDataset,
                                                                         uint32_t operationalDataset_Len, uint64_t breadcrumb,
                                                                         uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddThreadNetwork(nullptr, nullptr, chip::ByteSpan(operationalDataset, operationalDataset_Len), breadcrumb,
                                     timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                       const uint8_t * ssid, uint32_t ssid_Len,
                                                                       const uint8_t * credentials, uint32_t credentials_Len,
                                                                       uint64_t breadcrumb, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddWiFiNetwork(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), chip::ByteSpan(credentials, credentials_Len),
                                   breadcrumb, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                       const uint8_t * networkID, uint32_t networkID_Len,
                                                                       uint64_t breadcrumb, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.DisableNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(chip::Controller::Device * device, uint64_t command,
                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                      const uint8_t * networkID, uint32_t networkID_Len,
                                                                      uint64_t breadcrumb, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.EnableNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs);
 }
 CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult(chip::Controller::Device * device,
+                                                                                         uint64_t command,
                                                                                          chip::EndpointId ZCLendpointId,
                                                                                          chip::GroupId, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetLastNetworkCommissioningResult(nullptr, nullptr, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(chip::Controller::Device * device, uint64_t command,
                                                                      chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                      const uint8_t * networkID, uint32_t networkID_Len,
                                                                      uint64_t breadcrumb, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveNetwork(nullptr, nullptr, chip::ByteSpan(networkID, networkID_Len), breadcrumb, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                     const uint8_t * ssid, uint32_t ssid_Len, uint64_t breadcrumb,
                                                                     uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ScanNetworks(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), breadcrumb, timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(chip::Controller::Device * device, uint64_t command,
                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                            const uint8_t * operationalDataset,
                                                                            uint32_t operationalDataset_Len, uint64_t breadcrumb,
                                                                            uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.UpdateThreadNetwork(nullptr, nullptr, chip::ByteSpan(operationalDataset, operationalDataset_Len), breadcrumb,
                                        timeoutMs);
 }
-CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(chip::Controller::Device * device, uint64_t command,
                                                                          chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                          const uint8_t * ssid, uint32_t ssid_Len,
                                                                          const uint8_t * credentials, uint32_t credentials_Len,
                                                                          uint64_t breadcrumb, uint32_t timeoutMs)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::NetworkCommissioningCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.UpdateWiFiNetwork(nullptr, nullptr, chip::ByteSpan(ssid, ssid_Len), chip::ByteSpan(credentials, credentials_Len),
                                      breadcrumb, timeoutMs);
 }
@@ -2103,25 +2225,31 @@ CHIP_ERROR chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision(chip::Con
 // End of Cluster NetworkCommissioning
 // Cluster OnOff
 
-CHIP_ERROR chip_ime_AppendCommand_OnOff_Off(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_OnOff_Off(chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId,
+                                            chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Off(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_OnOff_On(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_OnOff_On(chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId,
+                                           chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.On(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_OnOff_Toggle(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_OnOff_Toggle(chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId,
+                                               chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OnOffCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Toggle(nullptr, nullptr);
 }
 
@@ -2155,7 +2283,7 @@ CHIP_ERROR chip_ime_ReadAttribute_OnOff_ClusterRevision(chip::Controller::Device
 // End of Cluster OnOff
 // Cluster OperationalCredentials
 
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_AddOpCert(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_AddOpCert(chip::Controller::Device * device, uint64_t command,
                                                                    chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                    const uint8_t * noc, uint32_t noc_Len,
                                                                    const uint8_t * iCACertificate, uint32_t iCACertificate_Len,
@@ -2163,53 +2291,59 @@ CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_AddOpCert(chip::Control
                                                                    chip::NodeId caseAdminNode, uint16_t adminVendorId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddOpCert(nullptr, nullptr, chip::ByteSpan(noc, noc_Len), chip::ByteSpan(iCACertificate, iCACertificate_Len),
                              chip::ByteSpan(iPKValue, iPKValue_Len), caseAdminNode, adminVendorId);
 }
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                       const uint8_t * cSRNonce, uint32_t cSRNonce_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.OpCSRRequest(nullptr, nullptr, chip::ByteSpan(cSRNonce, cSRNonce_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics(chip::Controller::Device * device, uint64_t command,
                                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveAllFabrics(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                       chip::FabricId fabricId, chip::NodeId nodeId,
                                                                       uint16_t vendorId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveFabric(nullptr, nullptr, fabricId, nodeId, vendorId);
 }
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_SetFabric(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_SetFabric(chip::Controller::Device * device, uint64_t command,
                                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t vendorId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetFabric(nullptr, nullptr, vendorId);
 }
-CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(chip::Controller::Device * device, uint64_t command,
                                                                            chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                            const uint8_t * label, uint32_t label_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::OperationalCredentialsCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.UpdateFabricLabel(nullptr, nullptr, chip::ByteSpan(label, label_Len));
 }
 
@@ -2319,63 +2453,73 @@ CHIP_ERROR chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision(ch
 // End of Cluster PumpConfigurationAndControl
 // Cluster Scenes
 
-CHIP_ERROR chip_ime_AppendCommand_Scenes_AddScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                  uint16_t groupId, uint8_t sceneId, uint16_t transitionTime,
-                                                  const uint8_t * sceneName, uint32_t sceneName_Len, chip::ClusterId clusterId,
-                                                  uint8_t length, uint8_t value)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_AddScene(chip::Controller::Device * device, uint64_t command,
+                                                  chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId, uint8_t sceneId,
+                                                  uint16_t transitionTime, const uint8_t * sceneName, uint32_t sceneName_Len,
+                                                  chip::ClusterId clusterId, uint8_t length, uint8_t value)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddScene(nullptr, nullptr, groupId, sceneId, transitionTime, chip::ByteSpan(sceneName, sceneName_Len), clusterId,
                             length, value);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_GetSceneMembership(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                            chip::GroupId, uint16_t groupId)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_GetSceneMembership(chip::Controller::Device * device, uint64_t command,
+                                                            chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetSceneMembership(nullptr, nullptr, groupId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_RecallScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, uint16_t groupId, uint8_t sceneId, uint16_t transitionTime)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_RecallScene(chip::Controller::Device * device, uint64_t command,
+                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId,
+                                                     uint8_t sceneId, uint16_t transitionTime)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RecallScene(nullptr, nullptr, groupId, sceneId, transitionTime);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_RemoveAllScenes(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                         chip::GroupId, uint16_t groupId)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_RemoveAllScenes(chip::Controller::Device * device, uint64_t command,
+                                                         chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveAllScenes(nullptr, nullptr, groupId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_RemoveScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                     chip::GroupId, uint16_t groupId, uint8_t sceneId)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_RemoveScene(chip::Controller::Device * device, uint64_t command,
+                                                     chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId,
+                                                     uint8_t sceneId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveScene(nullptr, nullptr, groupId, sceneId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_StoreScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                    chip::GroupId, uint16_t groupId, uint8_t sceneId)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_StoreScene(chip::Controller::Device * device, uint64_t command,
+                                                    chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId,
+                                                    uint8_t sceneId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.StoreScene(nullptr, nullptr, groupId, sceneId);
 }
-CHIP_ERROR chip_ime_AppendCommand_Scenes_ViewScene(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                   uint16_t groupId, uint8_t sceneId)
+CHIP_ERROR chip_ime_AppendCommand_Scenes_ViewScene(chip::Controller::Device * device, uint64_t command,
+                                                   chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t groupId, uint8_t sceneId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ScenesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ViewScene(nullptr, nullptr, groupId, sceneId);
 }
 
@@ -2475,28 +2619,33 @@ CHIP_ERROR chip_ime_ReadAttribute_Switch_ClusterRevision(chip::Controller::Devic
 // End of Cluster Switch
 // Cluster TvChannel
 
-CHIP_ERROR chip_ime_AppendCommand_TvChannel_ChangeChannel(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                          chip::GroupId, const uint8_t * match, uint32_t match_Len)
+CHIP_ERROR chip_ime_AppendCommand_TvChannel_ChangeChannel(chip::Controller::Device * device, uint64_t command,
+                                                          chip::EndpointId ZCLendpointId, chip::GroupId, const uint8_t * match,
+                                                          uint32_t match_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ChangeChannel(nullptr, nullptr, chip::ByteSpan(match, match_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                  chip::GroupId, uint16_t majorNumber, uint16_t minorNumber)
+CHIP_ERROR chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(chip::Controller::Device * device, uint64_t command,
+                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                                  uint16_t majorNumber, uint16_t minorNumber)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ChangeChannelByNumber(nullptr, nullptr, majorNumber, minorNumber);
 }
-CHIP_ERROR chip_ime_AppendCommand_TvChannel_SkipChannel(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                        chip::GroupId, uint16_t count)
+CHIP_ERROR chip_ime_AppendCommand_TvChannel_SkipChannel(chip::Controller::Device * device, uint64_t command,
+                                                        chip::EndpointId ZCLendpointId, chip::GroupId, uint16_t count)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TvChannelCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SkipChannel(nullptr, nullptr, count);
 }
 
@@ -2539,13 +2688,14 @@ CHIP_ERROR chip_ime_ReadAttribute_TvChannel_ClusterRevision(chip::Controller::De
 // End of Cluster TvChannel
 // Cluster TargetNavigator
 
-CHIP_ERROR chip_ime_AppendCommand_TargetNavigator_NavigateTarget(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId, uint8_t target, const uint8_t * data,
-                                                                 uint32_t data_Len)
+CHIP_ERROR chip_ime_AppendCommand_TargetNavigator_NavigateTarget(chip::Controller::Device * device, uint64_t command,
+                                                                 chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t target,
+                                                                 const uint8_t * data, uint32_t data_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TargetNavigatorCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.NavigateTarget(nullptr, nullptr, target, chip::ByteSpan(data, data_Len));
 }
 
@@ -2624,27 +2774,31 @@ CHIP_ERROR chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision(chip::C
 // End of Cluster TemperatureMeasurement
 // Cluster TestCluster
 
-CHIP_ERROR chip_ime_AppendCommand_TestCluster_Test(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_TestCluster_Test(chip::Controller::Device * device, uint64_t command,
+                                                   chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.Test(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_TestCluster_TestNotHandled(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                             chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_TestCluster_TestNotHandled(chip::Controller::Device * device, uint64_t command,
+                                                             chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.TestNotHandled(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_TestCluster_TestSpecific(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                           chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_TestCluster_TestSpecific(chip::Controller::Device * device, uint64_t command,
+                                                           chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TestClusterCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.TestSpecific(nullptr, nullptr);
 }
 
@@ -2804,47 +2958,54 @@ CHIP_ERROR chip_ime_ReadAttribute_TestCluster_ClusterRevision(chip::Controller::
 // End of Cluster TestCluster
 // Cluster Thermostat
 
-CHIP_ERROR chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                 chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(chip::Controller::Device * device, uint64_t command,
+                                                                 chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.ClearWeeklySchedule(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                               chip::GroupId)
+CHIP_ERROR chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(chip::Controller::Device * device, uint64_t command,
+                                                               chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetRelayStatusLog(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                               chip::GroupId, uint8_t daysToReturn, uint8_t modeToReturn)
+CHIP_ERROR chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(chip::Controller::Device * device, uint64_t command,
+                                                               chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t daysToReturn,
+                                                               uint8_t modeToReturn)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.GetWeeklySchedule(nullptr, nullptr, daysToReturn, modeToReturn);
 }
-CHIP_ERROR chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                               chip::GroupId, uint8_t numberOfTransitionsForSequence,
-                                                               uint8_t dayOfWeekForSequence, uint8_t modeForSequence,
-                                                               uint8_t payload)
+CHIP_ERROR chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(chip::Controller::Device * device, uint64_t command,
+                                                               chip::EndpointId ZCLendpointId, chip::GroupId,
+                                                               uint8_t numberOfTransitionsForSequence, uint8_t dayOfWeekForSequence,
+                                                               uint8_t modeForSequence, uint8_t payload)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetWeeklySchedule(nullptr, nullptr, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence,
                                      payload);
 }
-CHIP_ERROR chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(chip::Controller::Device * device, chip::EndpointId ZCLendpointId,
-                                                                chip::GroupId, uint8_t mode, int8_t amount)
+CHIP_ERROR chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(chip::Controller::Device * device, uint64_t command,
+                                                                chip::EndpointId ZCLendpointId, chip::GroupId, uint8_t mode,
+                                                                int8_t amount)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::ThermostatCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.SetpointRaiseLower(nullptr, nullptr, mode, amount);
 }
 
@@ -2917,24 +3078,25 @@ CHIP_ERROR chip_ime_ReadAttribute_Thermostat_ClusterRevision(chip::Controller::D
 // Cluster TrustedRootCertificates
 
 CHIP_ERROR chip_ime_AppendCommand_TrustedRootCertificates_AddTrustedRootCertificate(chip::Controller::Device * device,
+                                                                                    uint64_t command,
                                                                                     chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                                     const uint8_t * rootCertificate,
                                                                                     uint32_t rootCertificate_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TrustedRootCertificatesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.AddTrustedRootCertificate(nullptr, nullptr, chip::ByteSpan(rootCertificate, rootCertificate_Len));
 }
-CHIP_ERROR chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate(chip::Controller::Device * device,
-                                                                                       chip::EndpointId ZCLendpointId,
-                                                                                       chip::GroupId,
-                                                                                       const uint8_t * trustedRootIdentifier,
-                                                                                       uint32_t trustedRootIdentifier_Len)
+CHIP_ERROR chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate(
+    chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId, chip::GroupId,
+    const uint8_t * trustedRootIdentifier, uint32_t trustedRootIdentifier_Len)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::TrustedRootCertificatesCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.RemoveTrustedRootCertificate(nullptr, nullptr, chip::ByteSpan(trustedRootIdentifier, trustedRootIdentifier_Len));
 }
 
@@ -2972,64 +3134,71 @@ CHIP_ERROR chip_ime_ReadAttribute_WakeOnLan_ClusterRevision(chip::Controller::De
 // End of Cluster WakeOnLan
 // Cluster WindowCovering
 
-CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose(chip::Controller::Device * device, uint64_t command,
                                                                          chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringDownClose(nullptr, nullptr);
 }
 CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftPercentage(chip::Controller::Device * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t percentageLiftValue)
+                                                                                  uint64_t command, chip::EndpointId ZCLendpointId,
+                                                                                  chip::GroupId, uint8_t percentageLiftValue)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringGoToLiftPercentage(nullptr, nullptr, percentageLiftValue);
 }
-CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue(chip::Controller::Device * device, uint64_t command,
                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                              uint16_t liftValue)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringGoToLiftValue(nullptr, nullptr, liftValue);
 }
 CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltPercentage(chip::Controller::Device * device,
-                                                                                  chip::EndpointId ZCLendpointId, chip::GroupId,
-                                                                                  uint8_t percentageTiltValue)
+                                                                                  uint64_t command, chip::EndpointId ZCLendpointId,
+                                                                                  chip::GroupId, uint8_t percentageTiltValue)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringGoToTiltPercentage(nullptr, nullptr, percentageTiltValue);
 }
-CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue(chip::Controller::Device * device, uint64_t command,
                                                                              chip::EndpointId ZCLendpointId, chip::GroupId,
                                                                              uint16_t tiltValue)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringGoToTiltValue(nullptr, nullptr, tiltValue);
 }
-CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringStop(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringStop(chip::Controller::Device * device, uint64_t command,
                                                                     chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringStop(nullptr, nullptr);
 }
-CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen(chip::Controller::Device * device,
+CHIP_ERROR chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen(chip::Controller::Device * device, uint64_t command,
                                                                       chip::EndpointId ZCLendpointId, chip::GroupId)
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::WindowCoveringCluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.WindowCoveringUpOpen(nullptr, nullptr);
 }
 

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -879,12 +879,12 @@ class ChipClusters:
             ],
         }
 
-    def SendCommand(self, device: ctypes.c_void_p, cluster: str, command: str, endpoint: int, groupid: int, args, imEnabled):
+    def SendCommand(self, device: ctypes.c_void_p, commandSender: ctypes.c_void_p, cluster: str, command: str, endpoint: int, groupid: int, args, imEnabled):
         func = getattr(self, "Cluster{}_Command{}".format(cluster, command), None)
         if not func:
             raise UnknownCommand(cluster, command)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, groupid, **args))
+        funcCaller(lambda: func(device, commandSender, endpoint, groupid, **args))
 
     def ReadAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, imEnabled):
         func = getattr(self, "Cluster{}_ReadAttribute{}".format(cluster, attribute), None)
@@ -902,551 +902,551 @@ class ChipClusters:
 
     # Cluster commands
 
-    def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes):
+    def ClusterAccountLogin_CommandGetSetupPIN(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN(
-                device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier)
         )
-    def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes, setupPIN: bytes):
+    def ClusterAccountLogin_CommandLogin(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, tempAccountIdentifier: bytes, setupPIN: bytes):
         tempAccountIdentifier = tempAccountIdentifier.encode("utf-8") + b'\x00'
         setupPIN = setupPIN.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AccountLogin_Login(
-                device, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier), setupPIN, len(setupPIN)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, tempAccountIdentifier, len(tempAccountIdentifier), setupPIN, len(setupPIN)
         )
-    def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, data: bytes, catalogVendorId: int, applicationId: bytes):
+    def ClusterApplicationLauncher_CommandLaunchApp(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, data: bytes, catalogVendorId: int, applicationId: bytes):
         data = data.encode("utf-8") + b'\x00'
         applicationId = applicationId.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp(
-                device, ZCLendpoint, ZCLgroupid, data, len(data), catalogVendorId, applicationId, len(applicationId)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, data, len(data), catalogVendorId, applicationId, len(applicationId)
         )
-    def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
+    def ClusterAudioOutput_CommandRenameOutput(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput(
-                device, ZCLendpoint, ZCLgroupid, index, name, len(name)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, index, name, len(name)
         )
-    def ClusterAudioOutput_CommandSelectOutput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
+    def ClusterAudioOutput_CommandSelectOutput(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, index: int):
         return self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput(
-                device, ZCLendpoint, ZCLgroupid, index
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, index
         )
-    def ClusterBarrierControl_CommandBarrierControlGoToPercent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, percentOpen: int):
+    def ClusterBarrierControl_CommandBarrierControlGoToPercent(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, percentOpen: int):
         return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent(
-                device, ZCLendpoint, ZCLgroupid, percentOpen
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, percentOpen
         )
-    def ClusterBarrierControl_CommandBarrierControlStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterBarrierControl_CommandBarrierControlStop(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterBasic_CommandMfgSpecificPing(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterBasic_CommandMfgSpecificPing(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterBinding_CommandBind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
+    def ClusterBinding_CommandBind(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
         return self._chipLib.chip_ime_AppendCommand_Binding_Bind(
-                device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
         )
-    def ClusterBinding_CommandUnbind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
+    def ClusterBinding_CommandUnbind(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, nodeId: int, groupId: int, endpointId: int, clusterId: int):
         return self._chipLib.chip_ime_AppendCommand_Binding_Unbind(
-                device, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, nodeId, groupId, endpointId, clusterId
         )
-    def ClusterColorControl_CommandMoveColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rateX: int, rateY: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveColor(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, rateX: int, rateY: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor(
-                device, ZCLendpoint, ZCLgroupid, rateX, rateY, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, rateX, rateY, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveColorTemperature(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, moveMode, rate, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveHue(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveSaturation(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, moveMode, rate, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveToColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorX: int, colorY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveToColor(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, colorX: int, colorY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor(
-                device, ZCLendpoint, ZCLgroupid, colorX, colorY, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, colorX, colorY, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveToColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, colorTemperature: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveToColorTemperature(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, colorTemperature: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, colorTemperature, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, colorTemperature, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveToHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveToHue(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, hue: int, direction: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue(
-                device, ZCLendpoint, ZCLgroupid, hue, direction, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, hue, direction, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveToHueAndSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, hue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveToHueAndSaturation(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, hue: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation(
-                device, ZCLendpoint, ZCLgroupid, hue, saturation, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, hue, saturation, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandMoveToSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandMoveToSaturation(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, saturation: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation(
-                device, ZCLendpoint, ZCLgroupid, saturation, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, saturation, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandStepColor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepX: int, stepY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandStepColor(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepX: int, stepY: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor(
-                device, ZCLendpoint, ZCLgroupid, stepX, stepY, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepX, stepY, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandStepColorTemperature(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandStepColorTemperature(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, colorTemperatureMinimum: int, colorTemperatureMaximum: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, colorTemperatureMinimum, colorTemperatureMaximum, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandStepHue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandStepHue(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandStepSaturation(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandStepSaturation(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionsMask, optionsOverride
         )
-    def ClusterColorControl_CommandStopMoveStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionsMask: int, optionsOverride: int):
+    def ClusterColorControl_CommandStopMoveStep(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, optionsMask: int, optionsOverride: int):
         return self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep(
-                device, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, optionsMask, optionsOverride
         )
-    def ClusterContentLaunch_CommandLaunchContent(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, autoPlay: int, data: bytes):
+    def ClusterContentLaunch_CommandLaunchContent(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, autoPlay: int, data: bytes):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchContent(
-                device, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, autoPlay, data, len(data)
         )
-    def ClusterContentLaunch_CommandLaunchURL(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, contentURL: bytes, displayString: bytes):
+    def ClusterContentLaunch_CommandLaunchURL(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, contentURL: bytes, displayString: bytes):
         contentURL = contentURL.encode("utf-8") + b'\x00'
         displayString = displayString.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchURL(
-                device, ZCLendpoint, ZCLgroupid, contentURL, len(contentURL), displayString, len(displayString)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, contentURL, len(contentURL), displayString, len(displayString)
         )
-    def ClusterDoorLock_CommandClearAllPins(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterDoorLock_CommandClearAllPins(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterDoorLock_CommandClearAllRfids(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterDoorLock_CommandClearAllRfids(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterDoorLock_CommandClearHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
+    def ClusterDoorLock_CommandClearHolidaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId
         )
-    def ClusterDoorLock_CommandClearPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
+    def ClusterDoorLock_CommandClearPin(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin(
-                device, ZCLendpoint, ZCLgroupid, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId
         )
-    def ClusterDoorLock_CommandClearRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
+    def ClusterDoorLock_CommandClearRfid(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid(
-                device, ZCLendpoint, ZCLgroupid, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId
         )
-    def ClusterDoorLock_CommandClearWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
+    def ClusterDoorLock_CommandClearWeekdaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
-    def ClusterDoorLock_CommandClearYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
+    def ClusterDoorLock_CommandClearYeardaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
-    def ClusterDoorLock_CommandGetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
+    def ClusterDoorLock_CommandGetHolidaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId
         )
-    def ClusterDoorLock_CommandGetLogRecord(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, logIndex: int):
+    def ClusterDoorLock_CommandGetLogRecord(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, logIndex: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord(
-                device, ZCLendpoint, ZCLgroupid, logIndex
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, logIndex
         )
-    def ClusterDoorLock_CommandGetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
+    def ClusterDoorLock_CommandGetPin(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin(
-                device, ZCLendpoint, ZCLgroupid, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId
         )
-    def ClusterDoorLock_CommandGetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
+    def ClusterDoorLock_CommandGetRfid(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid(
-                device, ZCLendpoint, ZCLgroupid, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId
         )
-    def ClusterDoorLock_CommandGetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int):
+    def ClusterDoorLock_CommandGetUserType(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType(
-                device, ZCLendpoint, ZCLgroupid, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId
         )
-    def ClusterDoorLock_CommandGetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
+    def ClusterDoorLock_CommandGetWeekdaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
-    def ClusterDoorLock_CommandGetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
+    def ClusterDoorLock_CommandGetYeardaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId
         )
-    def ClusterDoorLock_CommandLockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
+    def ClusterDoorLock_CommandLockDoor(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
         pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor(
-                device, ZCLendpoint, ZCLgroupid, pin, len(pin)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
-    def ClusterDoorLock_CommandSetHolidaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, localStartTime: int, localEndTime: int, operatingModeDuringHoliday: int):
+    def ClusterDoorLock_CommandSetHolidaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, localStartTime: int, localEndTime: int, operatingModeDuringHoliday: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, localStartTime, localEndTime, operatingModeDuringHoliday
         )
-    def ClusterDoorLock_CommandSetPin(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, pin: bytes):
+    def ClusterDoorLock_CommandSetPin(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, pin: bytes):
         pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin(
-                device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(pin)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, pin, len(pin)
         )
-    def ClusterDoorLock_CommandSetRfid(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, id: bytes):
+    def ClusterDoorLock_CommandSetRfid(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int, userStatus: int, userType: int, id: bytes):
         id = id.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid(
-                device, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(id)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId, userStatus, userType, id, len(id)
         )
-    def ClusterDoorLock_CommandSetUserType(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, userId: int, userType: int):
+    def ClusterDoorLock_CommandSetUserType(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, userId: int, userType: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType(
-                device, ZCLendpoint, ZCLgroupid, userId, userType
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, userId, userType
         )
-    def ClusterDoorLock_CommandSetWeekdaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, daysMask: int, startHour: int, startMinute: int, endHour: int, endMinute: int):
+    def ClusterDoorLock_CommandSetWeekdaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, daysMask: int, startHour: int, startMinute: int, endHour: int, endMinute: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId, daysMask, startHour, startMinute, endHour, endMinute
         )
-    def ClusterDoorLock_CommandSetYeardaySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, localStartTime: int, localEndTime: int):
+    def ClusterDoorLock_CommandSetYeardaySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, scheduleId: int, userId: int, localStartTime: int, localEndTime: int):
         return self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule(
-                device, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, scheduleId, userId, localStartTime, localEndTime
         )
-    def ClusterDoorLock_CommandUnlockDoor(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
+    def ClusterDoorLock_CommandUnlockDoor(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, pin: bytes):
         pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor(
-                device, ZCLendpoint, ZCLgroupid, pin, len(pin)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, pin, len(pin)
         )
-    def ClusterDoorLock_CommandUnlockWithTimeout(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutInSeconds: int, pin: bytes):
+    def ClusterDoorLock_CommandUnlockWithTimeout(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, timeoutInSeconds: int, pin: bytes):
         pin = pin.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout(
-                device, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, timeoutInSeconds, pin, len(pin)
         )
-    def ClusterGeneralCommissioning_CommandArmFailSafe(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, expiryLengthSeconds: int, breadcrumb: int, timeoutMs: int):
+    def ClusterGeneralCommissioning_CommandArmFailSafe(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, expiryLengthSeconds: int, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe(
-                device, ZCLendpoint, ZCLgroupid, expiryLengthSeconds, breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, expiryLengthSeconds, breadcrumb, timeoutMs
         )
-    def ClusterGeneralCommissioning_CommandCommissioningComplete(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterGeneralCommissioning_CommandCommissioningComplete(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterGeneralCommissioning_CommandSetRegulatoryConfig(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, location: int, countryCode: bytes, breadcrumb: int, timeoutMs: int):
         countryCode = countryCode.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig(
-                device, ZCLendpoint, ZCLgroupid, location, countryCode, len(countryCode), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, location, countryCode, len(countryCode), breadcrumb, timeoutMs
         )
-    def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
+    def ClusterGroups_CommandAddGroup(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
         )
-    def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
+    def ClusterGroups_CommandAddGroupIfIdentifying(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, groupName: bytes):
         groupName = groupName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying(
-                device, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, groupName, len(groupName)
         )
-    def ClusterGroups_CommandGetGroupMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupCount: int, groupList: int):
+    def ClusterGroups_CommandGetGroupMembership(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupCount: int, groupList: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership(
-                device, ZCLendpoint, ZCLgroupid, groupCount, groupList
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupCount, groupList
         )
-    def ClusterGroups_CommandRemoveAllGroups(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterGroups_CommandRemoveAllGroups(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterGroups_CommandRemoveGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
+    def ClusterGroups_CommandRemoveGroup(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId
         )
-    def ClusterGroups_CommandViewGroup(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
+    def ClusterGroups_CommandViewGroup(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup(
-                device, ZCLendpoint, ZCLgroupid, groupId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId
         )
-    def ClusterIdentify_CommandIdentify(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, identifyTime: int):
+    def ClusterIdentify_CommandIdentify(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, identifyTime: int):
         return self._chipLib.chip_ime_AppendCommand_Identify_Identify(
-                device, ZCLendpoint, ZCLgroupid, identifyTime
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, identifyTime
         )
-    def ClusterIdentify_CommandIdentifyQuery(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterIdentify_CommandIdentifyQuery(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterKeypadInput_CommandSendKey(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, keyCode: int):
+    def ClusterKeypadInput_CommandSendKey(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, keyCode: int):
         return self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey(
-                device, ZCLendpoint, ZCLgroupid, keyCode
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, keyCode
         )
-    def ClusterLevelControl_CommandMove(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionMask: int, optionOverride: int):
+    def ClusterLevelControl_CommandMove(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Move(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate, optionMask, optionOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, moveMode, rate, optionMask, optionOverride
         )
-    def ClusterLevelControl_CommandMoveToLevel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int, optionMask: int, optionOverride: int):
+    def ClusterLevelControl_CommandMoveToLevel(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel(
-                device, ZCLendpoint, ZCLgroupid, level, transitionTime, optionMask, optionOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, level, transitionTime, optionMask, optionOverride
         )
-    def ClusterLevelControl_CommandMoveToLevelWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int):
+    def ClusterLevelControl_CommandMoveToLevelWithOnOff(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, level: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, level, transitionTime
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, level, transitionTime
         )
-    def ClusterLevelControl_CommandMoveWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int):
+    def ClusterLevelControl_CommandMoveWithOnOff(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, moveMode: int, rate: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, moveMode, rate
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, moveMode, rate
         )
-    def ClusterLevelControl_CommandStep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionMask: int, optionOverride: int):
+    def ClusterLevelControl_CommandStep(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Step(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionMask, optionOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime, optionMask, optionOverride
         )
-    def ClusterLevelControl_CommandStepWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int):
+    def ClusterLevelControl_CommandStepWithOnOff(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, stepMode: int, stepSize: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff(
-                device, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, stepMode, stepSize, transitionTime
         )
-    def ClusterLevelControl_CommandStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, optionMask: int, optionOverride: int):
+    def ClusterLevelControl_CommandStop(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, optionMask: int, optionOverride: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_Stop(
-                device, ZCLendpoint, ZCLgroupid, optionMask, optionOverride
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, optionMask, optionOverride
         )
-    def ClusterLevelControl_CommandStopWithOnOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterLevelControl_CommandStopWithOnOff(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterLowPower_CommandSleep(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterLowPower_CommandSleep(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_LowPower_Sleep(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaInput_CommandHideInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaInput_CommandHideInputStatus(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
+    def ClusterMediaInput_CommandRenameInput(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, index: int, name: bytes):
         name = name.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput(
-                device, ZCLendpoint, ZCLgroupid, index, name, len(name)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, index, name, len(name)
         )
-    def ClusterMediaInput_CommandSelectInput(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, index: int):
+    def ClusterMediaInput_CommandSelectInput(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, index: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput(
-                device, ZCLendpoint, ZCLgroupid, index
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, index
         )
-    def ClusterMediaInput_CommandShowInputStatus(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaInput_CommandShowInputStatus(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaFastForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaFastForward(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaNext(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaNext(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaPause(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaPause(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaPlay(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaPlay(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaPrevious(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaPrevious(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaRewind(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaRewind(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaSkipBackward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
+    def ClusterMediaPlayback_CommandMediaSkipBackward(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward(
-                device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
         )
-    def ClusterMediaPlayback_CommandMediaSkipForward(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
+    def ClusterMediaPlayback_CommandMediaSkipForward(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, deltaPositionMilliseconds: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward(
-                device, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, deltaPositionMilliseconds
         )
-    def ClusterMediaPlayback_CommandMediaSkipSeek(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, position: int):
+    def ClusterMediaPlayback_CommandMediaSkipSeek(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, position: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek(
-                device, ZCLendpoint, ZCLgroupid, position
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, position
         )
-    def ClusterMediaPlayback_CommandMediaStartOver(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaStartOver(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterMediaPlayback_CommandMediaStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterMediaPlayback_CommandMediaStop(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterNetworkCommissioning_CommandAddThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandAddThreadNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork(
-                device, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandAddWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandAddWiFiNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandDisableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandDisableNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandEnableNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandEnableNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandGetLastNetworkCommissioningResult(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandGetLastNetworkCommissioningResult(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult(
-                device, ZCLendpoint, ZCLgroupid, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandRemoveNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandRemoveNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, networkID: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork(
-                device, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, networkID, len(networkID), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandScanNetworks(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandScanNetworks(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, ssid, len(ssid), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandUpdateThreadNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandUpdateThreadNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, operationalDataset: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork(
-                device, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, operationalDataset, len(operationalDataset), breadcrumb, timeoutMs
         )
-    def ClusterNetworkCommissioning_CommandUpdateWiFiNetwork(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
+    def ClusterNetworkCommissioning_CommandUpdateWiFiNetwork(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, ssid: bytes, credentials: bytes, breadcrumb: int, timeoutMs: int):
         return self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork(
-                device, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, ssid, len(ssid), credentials, len(credentials), breadcrumb, timeoutMs
         )
-    def ClusterOnOff_CommandOff(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterOnOff_CommandOff(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_Off(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterOnOff_CommandOn(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterOnOff_CommandOn(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_On(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterOnOff_CommandToggle(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterOnOff_CommandToggle(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OnOff_Toggle(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterOperationalCredentials_CommandAddOpCert(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, noc: bytes, iCACertificate: bytes, iPKValue: bytes, caseAdminNode: int, adminVendorId: int):
+    def ClusterOperationalCredentials_CommandAddOpCert(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, noc: bytes, iCACertificate: bytes, iPKValue: bytes, caseAdminNode: int, adminVendorId: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddOpCert(
-                device, ZCLendpoint, ZCLgroupid, noc, len(noc), iCACertificate, len(iCACertificate), iPKValue, len(iPKValue), caseAdminNode, adminVendorId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, noc, len(noc), iCACertificate, len(iCACertificate), iPKValue, len(iPKValue), caseAdminNode, adminVendorId
         )
-    def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, cSRNonce: bytes):
+    def ClusterOperationalCredentials_CommandOpCSRRequest(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, cSRNonce: bytes):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest(
-                device, ZCLendpoint, ZCLgroupid, cSRNonce, len(cSRNonce)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, cSRNonce, len(cSRNonce)
         )
-    def ClusterOperationalCredentials_CommandRemoveAllFabrics(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterOperationalCredentials_CommandRemoveAllFabrics(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterOperationalCredentials_CommandRemoveFabric(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, fabricId: int, nodeId: int, vendorId: int):
+    def ClusterOperationalCredentials_CommandRemoveFabric(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, fabricId: int, nodeId: int, vendorId: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric(
-                device, ZCLendpoint, ZCLgroupid, fabricId, nodeId, vendorId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, fabricId, nodeId, vendorId
         )
-    def ClusterOperationalCredentials_CommandSetFabric(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, vendorId: int):
+    def ClusterOperationalCredentials_CommandSetFabric(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, vendorId: int):
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_SetFabric(
-                device, ZCLendpoint, ZCLgroupid, vendorId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, vendorId
         )
-    def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, label: bytes):
+    def ClusterOperationalCredentials_CommandUpdateFabricLabel(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, label: bytes):
         label = label.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel(
-                device, ZCLendpoint, ZCLgroupid, label, len(label)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, label, len(label)
         )
-    def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: bytes, clusterId: int, length: int, value: int):
+    def ClusterScenes_CommandAddScene(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int, sceneName: bytes, clusterId: int, length: int, value: int):
         sceneName = sceneName.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_Scenes_AddScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(sceneName), clusterId, length, value
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime, sceneName, len(sceneName), clusterId, length, value
         )
-    def ClusterScenes_CommandGetSceneMembership(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
+    def ClusterScenes_CommandGetSceneMembership(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership(
-                device, ZCLendpoint, ZCLgroupid, groupId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId
         )
-    def ClusterScenes_CommandRecallScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int):
+    def ClusterScenes_CommandRecallScene(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int, transitionTime: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, sceneId, transitionTime
         )
-    def ClusterScenes_CommandRemoveAllScenes(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
+    def ClusterScenes_CommandRemoveAllScenes(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes(
-                device, ZCLendpoint, ZCLgroupid, groupId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId
         )
-    def ClusterScenes_CommandRemoveScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
+    def ClusterScenes_CommandRemoveScene(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
-    def ClusterScenes_CommandStoreScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
+    def ClusterScenes_CommandStoreScene(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
-    def ClusterScenes_CommandViewScene(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
+    def ClusterScenes_CommandViewScene(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, groupId: int, sceneId: int):
         return self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene(
-                device, ZCLendpoint, ZCLgroupid, groupId, sceneId
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, groupId, sceneId
         )
-    def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, match: bytes):
+    def ClusterTvChannel_CommandChangeChannel(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, match: bytes):
         match = match.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel(
-                device, ZCLendpoint, ZCLgroupid, match, len(match)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, match, len(match)
         )
-    def ClusterTvChannel_CommandChangeChannelByNumber(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, majorNumber: int, minorNumber: int):
+    def ClusterTvChannel_CommandChangeChannelByNumber(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, majorNumber: int, minorNumber: int):
         return self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber(
-                device, ZCLendpoint, ZCLgroupid, majorNumber, minorNumber
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, majorNumber, minorNumber
         )
-    def ClusterTvChannel_CommandSkipChannel(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, count: int):
+    def ClusterTvChannel_CommandSkipChannel(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, count: int):
         return self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel(
-                device, ZCLendpoint, ZCLgroupid, count
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, count
         )
-    def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, target: int, data: bytes):
+    def ClusterTargetNavigator_CommandNavigateTarget(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, target: int, data: bytes):
         data = data.encode("utf-8") + b'\x00'
         return self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget(
-                device, ZCLendpoint, ZCLgroupid, target, data, len(data)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, target, data, len(data)
         )
-    def ClusterTestCluster_CommandTest(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterTestCluster_CommandTest(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_Test(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterTestCluster_CommandTestNotHandled(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterTestCluster_CommandTestNotHandled(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterTestCluster_CommandTestSpecific(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterTestCluster_CommandTestSpecific(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterThermostat_CommandClearWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterThermostat_CommandClearWeeklySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterThermostat_CommandGetRelayStatusLog(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterThermostat_CommandGetRelayStatusLog(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterThermostat_CommandGetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, daysToReturn: int, modeToReturn: int):
+    def ClusterThermostat_CommandGetWeeklySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, daysToReturn: int, modeToReturn: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid, daysToReturn, modeToReturn
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, daysToReturn, modeToReturn
         )
-    def ClusterThermostat_CommandSetWeeklySchedule(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, numberOfTransitionsForSequence: int, dayOfWeekForSequence: int, modeForSequence: int, payload: int):
+    def ClusterThermostat_CommandSetWeeklySchedule(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, numberOfTransitionsForSequence: int, dayOfWeekForSequence: int, modeForSequence: int, payload: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule(
-                device, ZCLendpoint, ZCLgroupid, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, numberOfTransitionsForSequence, dayOfWeekForSequence, modeForSequence, payload
         )
-    def ClusterThermostat_CommandSetpointRaiseLower(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, mode: int, amount: int):
+    def ClusterThermostat_CommandSetpointRaiseLower(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, mode: int, amount: int):
         return self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower(
-                device, ZCLendpoint, ZCLgroupid, mode, amount
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, mode, amount
         )
-    def ClusterTrustedRootCertificates_CommandAddTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, rootCertificate: bytes):
+    def ClusterTrustedRootCertificates_CommandAddTrustedRootCertificate(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, rootCertificate: bytes):
         return self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_AddTrustedRootCertificate(
-                device, ZCLendpoint, ZCLgroupid, rootCertificate, len(rootCertificate)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, rootCertificate, len(rootCertificate)
         )
-    def ClusterTrustedRootCertificates_CommandRemoveTrustedRootCertificate(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, trustedRootIdentifier: bytes):
+    def ClusterTrustedRootCertificates_CommandRemoveTrustedRootCertificate(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, trustedRootIdentifier: bytes):
         return self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate(
-                device, ZCLendpoint, ZCLgroupid, trustedRootIdentifier, len(trustedRootIdentifier)
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, trustedRootIdentifier, len(trustedRootIdentifier)
         )
-    def ClusterWindowCovering_CommandWindowCoveringDownClose(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterWindowCovering_CommandWindowCoveringDownClose(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterWindowCovering_CommandWindowCoveringGoToLiftPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, percentageLiftValue: int):
+    def ClusterWindowCovering_CommandWindowCoveringGoToLiftPercentage(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, percentageLiftValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftPercentage(
-                device, ZCLendpoint, ZCLgroupid, percentageLiftValue
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, percentageLiftValue
         )
-    def ClusterWindowCovering_CommandWindowCoveringGoToLiftValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, liftValue: int):
+    def ClusterWindowCovering_CommandWindowCoveringGoToLiftValue(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, liftValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue(
-                device, ZCLendpoint, ZCLgroupid, liftValue
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, liftValue
         )
-    def ClusterWindowCovering_CommandWindowCoveringGoToTiltPercentage(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, percentageTiltValue: int):
+    def ClusterWindowCovering_CommandWindowCoveringGoToTiltPercentage(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, percentageTiltValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltPercentage(
-                device, ZCLendpoint, ZCLgroupid, percentageTiltValue
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, percentageTiltValue
         )
-    def ClusterWindowCovering_CommandWindowCoveringGoToTiltValue(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int, tiltValue: int):
+    def ClusterWindowCovering_CommandWindowCoveringGoToTiltValue(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int, tiltValue: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue(
-                device, ZCLendpoint, ZCLgroupid, tiltValue
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid, tiltValue
         )
-    def ClusterWindowCovering_CommandWindowCoveringStop(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterWindowCovering_CommandWindowCoveringStop(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringStop(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
-    def ClusterWindowCovering_CommandWindowCoveringUpOpen(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int):
+    def ClusterWindowCovering_CommandWindowCoveringUpOpen(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int):
         return self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen(
-                device, ZCLendpoint, ZCLgroupid
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid
         )
 
     # Cluster attributes
@@ -1855,10 +1855,10 @@ class ChipClusters:
         self._chipLib.chip_ime_SetFailureResponseDelegate.res = None
         # Cluster AccountLogin
         # Cluster AccountLogin Command GetSetupPIN
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AccountLogin_GetSetupPIN.restype = ctypes.c_uint32
         # Cluster AccountLogin Command Login
-        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AccountLogin_Login.restype = ctypes.c_uint32
         # Cluster AccountLogin ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_AccountLogin_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -1890,7 +1890,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ApplicationBasic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher
         # Cluster ApplicationLauncher Command LaunchApp
-        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ApplicationLauncher_LaunchApp.restype = ctypes.c_uint32
         # Cluster ApplicationLauncher ReadAttribute ApplicationLauncherList
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ApplicationLauncherList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -1900,10 +1900,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ApplicationLauncher_ClusterRevision.restype = ctypes.c_uint32
         # Cluster AudioOutput
         # Cluster AudioOutput Command RenameOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_AudioOutput_RenameOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput Command SelectOutput
-        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_AudioOutput_SelectOutput.restype = ctypes.c_uint32
         # Cluster AudioOutput ReadAttribute AudioOutputList
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_AudioOutputList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -1913,10 +1913,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_AudioOutput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster BarrierControl
         # Cluster BarrierControl Command BarrierControlGoToPercent
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlGoToPercent.restype = ctypes.c_uint32
         # Cluster BarrierControl Command BarrierControlStop
-        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_BarrierControl_BarrierControlStop.restype = ctypes.c_uint32
         # Cluster BarrierControl ReadAttribute BarrierMovingState
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_BarrierMovingState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -1935,7 +1935,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_BarrierControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Basic
         # Cluster Basic Command MfgSpecificPing
-        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Basic_MfgSpecificPing.restype = ctypes.c_uint32
         # Cluster Basic ReadAttribute InteractionModelVersion
         self._chipLib.chip_ime_ReadAttribute_Basic_InteractionModelVersion.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -1993,56 +1993,56 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Basic_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Binding
         # Cluster Binding Command Bind
-        self._chipLib.chip_ime_AppendCommand_Binding_Bind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Binding_Bind.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Binding_Bind.restype = ctypes.c_uint32
         # Cluster Binding Command Unbind
-        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Binding_Unbind.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Binding_Unbind.restype = ctypes.c_uint32
         # Cluster Binding ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_Binding_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ColorControl
         # Cluster ColorControl Command MoveColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToHueAndSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToHueAndSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command MoveToSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_MoveToSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepColor
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_int16, ctypes.c_int16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepColor.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepColorTemperature
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepColorTemperature.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepHue
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepHue.restype = ctypes.c_uint32
         # Cluster ColorControl Command StepSaturation
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StepSaturation.restype = ctypes.c_uint32
         # Cluster ColorControl Command StopMoveStep
-        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_ColorControl_StopMoveStep.restype = ctypes.c_uint32
         # Cluster ColorControl ReadAttribute CurrentHue
         self._chipLib.chip_ime_ReadAttribute_ColorControl_CurrentHue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2214,10 +2214,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_ColorControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster ContentLaunch
         # Cluster ContentLaunch Command LaunchContent
-        self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchContent.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchContent.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchContent.restype = ctypes.c_uint32
         # Cluster ContentLaunch Command LaunchURL
-        self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchURL.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchURL.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_ContentLaunch_LaunchURL.restype = ctypes.c_uint32
         # Cluster ContentLaunch ReadAttribute AcceptsHeaderList
         self._chipLib.chip_ime_ReadAttribute_ContentLaunch_AcceptsHeaderList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2234,73 +2234,73 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Descriptor_ClusterRevision.restype = ctypes.c_uint32
         # Cluster DoorLock
         # Cluster DoorLock Command ClearAllPins
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllPins.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearAllRfids
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearAllRfids.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command ClearYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_ClearYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetLogRecord
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetLogRecord.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetUserType.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command GetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_DoorLock_GetYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command LockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_LockDoor.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetHolidaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetHolidaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetPin
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetPin.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetRfid
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetRfid.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetUserType
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetUserType.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetWeekdaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetWeekdaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command SetYeardaySchedule
-        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_SetYeardaySchedule.restype = ctypes.c_uint32
         # Cluster DoorLock Command UnlockDoor
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockDoor.restype = ctypes.c_uint32
         # Cluster DoorLock Command UnlockWithTimeout
-        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_DoorLock_UnlockWithTimeout.restype = ctypes.c_uint32
         # Cluster DoorLock ReadAttribute LockState
         self._chipLib.chip_ime_ReadAttribute_DoorLock_LockState.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2319,13 +2319,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_DoorLock_ClusterRevision.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning
         # Cluster GeneralCommissioning Command ArmFailSafe
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_ArmFailSafe.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning Command CommissioningComplete
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_CommissioningComplete.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning Command SetRegulatoryConfig
-        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_GeneralCommissioning_SetRegulatoryConfig.restype = ctypes.c_uint32
         # Cluster GeneralCommissioning ReadAttribute FabricId
         self._chipLib.chip_ime_ReadAttribute_GeneralCommissioning_FabricId.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2349,22 +2349,22 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_GroupKeyManagement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Groups
         # Cluster Groups Command AddGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Groups_AddGroup.restype = ctypes.c_uint32
         # Cluster Groups Command AddGroupIfIdentifying
-        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_Groups_AddGroupIfIdentifying.restype = ctypes.c_uint32
         # Cluster Groups Command GetGroupMembership
-        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_GetGroupMembership.restype = ctypes.c_uint32
         # Cluster Groups Command RemoveAllGroups
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_RemoveAllGroups.restype = ctypes.c_uint32
         # Cluster Groups Command RemoveGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_RemoveGroup.restype = ctypes.c_uint32
         # Cluster Groups Command ViewGroup
-        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Groups_ViewGroup.restype = ctypes.c_uint32
         # Cluster Groups ReadAttribute NameSupport
         self._chipLib.chip_ime_ReadAttribute_Groups_NameSupport.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2374,10 +2374,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Groups_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Identify
         # Cluster Identify Command Identify
-        self._chipLib.chip_ime_AppendCommand_Identify_Identify.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Identify_Identify.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Identify_Identify.restype = ctypes.c_uint32
         # Cluster Identify Command IdentifyQuery
-        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Identify_IdentifyQuery.restype = ctypes.c_uint32
         # Cluster Identify ReadAttribute IdentifyTime
         self._chipLib.chip_ime_ReadAttribute_Identify_IdentifyTime.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2387,35 +2387,35 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Identify_ClusterRevision.restype = ctypes.c_uint32
         # Cluster KeypadInput
         # Cluster KeypadInput Command SendKey
-        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_KeypadInput_SendKey.restype = ctypes.c_uint32
         # Cluster KeypadInput ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_KeypadInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LevelControl
         # Cluster LevelControl Command Move
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Move.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Move.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveToLevel
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevel.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveToLevelWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveToLevelWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command MoveWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_MoveWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command Step
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Step.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Step.restype = ctypes.c_uint32
         # Cluster LevelControl Command StepWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_StepWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl Command Stop
-        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_LevelControl_Stop.restype = ctypes.c_uint32
         # Cluster LevelControl Command StopWithOnOff
-        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LevelControl_StopWithOnOff.restype = ctypes.c_uint32
         # Cluster LevelControl ReadAttribute CurrentLevel
         self._chipLib.chip_ime_ReadAttribute_LevelControl_CurrentLevel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2428,23 +2428,23 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_LevelControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster LowPower
         # Cluster LowPower Command Sleep
-        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_LowPower_Sleep.restype = ctypes.c_uint32
         # Cluster LowPower ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_LowPower_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaInput
         # Cluster MediaInput Command HideInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaInput_HideInputStatus.restype = ctypes.c_uint32
         # Cluster MediaInput Command RenameInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_MediaInput_RenameInput.restype = ctypes.c_uint32
         # Cluster MediaInput Command SelectInput
-        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_MediaInput_SelectInput.restype = ctypes.c_uint32
         # Cluster MediaInput Command ShowInputStatus
-        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaInput_ShowInputStatus.restype = ctypes.c_uint32
         # Cluster MediaInput ReadAttribute MediaInputList
         self._chipLib.chip_ime_ReadAttribute_MediaInput_MediaInputList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2454,81 +2454,81 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_MediaInput_ClusterRevision.restype = ctypes.c_uint32
         # Cluster MediaPlayback
         # Cluster MediaPlayback Command MediaFastForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaFastForward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaNext
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaNext.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPause
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPause.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPlay
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPlay.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaPrevious
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaPrevious.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaRewind
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaRewind.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSkipBackward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipBackward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSkipForward
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipForward.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaSkipSeek
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaSkipSeek.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaStartOver
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStartOver.restype = ctypes.c_uint32
         # Cluster MediaPlayback Command MediaStop
-        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_MediaPlayback_MediaStop.restype = ctypes.c_uint32
         # Cluster MediaPlayback ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_MediaPlayback_ClusterRevision.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning
         # Cluster NetworkCommissioning Command AddThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddThreadNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command AddWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_AddWiFiNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command DisableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_DisableNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command EnableNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_EnableNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command GetLastNetworkCommissioningResult
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_GetLastNetworkCommissioningResult.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command RemoveNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_RemoveNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command ScanNetworks
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_ScanNetworks.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command UpdateThreadNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateThreadNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning Command UpdateWiFiNetwork
-        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_NetworkCommissioning_UpdateWiFiNetwork.restype = ctypes.c_uint32
         # Cluster NetworkCommissioning ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_ReadAttribute_NetworkCommissioning_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OnOff
         # Cluster OnOff Command Off
-        self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_Off.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Off.restype = ctypes.c_uint32
         # Cluster OnOff Command On
-        self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_On.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_On.restype = ctypes.c_uint32
         # Cluster OnOff Command Toggle
-        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OnOff_Toggle.restype = ctypes.c_uint32
         # Cluster OnOff ReadAttribute OnOff
         self._chipLib.chip_ime_ReadAttribute_OnOff_OnOff.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2541,22 +2541,22 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_OnOff_ClusterRevision.restype = ctypes.c_uint32
         # Cluster OperationalCredentials
         # Cluster OperationalCredentials Command AddOpCert
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddOpCert.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddOpCert.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint64, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_AddOpCert.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command OpCSRRequest
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_OpCSRRequest.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command RemoveAllFabrics
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveAllFabrics.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command RemoveFabric
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_RemoveFabric.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command SetFabric
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_SetFabric.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_SetFabric.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_SetFabric.restype = ctypes.c_uint32
         # Cluster OperationalCredentials Command UpdateFabricLabel
-        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_OperationalCredentials_UpdateFabricLabel.restype = ctypes.c_uint32
         # Cluster OperationalCredentials ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_OperationalCredentials_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2591,25 +2591,25 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_PumpConfigurationAndControl_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Scenes
         # Cluster Scenes Command AddScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_AddScene.restype = ctypes.c_uint32
         # Cluster Scenes Command GetSceneMembership
-        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_GetSceneMembership.restype = ctypes.c_uint32
         # Cluster Scenes Command RecallScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_RecallScene.restype = ctypes.c_uint32
         # Cluster Scenes Command RemoveAllScenes
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Scenes_RemoveAllScenes.restype = ctypes.c_uint32
         # Cluster Scenes Command RemoveScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_RemoveScene.restype = ctypes.c_uint32
         # Cluster Scenes Command StoreScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_StoreScene.restype = ctypes.c_uint32
         # Cluster Scenes Command ViewScene
-        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Scenes_ViewScene.restype = ctypes.c_uint32
         # Cluster Scenes ReadAttribute SceneCount
         self._chipLib.chip_ime_ReadAttribute_Scenes_SceneCount.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2644,13 +2644,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Switch_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TvChannel
         # Cluster TvChannel Command ChangeChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannel.restype = ctypes.c_uint32
         # Cluster TvChannel Command ChangeChannelByNumber
-        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TvChannel_ChangeChannelByNumber.restype = ctypes.c_uint32
         # Cluster TvChannel Command SkipChannel
-        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TvChannel_SkipChannel.restype = ctypes.c_uint32
         # Cluster TvChannel ReadAttribute TvChannelList
         self._chipLib.chip_ime_ReadAttribute_TvChannel_TvChannelList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2666,7 +2666,7 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TvChannel_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TargetNavigator
         # Cluster TargetNavigator Command NavigateTarget
-        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TargetNavigator_NavigateTarget.restype = ctypes.c_uint32
         # Cluster TargetNavigator ReadAttribute TargetNavigatorList
         self._chipLib.chip_ime_ReadAttribute_TargetNavigator_TargetNavigatorList.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2692,13 +2692,13 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TemperatureMeasurement_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TestCluster
         # Cluster TestCluster Command Test
-        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_Test.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_Test.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestNotHandled
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestNotHandled.restype = ctypes.c_uint32
         # Cluster TestCluster Command TestSpecific
-        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_TestCluster_TestSpecific.restype = ctypes.c_uint32
         # Cluster TestCluster ReadAttribute Boolean
         self._chipLib.chip_ime_ReadAttribute_TestCluster_Boolean.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2753,19 +2753,19 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_TestCluster_ClusterRevision.restype = ctypes.c_uint32
         # Cluster Thermostat
         # Cluster Thermostat Command ClearWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Thermostat_ClearWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command GetRelayStatusLog
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_Thermostat_GetRelayStatusLog.restype = ctypes.c_uint32
         # Cluster Thermostat Command GetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_GetWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command SetWeeklySchedule
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_SetWeeklySchedule.restype = ctypes.c_uint32
         # Cluster Thermostat Command SetpointRaiseLower
-        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_int8]
+        self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8, ctypes.c_int8]
         self._chipLib.chip_ime_AppendCommand_Thermostat_SetpointRaiseLower.restype = ctypes.c_uint32
         # Cluster Thermostat ReadAttribute LocalTemperature
         self._chipLib.chip_ime_ReadAttribute_Thermostat_LocalTemperature.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2790,10 +2790,10 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_Thermostat_ClusterRevision.restype = ctypes.c_uint32
         # Cluster TrustedRootCertificates
         # Cluster TrustedRootCertificates Command AddTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_AddTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_AddTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_AddTrustedRootCertificate.restype = ctypes.c_uint32
         # Cluster TrustedRootCertificates Command RemoveTrustedRootCertificate
-        self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
+        self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_char_p, ctypes.c_uint32]
         self._chipLib.chip_ime_AppendCommand_TrustedRootCertificates_RemoveTrustedRootCertificate.restype = ctypes.c_uint32
         # Cluster TrustedRootCertificates ReadAttribute ClusterRevision
         self._chipLib.chip_ime_ReadAttribute_TrustedRootCertificates_ClusterRevision.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
@@ -2807,25 +2807,25 @@ class ChipClusters:
         self._chipLib.chip_ime_ReadAttribute_WakeOnLan_ClusterRevision.restype = ctypes.c_uint32
         # Cluster WindowCovering
         # Cluster WindowCovering Command WindowCoveringDownClose
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringDownClose.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringGoToLiftPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringGoToLiftValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToLiftValue.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringGoToTiltPercentage
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltPercentage.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint8]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltPercentage.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringGoToTiltValue
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringGoToTiltValue.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringStop
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringStop.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringStop.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringStop.restype = ctypes.c_uint32
         # Cluster WindowCovering Command WindowCoveringUpOpen
-        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]
+        self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16]
         self._chipLib.chip_ime_AppendCommand_WindowCovering_WindowCoveringUpOpen.restype = ctypes.c_uint32
         # Cluster WindowCovering ReadAttribute WindowCoveringType
         self._chipLib.chip_ime_ReadAttribute_WindowCovering_WindowCoveringType.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16]

--- a/src/controller/python/chip/interaction_model/Delegate.h
+++ b/src/controller/python/chip/interaction_model/Delegate.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/InteractionModelDelegate.h>
+#include <controller/CHIPDeviceController.h>
 
 namespace chip {
 namespace Controller {
@@ -48,7 +49,7 @@ void pychip_InteractionModelDelegate_SetCommandResponseProtocolErrorCallback(
 void pychip_InteractionModelDelegate_SetCommandResponseErrorCallback(PythonInteractionModelDelegate_OnCommandResponseFunct f);
 }
 
-class PythonInteractionModelDelegate : public chip::app::InteractionModelDelegate
+class PythonInteractionModelDelegate : public chip::Controller::DeviceControllerInteractionModelDelegate
 {
 public:
     CHIP_ERROR CommandResponseStatus(const app::CommandSender * apCommandSender,

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -19,6 +19,7 @@ from ctypes import CFUNCTYPE, c_void_p, c_size_t, c_uint32, c_uint64, c_uint8
 import ctypes
 import chip.native
 import threading
+import chip.exceptions
 
 IMCommandStatus = Struct(
     "ProtocolId" /  Int32ul,
@@ -83,6 +84,7 @@ def InitIMDelegate():
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseStatusCallback", None, [_OnCommandResponseStatusCodeReceivedFunct])
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseProtocolErrorCallback", None, [_OnCommandResponseProtocolErrorFunct])
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseErrorCallback", None, [_OnCommandResponseFunct])
+        setter.Set("pychip_InteractionModel_GetCommandSenderHandle", c_uint32, [ctypes.POINTER(c_uint64)])
 
         handle.pychip_InteractionModelDelegate_SetCommandResponseStatusCallback(_OnCommandResponseStatusCodeReceived)
         handle.pychip_InteractionModelDelegate_SetCommandResponseProtocolErrorCallback(_OnCommandResponseProtocolError)
@@ -126,3 +128,12 @@ def WaitCommandIndexStatus(commandHandle: int, commandIndex: int):
         return (0, None)
     err = WaitCommandStatus(commandHandle)
     return (err, _GetCommandIndexStatus(commandHandle, commandIndex))
+
+def GetCommandSenderHandle()->int:
+    handle = chip.native.GetLibraryHandle()
+    resPointer = c_uint64()
+    res = handle.pychip_InteractionModel_GetCommandSenderHandle(ctypes.pointer(resPointer))
+    if res != 0:
+        raise chip.exceptions.ChipStackError(res)
+    ClearCommandStatus(resPointer.value)
+    return resPointer.value

--- a/src/controller/python/gen/CHIPClusters.cpp
+++ b/src/controller/python/gen/CHIPClusters.cpp
@@ -36,23 +36,26 @@ CHIP_ERROR AccountLoginCluster::GetSetupPIN(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSetupPINCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // tempAccountIdentifier: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -60,25 +63,28 @@ CHIP_ERROR AccountLoginCluster::Login(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLoginCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // tempAccountIdentifier: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), tempAccountIdentifier));
     // setupPIN: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), setupPIN));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // AccountLogin Cluster Attributes
@@ -176,13 +182,16 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchAppCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
@@ -191,12 +200,12 @@ CHIP_ERROR ApplicationLauncherCluster::LaunchApp(Callback::Cancelable * onSucces
     // applicationId: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), applicationId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ApplicationLauncher Cluster Attributes
@@ -230,25 +239,28 @@ CHIP_ERROR AudioOutputCluster::RenameOutput(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRenameOutputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), name));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR AudioOutputCluster::SelectOutput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -256,23 +268,26 @@ CHIP_ERROR AudioOutputCluster::SelectOutput(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSelectOutputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // AudioOutput Cluster Attributes
@@ -305,23 +320,26 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // percentOpen: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), percentOpen));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSuccessCallback,
@@ -329,20 +347,23 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // BarrierControl Cluster Attributes
@@ -398,20 +419,23 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Basic Cluster Attributes
@@ -588,13 +612,16 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -605,12 +632,12 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -619,13 +646,16 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -636,12 +666,12 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Binding Cluster Attributes
@@ -665,13 +695,16 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rateX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rateX));
@@ -682,12 +715,12 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -697,13 +730,16 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -718,12 +754,12 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -731,13 +767,16 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -748,12 +787,12 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -761,13 +800,16 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: saturationMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -778,12 +820,12 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -792,13 +834,16 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorX: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorX));
@@ -811,12 +856,12 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -825,13 +870,16 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorTemperature: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorTemperature));
@@ -842,12 +890,12 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -856,13 +904,16 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -875,12 +926,12 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * onSuccessCallback,
@@ -889,13 +940,16 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -908,12 +962,12 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -922,13 +976,16 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // saturation: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), saturation));
@@ -939,12 +996,12 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -953,13 +1010,16 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepX));
@@ -972,12 +1032,12 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -987,13 +1047,16 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1010,12 +1073,12 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1024,13 +1087,16 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1043,12 +1109,12 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1057,13 +1123,16 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: saturationStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -1076,12 +1145,12 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1089,25 +1158,28 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionsMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsMask));
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ColorControl Cluster Attributes
@@ -1719,25 +1791,28 @@ CHIP_ERROR ContentLaunchCluster::LaunchContent(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchContentCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // autoPlay: boolean
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), autoPlay));
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1745,25 +1820,28 @@ CHIP_ERROR ContentLaunchCluster::LaunchURL(Callback::Cancelable * onSuccessCallb
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLaunchURLCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // contentURL: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), contentURL));
     // displayString: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), displayString));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ContentLaunch Cluster Attributes
@@ -1851,40 +1929,46 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1892,23 +1976,26 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1916,23 +2003,26 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1940,23 +2030,26 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1964,25 +2057,28 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1990,25 +2086,28 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2016,23 +2115,26 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2040,23 +2142,26 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // logIndex: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), logIndex));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2064,23 +2169,26 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2088,23 +2196,26 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2112,23 +2223,26 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2136,25 +2250,28 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2162,25 +2279,28 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2188,23 +2308,26 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2213,13 +2336,16 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2230,12 +2356,12 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     // operatingModeDuringHoliday: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operatingModeDuringHoliday));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2243,13 +2369,16 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -2260,12 +2389,12 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2273,13 +2402,16 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -2290,12 +2422,12 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     // id: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), id));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2303,25 +2435,28 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
     // userType: doorLockUserType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userType));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2330,13 +2465,16 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2353,12 +2491,12 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     // endMinute: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), endMinute));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2366,13 +2504,16 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2383,12 +2524,12 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     // localEndTime: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), localEndTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2396,23 +2537,26 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2420,25 +2564,28 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutInSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutInSeconds));
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // DoorLock Cluster Attributes
@@ -2502,13 +2649,16 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // expiryLengthSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), expiryLengthSeconds));
@@ -2517,12 +2667,12 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelable * onSuccessCallback,
@@ -2530,20 +2680,23 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
@@ -2552,13 +2705,16 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRegulatoryConfigCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // location: regulatoryLocationType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), location));
@@ -2569,12 +2725,12 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // GeneralCommissioning Cluster Attributes
@@ -2689,25 +2845,28 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2715,25 +2874,28 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2741,45 +2903,51 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupCount: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupCount));
     // groupList: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupList));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2787,23 +2955,26 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2811,23 +2982,26 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Groups Cluster Attributes
@@ -2859,43 +3033,49 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // identifyTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), identifyTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Identify Cluster Attributes
@@ -2935,23 +3115,26 @@ CHIP_ERROR KeypadInputCluster::SendKey(Callback::Cancelable * onSuccessCallback,
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSendKeyCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // keyCode: keypadInputCecKeyCode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), keyCode));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // KeypadInput Cluster Attributes
@@ -2976,13 +3159,16 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -2993,12 +3179,12 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3006,13 +3192,16 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
@@ -3023,12 +3212,12 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSuccessCallback,
@@ -3037,25 +3226,28 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3063,25 +3255,28 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
     // rate: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3090,13 +3285,16 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -3109,12 +3307,12 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3122,13 +3320,16 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -3137,12 +3338,12 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3150,45 +3351,51 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionMask));
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LevelControl Cluster Attributes
@@ -3235,20 +3442,23 @@ CHIP_ERROR LowPowerCluster::Sleep(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSleepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LowPower Cluster Attributes
@@ -3271,20 +3481,23 @@ CHIP_ERROR MediaInputCluster::HideInputStatus(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kHideInputStatusCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3292,25 +3505,28 @@ CHIP_ERROR MediaInputCluster::RenameInput(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRenameInputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
     // name: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), name));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::SelectInput(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3318,43 +3534,49 @@ CHIP_ERROR MediaInputCluster::SelectInput(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSelectInputCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // index: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), index));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaInputCluster::ShowInputStatus(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kShowInputStatusCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // MediaInput Cluster Attributes
@@ -3386,120 +3608,138 @@ CHIP_ERROR MediaPlaybackCluster::MediaFastForward(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaFastForwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaNext(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaNextCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPause(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPauseCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPlay(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPlayCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaPrevious(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaPreviousCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaRewind(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaRewindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipBackward(Callback::Cancelable * onSuccessCallback,
@@ -3507,23 +3747,26 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipBackward(Callback::Cancelable * onSucc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipBackwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // deltaPositionMilliseconds: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), deltaPositionMilliseconds));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipForward(Callback::Cancelable * onSuccessCallback,
@@ -3531,23 +3774,26 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipForward(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipForwardCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // deltaPositionMilliseconds: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), deltaPositionMilliseconds));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaSkipSeek(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3555,63 +3801,72 @@ CHIP_ERROR MediaPlaybackCluster::MediaSkipSeek(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaSkipSeekCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // position: int64u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), position));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaStartOver(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaStartOverCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR MediaPlaybackCluster::MediaStop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMediaStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // MediaPlayback Cluster Attributes
@@ -3637,13 +3892,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -3652,12 +3910,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3666,13 +3924,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3683,12 +3944,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3697,13 +3958,16 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3712,12 +3976,12 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3726,13 +3990,16 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3741,12 +4008,12 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callback::Cancelable * onSuccessCallback,
@@ -3755,23 +4022,26 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3780,13 +4050,16 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3795,12 +4068,12 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSuccessCallback,
@@ -3809,13 +4082,16 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3824,12 +4100,12 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3839,13 +4115,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -3854,12 +4133,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3868,13 +4147,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3885,12 +4167,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // NetworkCommissioning Cluster Attributes
@@ -3914,60 +4196,69 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OnOff Cluster Attributes
@@ -4014,13 +4305,16 @@ CHIP_ERROR OperationalCredentialsCluster::AddOpCert(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddOpCertCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // noc: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), noc));
@@ -4033,12 +4327,12 @@ CHIP_ERROR OperationalCredentialsCluster::AddOpCert(Callback::Cancelable * onSuc
     // adminVendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), adminVendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * onSuccessCallback,
@@ -4046,23 +4340,26 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOpCSRRequestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // cSRNonce: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), cSRNonce));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::RemoveAllFabrics(Callback::Cancelable * onSuccessCallback,
@@ -4070,20 +4367,23 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveAllFabrics(Callback::Cancelable 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllFabricsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * onSuccessCallback,
@@ -4092,13 +4392,16 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // fabricId: fabricId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), fabricId));
@@ -4107,12 +4410,12 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuccessCallback,
@@ -4120,23 +4423,26 @@ CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
@@ -4144,23 +4450,26 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // label: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), label));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OperationalCredentials Cluster Attributes
@@ -4296,13 +4605,16 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -4319,12 +4631,12 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     // value: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), value));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4332,23 +4644,26 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4356,13 +4671,16 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -4371,12 +4689,12 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4384,23 +4702,26 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4408,25 +4729,28 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4434,25 +4758,28 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4460,25 +4787,28 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Scenes Cluster Attributes
@@ -4589,23 +4919,26 @@ CHIP_ERROR TvChannelCluster::ChangeChannel(Callback::Cancelable * onSuccessCallb
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kChangeChannelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // match: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), match));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TvChannelCluster::ChangeChannelByNumber(Callback::Cancelable * onSuccessCallback,
@@ -4614,25 +4947,28 @@ CHIP_ERROR TvChannelCluster::ChangeChannelByNumber(Callback::Cancelable * onSucc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kChangeChannelByNumberCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // majorNumber: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), majorNumber));
     // minorNumber: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), minorNumber));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TvChannelCluster::SkipChannel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4640,23 +4976,26 @@ CHIP_ERROR TvChannelCluster::SkipChannel(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSkipChannelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // count: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), count));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TvChannel Cluster Attributes
@@ -4704,25 +5043,28 @@ CHIP_ERROR TargetNavigatorCluster::NavigateTarget(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kNavigateTargetCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // target: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), target));
     // data: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), data));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TargetNavigator Cluster Attributes
@@ -4811,60 +5153,69 @@ CHIP_ERROR TestClusterCluster::Test(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestNotHandled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestNotHandledCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestSpecific(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestSpecificCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TestCluster Cluster Attributes
@@ -5169,40 +5520,46 @@ CHIP_ERROR ThermostatCluster::ClearWeeklySchedule(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetRelayStatusLog(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRelayStatusLogCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5210,25 +5567,28 @@ CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // daysToReturn: dayOfWeek
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), daysToReturn));
     // modeToReturn: modeForSequence
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), modeToReturn));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5237,13 +5597,16 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // numberOfTransitionsForSequence: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), numberOfTransitionsForSequence));
@@ -5254,12 +5617,12 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
     // payload: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), payload));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -5267,25 +5630,28 @@ CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetpointRaiseLowerCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // mode: setpointAdjustMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), mode));
     // amount: int8s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), amount));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Thermostat Cluster Attributes
@@ -5400,23 +5766,26 @@ CHIP_ERROR TrustedRootCertificatesCluster::AddTrustedRootCertificate(Callback::C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rootCertificate: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rootCertificate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TrustedRootCertificatesCluster::RemoveTrustedRootCertificate(Callback::Cancelable * onSuccessCallback,
@@ -5425,23 +5794,26 @@ CHIP_ERROR TrustedRootCertificatesCluster::RemoveTrustedRootCertificate(Callback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // trustedRootIdentifier: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), trustedRootIdentifier));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TrustedRootCertificates Cluster Attributes
@@ -5490,20 +5862,23 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringDownClose(Callback::Cancelable *
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringDownCloseCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftPercentage(Callback::Cancelable * onSuccessCallback,
@@ -5512,23 +5887,26 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftPercentage(Callback::Can
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftPercentageCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // percentageLiftValue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), percentageLiftValue));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftValue(Callback::Cancelable * onSuccessCallback,
@@ -5536,23 +5914,26 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToLiftValue(Callback::Cancelab
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToLiftValueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // liftValue: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), liftValue));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltPercentage(Callback::Cancelable * onSuccessCallback,
@@ -5561,23 +5942,26 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltPercentage(Callback::Can
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltPercentageCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // percentageTiltValue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), percentageTiltValue));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltValue(Callback::Cancelable * onSuccessCallback,
@@ -5585,23 +5969,26 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringGoToTiltValue(Callback::Cancelab
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringGoToTiltValueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // tiltValue: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), tiltValue));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringStop(Callback::Cancelable * onSuccessCallback,
@@ -5609,20 +5996,23 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringStop(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR WindowCoveringCluster::WindowCoveringUpOpen(Callback::Cancelable * onSuccessCallback,
@@ -5630,20 +6020,23 @@ CHIP_ERROR WindowCoveringCluster::WindowCoveringUpOpen(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kWindowCoveringUpOpenCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // WindowCovering Cluster Attributes

--- a/src/controller/python/templates/python-CHIPClusters-cpp.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-cpp.zapt
@@ -75,11 +75,12 @@ void chip_ime_SetFailureResponseDelegate(FailureResponseDelegate delegate)
 // Cluster {{asCamelCased name false}}
 
 {{#chip_server_cluster_commands}}
-CHIP_ERROR chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(chip::Controller::Device * device, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_server_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asCamelCased label}}, uint32_t {{asCamelCased label}}_Len{{else}}{{chipType}} {{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}})
+CHIP_ERROR chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(chip::Controller::Device * device, uint64_t command, chip::EndpointId ZCLendpointId, chip::GroupId{{#chip_server_cluster_command_arguments}}, {{#if (isString type)}}const uint8_t * {{asCamelCased label}}, uint32_t {{asCamelCased label}}_Len{{else}}{{chipType}} {{asCamelCased label}}{{/if}}{{/chip_server_cluster_command_arguments}})
 {
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    chip::app::CommandSender * commandSenderObj = reinterpret_cast<chip::app::CommandSender *>(command);
     chip::Controller::{{asCamelCased clusterName false}}Cluster cluster;
-    cluster.Associate(device, ZCLendpointId);
+    cluster.Associate(device, ZCLendpointId, commandSenderObj);
     return cluster.{{asCamelCased name false}}(nullptr, nullptr{{#chip_server_cluster_command_arguments}}, {{#if (isString type)}}chip::ByteSpan({{asCamelCased label}}, {{asCamelCased label}}_Len){{else}}{{asCamelCased label}}{{/if}}
     {{/chip_server_cluster_command_arguments}});
 }

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -47,12 +47,12 @@ class ChipClusters:
 {{/chip_client_clusters}}
         }
 
-    def SendCommand(self, device: ctypes.c_void_p, cluster: str, command: str, endpoint: int, groupid: int, args, imEnabled):
+    def SendCommand(self, device: ctypes.c_void_p, commandSender: ctypes.c_void_p, cluster: str, command: str, endpoint: int, groupid: int, args, imEnabled):
         func = getattr(self, "Cluster{}_Command{}".format(cluster, command), None)
         if not func:
             raise UnknownCommand(cluster, command)
         funcCaller = self._ChipStack.Call if imEnabled else self._ChipStack.CallAsync
-        funcCaller(lambda: func(device, endpoint, groupid, **args))
+        funcCaller(lambda: func(device, commandSender, endpoint, groupid, **args))
 
     def ReadAttribute(self, device: ctypes.c_void_p, cluster: str, attribute: str, endpoint: int, groupid: int, imEnabled):
         func = getattr(self, "Cluster{}_ReadAttribute{}".format(cluster, attribute), None)
@@ -72,14 +72,14 @@ class ChipClusters:
 
 {{#chip_client_clusters}}
 {{#chip_server_cluster_commands}}
-    def Cluster{{asCamelCased clusterName false}}_Command{{asCamelCased name false}}(self, device: ctypes.c_void_p, ZCLendpoint: int, ZCLgroupid: int{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}: {{asPythonType chipType}}{{/chip_server_cluster_command_arguments}}):
+    def Cluster{{asCamelCased clusterName false}}_Command{{asCamelCased name false}}(self, device: ctypes.c_void_p, commandSenderHandle: int, ZCLendpoint: int, ZCLgroupid: int{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}: {{asPythonType chipType}}{{/chip_server_cluster_command_arguments}}):
 {{#chip_server_cluster_command_arguments}}
 {{#if (isCharString type)}}
         {{asCamelCased label}} = {{asCamelCased label}}.encode("utf-8") + b'\x00'
 {{/if}}
 {{/chip_server_cluster_command_arguments}}
         return self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}(
-                device, ZCLendpoint, ZCLgroupid{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}{{#if (isString type)}}, len({{asCamelCased label}}){{/if}}{{/chip_server_cluster_command_arguments}}
+                device, commandSenderHandle, ZCLendpoint, ZCLgroupid{{#chip_server_cluster_command_arguments}}, {{asCamelCased label}}{{#if (isString type)}}, len({{asCamelCased label}}){{/if}}{{/chip_server_cluster_command_arguments}}
         )
 {{/chip_server_cluster_commands}}
 {{/chip_client_clusters}}
@@ -112,7 +112,7 @@ class ChipClusters:
         # Cluster {{asCamelCased name false}}
 {{#chip_server_cluster_commands}}
         # Cluster {{asCamelCased clusterName false}} Command {{asCamelCased name false}}
-        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint8, ctypes.c_uint16{{#chip_server_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_server_cluster_command_arguments}}]
+        self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_uint16{{#chip_server_cluster_command_arguments}}{{#if (isString type)}}, ctypes.c_char_p, ctypes.c_uint32{{else}}, ctypes.{{asPythonCType chipType}}{{/if}}{{/chip_server_cluster_command_arguments}}]
         self._chipLib.chip_ime_AppendCommand_{{asCamelCased clusterName false}}_{{asCamelCased name false}}.restype = ctypes.c_uint32
 {{/chip_server_cluster_commands}}
 {{#chip_server_cluster_attributes}}

--- a/src/darwin/Framework/CHIP/gen/CHIPClusters.cpp
+++ b/src/darwin/Framework/CHIP/gen/CHIPClusters.cpp
@@ -109,23 +109,26 @@ CHIP_ERROR BarrierControlCluster::BarrierControlGoToPercent(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlGoToPercentCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // percentOpen: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), percentOpen));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSuccessCallback,
@@ -133,20 +136,23 @@ CHIP_ERROR BarrierControlCluster::BarrierControlStop(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBarrierControlStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // BarrierControl Cluster Attributes
@@ -202,20 +208,23 @@ CHIP_ERROR BasicCluster::MfgSpecificPing(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMfgSpecificPingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Basic Cluster Attributes
@@ -392,13 +401,16 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kBindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -409,12 +421,12 @@ CHIP_ERROR BindingCluster::Bind(Callback::Cancelable * onSuccessCallback, Callba
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -423,13 +435,16 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnbindCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // nodeId: nodeId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), nodeId));
@@ -440,12 +455,12 @@ CHIP_ERROR BindingCluster::Unbind(Callback::Cancelable * onSuccessCallback, Call
     // clusterId: clusterId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), clusterId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Binding Cluster Attributes
@@ -469,13 +484,16 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rateX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rateX));
@@ -486,12 +504,12 @@ CHIP_ERROR ColorControlCluster::MoveColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -501,13 +519,16 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -522,12 +543,12 @@ CHIP_ERROR ColorControlCluster::MoveColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -535,13 +556,16 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: hueMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -552,12 +576,12 @@ CHIP_ERROR ColorControlCluster::MoveHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -565,13 +589,16 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: saturationMoveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -582,12 +609,12 @@ CHIP_ERROR ColorControlCluster::MoveSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -596,13 +623,16 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorX: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorX));
@@ -615,12 +645,12 @@ CHIP_ERROR ColorControlCluster::MoveToColor(Callback::Cancelable * onSuccessCall
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -629,13 +659,16 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // colorTemperature: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), colorTemperature));
@@ -646,12 +679,12 @@ CHIP_ERROR ColorControlCluster::MoveToColorTemperature(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -660,13 +693,16 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -679,12 +715,12 @@ CHIP_ERROR ColorControlCluster::MoveToHue(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * onSuccessCallback,
@@ -693,13 +729,16 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToHueAndSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // hue: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), hue));
@@ -712,12 +751,12 @@ CHIP_ERROR ColorControlCluster::MoveToHueAndSaturation(Callback::Cancelable * on
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -726,13 +765,16 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // saturation: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), saturation));
@@ -743,12 +785,12 @@ CHIP_ERROR ColorControlCluster::MoveToSaturation(Callback::Cancelable * onSucces
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -757,13 +799,16 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepX: int16s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepX));
@@ -776,12 +821,12 @@ CHIP_ERROR ColorControlCluster::StepColor(Callback::Cancelable * onSuccessCallba
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSuccessCallback,
@@ -791,13 +836,16 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepColorTemperatureCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -814,12 +862,12 @@ CHIP_ERROR ColorControlCluster::StepColorTemperature(Callback::Cancelable * onSu
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -828,13 +876,16 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepHueCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: hueStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -847,12 +898,12 @@ CHIP_ERROR ColorControlCluster::StepHue(Callback::Cancelable * onSuccessCallback
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -861,13 +912,16 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepSaturationCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: saturationStepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -880,12 +934,12 @@ CHIP_ERROR ColorControlCluster::StepSaturation(Callback::Cancelable * onSuccessC
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -893,25 +947,28 @@ CHIP_ERROR ColorControlCluster::StopMoveStep(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopMoveStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionsMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsMask));
     // optionsOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionsOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // ColorControl Cluster Attributes
@@ -1570,40 +1627,46 @@ CHIP_ERROR DoorLockCluster::ClearAllPins(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllPinsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearAllRfids(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearAllRfidsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1611,23 +1674,26 @@ CHIP_ERROR DoorLockCluster::ClearHolidaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1635,23 +1701,26 @@ CHIP_ERROR DoorLockCluster::ClearPin(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1659,23 +1728,26 @@ CHIP_ERROR DoorLockCluster::ClearRfid(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1683,25 +1755,28 @@ CHIP_ERROR DoorLockCluster::ClearWeekdaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1709,25 +1784,28 @@ CHIP_ERROR DoorLockCluster::ClearYeardaySchedule(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1735,23 +1813,26 @@ CHIP_ERROR DoorLockCluster::GetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1759,23 +1840,26 @@ CHIP_ERROR DoorLockCluster::GetLogRecord(Callback::Cancelable * onSuccessCallbac
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLogRecordCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // logIndex: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), logIndex));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1783,23 +1867,26 @@ CHIP_ERROR DoorLockCluster::GetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1807,23 +1894,26 @@ CHIP_ERROR DoorLockCluster::GetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1831,23 +1921,26 @@ CHIP_ERROR DoorLockCluster::GetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1855,25 +1948,28 @@ CHIP_ERROR DoorLockCluster::GetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1881,25 +1977,28 @@ CHIP_ERROR DoorLockCluster::GetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1907,23 +2006,26 @@ CHIP_ERROR DoorLockCluster::LockDoor(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kLockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1932,13 +2034,16 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetHolidayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -1949,12 +2054,12 @@ CHIP_ERROR DoorLockCluster::SetHolidaySchedule(Callback::Cancelable * onSuccessC
     // operatingModeDuringHoliday: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operatingModeDuringHoliday));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1962,13 +2067,16 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetPinCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -1979,12 +2087,12 @@ CHIP_ERROR DoorLockCluster::SetPin(Callback::Cancelable * onSuccessCallback, Cal
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -1992,13 +2100,16 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRfidCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
@@ -2009,12 +2120,12 @@ CHIP_ERROR DoorLockCluster::SetRfid(Callback::Cancelable * onSuccessCallback, Ca
     // id: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), id));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2022,25 +2133,28 @@ CHIP_ERROR DoorLockCluster::SetUserType(Callback::Cancelable * onSuccessCallback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetUserTypeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // userId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userId));
     // userType: doorLockUserType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), userType));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2049,13 +2163,16 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeekdayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2072,12 +2189,12 @@ CHIP_ERROR DoorLockCluster::SetWeekdaySchedule(Callback::Cancelable * onSuccessC
     // endMinute: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), endMinute));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2085,13 +2202,16 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetYeardayScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // scheduleId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), scheduleId));
@@ -2102,12 +2222,12 @@ CHIP_ERROR DoorLockCluster::SetYeardaySchedule(Callback::Cancelable * onSuccessC
     // localEndTime: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), localEndTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2115,23 +2235,26 @@ CHIP_ERROR DoorLockCluster::UnlockDoor(Callback::Cancelable * onSuccessCallback,
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockDoorCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2139,25 +2262,28 @@ CHIP_ERROR DoorLockCluster::UnlockWithTimeout(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUnlockWithTimeoutCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutInSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutInSeconds));
     // pin: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), pin));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // DoorLock Cluster Attributes
@@ -2221,13 +2347,16 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kArmFailSafeCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // expiryLengthSeconds: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), expiryLengthSeconds));
@@ -2236,12 +2365,12 @@ CHIP_ERROR GeneralCommissioningCluster::ArmFailSafe(Callback::Cancelable * onSuc
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelable * onSuccessCallback,
@@ -2249,20 +2378,23 @@ CHIP_ERROR GeneralCommissioningCluster::CommissioningComplete(Callback::Cancelab
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kCommissioningCompleteCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable * onSuccessCallback,
@@ -2271,13 +2403,16 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetRegulatoryConfigCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // location: regulatoryLocationType
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), location));
@@ -2288,12 +2423,12 @@ CHIP_ERROR GeneralCommissioningCluster::SetRegulatoryConfig(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // GeneralCommissioning Cluster Attributes
@@ -2408,25 +2543,28 @@ CHIP_ERROR GroupsCluster::AddGroup(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2434,25 +2572,28 @@ CHIP_ERROR GroupsCluster::AddGroupIfIdentifying(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddGroupIfIdentifyingCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // groupName: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupName));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2460,45 +2601,51 @@ CHIP_ERROR GroupsCluster::GetGroupMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetGroupMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupCount: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupCount));
     // groupList: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupList));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveAllGroups(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllGroupsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2506,23 +2653,26 @@ CHIP_ERROR GroupsCluster::RemoveGroup(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2530,23 +2680,26 @@ CHIP_ERROR GroupsCluster::ViewGroup(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewGroupCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Groups Cluster Attributes
@@ -2578,43 +2731,49 @@ CHIP_ERROR IdentifyCluster::Identify(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // identifyTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), identifyTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR IdentifyCluster::IdentifyQuery(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kIdentifyQueryCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Identify Cluster Attributes
@@ -2654,13 +2813,16 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
@@ -2671,12 +2833,12 @@ CHIP_ERROR LevelControlCluster::Move(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2684,13 +2846,16 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
@@ -2701,12 +2866,12 @@ CHIP_ERROR LevelControlCluster::MoveToLevel(Callback::Cancelable * onSuccessCall
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSuccessCallback,
@@ -2715,25 +2880,28 @@ CHIP_ERROR LevelControlCluster::MoveToLevelWithOnOff(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveToLevelWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // level: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), level));
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2741,25 +2909,28 @@ CHIP_ERROR LevelControlCluster::MoveWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kMoveWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // moveMode: moveMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), moveMode));
     // rate: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2768,13 +2939,16 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -2787,12 +2961,12 @@ CHIP_ERROR LevelControlCluster::Step(Callback::Cancelable * onSuccessCallback, C
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2800,13 +2974,16 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStepWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // stepMode: stepMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), stepMode));
@@ -2815,12 +2992,12 @@ CHIP_ERROR LevelControlCluster::StepWithOnOff(Callback::Cancelable * onSuccessCa
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -2828,45 +3005,51 @@ CHIP_ERROR LevelControlCluster::Stop(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // optionMask: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionMask));
     // optionOverride: bitmap8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), optionOverride));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR LevelControlCluster::StopWithOnOff(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStopWithOnOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LevelControl Cluster Attributes
@@ -2913,20 +3096,23 @@ CHIP_ERROR LowPowerCluster::Sleep(Callback::Cancelable * onSuccessCallback, Call
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSleepCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // LowPower Cluster Attributes
@@ -2951,13 +3137,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -2966,12 +3155,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddThreadNetwork(Callback::Cancelable * 
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -2980,13 +3169,16 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -2997,12 +3189,12 @@ CHIP_ERROR NetworkCommissioningCluster::AddWiFiNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3011,13 +3203,16 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kDisableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3026,12 +3221,12 @@ CHIP_ERROR NetworkCommissioningCluster::DisableNetwork(Callback::Cancelable * on
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3040,13 +3235,16 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kEnableNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3055,12 +3253,12 @@ CHIP_ERROR NetworkCommissioningCluster::EnableNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callback::Cancelable * onSuccessCallback,
@@ -3069,23 +3267,26 @@ CHIP_ERROR NetworkCommissioningCluster::GetLastNetworkCommissioningResult(Callba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetLastNetworkCommissioningResultCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3094,13 +3295,16 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // networkID: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), networkID));
@@ -3109,12 +3313,12 @@ CHIP_ERROR NetworkCommissioningCluster::RemoveNetwork(Callback::Cancelable * onS
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSuccessCallback,
@@ -3123,13 +3327,16 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kScanNetworksCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3138,12 +3345,12 @@ CHIP_ERROR NetworkCommissioningCluster::ScanNetworks(Callback::Cancelable * onSu
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3153,13 +3360,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateThreadNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // operationalDataset: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), operationalDataset));
@@ -3168,12 +3378,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateThreadNetwork(Callback::Cancelable
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable * onSuccessCallback,
@@ -3182,13 +3392,16 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateWiFiNetworkCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // ssid: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), ssid));
@@ -3199,12 +3412,12 @@ CHIP_ERROR NetworkCommissioningCluster::UpdateWiFiNetwork(Callback::Cancelable *
     // timeoutMs: int32u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), timeoutMs));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // NetworkCommissioning Cluster Attributes
@@ -3228,60 +3441,69 @@ CHIP_ERROR OnOffCluster::Off(Callback::Cancelable * onSuccessCallback, Callback:
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOffCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::On(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOnCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OnOffCluster::Toggle(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kToggleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OnOff Cluster Attributes
@@ -3328,13 +3550,16 @@ CHIP_ERROR OperationalCredentialsCluster::AddOpCert(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddOpCertCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // noc: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), noc));
@@ -3347,12 +3572,12 @@ CHIP_ERROR OperationalCredentialsCluster::AddOpCert(Callback::Cancelable * onSuc
     // adminVendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), adminVendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * onSuccessCallback,
@@ -3360,23 +3585,26 @@ CHIP_ERROR OperationalCredentialsCluster::OpCSRRequest(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kOpCSRRequestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // cSRNonce: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), cSRNonce));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::RemoveAllFabrics(Callback::Cancelable * onSuccessCallback,
@@ -3384,20 +3612,23 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveAllFabrics(Callback::Cancelable 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllFabricsCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * onSuccessCallback,
@@ -3406,13 +3637,16 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // fabricId: fabricId
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), fabricId));
@@ -3421,12 +3655,12 @@ CHIP_ERROR OperationalCredentialsCluster::RemoveFabric(Callback::Cancelable * on
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuccessCallback,
@@ -3434,23 +3668,26 @@ CHIP_ERROR OperationalCredentialsCluster::SetFabric(Callback::Cancelable * onSuc
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetFabricCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // vendorId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), vendorId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable * onSuccessCallback,
@@ -3458,23 +3695,26 @@ CHIP_ERROR OperationalCredentialsCluster::UpdateFabricLabel(Callback::Cancelable
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kUpdateFabricLabelCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // label: charString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), label));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // OperationalCredentials Cluster Attributes
@@ -3610,13 +3850,16 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -3633,12 +3876,12 @@ CHIP_ERROR ScenesCluster::AddScene(Callback::Cancelable * onSuccessCallback, Cal
     // value: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), value));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3646,23 +3889,26 @@ CHIP_ERROR ScenesCluster::GetSceneMembership(Callback::Cancelable * onSuccessCal
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetSceneMembershipCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3670,13 +3916,16 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRecallSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
@@ -3685,12 +3934,12 @@ CHIP_ERROR ScenesCluster::RecallScene(Callback::Cancelable * onSuccessCallback, 
     // transitionTime: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), transitionTime));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3698,23 +3947,26 @@ CHIP_ERROR ScenesCluster::RemoveAllScenes(Callback::Cancelable * onSuccessCallba
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveAllScenesCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3722,25 +3974,28 @@ CHIP_ERROR ScenesCluster::RemoveScene(Callback::Cancelable * onSuccessCallback, 
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3748,25 +4003,28 @@ CHIP_ERROR ScenesCluster::StoreScene(Callback::Cancelable * onSuccessCallback, C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kStoreSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -3774,25 +4032,28 @@ CHIP_ERROR ScenesCluster::ViewScene(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kViewSceneCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // groupId: int16u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), groupId));
     // sceneId: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), sceneId));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Scenes Cluster Attributes
@@ -3959,60 +4220,69 @@ CHIP_ERROR TestClusterCluster::Test(Callback::Cancelable * onSuccessCallback, Ca
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestNotHandled(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestNotHandledCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TestClusterCluster::TestSpecific(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kTestSpecificCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TestCluster Cluster Attributes
@@ -4317,40 +4587,46 @@ CHIP_ERROR ThermostatCluster::ClearWeeklySchedule(Callback::Cancelable * onSucce
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kClearWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetRelayStatusLog(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback)
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetRelayStatusLogCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
-
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
     // Command takes no arguments.
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4358,25 +4634,28 @@ CHIP_ERROR ThermostatCluster::GetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kGetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // daysToReturn: dayOfWeek
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), daysToReturn));
     // modeToReturn: modeForSequence
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), modeToReturn));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4385,13 +4664,16 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetWeeklyScheduleCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // numberOfTransitionsForSequence: enum8
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), numberOfTransitionsForSequence));
@@ -4402,12 +4684,12 @@ CHIP_ERROR ThermostatCluster::SetWeeklySchedule(Callback::Cancelable * onSuccess
     // payload: int8u
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), payload));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSuccessCallback, Callback::Cancelable * onFailureCallback,
@@ -4415,25 +4697,28 @@ CHIP_ERROR ThermostatCluster::SetpointRaiseLower(Callback::Cancelable * onSucces
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kSetpointRaiseLowerCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // mode: setpointAdjustMode
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), mode));
     // amount: int8s
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), amount));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // Thermostat Cluster Attributes
@@ -4548,23 +4833,26 @@ CHIP_ERROR TrustedRootCertificatesCluster::AddTrustedRootCertificate(Callback::C
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kAddTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // rootCertificate: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), rootCertificate));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 CHIP_ERROR TrustedRootCertificatesCluster::RemoveTrustedRootCertificate(Callback::Cancelable * onSuccessCallback,
@@ -4573,23 +4861,26 @@ CHIP_ERROR TrustedRootCertificatesCluster::RemoveTrustedRootCertificate(Callback
 {
     VerifyOrReturnError(mDevice != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    if (mpCommandSender == nullptr)
+    {
+        ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&mpCommandSender));
+    }
+
     app::CommandPathParams cmdParams = { mEndpoint, /* group id */ 0, mClusterId, kRemoveTrustedRootCertificateCommandId,
                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
-    app::Command * ZCLcommand        = mDevice->GetCommandSender();
+    ReturnErrorOnFailure(mpCommandSender->PrepareCommand(&cmdParams));
 
-    ReturnErrorOnFailure(ZCLcommand->PrepareCommand(&cmdParams));
-
-    TLV::TLVWriter * writer = ZCLcommand->GetCommandDataElementTLVWriter();
+    TLV::TLVWriter * writer = mpCommandSender->GetCommandDataElementTLVWriter();
     uint8_t argSeqNumber    = 0;
     // trustedRootIdentifier: octetString
     ReturnErrorOnFailure(writer->Put(TLV::ContextTag(argSeqNumber++), trustedRootIdentifier));
 
-    ReturnErrorOnFailure(ZCLcommand->FinishCommand());
+    ReturnErrorOnFailure(mpCommandSender->FinishCommand());
 
     // #6308: This is a temporary solution before we fully support IM on application side and should be replaced by IMDelegate.
-    mDevice->AddIMResponseHandler(onSuccessCallback, onFailureCallback);
+    mDevice->AddIMResponseHandler(mpCommandSender, onSuccessCallback, onFailureCallback);
 
-    return mDevice->SendCommands();
+    return mDevice->SendCommands(mpCommandSender);
 }
 
 // TrustedRootCertificates Cluster Attributes


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Current IM command interaction can send multiple command in one interaction, but device controller has limited this capabilit with one command, actually the ember needs to send multiple commands in one invoke command interaction in some user scenario,

<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes

- After this PR, the CHIPDevice nolonger holds the commandSender object, for backward compatibility, the ClusterObjects will accept an optional CommandSender object, if not provided, it will request one from IMDelegate.

- This also uses a pool of CommandSender with two objects (previous one), this will allow sending multiple commands at the same time.

- This also fixes the broken chip-device-ctrl after #6705 introduced OpCred provisioning.

Note: The API for sending multiple commands at the same time should be ready after this PR, it is used by OpCred provisioning routine now, will add Python api support for more commands later.

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

Fixes #6560
Also Fixes #6797, fixes #6803.

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
