### PR TITLE
Fix Variant move assign

### DIFF
--- a/src/lib/support/Variant.h
+++ b/src/lib/support/Variant.h
@@ -131,6 +131,8 @@ public:
         Curry::Destroy(mTypeId, &mData);
         mTypeId = that.mTypeId;
         Curry::Move(that.mTypeId, &that.mData, &mData);
+        Curry::Destroy(that.mTypeId, &that.mData);
+        that.mTypeId = kInvalidType;
         return *this;
     }
 


### PR DESCRIPTION
There is a bug that move assign doesn't destroy the original variant.

Also added test cases to check that.