### PR TITLE
Ensure the Clusters template helper is initialized when calling an he…

### DIFF
--- a/src/app/zap-templates/templates/chip/helper.js
+++ b/src/app/zap-templates/templates/chip/helper.js
@@ -26,16 +26,14 @@ const ChipTypesHelper = require('../../common/ChipTypesHelper.js');
 
 function asBlocks(promise, options)
 {
-  function fn(pkgId)
-  {
-    return Clusters.init(this, pkgId).then(() => promise.then(data => templateUtil.collectBlocks(data, options, this)));
-  }
-  return templateUtil.ensureZclPackageId(this).then(fn.bind(this)).catch(err => console.log(err));
+  const fn = pkgId => Clusters.init(this, pkgId).then(() => promise.then(data => templateUtil.collectBlocks(data, options, this)));
+  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => console.log(err));
 }
 
 function asPromise(promise)
 {
-  return templateUtil.templatePromise(this.global, promise);
+  const fn = pkgId => Clusters.init(this, pkgId).then(() => promise);
+  return templateUtil.ensureZclPackageId(this).then(fn).catch(err => console.log(err));
 }
 
 function throwErrorIfUndefined(item, errorMsg, conditions)


### PR DESCRIPTION
…lper that does not returns a block


 #### Problem

If someone calls `./scripts/tools/zap/generate.py path/to/zap/file.zap -t path/to/templates/templates.json` with templates that relies on `src/app/zap-templates/common/ClustersHelper.js` but without using any block function, then the templates will not be generated.

This is because `asBlocks` initialise the helper if it has not been initialised before, while `asPromise` does not.

 #### Summary of Changes
 * Ensure `asPromise` initialise the helper as well.