### PR TITLE
Persist keypair used by example opcert signer

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -41,10 +41,12 @@ CHIP_ERROR ModelCommand::Run(PersistentStorage & storage, NodeId localId, NodeId
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mOpCredsIssuer.Initialize();
-
     chip::Controller::CommissionerInitParams initParams;
-    initParams.storageDelegate                = &storage;
+    initParams.storageDelegate = &storage;
+
+    err = mOpCredsIssuer.Initialize(storage);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
+
     initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -31,12 +31,14 @@ CHIP_ERROR PairingCommand::Run(PersistentStorage & storage, NodeId localId, Node
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mOpCredsIssuer.Initialize();
-
     chip::Controller::CommissionerInitParams params;
-    params.storageDelegate                = &storage;
-    params.mDeviceAddressUpdateDelegate   = this;
-    params.pairingDelegate                = this;
+    params.storageDelegate              = &storage;
+    params.mDeviceAddressUpdateDelegate = this;
+    params.pairingDelegate              = this;
+
+    err = mOpCredsIssuer.Initialize(storage);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
+
     params.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -93,7 +93,6 @@ public:
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             break;
         }
-        mOpCredsIssuer.Initialize();
     }
 
     /////////// Command Interface /////////

--- a/examples/chip-tool/commands/reporting/ReportingCommand.cpp
+++ b/examples/chip-tool/commands/reporting/ReportingCommand.cpp
@@ -32,12 +32,14 @@ CHIP_ERROR ReportingCommand::Run(PersistentStorage & storage, NodeId localId, No
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mOpCredsIssuer.Initialize();
-
     chip::Controller::BasicCluster cluster;
     chip::Controller::CommissionerInitParams initParams;
 
-    initParams.storageDelegate                = &storage;
+    initParams.storageDelegate = &storage;
+
+    err = mOpCredsIssuer.Initialize(storage);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Init failure! Operational Cred Issuer: %s", ErrorStr(err)));
+
     initParams.operationalCredentialsDelegate = &mOpCredsIssuer;
 
     err = mCommissioner.SetUdpListenPort(storage.GetListenPort());

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -22,6 +22,9 @@
  *    issuer for CHIP devices. The class can be used as a guideline on how to
  *    construct your own certificate issuer. It can also be used in tests and tools
  *    if a specific signing authority is not required.
+ *
+ *    NOTE: This class stores the encryption key in clear storage. This is not suited
+ *          for production use. This should only be used in test tools.
  */
 
 #pragma once
@@ -55,7 +58,8 @@ public:
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Initialize(PersistentStorageDelegate & storage);
+    [[deprecated("This class stores the encryption key in clear storage. Don't use it for production code.")]] CHIP_ERROR
+    Initialize(PersistentStorageDelegate & storage);
 
     void SetIssuerId(uint32_t id) { mIssuerId = id; }
 

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -28,6 +28,7 @@
 
 #include <controller/OperationalCredentialsDelegate.h>
 #include <core/CHIPError.h>
+#include <core/CHIPPersistentStorageDelegate.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <support/CodeUtils.h>
 
@@ -45,36 +46,16 @@ public:
     CHIP_ERROR GetRootCACertificate(FabricId fabricId, uint8_t * certBuf, uint32_t certBufSize, uint32_t & outCertLen) override;
 
     /**
-     * @brief Serialize the issuer's keypair.
+     * @brief Initialize the issuer with the keypair in the storage.
+     *        If the storage doesn't have one, it'll create one, and it to the storage.
+     *
+     * @param[in] storage  A reference to the storage, where the keypair is stored.
+     *                     The object of ExampleOperationalCredentialsIssuer doesn't hold
+     *                     on the reference of storage.
+     *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR Serialize(Crypto::P256SerializedKeypair & issuer)
-    {
-        VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
-        return mIssuer.Serialize(issuer);
-    }
-
-    /**
-     * @brief Deserialize the keypair as issuer's keypair.
-     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
-     **/
-    CHIP_ERROR Deserialize(Crypto::P256SerializedKeypair & issuer)
-    {
-        ReturnErrorOnFailure(mIssuer.Deserialize(issuer));
-        mInitialized = true;
-        return CHIP_NO_ERROR;
-    }
-
-    /**
-     * @brief Initialize the issuer with a new keypair.
-     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
-     **/
-    CHIP_ERROR Initialize()
-    {
-        ReturnErrorOnFailure(mIssuer.Initialize());
-        mInitialized = true;
-        return CHIP_NO_ERROR;
-    }
+    CHIP_ERROR Initialize(PersistentStorageDelegate & storage);
 
     void SetIssuerId(uint32_t id) { mIssuerId = id; }
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -143,7 +143,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
     initParams.inetLayer       = inetLayer;
     initParams.bleLayer        = GetJNIBleLayer();
 
-    *errInfoOnFailure = wrapper->OpCredsIssuer().Initialize();
+    *errInfoOnFailure = wrapper->OpCredsIssuer().Initialize(*initParams.storageDelegate);
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {
         return nullptr;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR pychip_DeviceController_NewDeviceController(chip::Controller::DeviceC
         localDeviceId = kDefaultLocalDeviceId;
     }
 
-    ReturnErrorOnFailure(sOperationalCredentialsIssuer.Initialize());
+    ReturnErrorOnFailure(sOperationalCredentialsIssuer.Initialize(sStorageDelegate));
 
     initParams.storageDelegate                = &sStorageDelegate;
     initParams.mDeviceAddressUpdateDelegate   = &sDeviceAddressUpdateDelegate;

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -101,8 +101,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         params.inetLayer       = &chip::DeviceLayer::InetLayer;
         params.pairingDelegate = &gPairingDelegate;
 
-        err = gOperationalCredentialsIssuer.Initialize();
-
+        err = gOperationalCredentialsIssuer.Initialize(gServerStorage);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Operational credentials issuer initialization failed: %s", chip::ErrorStr(err));


### PR DESCRIPTION
 #### Problem
The tools that are using example operational certificate signer should persist their signing key, so that on reruns same credentials are used for CASE session establishment.

 #### Summary of Changes
Updated `ExampleOperationalCredentialsIssuer` class to take a reference to storage delegate. On `Init`, it'll lookup the storage for an existing keypair. If not found, it'll create one and persist it for the next run.

Updated users of `ExampleOperationalCredentialsIssuer` to provide their storage delegates.