### PR TITLE
ESP32: Fix compilation of examples with CMake

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -178,6 +178,9 @@ if(NOT CONFIG_USE_MINIMAL_MDNS)
     list(APPEND chip_libraries $<TARGET_FILE:${mdns_lib}>)
 endif()
 
+idf_component_get_property(main_lib main COMPONENT_LIB)
+list(APPEND chip_libraries $<TARGET_FILE:${main_lib}>)
+
 target_link_libraries(${COMPONENT_LIB} INTERFACE -Wl,--start-group 
                                                 ${chip_libraries}
                                                 $<TARGET_FILE:mbedcrypto> $<TARGET_FILE:${esp32_mbedtls_lib}> 


### PR DESCRIPTION
 #### Problem
ESP32 examples fail with CMake.

 #### Summary of Changes
As described here: https://github.com/project-chip/connectedhomeip/issues/6774#issuecomment-840447955

Fixes #6774 