### PR TITLE
Include length of key when it's stored in persistent storage

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -30,16 +30,14 @@ using namespace Crypto;
 CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDelegate & storage)
 {
     Crypto::P256SerializedKeypair serializedKey;
-    uint16_t keySize = static_cast<uint16_t>(serializedKey.Capacity());
+    uint16_t keySize = static_cast<uint16_t>(sizeof(serializedKey));
 
-    if (storage.SyncGetKeyValue(kOperationalCredentialsIssuerKeypairStorage, serializedKey, keySize) != CHIP_NO_ERROR)
+    if (storage.SyncGetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize) != CHIP_NO_ERROR)
     {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
-
-        keySize = static_cast<uint16_t>(serializedKey.Length());
-        ReturnErrorOnFailure(storage.SyncSetKeyValue(kOperationalCredentialsIssuerKeypairStorage, serializedKey, keySize));
+        ReturnErrorOnFailure(storage.SyncSetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize));
     }
     else
     {


### PR DESCRIPTION
 #### Problem
The `chip-tool` is failing to launch on second and subsequent runs.

 #### Summary of Changes
The programs stores the operational credential issuer's key in persistent storage now. It was not storing the key length as part of the key. That caused the key to fail to deserialize.

This PR changes it to store the whole keypair data structure (instead of just the key bytes). It'll include the length as well.
