### PR TITLE
[network commissioning] Add response command for commands

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -33,23 +33,32 @@
 #include <app/common/gen/enums.h>
 #include <app/util/af.h>
 #include <gen/callback.h>
+#include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
 
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, ByteSpan operationalDataset,
                                                                 uint64_t breadcrumb, uint32_t timeoutMs)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(commandObj, emberAfCurrentEndpoint(),
                                                                                          operationalDataset, breadcrumb, timeoutMs);
     return true;
+#else
+    return false;
+#endif
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, ByteSpan ssid, ByteSpan credentials,
                                                               uint64_t breadcrumb, uint32_t timeoutMs)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(commandObj, emberAfCurrentEndpoint(), ssid,
                                                                                        credentials, breadcrumb, timeoutMs);
     return true;
+#else
+    return false;
+#endif
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, ByteSpan networkID,

--- a/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning-ember.cpp
@@ -16,6 +16,10 @@
  *    limitations under the License.
  */
 
+/**
+ * @file  Wrappers for namespaced network commissioning cluster implementation.
+ */
+
 #include "network-commissioning.h"
 
 #include <cstring>
@@ -35,30 +39,24 @@ using namespace chip;
 bool emberAfNetworkCommissioningClusterAddThreadNetworkCallback(chip::app::Command * commandObj, ByteSpan operationalDataset,
                                                                 uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), operationalDataset, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    chip::app::clusters::NetworkCommissioning::OnAddThreadNetworkCommandCallbackInternal(commandObj, emberAfCurrentEndpoint(),
+                                                                                         operationalDataset, breadcrumb, timeoutMs);
     return true;
 }
 
 bool emberAfNetworkCommissioningClusterAddWiFiNetworkCallback(chip::app::Command * commandObj, ByteSpan ssid, ByteSpan credentials,
                                                               uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), ssid, credentials, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    chip::app::clusters::NetworkCommissioning::OnAddWiFiNetworkCommandCallbackInternal(commandObj, emberAfCurrentEndpoint(), ssid,
+                                                                                       credentials, breadcrumb, timeoutMs);
     return true;
 }
 
 bool emberAfNetworkCommissioningClusterEnableNetworkCallback(chip::app::Command * commandObj, ByteSpan networkID,
                                                              uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    EmberAfNetworkCommissioningError err = chip::app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(
-        nullptr, emberAfCurrentEndpoint(), networkID, breadcrumb, timeoutMs);
-    emberAfSendImmediateDefaultResponse(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS ? EMBER_ZCL_STATUS_SUCCESS
-                                                                                             : EMBER_ZCL_STATUS_FAILURE);
+    chip::app::clusters::NetworkCommissioning::OnEnableNetworkCommandCallbackInternal(commandObj, emberAfCurrentEndpoint(),
+                                                                                      networkID, breadcrumb, timeoutMs);
     return true;
 }
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -21,6 +21,18 @@
 #include <cstring>
 #include <type_traits>
 
+#include <app/util/af.h>
+#include <gen/att-storage.h>
+#include <gen/attribute-id.h>
+#include <gen/attribute-type.h>
+#include <gen/callback.h>
+#include <gen/cluster-id.h>
+#include <gen/command-id.h>
+#include <gen/enums.h>
+
+#include <app/CommandPathParams.h>
+#include <app/CommandSender.h>
+#include <app/InteractionModelEngine.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/Span.h>
@@ -50,171 +62,323 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::clusters;
 using namespace chip::app::clusters::NetworkCommissioning;
+using namespace chip::app::clusters::NetworkCommissioning::Internal;
 
 namespace chip {
 namespace app {
 namespace clusters {
 namespace NetworkCommissioning {
 
-constexpr uint8_t kMaxNetworkIDLen       = 32;
-constexpr uint8_t kMaxThreadDatasetLen   = 254; // As defined in Thread spec.
-constexpr uint8_t kMaxWiFiSSIDLen        = 32;
-constexpr uint8_t kMaxWiFiCredentialsLen = 64;
-constexpr uint8_t kMaxNetworks           = CHIP_CLUSTER_NETWORK_COMMISSIONING_MAX_NETWORKS;
-
-enum class NetworkType : uint8_t
-{
-    kUndefined = 0,
-    kWiFi      = 1,
-    kThread    = 2,
-    kEthernet  = 3,
-};
-
-struct ThreadNetworkInfo
-{
-    uint8_t mDataset[kMaxThreadDatasetLen];
-    uint8_t mDatasetLen;
-};
-
-struct WiFiNetworkInfo
-{
-    uint8_t mSSID[kMaxWiFiSSIDLen + 1];
-    uint8_t mSSIDLen;
-    uint8_t mCredentials[kMaxWiFiCredentialsLen];
-    uint8_t mCredentialsLen;
-};
-
-struct NetworkInfo
-{
-    uint8_t mNetworkID[kMaxNetworkIDLen];
-    uint8_t mNetworkIDLen;
-    uint8_t mEnabled;
-    NetworkType mNetworkType;
-    union NetworkData
-    {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        Thread::OperationalDataset mThread;
-#endif
-#if defined(CHIP_DEVICE_LAYER_TARGET)
-        WiFiNetworkInfo mWiFi;
-#endif
-    } mData;
-};
-
 namespace {
 // The internal network info containing credentials. Need to find some better place to save these info.
 NetworkInfo sNetworks[kMaxNetworks];
 } // namespace
 
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset,
-                                                                           uint64_t breadcrumb, uint32_t timeoutMs)
+namespace Internal {
+
+chip::NodeId networkCommissionerNodeId = chip::kAnyNodeId;
+ClusterState sClusterState             = ClusterState::kIdle;
+uint8_t sCurrentEnablingNetworkSeq     = kInvalidNetworkSeq;
+SecureSessionHandle sCommissionerSecureSessionHandle;
+
+NetworkInfo * GetNetworkBySeq(uint8_t seq)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
-
-    for (size_t i = 0; i < kMaxNetworks; i++)
-    {
-        if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
-        {
-            Thread::OperationalDataset & dataset = sNetworks[i].mData.mThread;
-            CHIP_ERROR error                     = dataset.Init(operationalDataset);
-
-            if (error != CHIP_NO_ERROR)
-            {
-                ChipLogDetail(Zcl, "Failed to parse Thread operational dataset: %s", ErrorStr(error));
-                err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
-                break;
-            }
-
-            uint8_t extendedPanId[Thread::kSizeExtendedPanId];
-
-            static_assert(sizeof(sNetworks[i].mNetworkID) >= sizeof(extendedPanId),
-                          "Network ID must be larger than Thread extended PAN ID!");
-            SuccessOrExit(dataset.GetExtendedPanId(extendedPanId));
-            memcpy(sNetworks[i].mNetworkID, extendedPanId, sizeof(extendedPanId));
-            sNetworks[i].mNetworkIDLen = sizeof(extendedPanId);
-
-            sNetworks[i].mNetworkType = NetworkType::kThread;
-            sNetworks[i].mEnabled     = false;
-
-            err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
-            break;
-        }
-    }
-
-exit:
-    // TODO: We should encode response command here.
-
-    ChipLogDetail(Zcl, "AddThreadNetwork: %d", err);
-    return err;
-#else
-    // The target does not supports ThreadNetwork. We should not add AddThreadNetwork command in that case then the upper layer will
-    // return "Command not found" error.
-    return EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
-#endif
+    return seq >= kMaxNetworks ? nullptr : &sNetworks[seq];
 }
 
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid,
-                                                                         ByteSpan credentials, uint64_t breadcrumb,
-                                                                         uint32_t timeoutMs)
+void SetEnablingNetworkSeq(uint8_t seq)
 {
-#if defined(CHIP_DEVICE_LAYER_TARGET)
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+    sCurrentEnablingNetworkSeq = seq;
+}
 
-    for (size_t i = 0; i < kMaxNetworks; i++)
+ClusterState GetClusterState()
+{
+    return sClusterState;
+}
+
+CHIP_ERROR __attribute__((warn_unused_result)) MoveClusterState(ClusterState newState)
+{
+    if (newState != ClusterState::kIdle)
     {
-        if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
+        // We can transist to some working state only when we are current idle since we does not allow multiple network
+        // commissioning cluster transactions in parallel.
+        if (sClusterState != ClusterState::kIdle)
         {
-            VerifyOrExit(ssid.size() <= sizeof(sNetworks[i].mData.mWiFi.mSSID),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mData.mWiFi.mSSID, ssid.data(), ssid.size());
-
-            using WiFiSSIDLenType = decltype(sNetworks[i].mData.mWiFi.mSSIDLen);
-            VerifyOrExit(chip::CanCastTo<WiFiSSIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mData.mWiFi.mSSIDLen = static_cast<WiFiSSIDLenType>(ssid.size());
-
-            VerifyOrExit(credentials.size() <= sizeof(sNetworks[i].mData.mWiFi.mCredentials),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mData.mWiFi.mCredentials, credentials.data(), credentials.size());
-
-            using WiFiCredentialsLenType = decltype(sNetworks[i].mData.mWiFi.mCredentialsLen);
-            VerifyOrExit(chip::CanCastTo<WiFiCredentialsLenType>(ssid.size()),
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mData.mWiFi.mCredentialsLen = static_cast<WiFiCredentialsLenType>(credentials.size());
-
-            VerifyOrExit(ssid.size() <= sizeof(sNetworks[i].mNetworkID), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            memcpy(sNetworks[i].mNetworkID, sNetworks[i].mData.mWiFi.mSSID, ssid.size());
-
-            using NetworkIDLenType = decltype(sNetworks[i].mNetworkIDLen);
-            VerifyOrExit(chip::CanCastTo<NetworkIDLenType>(ssid.size()), err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE);
-            sNetworks[i].mNetworkIDLen = static_cast<NetworkIDLenType>(ssid.size());
-
-            sNetworks[i].mNetworkType = NetworkType::kWiFi;
-            sNetworks[i].mEnabled     = false;
-
-            err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
-            break;
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+    }
+    else if (newState == ClusterState::kIdle && sClusterState == ClusterState::kIdle)
+    {
+        ChipLogError(Zcl, "NetworkCommissioning -- Moving Idle to Idle -- Programming error!");
+        assert(false);
+        // Should not reach this, but it should be OK if we really move from kIdle to kIdle.
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    else if (sClusterState != ClusterState::kIdle)
+    {
+        switch (sClusterState)
+        {
+        case ClusterState::kEnablingNetwork: {
+            SetEnablingNetworkSeq(kInvalidNetworkSeq);
+            SetCommissionerSecureSessionHandle(SecureSessionHandle());
+        }
+        break;
+        default:
+            ChipLogError(Zcl, "NetworkCommissioning -- Unexpected current state!");
+            return CHIP_ERROR_INCORRECT_STATE;
         }
     }
 
-    VerifyOrExit(err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS, );
+    // We can only move a Idle state to a working state, or moving from a working state to a idle state, we have checked those cases
+    // above, so we can safely set cluster state to the new state now.
+    sClusterState = newState;
+    return CHIP_NO_ERROR;
+}
 
-    ChipLogDetail(Zcl, "WiFi provisioning data: SSID: %s", ssid);
-exit:
-    // TODO: We should encode response command here.
+void OnNetworkEnableStatusChangeCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+{
+    NetworkInfo * networkInfo = nullptr;
+    CHIP_ERROR err            = CHIP_NO_ERROR;
+    // Skip if we received network state change but not during network commissioning.
+    VerifyOrReturn(sClusterState == ClusterState::kEnablingNetwork);
+    VerifyOrReturn((networkInfo = GetNetworkBySeq(sCurrentEnablingNetworkSeq)) != nullptr);
 
-    ChipLogDetail(Zcl, "AddWiFiNetwork: %d", err);
-    return err;
-#else
-    // The target does not supports WiFiNetwork.
-    // return "Command not found" error.
-    return EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (networkInfo->mNetworkType == NetworkType::kThread && event->Type == chip::DeviceLayer::DeviceEventType::kThreadStateChange)
+    {
+        if (DeviceLayer::ThreadStackMgr().IsThreadAttached())
+        {
+            ChipLogError(Zcl, "OnNetworkEnableStatusChangeCallback -- Connected to Thread");
+            EncodeAndSendEnableNetworkResponse(CHIP_NO_ERROR);
+            err = MoveClusterState(ClusterState::kIdle);
+        }
+    }
 #endif
+    if (networkInfo->mNetworkType == NetworkType::kWiFi &&
+        event->Type == chip::DeviceLayer::DeviceEventType::kInternetConnectivityChange &&
+        (event->InternetConnectivityChange.IPv4 == chip::DeviceLayer::ConnectivityChange::kConnectivity_Established ||
+         event->InternetConnectivityChange.IPv6 == chip::DeviceLayer::ConnectivityChange::kConnectivity_Established))
+    {
+        ChipLogError(Zcl, "OnNetworkEnableStatusChangeCallback -- Connected to WiFi");
+        EncodeAndSendEnableNetworkResponse(CHIP_NO_ERROR);
+        err = MoveClusterState(ClusterState::kIdle);
+    }
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "OnNetworkEnableStatusChangeCallback error: %d", err);
+    }
+}
+
+void SetCommissionerSecureSessionHandle(const SecureSessionHandle & secureSessionHandle)
+{
+    sCommissionerSecureSessionHandle = secureSessionHandle;
+}
+
+void EncodeAndSendEnableNetworkResponse(CHIP_ERROR err)
+{
+    CHIP_ERROR processError                  = CHIP_NO_ERROR;
+    chip::app::CommandSender * commandSender = nullptr;
+    EmberAfNetworkCommissioningError commissioningError =
+        (err == CHIP_NO_ERROR ? EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS
+                              : EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR);
+    NodeId commissionerNodeId              = sCommissionerSecureSessionHandle.GetPeerNodeId();
+    Transport::AdminId commissionerAdminId = sCommissionerSecureSessionHandle.GetAdminId();
+
+    // From the Network Commissioning cluster spec, we MAY put response command in seperate exchange, and may have a StatusCode
+    // before the ResponseCommand.
+    app::CommandPathParams cmdParams = { 0, /* group id */ 0, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID,
+                                         ZCL_ENABLE_NETWORK_RESPONSE_COMMAND_ID, (chip::app::CommandPathFlags::kEndpointIdValid) };
+    TLV::TLVWriter * writer          = nullptr;
+    SuccessOrExit(processError = chip::app::InteractionModelEngine::GetInstance()->NewCommandSender(&commandSender));
+    SuccessOrExit(processError = commandSender->PrepareCommand(&cmdParams));
+    writer = commandSender->GetCommandDataElementTLVWriter();
+    SuccessOrExit(processError = writer->Put(TLV::ContextTag(0), static_cast<uint32_t>(commissioningError)));
+    SuccessOrExit(processError = writer->PutString(TLV::ContextTag(1), ""));
+    SuccessOrExit(processError = commandSender->FinishCommand());
+    SuccessOrExit(processError = commandSender->SendCommandRequest(commissionerNodeId, commissionerAdminId));
+
+    // Interaction model engine will manage the state of command sender when successfully send this command, so we can safely delete
+    // this.
+    commandSender = nullptr;
+
+exit:
+    if (commandSender != nullptr)
+    {
+        commandSender->Shutdown();
+    }
+    ChipLogError(Zcl, "Failed to send response command to commissioner: %d", processError);
+}
+
+} // namespace Internal
+
+// Actual command handlers.
+
+void OnAddThreadNetworkCommandCallbackInternal(app::Command * apCommandObj, EndpointId endpointId, ByteSpan operationalDataset,
+                                               uint64_t breadcrumb, uint32_t timeoutMs)
+{
+    CHIP_ERROR encodingError             = CHIP_NO_ERROR;
+    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (GetClusterState() != ClusterState::kIdle)
+    {
+        err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+    }
+    else
+    {
+        for (size_t i = 0; i < kMaxNetworks; i++)
+        {
+            if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
+            {
+                Thread::OperationalDataset & dataset = sNetworks[i].mData.mThread;
+                CHIP_ERROR error                     = dataset.Init(operationalDataset);
+
+                if (error != CHIP_NO_ERROR)
+                {
+                    ChipLogDetail(Zcl, "Failed to parse Thread operational dataset: %s", ErrorStr(error));
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+                    break;
+                }
+
+                uint8_t extendedPanId[Thread::kSizeExtendedPanId];
+
+                static_assert(sizeof(sNetworks[i].mNetworkID) >= sizeof(extendedPanId),
+                              "Network ID must be larger than Thread extended PAN ID!");
+                if ((error = dataset.GetExtendedPanId(extendedPanId)) != CHIP_NO_ERROR)
+                {
+                    ChipLogDetail(Zcl, "Failed to get Thread extpanid: %s", ErrorStr(error));
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+                    break;
+                }
+                memcpy(sNetworks[i].mNetworkID, extendedPanId, sizeof(extendedPanId));
+                sNetworks[i].mNetworkIDLen = sizeof(extendedPanId);
+
+                sNetworks[i].mNetworkType = NetworkType::kThread;
+                sNetworks[i].mEnabled     = false;
+
+                err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
+                break;
+            }
+        }
+    }
+#else
+    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+#endif
+
+    TLV::TLVWriter * writer          = nullptr;
+    app::CommandPathParams cmdParams = { /* endpoint id */ endpointId, /* group id */ 0, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID,
+                                         ZCL_ADD_THREAD_NETWORK_RESPONSE_COMMAND_ID,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+    SuccessOrExit(encodingError = apCommandObj->PrepareCommand(&cmdParams));
+    VerifyOrExit((writer = apCommandObj->GetCommandDataElementTLVWriter()) != nullptr, encodingError = CHIP_ERROR_INCORRECT_STATE);
+    SuccessOrExit(encodingError = writer->Put(TLV::ContextTag(0), static_cast<uint32_t>(err)));
+    SuccessOrExit(encodingError = writer->PutString(TLV::ContextTag(1), ""));
+    SuccessOrExit(encodingError = apCommandObj->FinishCommand());
+exit:
+    if (encodingError != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "Failed to encode response command for AddThreadNetwork: %d (Command Error: %d)", encodingError, err);
+    }
+}
+
+void OnAddWiFiNetworkCommandCallbackInternal(app::Command * apCommandObj, EndpointId endpointId, ByteSpan ssid,
+                                             ByteSpan credentials, uint64_t breadcrumb, uint32_t timeoutMs)
+{
+    CHIP_ERROR encodingError             = CHIP_NO_ERROR;
+    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+#if defined(CHIP_DEVICE_LAYER_TARGET)
+    if (GetClusterState() != ClusterState::kIdle)
+    {
+        err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR;
+    }
+    else
+    {
+        for (size_t i = 0; i < kMaxNetworks; i++)
+        {
+            if (sNetworks[i].mNetworkType == NetworkType::kUndefined)
+            {
+                if (!(ssid.size() <= sizeof(sNetworks[i].mData.mWiFi.mSSID)))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                memcpy(sNetworks[i].mData.mWiFi.mSSID, ssid.data(), ssid.size());
+
+                using WiFiSSIDLenType = decltype(sNetworks[i].mData.mWiFi.mSSIDLen);
+                if (!chip::CanCastTo<WiFiSSIDLenType>(ssid.size()))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                sNetworks[i].mData.mWiFi.mSSIDLen = static_cast<WiFiSSIDLenType>(ssid.size());
+
+                if (!(credentials.size() <= sizeof(sNetworks[i].mData.mWiFi.mCredentials)))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                memcpy(sNetworks[i].mData.mWiFi.mCredentials, credentials.data(), credentials.size());
+
+                using WiFiCredentialsLenType = decltype(sNetworks[i].mData.mWiFi.mCredentialsLen);
+                if (!chip::CanCastTo<WiFiCredentialsLenType>(ssid.size()))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                sNetworks[i].mData.mWiFi.mCredentialsLen = static_cast<WiFiCredentialsLenType>(credentials.size());
+
+                if (!(ssid.size() <= sizeof(sNetworks[i].mNetworkID)))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                memcpy(sNetworks[i].mNetworkID, sNetworks[i].mData.mWiFi.mSSID, ssid.size());
+
+                using NetworkIDLenType = decltype(sNetworks[i].mNetworkIDLen);
+                if (!chip::CanCastTo<NetworkIDLenType>(ssid.size()))
+                {
+                    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_OUT_OF_RANGE;
+                    break;
+                }
+                sNetworks[i].mNetworkIDLen = static_cast<NetworkIDLenType>(ssid.size());
+
+                sNetworks[i].mNetworkType = NetworkType::kWiFi;
+                sNetworks[i].mEnabled     = false;
+
+                err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
+                ChipLogDetail(Zcl, "WiFi provisioning data: SSID: %s", ssid);
+                break;
+            }
+        }
+    }
+
+#else
+    err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_BOUNDS_EXCEEDED;
+#endif
+
+    TLV::TLVWriter * writer          = nullptr;
+    app::CommandPathParams cmdParams = { /* endpoint id */ endpointId, /* group id */ 0, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID,
+                                         ZCL_ADD_WI_FI_NETWORK_RESPONSE_COMMAND_ID,
+                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+    SuccessOrExit(encodingError = apCommandObj->PrepareCommand(&cmdParams));
+    VerifyOrExit((writer = apCommandObj->GetCommandDataElementTLVWriter()) != nullptr, encodingError = CHIP_ERROR_INCORRECT_STATE);
+    SuccessOrExit(encodingError = writer->Put(TLV::ContextTag(0), static_cast<uint32_t>(err)));
+    SuccessOrExit(encodingError = writer->PutString(TLV::ContextTag(1), ""));
+    SuccessOrExit(encodingError = apCommandObj->FinishCommand());
+
+exit:
+    if (encodingError != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "Failed to encode response command for AddWiFiNetwork: %d (Command Error: %d)", encodingError, err);
+    }
 }
 
 namespace {
-CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
+void DoEnableNetwork(intptr_t networkPtr)
 {
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    NetworkInfo * network = reinterpret_cast<NetworkInfo *>(networkPtr);
     switch (network->mNetworkType)
     {
     case NetworkType::kThread:
@@ -222,12 +386,12 @@ CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
 // TODO: On linux, we are using Reset() instead of Detach() to disable thread network, which is not expected.
 // Upstream issue: https://github.com/openthread/ot-br-posix/issues/755
 #if !CHIP_DEVICE_LAYER_TARGET_LINUX
-        ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadEnabled(false));
+        SuccessOrExit(err = DeviceLayer::ThreadStackMgr().SetThreadEnabled(false));
 #endif
-        ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadProvision(network->mData.mThread.AsByteSpan()));
-        ReturnErrorOnFailure(DeviceLayer::ThreadStackMgr().SetThreadEnabled(true));
+        SuccessOrExit(err = DeviceLayer::ThreadStackMgr().SetThreadProvision(network->mData.mThread.AsByteSpan()));
+        SuccessOrExit(err = DeviceLayer::ThreadStackMgr().SetThreadEnabled(true));
 #else
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        ExitNow(err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 #endif
         break;
     case NetworkType::kWiFi:
@@ -236,29 +400,42 @@ CHIP_ERROR DoEnableNetwork(NetworkInfo * network)
         // TODO: Currently, DeviceNetworkProvisioningDelegateImpl assumes that ssid and credentials are null terminated strings,
         // which is not correct, this should be changed once we have better method for commissioning wifi networks.
         DeviceLayer::DeviceNetworkProvisioningDelegateImpl deviceDelegate;
-        ReturnErrorOnFailure(deviceDelegate.ProvisionWiFi(reinterpret_cast<const char *>(network->mData.mWiFi.mSSID),
-                                                          reinterpret_cast<const char *>(network->mData.mWiFi.mCredentials)));
-        break;
+        SuccessOrExit(err = deviceDelegate.ProvisionWiFi(reinterpret_cast<const char *>(network->mData.mWiFi.mSSID),
+                                                         reinterpret_cast<const char *>(network->mData.mWiFi.mCredentials)));
     }
 #else
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        ExitNow(err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 #endif
     break;
     case NetworkType::kEthernet:
     case NetworkType::kUndefined:
     default:
-        return CHIP_ERROR_NOT_IMPLEMENTED;
+        ExitNow(err = CHIP_ERROR_NOT_IMPLEMENTED);
     }
-    network->mEnabled = true;
-    return CHIP_NO_ERROR;
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        EncodeAndSendEnableNetworkResponse(err);
+        err = MoveClusterState(ClusterState::kIdle);
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(Zcl, "Network Commissioning Cluster -- Failed to move to Idle state: %d", err);
+        }
+    }
+    else
+    {
+        network->mEnabled = true;
+    }
 }
 } // namespace
 
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID,
-                                                                        uint64_t breadcrumb, uint32_t timeoutMs)
+void OnEnableNetworkCommandCallbackInternal(app::Command * apCommandObj, EndpointId endpointId, ByteSpan networkID,
+                                            uint64_t breadcrumb, uint32_t timeoutMs)
 {
-    size_t networkSeq;
-    EmberAfNetworkCommissioningError err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_NETWORK_ID_NOT_FOUND;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    uint8_t networkSeq;
+    EmberAfNetworkCommissioningError emberError = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_NETWORK_ID_NOT_FOUND;
+
     // TODO(cecille): This is very dangerous - need to check against real netif name, ensure no password.
     constexpr char ethernetNetifMagicCode[] = "ETH0";
     if (networkID.size() == sizeof(ethernetNetifMagicCode) &&
@@ -266,6 +443,12 @@ EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Com
     {
         ChipLogProgress(Zcl, "Wired network enabling requested. Assuming success.");
         ExitNow(err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS);
+    }
+
+    SuccessOrExit(err = MoveClusterState(ClusterState::kEnablingNetwork));
+    if (apCommandObj != nullptr)
+    {
+        SetCommissionerSecureSessionHandle(apCommandObj->GetExchangeContext()->GetSecureSession());
     }
 
     for (networkSeq = 0; networkSeq < kMaxNetworks; networkSeq++)
@@ -276,18 +459,48 @@ EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Com
         {
             // TODO: Currently, we cannot figure out the detailed error from network provisioning on DeviceLayer, we should
             // implement this in device layer.
-            VerifyOrExit(DoEnableNetwork(&sNetworks[networkSeq]) == CHIP_NO_ERROR,
-                         err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_UNKNOWN_ERROR);
-            ExitNow(err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS);
+            SetEnablingNetworkSeq(networkSeq);
+            DeviceLayer::PlatformMgr().ScheduleWork(DoEnableNetwork, reinterpret_cast<intptr_t>(&sNetworks[networkSeq]));
+            err = EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS;
+            break;
         }
     }
-    // TODO: We should encode response command here.
+
+    // When DoEnableNetwork success, there is a background task waiting
+    if (emberError != EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS)
+    {
+        SuccessOrExit(err = MoveClusterState(ClusterState::kIdle));
+        TLV::TLVWriter * writer          = nullptr;
+        app::CommandPathParams cmdParams = { endpointId, /* group id */ 0, ZCL_NETWORK_COMMISSIONING_CLUSTER_ID,
+                                             ZCL_ENABLE_NETWORK_RESPONSE_COMMAND_ID,
+                                             (chip::app::CommandPathFlags::kEndpointIdValid) };
+        SuccessOrExit(err = apCommandObj->PrepareCommand(&cmdParams));
+        VerifyOrExit((writer = apCommandObj->GetCommandDataElementTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+        SuccessOrExit(err = writer->Put(TLV::ContextTag(0), static_cast<uint32_t>(err)));
+        SuccessOrExit(err = writer->PutString(TLV::ContextTag(1), ""));
+        SuccessOrExit(err = apCommandObj->FinishCommand());
+    }
+    else
+    {
+        chip::app::CommandPathParams returnStatusParam = { endpointId,
+                                                           0, // GroupId
+                                                           ZCL_NETWORK_COMMISSIONING_CLUSTER_ID, ZCL_ENABLE_NETWORK_COMMAND_ID,
+                                                           (chip::app::CommandPathFlags::kEndpointIdValid) };
+
+        SuccessOrExit(err = apCommandObj->AddStatusCode(&returnStatusParam,
+                                                        chip::Protocols::SecureChannel::GeneralStatusCode::kSuccess,
+                                                        chip::Protocols::InteractionModel::Id, 0));
+    }
 exit:
     if (err == EMBER_ZCL_NETWORK_COMMISSIONING_ERROR_SUCCESS)
     {
         DeviceLayer::Internal::DeviceControlServer::DeviceControlSvr().EnableNetworkForOperational(networkID);
     }
     return err;
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "Failed to handle EnableNetwork command: %d (Command Error: %d)", err, emberError);
+    }
 }
 
 } // namespace NetworkCommissioning

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -21,8 +21,6 @@
 #include <cinttypes>
 #include <cstdint>
 
-#include <gen/enums.h>
-
 #include <app/Command.h>
 #include <app/common/gen/enums.h>
 #include <lib/core/CHIPCore.h>
@@ -34,59 +32,15 @@ namespace app {
 namespace clusters {
 namespace NetworkCommissioning {
 
+namespace Internal {
+// Predefine the internal namespace here, it does not expose any functions to other files.
+}
+
 constexpr uint8_t kMaxNetworkIDLen       = 32;
 constexpr uint8_t kMaxThreadDatasetLen   = 254; // As defined in Thread spec.
 constexpr uint8_t kMaxWiFiSSIDLen        = 32;
 constexpr uint8_t kMaxWiFiCredentialsLen = 64;
 constexpr uint8_t kMaxNetworks           = 4;
-
-namespace Internal {
-enum class NetworkType : uint8_t
-{
-    kUndefined = 0,
-    kWiFi      = 1,
-    kThread    = 2,
-    kEthernet  = 3,
-};
-
-struct WiFiNetworkInfo
-{
-    uint8_t mSSID[kMaxWiFiSSIDLen + 1];
-    uint8_t mSSIDLen;
-    uint8_t mCredentials[kMaxWiFiCredentialsLen];
-    uint8_t mCredentialsLen;
-};
-
-struct NetworkInfo
-{
-    uint8_t mNetworkID[kMaxNetworkIDLen];
-    uint8_t mNetworkIDLen;
-    uint8_t mEnabled;
-    NetworkType mNetworkType;
-    union NetworkData
-    {
-        Thread::OperationalDataset mThread;
-        WiFiNetworkInfo mWiFi;
-    } mData;
-};
-
-enum class ClusterState : uint8_t
-{
-    kIdle            = 0,
-    kEnablingNetwork = 1,
-};
-
-constexpr uint8_t kInvalidNetworkSeq = 0xFF;
-
-void EncodeAndSendEnableNetworkResponse(CHIP_ERROR err);
-void SetEnablingNetworkSeq(uint8_t seq);
-ClusterState GetClusterState();
-CHIP_ERROR __attribute__((warn_unused_result)) MoveClusterState(ClusterState newState);
-void OnNetworkEnableStatusChangeCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
-void SetCommissionerSecureSessionHandle(const SecureSessionHandle & handle);
-
-NetworkInfo * GetNetworkBySeq(uint8_t seq);
-} // namespace Internal
 
 void OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset, uint64_t breadcrumb,
                                                uint32_t timeoutMs);
@@ -94,9 +48,6 @@ void OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpa
                                              uint32_t timeoutMs);
 void OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID, uint64_t breadcrumb,
                                             uint32_t timeoutMs);
-
-namespace Internal {
-} // namespace Internal
 } // namespace NetworkCommissioning
 
 } // namespace clusters

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -18,22 +18,85 @@
 
 #pragma once
 
+#include <cinttypes>
+#include <cstdint>
+
+#include <gen/enums.h>
+
 #include <app/Command.h>
 #include <app/common/gen/enums.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/support/ThreadOperationalDataset.h>
 #include <platform/internal/DeviceNetworkProvisioning.h>
 
 namespace chip {
 namespace app {
 namespace clusters {
 namespace NetworkCommissioning {
-EmberAfNetworkCommissioningError OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset,
-                                                                           uint64_t breadcrumb, uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid,
-                                                                         ByteSpan credentials, uint64_t breadcrumb,
-                                                                         uint32_t timeoutMs);
-EmberAfNetworkCommissioningError OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID,
-                                                                        uint64_t breadcrumb, uint32_t timeoutMs);
+
+constexpr uint8_t kMaxNetworkIDLen       = 32;
+constexpr uint8_t kMaxThreadDatasetLen   = 254; // As defined in Thread spec.
+constexpr uint8_t kMaxWiFiSSIDLen        = 32;
+constexpr uint8_t kMaxWiFiCredentialsLen = 64;
+constexpr uint8_t kMaxNetworks           = 4;
+
+namespace Internal {
+enum class NetworkType : uint8_t
+{
+    kUndefined = 0,
+    kWiFi      = 1,
+    kThread    = 2,
+    kEthernet  = 3,
+};
+
+struct WiFiNetworkInfo
+{
+    uint8_t mSSID[kMaxWiFiSSIDLen + 1];
+    uint8_t mSSIDLen;
+    uint8_t mCredentials[kMaxWiFiCredentialsLen];
+    uint8_t mCredentialsLen;
+};
+
+struct NetworkInfo
+{
+    uint8_t mNetworkID[kMaxNetworkIDLen];
+    uint8_t mNetworkIDLen;
+    uint8_t mEnabled;
+    NetworkType mNetworkType;
+    union NetworkData
+    {
+        Thread::OperationalDataset mThread;
+        WiFiNetworkInfo mWiFi;
+    } mData;
+};
+
+enum class ClusterState : uint8_t
+{
+    kIdle            = 0,
+    kEnablingNetwork = 1,
+};
+
+constexpr uint8_t kInvalidNetworkSeq = 0xFF;
+
+void EncodeAndSendEnableNetworkResponse(CHIP_ERROR err);
+void SetEnablingNetworkSeq(uint8_t seq);
+ClusterState GetClusterState();
+CHIP_ERROR __attribute__((warn_unused_result)) MoveClusterState(ClusterState newState);
+void OnNetworkEnableStatusChangeCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
+void SetCommissionerSecureSessionHandle(const SecureSessionHandle & handle);
+
+NetworkInfo * GetNetworkBySeq(uint8_t seq);
+} // namespace Internal
+
+void OnAddThreadNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan operationalDataset, uint64_t breadcrumb,
+                                               uint32_t timeoutMs);
+void OnAddWiFiNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan ssid, ByteSpan credentials, uint64_t breadcrumb,
+                                             uint32_t timeoutMs);
+void OnEnableNetworkCommandCallbackInternal(app::Command *, EndpointId, ByteSpan networkID, uint64_t breadcrumb,
+                                            uint32_t timeoutMs);
+
+namespace Internal {
+} // namespace Internal
 } // namespace NetworkCommissioning
 
 } // namespace clusters

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -85,6 +85,8 @@ public:
     CHIP_ERROR SetThreadProvision(ByteSpan aDataset);
     CHIP_ERROR SetThreadEnabled(bool val);
 
+    bool IsThreadAttached();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     CHIP_ERROR AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort, chip::Mdns::TextEntry * aTxtEntries,
                              size_t aTxtEntiresSize, uint32_t aLeaseInterval, uint32_t aKeyLeaseInterval);
@@ -120,7 +122,6 @@ private:
     void OnPlatformEvent(const ChipDeviceEvent * event);
     bool IsThreadEnabled();
     bool IsThreadProvisioned();
-    bool IsThreadAttached();
     CHIP_ERROR GetThreadProvision(ByteSpan & netInfo);
     void ErasePersistentInfo();
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType();

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -112,6 +112,7 @@ void ThreadStackManagerImpl::_ThreadDevcieRoleChangedHandler(DeviceRole role)
 
     if (attached != mAttached)
     {
+        mAttached  = (role != DeviceRole::OTBR_DEVICE_ROLE_DETACHED && role != DeviceRole::OTBR_DEVICE_ROLE_DISABLED);
         event.Type = DeviceEventType::kThreadConnectivityChange;
         event.ThreadConnectivityChange.Result =
             attached ? ConnectivityChange::kConnectivity_Established : ConnectivityChange::kConnectivity_Lost;


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

#### Problem

We are net sending responses as responses to commands, which does not match the spec.).

#### Change overview

Send response command as required when network attach status changes.

This PR introduced a server side state machine for handling network attaching events, 

This pr also depends on #6802 which makes it possible to send command from server side.

#### Testing
How was this tested?
* If integration tests were added, how do they verify this change?
  The cirque tests already covered the network commissioning steps for thread commissioning.
    - The MobileDevice test script will check if the device attached to the desired network and fail if not.
* If manually tested, what platforms controller and device platforms were manually tested, and how?
  Tested with normal network commissioning steps with chip-device-ctrl.

 Issue #5619

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
