### PR TITLE
[esp32] increase default stack size

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -334,7 +334,7 @@ menu "CHIP Device Layer"
         config CHIP_TASK_STACK_SIZE
             int "CHIP Task Stack Size"
             range 0 65535
-            default 6144
+            default 8192
             help
                 The size (in bytes) of the CHIP task stack.
 


### PR DESCRIPTION

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

The stack overflows when running PASE pairing after the operational credentials change.

 #### Summary of Changes

Increase the default stack size to 8192.