### PR TITLE
Add -fno-sanitize=vptr,function when ubsan is activated

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -287,6 +287,7 @@ config("sanitize_undefined_behavior") {
     "-fsanitize=unsigned-integer-overflow",
     "-fsanitize=implicit-conversion",
     "-fsanitize=nullability",
+    "-fno-sanitize=vptr,function",
   ]
   ldflags = cflags
 }


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Turning on `ubsan` does not compile anymore.


 #### Summary of Changes
 * Add `-fno-sanitize=vptr,function`