### PR TITLE
Zap fix attribute size name for list

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
+++ b/examples/all-clusters-app/all-clusters-common/gen/attribute-size.cpp
@@ -293,17 +293,17 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                 return 0;
             }
 
-            chip::ByteSpan * list_octet_stringSpan   = reinterpret_cast<chip::ByteSpan *>(write ? src : dest); // OCTET_STRING
-            uint16_t list_octet_stringRemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
+            chip::ByteSpan * listOctetStringSpan   = reinterpret_cast<chip::ByteSpan *>(write ? src : dest); // OCTET_STRING
+            uint16_t listOctetStringRemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
             if (CHIP_NO_ERROR !=
-                (write ? WriteByteSpan(dest + entryOffset, list_octet_stringRemainingSpace, list_octet_stringSpan)
-                       : ReadByteSpan(src + entryOffset, list_octet_stringRemainingSpace, list_octet_stringSpan)))
+                (write ? WriteByteSpan(dest + entryOffset, listOctetStringRemainingSpace, listOctetStringSpan)
+                       : ReadByteSpan(src + entryOffset, listOctetStringRemainingSpace, listOctetStringSpan)))
             {
                 ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
                 return 0;
             }
 
-            entryLength = list_octet_stringSpan->size();
+            entryLength = listOctetStringSpan->size();
             break;
         }
         case 0x001C: // list_struct_octet_string

--- a/src/app/zap-templates/templates/app/attribute-size-src.zapt
+++ b/src/app/zap-templates/templates/app/attribute-size-src.zapt
@@ -106,15 +106,15 @@ uint16_t emberAfCopyList(ClusterId clusterId, EmberAfAttributeMetadata * am, boo
                     return 0;
                 }
 
-                chip::ByteSpan * {{name}}Span   = reinterpret_cast<chip::ByteSpan *>(write ? src : dest); // {{type}}
-                uint16_t {{name}}RemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
-                if (CHIP_NO_ERROR != (write ? WriteByteSpan(dest + entryOffset, {{name}}RemainingSpace, {{name}}Span) : ReadByteSpan(src + entryOffset, {{name}}RemainingSpace, {{name}}Span)))
+                chip::ByteSpan * {{asCamelCased name}}Span   = reinterpret_cast<chip::ByteSpan *>(write ? src : dest); // {{type}}
+                uint16_t {{asCamelCased name}}RemainingSpace = static_cast<uint16_t>(am->size - entryOffset);
+                if (CHIP_NO_ERROR != (write ? WriteByteSpan(dest + entryOffset, {{asCamelCased name}}RemainingSpace, {{asCamelCased name}}Span) : ReadByteSpan(src + entryOffset, {{asCamelCased name}}RemainingSpace, {{asCamelCased name}}Span)))
                 {
                     ChipLogError(Zcl, "Index %l is invalid. Not enough remaining space", index);
                     return 0;
                 }
 
-                entryLength = {{name}}Span->size();
+                entryLength = {{asCamelCased name}}Span->size();
                 {{else}}
                 copyListMember(dest, src, write, &entryOffset, entryLength); // {{type}}
                 {{/if}}


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
 
Having a name such as `<attribute side="server"… type="ARRAY" entryType="OCTET_STRING" length="254" writable="false" optional="false">foo bar</attribute>` results into generated code: `chip::ByteSpan * foo bar listSpan   = reinterpret_cast<chip::ByteSpan *>(write ? src : dest); // OCTET_STRING`

 #### Summary of Changes
 * Fix the template to use `{{asCamelCased name false}} instead of {{name}}
 * Update `gen/` folders