### PR TITLE
Revert "Update pigweed to 4afe7a4158"

### DIFF
--- a/examples/pigweed-app/esp32/main/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/main/CMakeLists.txt
@@ -65,6 +65,6 @@ target_link_libraries(${chip_lib} INTERFACE "-Wl,--wrap=${WRAP_FUNCTIONS}")
 
 set_property(TARGET ${chip_lib} APPEND PROPERTY LINK_LIBRARIES ${COMPONENT_LIB})
 target_include_directories(${chip_lib} PUBLIC
-                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc"
-                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb"
-                          "$<TARGET_FILE_DIR:${chip_lib}>/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb")
+                          "$<TARGET_FILE_DIR:${chip_lib}>/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb"
+                          "$<TARGET_FILE_DIR:${chip_lib}>/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb")

--- a/examples/pigweed-app/esp32/main/component.mk
+++ b/examples/pigweed-app/esp32/main/component.mk
@@ -58,9 +58,9 @@ COMPONENT_ADD_INCLUDEDIRS += ../third_party/connectedhomeip/third_party/pigweed/
 							../../../platform/esp32                                 \
 							../../../common/pigweed									\
 							../../../common/pigweed/esp32                           \
-							../build/chip/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb \
-							../build/chip/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc \
-							../build/chip/protocol_buffer/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb \
+							../build/chip/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb \
+							../build/chip/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/nanopb_rpc \
+							../build/chip/gen/third_party/connectedhomeip/third_party/pigweed/repo/pw_rpc/protos.proto_library/pwpb \
 							../../../../src/lib/support    \
 
 COMPONENT_EXTRA_INCLUDES := ${IDF_PATH}/components/freertos/include/freertos/      \


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#6736

Reason: https://github.com/project-chip/connectedhomeip/issues/6883

