### PR TITLE
[android] Peristent storage fixes

### DIFF
--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -37,6 +37,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIssuer.Initialize());
         ReturnErrorOnFailure(mIssuer.Serialize(serializedKey));
+
+        keySize = static_cast<uint16_t>(sizeof(serializedKey));
         ReturnErrorOnFailure(storage.SyncSetKeyValue(kOperationalCredentialsIssuerKeypairStorage, &serializedKey, keySize));
     }
     else

--- a/src/controller/java/AndroidKeyValueStoreManagerImpl.cpp
+++ b/src/controller/java/AndroidKeyValueStoreManagerImpl.cpp
@@ -17,8 +17,8 @@
 #include <platform/KeyValueStoreManager.h>
 
 #include <algorithm>
-#include <string.h>
 #include <memory>
+#include <string.h>
 
 #include "CHIPJNIError.h"
 #include "JniReferences.h"
@@ -129,7 +129,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
 
     std::unique_ptr<char[]> buffer(new char[BASE64_ENCODED_LEN(value_size) + 1]);
 
-    size_t length = chip::Base64Encode(static_cast<const uint8_t *>(value), value_size, buffer.get());
+    size_t length        = chip::Base64Encode(static_cast<const uint8_t *>(value), value_size, buffer.get());
     buffer.get()[length] = 0;
 
     UtfString utfKey(env, key);

--- a/src/transport/AdminPairingTable.cpp
+++ b/src/transport/AdminPairingTable.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR AdminPairingInfo::StoreIntoKVS(PersistentStorageDelegate * kvs)
     err = kvs->SyncSetKeyValue(key, info, sizeof(StorableAdminPairingInfo));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue.");
+        ChipLogError(Discovery, "Error occurred calling SyncSetKeyValue: %s", chip::ErrorStr(err));
     }
 
 exit:


### PR DESCRIPTION
 #### Problem
Android CHIPTool crashes when trying to commission a device.

 #### Summary of Changes
Fix issues in the code for storing persistent data, causing crashes at the beginning of commissioning process in Android
CHIP Tool.
Note that the commissioning in Android CHIP Tool still must be switched to the new commissioning flow, but this is the first step to make it usable again.