### PR TITLE
Add timer to reboot RPC for NRF lighting example

### DIFF
--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -358,11 +358,11 @@ Semiconductor's kit you own.
 
 ### Building with Pigweed RPCs
 
-The RPCs in `lighting-common/pigweed-lighting.proto` can be used to control
-various functionalities of the lighting app from a USB-connected host computer.
-To build the example with the RPC server, run the following command with
-_build-target_ replaced with the build target name of the Nordic Semiconductor's
-kit you own:
+The RPCs in `lighting-common/lighting_service/lighting_service.proto` can be
+used to control various functionalities of the lighting app from a USB-connected
+host computer. To build the example with the RPC server, run the following
+command with _build-target_ replaced with the build target name of the Nordic
+Semiconductor's kit you own:
 
     $ west build -b build-target -- -DOVERLAY_CONFIG=rpc.overlay
 


### PR DESCRIPTION
 #### Problem
Reboot RPC command doesn't return Status::OK. Instead it reboots immediately before returning, which can be difficult for the host code to handle. 

 #### Summary of Changes
Add a timer to reboot after the RPC returns, this ensures the host
code knows the RPC command was successfully received before the
device reboots.

Also reboot after doing a FDR.

Testing: Verified new RPC behavior worked as expected on lighting-app RPC build, with nRF52840