### PR TITLE
Add building of TV example to gn_build.sh

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -199,6 +199,10 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     enable_linux_all_clusters_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
 
+    # Build the Linux tv app example.
+    enable_linux_tv_app_build =
+        enable_default_builds && (host_os == "linux" || host_os == "mac")
+
     # Build the Linux bridge app example.
     enable_linux_bridge_app_build =
         enable_default_builds && (host_os == "linux" || host_os == "mac")
@@ -299,6 +303,12 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
   }
 
+  if (enable_linux_tv_app_build) {
+    group("linux_tv_app") {
+      deps = [ "${chip_root}/examples/tv-app/linux(${standalone_toolchain})" ]
+    }
+  }
+
   if (enable_linux_bridge_app_build) {
     group("linux_bridge_app") {
       deps =
@@ -374,6 +384,9 @@ if (current_toolchain != "${dir_pw_toolchain}/dummy:dummy") {
     }
     if (enable_linux_all_clusters_app_build) {
       deps += [ ":linux_all_clusters_app" ]
+    }
+    if (enable_linux_tv_app_build) {
+      deps += [ ":linux_tv_app" ]
     }
     if (enable_linux_bridge_app_build) {
       deps += [ ":linux_bridge_app" ]


### PR DESCRIPTION
#### Problem
TV example app is not built using gn_build.sh script

#### Summary of Changes
- Updated the ./BUILD.gn to support building of tv-example-app

#### Test
- Tested locally using chip-tool client and tv-server
- Used the  `./gn_build.sh ` to verify the building is successful 