### PR TITLE
Revert "Use RAII for ExchangeContext contruction and destruction instead of Alloc/Free."

### DIFF
--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -54,18 +54,14 @@ public:
  *    It defines methods for encoding and communicating CHIP messages within an ExchangeContext
  *    over various transport mechanisms, for example, TCP, UDP, or CHIP Reliable Messaging.
  */
-class DLL_EXPORT ExchangeContext : public ReliableMessageContext, public ReferenceCounted<ExchangeContext, ExchangeContextDeletor>
+class DLL_EXPORT ExchangeContext : public ReliableMessageContext,
+                                   public ReferenceCounted<ExchangeContext, ExchangeContextDeletor, 0>
 {
     friend class ExchangeManager;
     friend class ExchangeContextDeletor;
 
 public:
     typedef uint32_t Timeout; // Type used to express the timeout in this ExchangeContext, in milliseconds
-
-    ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
-                    ExchangeDelegateBase * delegate);
-
-    ~ExchangeContext();
 
     /**
      *  Determine whether the context is the initiator of the exchange.
@@ -174,6 +170,11 @@ private:
     SecureSessionHandle mSecureSession; // The connection state
     uint16_t mExchangeId;               // Assigned exchange ID.
 
+    ExchangeContext * Alloc(ExchangeManager * em, uint16_t ExchangeId, SecureSessionHandle session, bool Initiator,
+                            ExchangeDelegateBase * delegate);
+    void Free();
+    void Reset();
+
     /**
      *  Determine whether a response is currently expected for a message that was sent over
      *  this exchange.  While this is true, attempts to send other messages that expect a response
@@ -214,6 +215,11 @@ private:
 
     void DoClose(bool clearRetransTable);
 };
+
+inline void ExchangeContextDeletor::Release(ExchangeContext * obj)
+{
+    obj->Free();
+}
 
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -39,7 +39,7 @@ namespace Messaging {
 
 ReliableMessageMgr::RetransTableEntry::RetransTableEntry() : rc(nullptr), nextRetransTimeTick(0), sendCount(0) {}
 
-ReliableMessageMgr::ReliableMessageMgr(BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool) :
+ReliableMessageMgr::ReliableMessageMgr(std::array<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool) :
     mContextPool(contextPool), mSystemLayer(nullptr), mSessionMgr(nullptr), mCurrentTimerExpiry(0),
     mTimerIntervalShift(CHIP_CONFIG_RMP_TIMER_DEFAULT_PERIOD_SHIFT)
 {}

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -31,7 +31,6 @@
 
 #include <core/CHIPError.h>
 #include <support/BitFlags.h>
-#include <support/Pool.h>
 #include <system/SystemLayer.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/SystemTimer.h>
@@ -67,7 +66,7 @@ public:
     };
 
 public:
-    ReliableMessageMgr(BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);
+    ReliableMessageMgr(std::array<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);
     ~ReliableMessageMgr();
 
     void Init(chip::System::Layer * systemLayer, SecureSessionMgr * sessionMgr);
@@ -224,7 +223,7 @@ public:
     void TestSetIntervalShift(uint16_t value) { mTimerIntervalShift = value; }
 
 private:
-    BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & mContextPool;
+    std::array<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & mContextPool;
     chip::System::Layer * mSystemLayer;
     SecureSessionMgr * mSessionMgr;
     uint64_t mTimeStampBase;                  // ReliableMessageProtocol timer base value to add offsets to evaluate timeouts
@@ -235,10 +234,10 @@ private:
     template <typename Function>
     void ExecuteForAllContext(Function function)
     {
-        mContextPool.ForEachActiveObject([&](auto * ec) {
-            function(ec->GetReliableMessageContext());
-            return true;
-        });
+        for (auto & ec : mContextPool)
+        {
+            function(ec.GetReliableMessageContext());
+        }
     }
 
     void TicklessDebugDumpRetransTable(const char * log);


### PR DESCRIPTION
Summary of Changes:
This issue is making Last exchange context of every PASE/CASE exchange is leaked in issue #6856
and also make cirque IM test under weather again because of this leak.

chip::Messaging::ExchangeManager::Shutdown()::<lambda(auto:2*)> [with auto:2 = chip::Messaging::ExchangeContext]: Assertion `false' failed.


Not sure how we guarantee the ec are deterministically released after this change.
since the app can call Shutdown at anytime, if any exchange is not deterministically released we should see the error.

Reverts project-chip/connectedhomeip#6808