### PR TITLE
Fix compile errors from TV example on Ubuntu x86-64

### DIFF
--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -57,7 +57,7 @@ vector<EmberAfAudioOutputInfo> AudioOutputManager::proxyGetListOfAudioOutputInfo
         EmberAfAudioOutputInfo audioOutputInfo;
         audioOutputInfo.outputType = EMBER_ZCL_AUDIO_OUTPUT_TYPE_HDMI;
         audioOutputInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
-        audioOutputInfo.index      = 1 + i;
+        audioOutputInfo.index      = ++i;
         audioOutputInfos.push_back(audioOutputInfo);
     }
 

--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -57,7 +57,7 @@ vector<EmberAfAudioOutputInfo> AudioOutputManager::proxyGetListOfAudioOutputInfo
         EmberAfAudioOutputInfo audioOutputInfo;
         audioOutputInfo.outputType = EMBER_ZCL_AUDIO_OUTPUT_TYPE_HDMI;
         audioOutputInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
-        audioOutputInfo.index      = ++i;
+        audioOutputInfo.index      = static_cast<uint8_t>(1 + i);
         audioOutputInfos.push_back(audioOutputInfo);
     }
 

--- a/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp
@@ -52,7 +52,7 @@ vector<EmberAfAudioOutputInfo> AudioOutputManager::proxyGetListOfAudioOutputInfo
     int maximumVectorSize = 3;
     char name[]           = "exampleName";
 
-    for (uint8_t i = 0; i < maximumVectorSize; ++i)
+    for (int i = 0; i < maximumVectorSize; ++i)
     {
         EmberAfAudioOutputInfo audioOutputInfo;
         audioOutputInfo.outputType = EMBER_ZCL_AUDIO_OUTPUT_TYPE_HDMI;

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -77,7 +77,7 @@ std::vector<EmberAfMediaInputInfo> MediaInputManager::proxyGetInputList()
         mediaInput.description = chip::ByteSpan(chip::Uint8::from_char(description), sizeof(description));
         mediaInput.name        = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
         mediaInput.inputType   = EMBER_ZCL_MEDIA_INPUT_TYPE_HDMI;
-        mediaInput.index       = 1 + i;
+        mediaInput.index       = ++i;
         mediaInputList.push_back(mediaInput);
     }
 

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -71,13 +71,13 @@ std::vector<EmberAfMediaInputInfo> MediaInputManager::proxyGetInputList()
     char description[]    = "exampleDescription";
     char name[]           = "exampleName";
 
-    for (uint8_t i = 0; i < maximumVectorSize; ++i)
+    for (int i = 0; i < maximumVectorSize; ++i)
     {
         EmberAfMediaInputInfo mediaInput;
         mediaInput.description = chip::ByteSpan(chip::Uint8::from_char(description), sizeof(description));
         mediaInput.name        = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
         mediaInput.inputType   = EMBER_ZCL_MEDIA_INPUT_TYPE_HDMI;
-        mediaInput.index       = static_cast<uint8_t>(1 + i)i;
+        mediaInput.index       = static_cast<uint8_t>(1 + i);
         mediaInputList.push_back(mediaInput);
     }
 

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -77,7 +77,7 @@ std::vector<EmberAfMediaInputInfo> MediaInputManager::proxyGetInputList()
         mediaInput.description = chip::ByteSpan(chip::Uint8::from_char(description), sizeof(description));
         mediaInput.name        = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
         mediaInput.inputType   = EMBER_ZCL_MEDIA_INPUT_TYPE_HDMI;
-        mediaInput.index       = ++i;
+        mediaInput.index       = static_cast<uint8_t>(1 + i)i;
         mediaInputList.push_back(mediaInput);
     }
 

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -52,7 +52,7 @@ std::vector<EmberAfNavigateTargetTargetInfo> TargetNavigatorManager::proxyGetTar
     {
         EmberAfNavigateTargetTargetInfo targetInfo;
         targetInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
-        targetInfo.identifier = ++i;
+        targetInfo.identifier = static_cast<uint8_t>(1 + i);
         targets.push_back(targetInfo);
     }
 

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -52,7 +52,7 @@ std::vector<EmberAfNavigateTargetTargetInfo> TargetNavigatorManager::proxyGetTar
     {
         EmberAfNavigateTargetTargetInfo targetInfo;
         targetInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));
-        targetInfo.identifier = 1 + i;
+        targetInfo.identifier = ++i;
         targets.push_back(targetInfo);
     }
 

--- a/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/linux/include/target-navigator/TargetNavigatorManager.cpp
@@ -48,7 +48,7 @@ std::vector<EmberAfNavigateTargetTargetInfo> TargetNavigatorManager::proxyGetTar
     int maximumVectorSize = 2;
     char name[]           = "exampleName";
 
-    for (uint8_t i = 0; i < maximumVectorSize; ++i)
+    for (int i = 0; i < maximumVectorSize; ++i)
     {
         EmberAfNavigateTargetTargetInfo targetInfo;
         targetInfo.name       = chip::ByteSpan(chip::Uint8::from_char(name), sizeof(name));

--- a/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
+++ b/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
@@ -81,8 +81,8 @@ std::vector<EmberAfTvChannelInfo> TvChannelManager::proxyGetTvChannelList()
         channelInfo.affiliateCallSign = ByteSpan(Uint8::from_char(affiliateCallSign), sizeof(affiliateCallSign));
         channelInfo.callSign          = ByteSpan(Uint8::from_char(callSign), sizeof(callSign));
         channelInfo.name              = ByteSpan(Uint8::from_char(name), sizeof(name));
-        channelInfo.majorNumber       = 1 + i;
-        channelInfo.minorNumber       = 2 + i;
+        channelInfo.majorNumber       = ++i;
+        channelInfo.minorNumber       = static_cast<uint16_t>(2 + i);
         tvChannels.push_back(channelInfo);
     }
 

--- a/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
+++ b/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
@@ -81,7 +81,7 @@ std::vector<EmberAfTvChannelInfo> TvChannelManager::proxyGetTvChannelList()
         channelInfo.affiliateCallSign = ByteSpan(Uint8::from_char(affiliateCallSign), sizeof(affiliateCallSign));
         channelInfo.callSign          = ByteSpan(Uint8::from_char(callSign), sizeof(callSign));
         channelInfo.name              = ByteSpan(Uint8::from_char(name), sizeof(name));
-        channelInfo.majorNumber       = ++i;
+        channelInfo.majorNumber       = static_cast<uint8_t>(1 + i);
         channelInfo.minorNumber       = static_cast<uint16_t>(2 + i);
         tvChannels.push_back(channelInfo);
     }

--- a/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
+++ b/examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp
@@ -75,7 +75,7 @@ std::vector<EmberAfTvChannelInfo> TvChannelManager::proxyGetTvChannelList()
     char callSign[]          = "exampleCSign";
     char name[]              = "exampleName";
 
-    for (uint16_t i = 0; i < maximumVectorSize; ++i)
+    for (int i = 0; i < maximumVectorSize; ++i)
     {
         EmberAfTvChannelInfo channelInfo;
         channelInfo.affiliateCallSign = ByteSpan(Uint8::from_char(affiliateCallSign), sizeof(affiliateCallSign));

--- a/examples/tv-app/linux/include/tv-channel/TvChannelManager.h
+++ b/examples/tv-app/linux/include/tv-channel/TvChannelManager.h
@@ -21,6 +21,7 @@
 
 #include <core/CHIPError.h>
 #include <string>
+#include <vector>
 
 class TvChannelManager
 {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
I hit a couple of compile errors on Ubuntu x86-64 after #6903.

../../examples/tv-app/linux/include/audio-output/AudioOutputManager.cpp:60:40: error: conversion from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} may change value [-Werror=conversion]
   60 |         audioOutputInfo.index      = 1 + i;
      |                                      ~~^~~
At global scope:


../../examples/tv-app/linux/include/tv-channel/TvChannelManager.h:32:10: error: ‘vector’ in namespace ‘std’ does not name a template type
   32 |     std::vector<EmberAfTvChannelInfo> proxyGetTvChannelList();
      |          ^~~~~~
../../examples/tv-app/linux/include/tv-channel/TvChannelManager.h:24:1: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?
   23 | #include <string>
  +++ |+#include <vector>
   24 | 

../../examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp:84:43: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
   84 |         channelInfo.majorNumber       = 1 + i;
      |                                         ~~^~~
../../examples/tv-app/linux/include/tv-channel/TvChannelManager.cpp:85:43: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
   85 |         channelInfo.minorNumber       = 2 + i;
      |                                         ~~^~~


<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
1. Add missing #include <vector>
2. Address conversion warnings

<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->


<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
