### PR TITLE
[cirque] Basic Cluster Attributes test

### DIFF
--- a/src/controller/python/test/Dockerfile
+++ b/src/controller/python/test/Dockerfile
@@ -5,11 +5,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 COPY /out/debug/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl /whl/
 COPY /test/entrypoint.sh /entrypoint.sh
-COPY /test/mobile-device-test.py /usr/bin/
+COPY /test/test_scripts /usr/bin/
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y ca-certificates libglib2.0-dev avahi-daemon libavahi-client3 \
-    python3 python3-dev python3-pip libcairo2-dev libdbus-1-dev libgirepository1.0-dev \
+    python3 python3-dev python3-pip libcairo2-dev libdbus-1-dev libgirepository1.0-dev avahi-utils \
     libjpeg-dev libgif-dev gdb && \
     pip3 install /whl/chip-0.0-cp37-abi3-linux_x86_64.whl
 

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Commissioning test.
+import os
+import sys
+from optparse import OptionParser
+from base import TestTimeout, BaseTestHelper, FailIfNot, logger
+
+# The thread network dataset tlv for testing, splited into T-L-V.
+
+TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
+                "000300000c" + \
+                "35060004001fffe0" + \
+                "0208fedcba9876543210" + \
+                "0708fd00000000001234" + \
+                "0510ffeeddccbbaa99887766554433221100" + \
+                "030e54657374696e674e6574776f726b" + \
+                "0102d252" + \
+                "041081cb3b2efa781cc778397497ff520fa50c0302a0ff"
+# Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
+TEST_THREAD_NETWORK_ID = "fedcba9876543210"
+
+ENDPOINT_ID = 0
+GROUP_ID = 0
+
+
+def main():
+    optParser = OptionParser()
+    optParser.add_option(
+        "-t",
+        "--timeout",
+        action="store",
+        dest="testTimeout",
+        default=75,
+        type='int',
+        help="The program will return with timeout after specified seconds.",
+        metavar="<timeout-second>",
+    )
+    optParser.add_option(
+        "-a",
+        "--address",
+        action="store",
+        dest="deviceAddress",
+        default='',
+        type='str',
+        help="Address of the device",
+        metavar="<device-addr>",
+    )
+
+    (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
+
+    timeoutTicker = TestTimeout(options.testTimeout)
+    timeoutTicker.start()
+
+    test = BaseTestHelper(nodeid=112233)
+
+    FailIfNot(test.TestKeyExchange(ip=options.deviceAddress,
+                                   setuppin=20202021,
+                                   nodeid=1),
+              "Failed to finish key exchange")
+
+    FailIfNot(test.TestNetworkCommissioning(nodeid=1,
+                                            endpoint=ENDPOINT_ID,
+                                            group=GROUP_ID,
+                                            dataset=TEST_THREAD_NETWORK_DATASET_TLV,
+                                            network_id=TEST_THREAD_NETWORK_ID),
+              "Failed to finish network commissioning")
+
+    FailIfNot(test.TestOnOffCluster(nodeid=1,
+                                    endpoint=ENDPOINT_ID,
+                                    group=GROUP_ID)
+              , "Failed to test on off cluster")
+
+    FailIfNot(test.TestReadBasicAttribiutes(nodeid=1,
+                                            endpoint=ENDPOINT_ID,
+                                            group=GROUP_ID),
+              "Failed to test Read Basic Attributes")
+
+    timeoutTicker.stop()
+
+    logger.info("Test finished")
+
+    # TODO: Python device controller cannot be shutdown clean sometimes and will block on AsyncDNSResolverSockets shutdown.
+    # Call os._exit(0) to force close it.
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Change overview
 * Refactor python chip controller test_scripts
 * Extending the MobileDeviceTest to Basic Cluster Attributes verification

### Testing
Verified on Linux machine (Ubuntu 20.04)

scripts/tests/cirque_tests.sh run_all_tests
Logs will be stored at /tmp/tmp.xdbjrcbhN2
[ RUN] EchoTest
[PASS] EchoTest
[ RUN] MobileDeviceTest
[PASS] MobileDeviceTest
[ RUN] InteractionModelTest
[PASS] InteractionModelTest
[PASS] Test finished, test log can be found at /tmp/tmp.xdbjrcbhN2