### PR TITLE
Update the zap template used for chip-tool to not forced the first le…

### DIFF
--- a/examples/chip-tool/commands/clusters/Commands.h
+++ b/examples/chip-tool/commands/clusters/Commands.h
@@ -1199,7 +1199,7 @@ class AccountLoginGetSetupPIN : public ModelCommand
 public:
     AccountLoginGetSetupPIN() : ModelCommand("get-setup-pin")
     {
-        AddArgument("tempAccountIdentifier", &mTempAccountIdentifier);
+        AddArgument("TempAccountIdentifier", &mTempAccountIdentifier);
         ModelCommand::AddArguments();
     }
     ~AccountLoginGetSetupPIN()
@@ -1235,8 +1235,8 @@ class AccountLoginLogin : public ModelCommand
 public:
     AccountLoginLogin() : ModelCommand("login")
     {
-        AddArgument("tempAccountIdentifier", &mTempAccountIdentifier);
-        AddArgument("setupPIN", &mSetupPIN);
+        AddArgument("TempAccountIdentifier", &mTempAccountIdentifier);
+        AddArgument("SetupPIN", &mSetupPIN);
         ModelCommand::AddArguments();
     }
     ~AccountLoginLogin()
@@ -1354,7 +1354,7 @@ class ApplicationBasicChangeStatus : public ModelCommand
 public:
     ApplicationBasicChangeStatus() : ModelCommand("change-status")
     {
-        AddArgument("status", 0, UINT8_MAX, &mStatus);
+        AddArgument("Status", 0, UINT8_MAX, &mStatus);
         ModelCommand::AddArguments();
     }
     ~ApplicationBasicChangeStatus()
@@ -1701,9 +1701,9 @@ class ApplicationLauncherLaunchApp : public ModelCommand
 public:
     ApplicationLauncherLaunchApp() : ModelCommand("launch-app")
     {
-        AddArgument("data", &mData);
-        AddArgument("catalogVendorId", 0, UINT16_MAX, &mCatalogVendorId);
-        AddArgument("applicationId", &mApplicationId);
+        AddArgument("Data", &mData);
+        AddArgument("CatalogVendorId", 0, UINT16_MAX, &mCatalogVendorId);
+        AddArgument("ApplicationId", &mApplicationId);
         ModelCommand::AddArguments();
     }
     ~ApplicationLauncherLaunchApp()
@@ -1853,8 +1853,8 @@ class AudioOutputRenameOutput : public ModelCommand
 public:
     AudioOutputRenameOutput() : ModelCommand("rename-output")
     {
-        AddArgument("index", 0, UINT8_MAX, &mIndex);
-        AddArgument("name", &mName);
+        AddArgument("Index", 0, UINT8_MAX, &mIndex);
+        AddArgument("Name", &mName);
         ModelCommand::AddArguments();
     }
     ~AudioOutputRenameOutput()
@@ -1890,7 +1890,7 @@ class AudioOutputSelectOutput : public ModelCommand
 public:
     AudioOutputSelectOutput() : ModelCommand("select-output")
     {
-        AddArgument("index", 0, UINT8_MAX, &mIndex);
+        AddArgument("Index", 0, UINT8_MAX, &mIndex);
         ModelCommand::AddArguments();
     }
     ~AudioOutputSelectOutput()
@@ -2038,7 +2038,7 @@ class BarrierControlBarrierControlGoToPercent : public ModelCommand
 public:
     BarrierControlBarrierControlGoToPercent() : ModelCommand("barrier-control-go-to-percent")
     {
-        AddArgument("percentOpen", 0, UINT8_MAX, &mPercentOpen);
+        AddArgument("PercentOpen", 0, UINT8_MAX, &mPercentOpen);
         ModelCommand::AddArguments();
     }
     ~BarrierControlBarrierControlGoToPercent()
@@ -3482,10 +3482,10 @@ class BindingBind : public ModelCommand
 public:
     BindingBind() : ModelCommand("bind")
     {
-        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("endpointId", 0, UINT8_MAX, &mEndpointId);
-        AddArgument("clusterId", 0, UINT16_MAX, &mClusterId);
+        AddArgument("NodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("EndpointId", 0, UINT8_MAX, &mEndpointId);
+        AddArgument("ClusterId", 0, UINT16_MAX, &mClusterId);
         ModelCommand::AddArguments();
     }
     ~BindingBind()
@@ -3522,10 +3522,10 @@ class BindingUnbind : public ModelCommand
 public:
     BindingUnbind() : ModelCommand("unbind")
     {
-        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("endpointId", 0, UINT8_MAX, &mEndpointId);
-        AddArgument("clusterId", 0, UINT16_MAX, &mClusterId);
+        AddArgument("NodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("EndpointId", 0, UINT8_MAX, &mEndpointId);
+        AddArgument("ClusterId", 0, UINT16_MAX, &mClusterId);
         ModelCommand::AddArguments();
     }
     ~BindingUnbind()
@@ -4296,10 +4296,10 @@ class ColorControlMoveColor : public ModelCommand
 public:
     ColorControlMoveColor() : ModelCommand("move-color")
     {
-        AddArgument("rateX", INT16_MIN, INT16_MAX, &mRateX);
-        AddArgument("rateY", INT16_MIN, INT16_MAX, &mRateY);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("RateX", INT16_MIN, INT16_MAX, &mRateX);
+        AddArgument("RateY", INT16_MIN, INT16_MAX, &mRateY);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveColor()
@@ -4337,12 +4337,12 @@ class ColorControlMoveColorTemperature : public ModelCommand
 public:
     ColorControlMoveColorTemperature() : ModelCommand("move-color-temperature")
     {
-        AddArgument("moveMode", 0, UINT8_MAX, &mMoveMode);
-        AddArgument("rate", 0, UINT16_MAX, &mRate);
-        AddArgument("colorTemperatureMinimum", 0, UINT16_MAX, &mColorTemperatureMinimum);
-        AddArgument("colorTemperatureMaximum", 0, UINT16_MAX, &mColorTemperatureMaximum);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("MoveMode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("Rate", 0, UINT16_MAX, &mRate);
+        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mColorTemperatureMinimum);
+        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mColorTemperatureMaximum);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveColorTemperature()
@@ -4382,10 +4382,10 @@ class ColorControlMoveHue : public ModelCommand
 public:
     ColorControlMoveHue() : ModelCommand("move-hue")
     {
-        AddArgument("moveMode", 0, UINT8_MAX, &mMoveMode);
-        AddArgument("rate", 0, UINT8_MAX, &mRate);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("MoveMode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("Rate", 0, UINT8_MAX, &mRate);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveHue()
@@ -4423,10 +4423,10 @@ class ColorControlMoveSaturation : public ModelCommand
 public:
     ColorControlMoveSaturation() : ModelCommand("move-saturation")
     {
-        AddArgument("moveMode", 0, UINT8_MAX, &mMoveMode);
-        AddArgument("rate", 0, UINT8_MAX, &mRate);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("MoveMode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("Rate", 0, UINT8_MAX, &mRate);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveSaturation()
@@ -4464,11 +4464,11 @@ class ColorControlMoveToColor : public ModelCommand
 public:
     ColorControlMoveToColor() : ModelCommand("move-to-color")
     {
-        AddArgument("colorX", 0, UINT16_MAX, &mColorX);
-        AddArgument("colorY", 0, UINT16_MAX, &mColorY);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("ColorX", 0, UINT16_MAX, &mColorX);
+        AddArgument("ColorY", 0, UINT16_MAX, &mColorY);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveToColor()
@@ -4507,10 +4507,10 @@ class ColorControlMoveToColorTemperature : public ModelCommand
 public:
     ColorControlMoveToColorTemperature() : ModelCommand("move-to-color-temperature")
     {
-        AddArgument("colorTemperature", 0, UINT16_MAX, &mColorTemperature);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("ColorTemperature", 0, UINT16_MAX, &mColorTemperature);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveToColorTemperature()
@@ -4548,11 +4548,11 @@ class ColorControlMoveToHue : public ModelCommand
 public:
     ColorControlMoveToHue() : ModelCommand("move-to-hue")
     {
-        AddArgument("hue", 0, UINT8_MAX, &mHue);
-        AddArgument("direction", 0, UINT8_MAX, &mDirection);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("Hue", 0, UINT8_MAX, &mHue);
+        AddArgument("Direction", 0, UINT8_MAX, &mDirection);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveToHue()
@@ -4591,11 +4591,11 @@ class ColorControlMoveToHueAndSaturation : public ModelCommand
 public:
     ColorControlMoveToHueAndSaturation() : ModelCommand("move-to-hue-and-saturation")
     {
-        AddArgument("hue", 0, UINT8_MAX, &mHue);
-        AddArgument("saturation", 0, UINT8_MAX, &mSaturation);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("Hue", 0, UINT8_MAX, &mHue);
+        AddArgument("Saturation", 0, UINT8_MAX, &mSaturation);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveToHueAndSaturation()
@@ -4634,10 +4634,10 @@ class ColorControlMoveToSaturation : public ModelCommand
 public:
     ColorControlMoveToSaturation() : ModelCommand("move-to-saturation")
     {
-        AddArgument("saturation", 0, UINT8_MAX, &mSaturation);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("Saturation", 0, UINT8_MAX, &mSaturation);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlMoveToSaturation()
@@ -4675,11 +4675,11 @@ class ColorControlStepColor : public ModelCommand
 public:
     ColorControlStepColor() : ModelCommand("step-color")
     {
-        AddArgument("stepX", INT16_MIN, INT16_MAX, &mStepX);
-        AddArgument("stepY", INT16_MIN, INT16_MAX, &mStepY);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("StepX", INT16_MIN, INT16_MAX, &mStepX);
+        AddArgument("StepY", INT16_MIN, INT16_MAX, &mStepY);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlStepColor()
@@ -4718,13 +4718,13 @@ class ColorControlStepColorTemperature : public ModelCommand
 public:
     ColorControlStepColorTemperature() : ModelCommand("step-color-temperature")
     {
-        AddArgument("stepMode", 0, UINT8_MAX, &mStepMode);
-        AddArgument("stepSize", 0, UINT16_MAX, &mStepSize);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("colorTemperatureMinimum", 0, UINT16_MAX, &mColorTemperatureMinimum);
-        AddArgument("colorTemperatureMaximum", 0, UINT16_MAX, &mColorTemperatureMaximum);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("StepMode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("StepSize", 0, UINT16_MAX, &mStepSize);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("ColorTemperatureMinimum", 0, UINT16_MAX, &mColorTemperatureMinimum);
+        AddArgument("ColorTemperatureMaximum", 0, UINT16_MAX, &mColorTemperatureMaximum);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlStepColorTemperature()
@@ -4766,11 +4766,11 @@ class ColorControlStepHue : public ModelCommand
 public:
     ColorControlStepHue() : ModelCommand("step-hue")
     {
-        AddArgument("stepMode", 0, UINT8_MAX, &mStepMode);
-        AddArgument("stepSize", 0, UINT8_MAX, &mStepSize);
-        AddArgument("transitionTime", 0, UINT8_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("StepMode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("StepSize", 0, UINT8_MAX, &mStepSize);
+        AddArgument("TransitionTime", 0, UINT8_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlStepHue()
@@ -4809,11 +4809,11 @@ class ColorControlStepSaturation : public ModelCommand
 public:
     ColorControlStepSaturation() : ModelCommand("step-saturation")
     {
-        AddArgument("stepMode", 0, UINT8_MAX, &mStepMode);
-        AddArgument("stepSize", 0, UINT8_MAX, &mStepSize);
-        AddArgument("transitionTime", 0, UINT8_MAX, &mTransitionTime);
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("StepMode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("StepSize", 0, UINT8_MAX, &mStepSize);
+        AddArgument("TransitionTime", 0, UINT8_MAX, &mTransitionTime);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlStepSaturation()
@@ -4852,8 +4852,8 @@ class ColorControlStopMoveStep : public ModelCommand
 public:
     ColorControlStopMoveStep() : ModelCommand("stop-move-step")
     {
-        AddArgument("optionsMask", 0, UINT8_MAX, &mOptionsMask);
-        AddArgument("optionsOverride", 0, UINT8_MAX, &mOptionsOverride);
+        AddArgument("OptionsMask", 0, UINT8_MAX, &mOptionsMask);
+        AddArgument("OptionsOverride", 0, UINT8_MAX, &mOptionsOverride);
         ModelCommand::AddArguments();
     }
     ~ColorControlStopMoveStep()
@@ -7335,8 +7335,8 @@ class ContentLauncherLaunchContent : public ModelCommand
 public:
     ContentLauncherLaunchContent() : ModelCommand("launch-content")
     {
-        AddArgument("autoPlay", 0, UINT8_MAX, &mAutoPlay);
-        AddArgument("data", &mData);
+        AddArgument("AutoPlay", 0, UINT8_MAX, &mAutoPlay);
+        AddArgument("Data", &mData);
         ModelCommand::AddArguments();
     }
     ~ContentLauncherLaunchContent()
@@ -7373,8 +7373,8 @@ class ContentLauncherLaunchURL : public ModelCommand
 public:
     ContentLauncherLaunchURL() : ModelCommand("launch-url")
     {
-        AddArgument("contentURL", &mContentURL);
-        AddArgument("displayString", &mDisplayString);
+        AddArgument("ContentURL", &mContentURL);
+        AddArgument("DisplayString", &mDisplayString);
         ModelCommand::AddArguments();
     }
     ~ContentLauncherLaunchURL()
@@ -7768,9 +7768,9 @@ class DiagnosticLogsRetrieveLogsRequest : public ModelCommand
 public:
     DiagnosticLogsRetrieveLogsRequest() : ModelCommand("retrieve-logs-request")
     {
-        AddArgument("intent", 0, UINT8_MAX, &mIntent);
-        AddArgument("requestedProtocol", 0, UINT8_MAX, &mRequestedProtocol);
-        AddArgument("transferFileDesignator", &mTransferFileDesignator);
+        AddArgument("Intent", 0, UINT8_MAX, &mIntent);
+        AddArgument("RequestedProtocol", 0, UINT8_MAX, &mRequestedProtocol);
+        AddArgument("TransferFileDesignator", &mTransferFileDesignator);
         ModelCommand::AddArguments();
     }
     ~DiagnosticLogsRetrieveLogsRequest()
@@ -7930,7 +7930,7 @@ class DoorLockClearHolidaySchedule : public ModelCommand
 public:
     DoorLockClearHolidaySchedule() : ModelCommand("clear-holiday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
         ModelCommand::AddArguments();
     }
     ~DoorLockClearHolidaySchedule()
@@ -7965,7 +7965,7 @@ class DoorLockClearPin : public ModelCommand
 public:
     DoorLockClearPin() : ModelCommand("clear-pin")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockClearPin()
@@ -7999,7 +7999,7 @@ class DoorLockClearRfid : public ModelCommand
 public:
     DoorLockClearRfid() : ModelCommand("clear-rfid")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockClearRfid()
@@ -8033,8 +8033,8 @@ class DoorLockClearWeekdaySchedule : public ModelCommand
 public:
     DoorLockClearWeekdaySchedule() : ModelCommand("clear-weekday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockClearWeekdaySchedule()
@@ -8070,8 +8070,8 @@ class DoorLockClearYeardaySchedule : public ModelCommand
 public:
     DoorLockClearYeardaySchedule() : ModelCommand("clear-yearday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockClearYeardaySchedule()
@@ -8107,7 +8107,7 @@ class DoorLockGetHolidaySchedule : public ModelCommand
 public:
     DoorLockGetHolidaySchedule() : ModelCommand("get-holiday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetHolidaySchedule()
@@ -8142,7 +8142,7 @@ class DoorLockGetLogRecord : public ModelCommand
 public:
     DoorLockGetLogRecord() : ModelCommand("get-log-record")
     {
-        AddArgument("logIndex", 0, UINT16_MAX, &mLogIndex);
+        AddArgument("LogIndex", 0, UINT16_MAX, &mLogIndex);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetLogRecord()
@@ -8176,7 +8176,7 @@ class DoorLockGetPin : public ModelCommand
 public:
     DoorLockGetPin() : ModelCommand("get-pin")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetPin()
@@ -8210,7 +8210,7 @@ class DoorLockGetRfid : public ModelCommand
 public:
     DoorLockGetRfid() : ModelCommand("get-rfid")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetRfid()
@@ -8244,7 +8244,7 @@ class DoorLockGetUserType : public ModelCommand
 public:
     DoorLockGetUserType() : ModelCommand("get-user-type")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetUserType()
@@ -8278,8 +8278,8 @@ class DoorLockGetWeekdaySchedule : public ModelCommand
 public:
     DoorLockGetWeekdaySchedule() : ModelCommand("get-weekday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetWeekdaySchedule()
@@ -8315,8 +8315,8 @@ class DoorLockGetYeardaySchedule : public ModelCommand
 public:
     DoorLockGetYeardaySchedule() : ModelCommand("get-yearday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
         ModelCommand::AddArguments();
     }
     ~DoorLockGetYeardaySchedule()
@@ -8352,7 +8352,7 @@ class DoorLockLockDoor : public ModelCommand
 public:
     DoorLockLockDoor() : ModelCommand("lock-door")
     {
-        AddArgument("pin", &mPin);
+        AddArgument("Pin", &mPin);
         ModelCommand::AddArguments();
     }
     ~DoorLockLockDoor()
@@ -8387,10 +8387,10 @@ class DoorLockSetHolidaySchedule : public ModelCommand
 public:
     DoorLockSetHolidaySchedule() : ModelCommand("set-holiday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("localStartTime", 0, UINT32_MAX, &mLocalStartTime);
-        AddArgument("localEndTime", 0, UINT32_MAX, &mLocalEndTime);
-        AddArgument("operatingModeDuringHoliday", 0, UINT8_MAX, &mOperatingModeDuringHoliday);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("LocalStartTime", 0, UINT32_MAX, &mLocalStartTime);
+        AddArgument("LocalEndTime", 0, UINT32_MAX, &mLocalEndTime);
+        AddArgument("OperatingModeDuringHoliday", 0, UINT8_MAX, &mOperatingModeDuringHoliday);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetHolidaySchedule()
@@ -8429,10 +8429,10 @@ class DoorLockSetPin : public ModelCommand
 public:
     DoorLockSetPin() : ModelCommand("set-pin")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
-        AddArgument("userStatus", 0, UINT8_MAX, &mUserStatus);
-        AddArgument("userType", 0, UINT8_MAX, &mUserType);
-        AddArgument("pin", &mPin);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserStatus", 0, UINT8_MAX, &mUserStatus);
+        AddArgument("UserType", 0, UINT8_MAX, &mUserType);
+        AddArgument("Pin", &mPin);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetPin()
@@ -8470,10 +8470,10 @@ class DoorLockSetRfid : public ModelCommand
 public:
     DoorLockSetRfid() : ModelCommand("set-rfid")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
-        AddArgument("userStatus", 0, UINT8_MAX, &mUserStatus);
-        AddArgument("userType", 0, UINT8_MAX, &mUserType);
-        AddArgument("id", &mId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserStatus", 0, UINT8_MAX, &mUserStatus);
+        AddArgument("UserType", 0, UINT8_MAX, &mUserType);
+        AddArgument("Id", &mId);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetRfid()
@@ -8511,8 +8511,8 @@ class DoorLockSetUserType : public ModelCommand
 public:
     DoorLockSetUserType() : ModelCommand("set-user-type")
     {
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
-        AddArgument("userType", 0, UINT8_MAX, &mUserType);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
+        AddArgument("UserType", 0, UINT8_MAX, &mUserType);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetUserType()
@@ -8547,13 +8547,13 @@ class DoorLockSetWeekdaySchedule : public ModelCommand
 public:
     DoorLockSetWeekdaySchedule() : ModelCommand("set-weekday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
-        AddArgument("daysMask", 0, UINT8_MAX, &mDaysMask);
-        AddArgument("startHour", 0, UINT8_MAX, &mStartHour);
-        AddArgument("startMinute", 0, UINT8_MAX, &mStartMinute);
-        AddArgument("endHour", 0, UINT8_MAX, &mEndHour);
-        AddArgument("endMinute", 0, UINT8_MAX, &mEndMinute);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
+        AddArgument("DaysMask", 0, UINT8_MAX, &mDaysMask);
+        AddArgument("StartHour", 0, UINT8_MAX, &mStartHour);
+        AddArgument("StartMinute", 0, UINT8_MAX, &mStartMinute);
+        AddArgument("EndHour", 0, UINT8_MAX, &mEndHour);
+        AddArgument("EndMinute", 0, UINT8_MAX, &mEndMinute);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetWeekdaySchedule()
@@ -8595,10 +8595,10 @@ class DoorLockSetYeardaySchedule : public ModelCommand
 public:
     DoorLockSetYeardaySchedule() : ModelCommand("set-yearday-schedule")
     {
-        AddArgument("scheduleId", 0, UINT8_MAX, &mScheduleId);
-        AddArgument("userId", 0, UINT16_MAX, &mUserId);
-        AddArgument("localStartTime", 0, UINT32_MAX, &mLocalStartTime);
-        AddArgument("localEndTime", 0, UINT32_MAX, &mLocalEndTime);
+        AddArgument("ScheduleId", 0, UINT8_MAX, &mScheduleId);
+        AddArgument("UserId", 0, UINT16_MAX, &mUserId);
+        AddArgument("LocalStartTime", 0, UINT32_MAX, &mLocalStartTime);
+        AddArgument("LocalEndTime", 0, UINT32_MAX, &mLocalEndTime);
         ModelCommand::AddArguments();
     }
     ~DoorLockSetYeardaySchedule()
@@ -8637,7 +8637,7 @@ class DoorLockUnlockDoor : public ModelCommand
 public:
     DoorLockUnlockDoor() : ModelCommand("unlock-door")
     {
-        AddArgument("pin", &mPin);
+        AddArgument("Pin", &mPin);
         ModelCommand::AddArguments();
     }
     ~DoorLockUnlockDoor()
@@ -8672,8 +8672,8 @@ class DoorLockUnlockWithTimeout : public ModelCommand
 public:
     DoorLockUnlockWithTimeout() : ModelCommand("unlock-with-timeout")
     {
-        AddArgument("timeoutInSeconds", 0, UINT16_MAX, &mTimeoutInSeconds);
-        AddArgument("pin", &mPin);
+        AddArgument("TimeoutInSeconds", 0, UINT16_MAX, &mTimeoutInSeconds);
+        AddArgument("Pin", &mPin);
         ModelCommand::AddArguments();
     }
     ~DoorLockUnlockWithTimeout()
@@ -9322,9 +9322,9 @@ class GeneralCommissioningArmFailSafe : public ModelCommand
 public:
     GeneralCommissioningArmFailSafe() : ModelCommand("arm-fail-safe")
     {
-        AddArgument("expiryLengthSeconds", 0, UINT16_MAX, &mExpiryLengthSeconds);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("ExpiryLengthSeconds", 0, UINT16_MAX, &mExpiryLengthSeconds);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~GeneralCommissioningArmFailSafe()
@@ -9392,10 +9392,10 @@ class GeneralCommissioningSetRegulatoryConfig : public ModelCommand
 public:
     GeneralCommissioningSetRegulatoryConfig() : ModelCommand("set-regulatory-config")
     {
-        AddArgument("location", 0, UINT8_MAX, &mLocation);
-        AddArgument("countryCode", &mCountryCode);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("Location", 0, UINT8_MAX, &mLocation);
+        AddArgument("CountryCode", &mCountryCode);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~GeneralCommissioningSetRegulatoryConfig()
@@ -9905,8 +9905,8 @@ class GroupsAddGroup : public ModelCommand
 public:
     GroupsAddGroup() : ModelCommand("add-group")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("groupName", &mGroupName);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupName", &mGroupName);
         ModelCommand::AddArguments();
     }
     ~GroupsAddGroup()
@@ -9942,8 +9942,8 @@ class GroupsAddGroupIfIdentifying : public ModelCommand
 public:
     GroupsAddGroupIfIdentifying() : ModelCommand("add-group-if-identifying")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("groupName", &mGroupName);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupName", &mGroupName);
         ModelCommand::AddArguments();
     }
     ~GroupsAddGroupIfIdentifying()
@@ -9979,8 +9979,8 @@ class GroupsGetGroupMembership : public ModelCommand
 public:
     GroupsGetGroupMembership() : ModelCommand("get-group-membership")
     {
-        AddArgument("groupCount", 0, UINT8_MAX, &mGroupCount);
-        AddArgument("groupList", 0, UINT16_MAX, &mGroupList);
+        AddArgument("GroupCount", 0, UINT8_MAX, &mGroupCount);
+        AddArgument("GroupList", 0, UINT16_MAX, &mGroupList);
         ModelCommand::AddArguments();
     }
     ~GroupsGetGroupMembership()
@@ -10045,7 +10045,7 @@ class GroupsRemoveGroup : public ModelCommand
 public:
     GroupsRemoveGroup() : ModelCommand("remove-group")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
         ModelCommand::AddArguments();
     }
     ~GroupsRemoveGroup()
@@ -10079,7 +10079,7 @@ class GroupsViewGroup : public ModelCommand
 public:
     GroupsViewGroup() : ModelCommand("view-group")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
         ModelCommand::AddArguments();
     }
     ~GroupsViewGroup()
@@ -10223,7 +10223,7 @@ class IdentifyIdentify : public ModelCommand
 public:
     IdentifyIdentify() : ModelCommand("identify")
     {
-        AddArgument("identifyTime", 0, UINT16_MAX, &mIdentifyTime);
+        AddArgument("IdentifyTime", 0, UINT16_MAX, &mIdentifyTime);
         ModelCommand::AddArguments();
     }
     ~IdentifyIdentify()
@@ -10427,7 +10427,7 @@ class KeypadInputSendKey : public ModelCommand
 public:
     KeypadInputSendKey() : ModelCommand("send-key")
     {
-        AddArgument("keyCode", 0, UINT8_MAX, &mKeyCode);
+        AddArgument("KeyCode", 0, UINT8_MAX, &mKeyCode);
         ModelCommand::AddArguments();
     }
     ~KeypadInputSendKey()
@@ -10543,10 +10543,10 @@ class LevelControlMove : public ModelCommand
 public:
     LevelControlMove() : ModelCommand("move")
     {
-        AddArgument("moveMode", 0, UINT8_MAX, &mMoveMode);
-        AddArgument("rate", 0, UINT8_MAX, &mRate);
-        AddArgument("optionMask", 0, UINT8_MAX, &mOptionMask);
-        AddArgument("optionOverride", 0, UINT8_MAX, &mOptionOverride);
+        AddArgument("MoveMode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("Rate", 0, UINT8_MAX, &mRate);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mOptionMask);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mOptionOverride);
         ModelCommand::AddArguments();
     }
     ~LevelControlMove()
@@ -10584,10 +10584,10 @@ class LevelControlMoveToLevel : public ModelCommand
 public:
     LevelControlMoveToLevel() : ModelCommand("move-to-level")
     {
-        AddArgument("level", 0, UINT8_MAX, &mLevel);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionMask", 0, UINT8_MAX, &mOptionMask);
-        AddArgument("optionOverride", 0, UINT8_MAX, &mOptionOverride);
+        AddArgument("Level", 0, UINT8_MAX, &mLevel);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mOptionMask);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mOptionOverride);
         ModelCommand::AddArguments();
     }
     ~LevelControlMoveToLevel()
@@ -10625,8 +10625,8 @@ class LevelControlMoveToLevelWithOnOff : public ModelCommand
 public:
     LevelControlMoveToLevelWithOnOff() : ModelCommand("move-to-level-with-on-off")
     {
-        AddArgument("level", 0, UINT8_MAX, &mLevel);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("Level", 0, UINT8_MAX, &mLevel);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
         ModelCommand::AddArguments();
     }
     ~LevelControlMoveToLevelWithOnOff()
@@ -10661,8 +10661,8 @@ class LevelControlMoveWithOnOff : public ModelCommand
 public:
     LevelControlMoveWithOnOff() : ModelCommand("move-with-on-off")
     {
-        AddArgument("moveMode", 0, UINT8_MAX, &mMoveMode);
-        AddArgument("rate", 0, UINT8_MAX, &mRate);
+        AddArgument("MoveMode", 0, UINT8_MAX, &mMoveMode);
+        AddArgument("Rate", 0, UINT8_MAX, &mRate);
         ModelCommand::AddArguments();
     }
     ~LevelControlMoveWithOnOff()
@@ -10697,11 +10697,11 @@ class LevelControlStep : public ModelCommand
 public:
     LevelControlStep() : ModelCommand("step")
     {
-        AddArgument("stepMode", 0, UINT8_MAX, &mStepMode);
-        AddArgument("stepSize", 0, UINT8_MAX, &mStepSize);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("optionMask", 0, UINT8_MAX, &mOptionMask);
-        AddArgument("optionOverride", 0, UINT8_MAX, &mOptionOverride);
+        AddArgument("StepMode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("StepSize", 0, UINT8_MAX, &mStepSize);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mOptionMask);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mOptionOverride);
         ModelCommand::AddArguments();
     }
     ~LevelControlStep()
@@ -10740,9 +10740,9 @@ class LevelControlStepWithOnOff : public ModelCommand
 public:
     LevelControlStepWithOnOff() : ModelCommand("step-with-on-off")
     {
-        AddArgument("stepMode", 0, UINT8_MAX, &mStepMode);
-        AddArgument("stepSize", 0, UINT8_MAX, &mStepSize);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("StepMode", 0, UINT8_MAX, &mStepMode);
+        AddArgument("StepSize", 0, UINT8_MAX, &mStepSize);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
         ModelCommand::AddArguments();
     }
     ~LevelControlStepWithOnOff()
@@ -10779,8 +10779,8 @@ class LevelControlStop : public ModelCommand
 public:
     LevelControlStop() : ModelCommand("stop")
     {
-        AddArgument("optionMask", 0, UINT8_MAX, &mOptionMask);
-        AddArgument("optionOverride", 0, UINT8_MAX, &mOptionOverride);
+        AddArgument("OptionMask", 0, UINT8_MAX, &mOptionMask);
+        AddArgument("OptionOverride", 0, UINT8_MAX, &mOptionOverride);
         ModelCommand::AddArguments();
     }
     ~LevelControlStop()
@@ -11136,8 +11136,8 @@ class MediaInputRenameInput : public ModelCommand
 public:
     MediaInputRenameInput() : ModelCommand("rename-input")
     {
-        AddArgument("index", 0, UINT8_MAX, &mIndex);
-        AddArgument("name", &mName);
+        AddArgument("Index", 0, UINT8_MAX, &mIndex);
+        AddArgument("Name", &mName);
         ModelCommand::AddArguments();
     }
     ~MediaInputRenameInput()
@@ -11173,7 +11173,7 @@ class MediaInputSelectInput : public ModelCommand
 public:
     MediaInputSelectInput() : ModelCommand("select-input")
     {
-        AddArgument("index", 0, UINT8_MAX, &mIndex);
+        AddArgument("Index", 0, UINT8_MAX, &mIndex);
         ModelCommand::AddArguments();
     }
     ~MediaInputSelectInput()
@@ -11533,7 +11533,7 @@ class MediaPlaybackMediaSkipBackward : public ModelCommand
 public:
     MediaPlaybackMediaSkipBackward() : ModelCommand("media-skip-backward")
     {
-        AddArgument("deltaPositionMilliseconds", 0, UINT64_MAX, &mDeltaPositionMilliseconds);
+        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mDeltaPositionMilliseconds);
         ModelCommand::AddArguments();
     }
     ~MediaPlaybackMediaSkipBackward()
@@ -11568,7 +11568,7 @@ class MediaPlaybackMediaSkipForward : public ModelCommand
 public:
     MediaPlaybackMediaSkipForward() : ModelCommand("media-skip-forward")
     {
-        AddArgument("deltaPositionMilliseconds", 0, UINT64_MAX, &mDeltaPositionMilliseconds);
+        AddArgument("DeltaPositionMilliseconds", 0, UINT64_MAX, &mDeltaPositionMilliseconds);
         ModelCommand::AddArguments();
     }
     ~MediaPlaybackMediaSkipForward()
@@ -11603,7 +11603,7 @@ class MediaPlaybackMediaSkipSeek : public ModelCommand
 public:
     MediaPlaybackMediaSkipSeek() : ModelCommand("media-skip-seek")
     {
-        AddArgument("position", 0, UINT64_MAX, &mPosition);
+        AddArgument("Position", 0, UINT64_MAX, &mPosition);
         ModelCommand::AddArguments();
     }
     ~MediaPlaybackMediaSkipSeek()
@@ -11779,9 +11779,9 @@ class NetworkCommissioningAddThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningAddThreadNetwork() : ModelCommand("add-thread-network")
     {
-        AddArgument("operationalDataset", &mOperationalDataset);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("OperationalDataset", &mOperationalDataset);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningAddThreadNetwork()
@@ -11819,10 +11819,10 @@ class NetworkCommissioningAddWiFiNetwork : public ModelCommand
 public:
     NetworkCommissioningAddWiFiNetwork() : ModelCommand("add-wi-fi-network")
     {
-        AddArgument("ssid", &mSsid);
-        AddArgument("credentials", &mCredentials);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("Ssid", &mSsid);
+        AddArgument("Credentials", &mCredentials);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningAddWiFiNetwork()
@@ -11861,9 +11861,9 @@ class NetworkCommissioningDisableNetwork : public ModelCommand
 public:
     NetworkCommissioningDisableNetwork() : ModelCommand("disable-network")
     {
-        AddArgument("networkID", &mNetworkID);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("NetworkID", &mNetworkID);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningDisableNetwork()
@@ -11901,9 +11901,9 @@ class NetworkCommissioningEnableNetwork : public ModelCommand
 public:
     NetworkCommissioningEnableNetwork() : ModelCommand("enable-network")
     {
-        AddArgument("networkID", &mNetworkID);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("NetworkID", &mNetworkID);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningEnableNetwork()
@@ -11940,7 +11940,7 @@ class NetworkCommissioningGetLastNetworkCommissioningResult : public ModelComman
 public:
     NetworkCommissioningGetLastNetworkCommissioningResult() : ModelCommand("get-last-network-commissioning-result")
     {
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningGetLastNetworkCommissioningResult()
@@ -11974,9 +11974,9 @@ class NetworkCommissioningRemoveNetwork : public ModelCommand
 public:
     NetworkCommissioningRemoveNetwork() : ModelCommand("remove-network")
     {
-        AddArgument("networkID", &mNetworkID);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("NetworkID", &mNetworkID);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningRemoveNetwork()
@@ -12013,9 +12013,9 @@ class NetworkCommissioningScanNetworks : public ModelCommand
 public:
     NetworkCommissioningScanNetworks() : ModelCommand("scan-networks")
     {
-        AddArgument("ssid", &mSsid);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("Ssid", &mSsid);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningScanNetworks()
@@ -12052,9 +12052,9 @@ class NetworkCommissioningUpdateThreadNetwork : public ModelCommand
 public:
     NetworkCommissioningUpdateThreadNetwork() : ModelCommand("update-thread-network")
     {
-        AddArgument("operationalDataset", &mOperationalDataset);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("OperationalDataset", &mOperationalDataset);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningUpdateThreadNetwork()
@@ -12092,10 +12092,10 @@ class NetworkCommissioningUpdateWiFiNetwork : public ModelCommand
 public:
     NetworkCommissioningUpdateWiFiNetwork() : ModelCommand("update-wi-fi-network")
     {
-        AddArgument("ssid", &mSsid);
-        AddArgument("credentials", &mCredentials);
-        AddArgument("breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
-        AddArgument("timeoutMs", 0, UINT32_MAX, &mTimeoutMs);
+        AddArgument("Ssid", &mSsid);
+        AddArgument("Credentials", &mCredentials);
+        AddArgument("Breadcrumb", 0, UINT64_MAX, &mBreadcrumb);
+        AddArgument("TimeoutMs", 0, UINT32_MAX, &mTimeoutMs);
         ModelCommand::AddArguments();
     }
     ~NetworkCommissioningUpdateWiFiNetwork()
@@ -12210,8 +12210,8 @@ class OtaSoftwareUpdateServerApplyUpdateRequest : public ModelCommand
 public:
     OtaSoftwareUpdateServerApplyUpdateRequest() : ModelCommand("apply-update-request")
     {
-        AddArgument("updateToken", &mUpdateToken);
-        AddArgument("newVersion", 0, UINT32_MAX, &mNewVersion);
+        AddArgument("UpdateToken", &mUpdateToken);
+        AddArgument("NewVersion", 0, UINT32_MAX, &mNewVersion);
         ModelCommand::AddArguments();
     }
     ~OtaSoftwareUpdateServerApplyUpdateRequest()
@@ -12247,8 +12247,8 @@ class OtaSoftwareUpdateServerNotifyUpdateApplied : public ModelCommand
 public:
     OtaSoftwareUpdateServerNotifyUpdateApplied() : ModelCommand("notify-update-applied")
     {
-        AddArgument("updateToken", &mUpdateToken);
-        AddArgument("currentVersion", 0, UINT32_MAX, &mCurrentVersion);
+        AddArgument("UpdateToken", &mUpdateToken);
+        AddArgument("CurrentVersion", 0, UINT32_MAX, &mCurrentVersion);
         ModelCommand::AddArguments();
     }
     ~OtaSoftwareUpdateServerNotifyUpdateApplied()
@@ -12283,15 +12283,15 @@ class OtaSoftwareUpdateServerQueryImage : public ModelCommand
 public:
     OtaSoftwareUpdateServerQueryImage() : ModelCommand("query-image")
     {
-        AddArgument("vendorId", 0, UINT16_MAX, &mVendorId);
-        AddArgument("productId", 0, UINT16_MAX, &mProductId);
-        AddArgument("imageType", 0, UINT16_MAX, &mImageType);
-        AddArgument("hardwareVersion", 0, UINT16_MAX, &mHardwareVersion);
-        AddArgument("currentVersion", 0, UINT32_MAX, &mCurrentVersion);
-        AddArgument("protocolsSupported", 0, UINT8_MAX, &mProtocolsSupported);
-        AddArgument("location", &mLocation);
-        AddArgument("clientCanConsent", 0, UINT8_MAX, &mClientCanConsent);
-        AddArgument("metadataForServer", &mMetadataForServer);
+        AddArgument("VendorId", 0, UINT16_MAX, &mVendorId);
+        AddArgument("ProductId", 0, UINT16_MAX, &mProductId);
+        AddArgument("ImageType", 0, UINT16_MAX, &mImageType);
+        AddArgument("HardwareVersion", 0, UINT16_MAX, &mHardwareVersion);
+        AddArgument("CurrentVersion", 0, UINT32_MAX, &mCurrentVersion);
+        AddArgument("ProtocolsSupported", 0, UINT8_MAX, &mProtocolsSupported);
+        AddArgument("Location", &mLocation);
+        AddArgument("ClientCanConsent", 0, UINT8_MAX, &mClientCanConsent);
+        AddArgument("MetadataForServer", &mMetadataForServer);
         ModelCommand::AddArguments();
     }
     ~OtaSoftwareUpdateServerQueryImage()
@@ -12937,10 +12937,10 @@ class OperationalCredentialsAddOpCert : public ModelCommand
 public:
     OperationalCredentialsAddOpCert() : ModelCommand("add-op-cert")
     {
-        AddArgument("operationalCert", &mOperationalCert);
-        AddArgument("iPKValue", &mIPKValue);
-        AddArgument("caseAdminNode", 0, UINT64_MAX, &mCaseAdminNode);
-        AddArgument("adminVendorId", 0, UINT16_MAX, &mAdminVendorId);
+        AddArgument("OperationalCert", &mOperationalCert);
+        AddArgument("IPKValue", &mIPKValue);
+        AddArgument("CaseAdminNode", 0, UINT64_MAX, &mCaseAdminNode);
+        AddArgument("AdminVendorId", 0, UINT16_MAX, &mAdminVendorId);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsAddOpCert()
@@ -12979,7 +12979,7 @@ class OperationalCredentialsAddTrustedRootCertificate : public ModelCommand
 public:
     OperationalCredentialsAddTrustedRootCertificate() : ModelCommand("add-trusted-root-certificate")
     {
-        AddArgument("rootCertificate", &mRootCertificate);
+        AddArgument("RootCertificate", &mRootCertificate);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsAddTrustedRootCertificate()
@@ -13013,7 +13013,7 @@ class OperationalCredentialsOpCSRRequest : public ModelCommand
 public:
     OperationalCredentialsOpCSRRequest() : ModelCommand("op-csrrequest")
     {
-        AddArgument("cSRNonce", &mCSRNonce);
+        AddArgument("CSRNonce", &mCSRNonce);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsOpCSRRequest()
@@ -13077,9 +13077,9 @@ class OperationalCredentialsRemoveFabric : public ModelCommand
 public:
     OperationalCredentialsRemoveFabric() : ModelCommand("remove-fabric")
     {
-        AddArgument("fabricId", 0, UINT64_MAX, &mFabricId);
-        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
-        AddArgument("vendorId", 0, UINT16_MAX, &mVendorId);
+        AddArgument("FabricId", 0, UINT64_MAX, &mFabricId);
+        AddArgument("NodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("VendorId", 0, UINT16_MAX, &mVendorId);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsRemoveFabric()
@@ -13116,7 +13116,7 @@ class OperationalCredentialsRemoveTrustedRootCertificate : public ModelCommand
 public:
     OperationalCredentialsRemoveTrustedRootCertificate() : ModelCommand("remove-trusted-root-certificate")
     {
-        AddArgument("trustedRootIdentifier", &mTrustedRootIdentifier);
+        AddArgument("TrustedRootIdentifier", &mTrustedRootIdentifier);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsRemoveTrustedRootCertificate()
@@ -13151,7 +13151,7 @@ class OperationalCredentialsSetFabric : public ModelCommand
 public:
     OperationalCredentialsSetFabric() : ModelCommand("set-fabric")
     {
-        AddArgument("vendorId", 0, UINT16_MAX, &mVendorId);
+        AddArgument("VendorId", 0, UINT16_MAX, &mVendorId);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsSetFabric()
@@ -13186,7 +13186,7 @@ class OperationalCredentialsUpdateFabricLabel : public ModelCommand
 public:
     OperationalCredentialsUpdateFabricLabel() : ModelCommand("update-fabric-label")
     {
-        AddArgument("label", &mLabel);
+        AddArgument("Label", &mLabel);
         ModelCommand::AddArguments();
     }
     ~OperationalCredentialsUpdateFabricLabel()
@@ -14193,13 +14193,13 @@ class ScenesAddScene : public ModelCommand
 public:
     ScenesAddScene() : ModelCommand("add-scene")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("sceneId", 0, UINT8_MAX, &mSceneId);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
-        AddArgument("sceneName", &mSceneName);
-        AddArgument("clusterId", 0, UINT16_MAX, &mClusterId);
-        AddArgument("length", 0, UINT8_MAX, &mLength);
-        AddArgument("value", 0, UINT8_MAX, &mValue);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("SceneId", 0, UINT8_MAX, &mSceneId);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("SceneName", &mSceneName);
+        AddArgument("ClusterId", 0, UINT16_MAX, &mClusterId);
+        AddArgument("Length", 0, UINT8_MAX, &mLength);
+        AddArgument("Value", 0, UINT8_MAX, &mValue);
         ModelCommand::AddArguments();
     }
     ~ScenesAddScene()
@@ -14241,7 +14241,7 @@ class ScenesGetSceneMembership : public ModelCommand
 public:
     ScenesGetSceneMembership() : ModelCommand("get-scene-membership")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
         ModelCommand::AddArguments();
     }
     ~ScenesGetSceneMembership()
@@ -14276,9 +14276,9 @@ class ScenesRecallScene : public ModelCommand
 public:
     ScenesRecallScene() : ModelCommand("recall-scene")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("sceneId", 0, UINT8_MAX, &mSceneId);
-        AddArgument("transitionTime", 0, UINT16_MAX, &mTransitionTime);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("SceneId", 0, UINT8_MAX, &mSceneId);
+        AddArgument("TransitionTime", 0, UINT16_MAX, &mTransitionTime);
         ModelCommand::AddArguments();
     }
     ~ScenesRecallScene()
@@ -14314,7 +14314,7 @@ class ScenesRemoveAllScenes : public ModelCommand
 public:
     ScenesRemoveAllScenes() : ModelCommand("remove-all-scenes")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
         ModelCommand::AddArguments();
     }
     ~ScenesRemoveAllScenes()
@@ -14348,8 +14348,8 @@ class ScenesRemoveScene : public ModelCommand
 public:
     ScenesRemoveScene() : ModelCommand("remove-scene")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("sceneId", 0, UINT8_MAX, &mSceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("SceneId", 0, UINT8_MAX, &mSceneId);
         ModelCommand::AddArguments();
     }
     ~ScenesRemoveScene()
@@ -14384,8 +14384,8 @@ class ScenesStoreScene : public ModelCommand
 public:
     ScenesStoreScene() : ModelCommand("store-scene")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("sceneId", 0, UINT8_MAX, &mSceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("SceneId", 0, UINT8_MAX, &mSceneId);
         ModelCommand::AddArguments();
     }
     ~ScenesStoreScene()
@@ -14420,8 +14420,8 @@ class ScenesViewScene : public ModelCommand
 public:
     ScenesViewScene() : ModelCommand("view-scene")
     {
-        AddArgument("groupId", 0, UINT16_MAX, &mGroupId);
-        AddArgument("sceneId", 0, UINT8_MAX, &mSceneId);
+        AddArgument("GroupId", 0, UINT16_MAX, &mGroupId);
+        AddArgument("SceneId", 0, UINT8_MAX, &mSceneId);
         ModelCommand::AddArguments();
     }
     ~ScenesViewScene()
@@ -15034,7 +15034,7 @@ class TvChannelChangeChannel : public ModelCommand
 public:
     TvChannelChangeChannel() : ModelCommand("change-channel")
     {
-        AddArgument("match", &mMatch);
+        AddArgument("Match", &mMatch);
         ModelCommand::AddArguments();
     }
     ~TvChannelChangeChannel()
@@ -15069,8 +15069,8 @@ class TvChannelChangeChannelByNumber : public ModelCommand
 public:
     TvChannelChangeChannelByNumber() : ModelCommand("change-channel-by-number")
     {
-        AddArgument("majorNumber", 0, UINT16_MAX, &mMajorNumber);
-        AddArgument("minorNumber", 0, UINT16_MAX, &mMinorNumber);
+        AddArgument("MajorNumber", 0, UINT16_MAX, &mMajorNumber);
+        AddArgument("MinorNumber", 0, UINT16_MAX, &mMinorNumber);
         ModelCommand::AddArguments();
     }
     ~TvChannelChangeChannelByNumber()
@@ -15105,7 +15105,7 @@ class TvChannelSkipChannel : public ModelCommand
 public:
     TvChannelSkipChannel() : ModelCommand("skip-channel")
     {
-        AddArgument("count", 0, UINT16_MAX, &mCount);
+        AddArgument("Count", 0, UINT16_MAX, &mCount);
         ModelCommand::AddArguments();
     }
     ~TvChannelSkipChannel()
@@ -15317,8 +15317,8 @@ class TargetNavigatorNavigateTarget : public ModelCommand
 public:
     TargetNavigatorNavigateTarget() : ModelCommand("navigate-target")
     {
-        AddArgument("target", 0, UINT8_MAX, &mTarget);
-        AddArgument("data", &mData);
+        AddArgument("Target", 0, UINT8_MAX, &mTarget);
+        AddArgument("Data", &mData);
         ModelCommand::AddArguments();
     }
     ~TargetNavigatorNavigateTarget()
@@ -17282,8 +17282,8 @@ class ThermostatGetWeeklySchedule : public ModelCommand
 public:
     ThermostatGetWeeklySchedule() : ModelCommand("get-weekly-schedule")
     {
-        AddArgument("daysToReturn", 0, UINT8_MAX, &mDaysToReturn);
-        AddArgument("modeToReturn", 0, UINT8_MAX, &mModeToReturn);
+        AddArgument("DaysToReturn", 0, UINT8_MAX, &mDaysToReturn);
+        AddArgument("ModeToReturn", 0, UINT8_MAX, &mModeToReturn);
         ModelCommand::AddArguments();
     }
     ~ThermostatGetWeeklySchedule()
@@ -17318,10 +17318,10 @@ class ThermostatSetWeeklySchedule : public ModelCommand
 public:
     ThermostatSetWeeklySchedule() : ModelCommand("set-weekly-schedule")
     {
-        AddArgument("numberOfTransitionsForSequence", 0, UINT8_MAX, &mNumberOfTransitionsForSequence);
-        AddArgument("dayOfWeekForSequence", 0, UINT8_MAX, &mDayOfWeekForSequence);
-        AddArgument("modeForSequence", 0, UINT8_MAX, &mModeForSequence);
-        AddArgument("payload", 0, UINT8_MAX, &mPayload);
+        AddArgument("NumberOfTransitionsForSequence", 0, UINT8_MAX, &mNumberOfTransitionsForSequence);
+        AddArgument("DayOfWeekForSequence", 0, UINT8_MAX, &mDayOfWeekForSequence);
+        AddArgument("ModeForSequence", 0, UINT8_MAX, &mModeForSequence);
+        AddArgument("Payload", 0, UINT8_MAX, &mPayload);
         ModelCommand::AddArguments();
     }
     ~ThermostatSetWeeklySchedule()
@@ -17359,8 +17359,8 @@ class ThermostatSetpointRaiseLower : public ModelCommand
 public:
     ThermostatSetpointRaiseLower() : ModelCommand("setpoint-raise-lower")
     {
-        AddArgument("mode", 0, UINT8_MAX, &mMode);
-        AddArgument("amount", INT8_MIN, INT8_MAX, &mAmount);
+        AddArgument("Mode", 0, UINT8_MAX, &mMode);
+        AddArgument("Amount", INT8_MIN, INT8_MAX, &mAmount);
         ModelCommand::AddArguments();
     }
     ~ThermostatSetpointRaiseLower()
@@ -20179,8 +20179,8 @@ class WindowCoveringGoToLiftPercentage : public ModelCommand
 public:
     WindowCoveringGoToLiftPercentage() : ModelCommand("go-to-lift-percentage")
     {
-        AddArgument("liftPercentageValue", 0, UINT8_MAX, &mLiftPercentageValue);
-        AddArgument("liftPercent100thsValue", 0, UINT16_MAX, &mLiftPercent100thsValue);
+        AddArgument("LiftPercentageValue", 0, UINT8_MAX, &mLiftPercentageValue);
+        AddArgument("LiftPercent100thsValue", 0, UINT16_MAX, &mLiftPercent100thsValue);
         ModelCommand::AddArguments();
     }
     ~WindowCoveringGoToLiftPercentage()
@@ -20216,7 +20216,7 @@ class WindowCoveringGoToLiftValue : public ModelCommand
 public:
     WindowCoveringGoToLiftValue() : ModelCommand("go-to-lift-value")
     {
-        AddArgument("liftValue", 0, UINT16_MAX, &mLiftValue);
+        AddArgument("LiftValue", 0, UINT16_MAX, &mLiftValue);
         ModelCommand::AddArguments();
     }
     ~WindowCoveringGoToLiftValue()
@@ -20250,8 +20250,8 @@ class WindowCoveringGoToTiltPercentage : public ModelCommand
 public:
     WindowCoveringGoToTiltPercentage() : ModelCommand("go-to-tilt-percentage")
     {
-        AddArgument("tiltPercentageValue", 0, UINT8_MAX, &mTiltPercentageValue);
-        AddArgument("tiltPercent100thsValue", 0, UINT16_MAX, &mTiltPercent100thsValue);
+        AddArgument("TiltPercentageValue", 0, UINT8_MAX, &mTiltPercentageValue);
+        AddArgument("TiltPercent100thsValue", 0, UINT16_MAX, &mTiltPercent100thsValue);
         ModelCommand::AddArguments();
     }
     ~WindowCoveringGoToTiltPercentage()
@@ -20287,7 +20287,7 @@ class WindowCoveringGoToTiltValue : public ModelCommand
 public:
     WindowCoveringGoToTiltValue() : ModelCommand("go-to-tilt-value")
     {
-        AddArgument("tiltValue", 0, UINT16_MAX, &mTiltValue);
+        AddArgument("TiltValue", 0, UINT16_MAX, &mTiltValue);
         ModelCommand::AddArguments();
     }
     ~WindowCoveringGoToTiltValue()

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -186,9 +186,9 @@ public:
     {
         {{#chip_server_cluster_command_arguments}}
         {{#if (isString type)}}
-        AddArgument("{{asCamelCased label}}", &m{{asCamelCased label false}});
+        AddArgument("{{asCamelCased label false}}", &m{{asCamelCased label false}});
         {{else}}
-        AddArgument("{{asCamelCased label}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asCamelCased label false}});
+        AddArgument("{{asCamelCased label false}}", {{asTypeMinValue type}}, {{asTypeMaxValue type}}, &m{{asCamelCased label false}});
         {{/if}}
         {{/chip_server_cluster_command_arguments}}
         ModelCommand::AddArguments();
@@ -266,7 +266,7 @@ class Read{{asCamelCased parent.name false}}{{asCamelCased name false}}: public 
 public:
     Read{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("read")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
         ModelCommand::AddArguments();
     }
 
@@ -300,7 +300,7 @@ class Write{{asCamelCased parent.name false}}{{asCamelCased name false}}: public
 public:
     Write{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("write")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
         {{#if (isString type)}}
         AddArgument("attr-value", &mValue);
         {{else}}
@@ -341,7 +341,7 @@ class Report{{asCamelCased parent.name false}}{{asCamelCased name false}}: publi
 public:
     Report{{asCamelCased parent.name false}}{{asCamelCased name false}}(): ModelCommand("report")
     {
-        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name)}}");
+        AddArgument("attr-name", "{{asDelimitedCommand (asCamelCased name false)}}");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
         {{#unless (isDiscreteType)}}


### PR DESCRIPTION
…tter of arguments to be lower cased

<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem

Followup to #6873  where arguments such as `CSRNonce` ends up as `cSRNonce`. 

 #### Summary of Changes
 * Update the template so it does not enforce the first letter to be lowercased

#### Testing
 * I have runned `./scripts/tests/test_suites.sh` just to validate that argument parsing is not broken