### PR TITLE
Run cirque test with GDB for backtrace

### DIFF
--- a/src/app/tests/integration/Dockerfile.initiator
+++ b/src/app/tests/integration/Dockerfile.initiator
@@ -17,6 +17,9 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y gdb
+
 COPY out/chip-im-initiator /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/app/tests/integration/Dockerfile.responder
+++ b/src/app/tests/integration/Dockerfile.responder
@@ -17,6 +17,9 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y gdb
+
 COPY out/chip-im-responder /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/app/tests/integration/entrypoint.sh
+++ b/src/app/tests/integration/entrypoint.sh
@@ -10,7 +10,7 @@ ot-ctl ifconfig up
 ot-ctl thread start
 
 if [ "$1" = "responder" ]; then
-    chip-im-responder
+    gdb -return-child-result -q -ex run -ex bt chip-im-responder
 else
     sleep infinity
 fi

--- a/src/app/tests/integration/entrypoint.sh
+++ b/src/app/tests/integration/entrypoint.sh
@@ -10,7 +10,7 @@ ot-ctl ifconfig up
 ot-ctl thread start
 
 if [ "$1" = "responder" ]; then
-    gdb -return-child-result -q -ex run -ex bt chip-im-responder
+    gdb -batch -return-child-result -q -ex run -ex bt chip-im-responder
 else
     sleep infinity
 fi

--- a/src/messaging/tests/echo/Dockerfile.requester
+++ b/src/messaging/tests/echo/Dockerfile.requester
@@ -17,6 +17,9 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y gdb
+
 COPY out/chip-echo-requester /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/messaging/tests/echo/Dockerfile.responder
+++ b/src/messaging/tests/echo/Dockerfile.responder
@@ -17,6 +17,9 @@
 
 FROM connectedhomeip/chip-cirque-device-base:latest
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y gdb
+
 COPY out/chip-echo-responder /usr/bin/
 COPY entrypoint.sh /
 

--- a/src/messaging/tests/echo/entrypoint.sh
+++ b/src/messaging/tests/echo/entrypoint.sh
@@ -10,7 +10,7 @@ ot-ctl ifconfig up
 ot-ctl thread start
 
 if [ "$1" = "responder" ]; then
-    chip-echo-responder
+    gdb -return-child-result -q -ex run -ex bt chip-echo-responder
 else
     sleep infinity
 fi

--- a/src/messaging/tests/echo/entrypoint.sh
+++ b/src/messaging/tests/echo/entrypoint.sh
@@ -10,7 +10,7 @@ ot-ctl ifconfig up
 ot-ctl thread start
 
 if [ "$1" = "responder" ]; then
-    gdb -return-child-result -q -ex run -ex bt chip-echo-responder
+    gdb -batch -return-child-result -q -ex run -ex bt chip-echo-responder
 else
     sleep infinity
 fi

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -71,7 +71,7 @@ class TestEcho(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "chip-echo-requester {}"
+        command = "gdb -return-child-result -q -ex run -ex bt --args chip-echo-requester {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(

--- a/src/test_driver/linux-cirque/test-echo.py
+++ b/src/test_driver/linux-cirque/test-echo.py
@@ -71,7 +71,7 @@ class TestEcho(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args chip-echo-requester {}"
+        command = "gdb -batch -return-child-result -q -ex run -ex bt --args chip-echo-requester {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -71,7 +71,7 @@ class TestInteractionModel(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "chip-im-initiator {}"
+        command = "gdb -return-child-result -q -ex run -ex bt --args chip-im-initiator {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(

--- a/src/test_driver/linux-cirque/test-interaction-model.py
+++ b/src/test_driver/linux-cirque/test-interaction-model.py
@@ -71,7 +71,7 @@ class TestInteractionModel(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args chip-im-initiator {}"
+        command = "gdb -batch -return-child-result -q -ex run -ex bt --args chip-im-initiator {}"
 
         for ip in resp_ips:
             ret = self.execute_device_cmd(


### PR DESCRIPTION
#### Problem

Currently, Cirque is still disabled and we are running Cirque tests manually from our debug branch with GDB enabled. Enabling GDB for Cirque on master branch will help us run the regression check manually directly from master ToT with backtrace.

#### Change overview
Use GDB to run cirque test for IM and Echo for backtrace

#### Testing
How was this tested? 

Cirque is still disabled, testing is done manually with the following steps:

`Setting up cirque environment `
git submodule update --init
./scripts/tests/cirque_tests.sh bootstrap

`Run all tests `
./scripts/tests/cirque_tests.sh run_all_tests

Currently, Cirque test always failed, confirmed backtrace stack is dumped when test failed.