### PR TITLE
Remove double lock in EFR32 "GetEntropy"

### DIFF
--- a/src/platform/EFR32/Entropy.cpp
+++ b/src/platform/EFR32/Entropy.cpp
@@ -67,13 +67,6 @@ int GetEntropy_EFR32(uint8_t * buf, size_t count)
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    if (ThreadStackManagerImpl::IsInitialized())
-    {
-        ThreadStackMgr().LockThreadStack();
-    }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
     otError otErr = otPlatEntropyGet(buf, (uint16_t) count);
     if (otErr != OT_ERROR_NONE)
     {


### PR DESCRIPTION
<!-- ----------------------------------------------------------------
  If you're editing this as a result of an invocation of a GitHub CLI
   tool, note that lines that begin with '#' are stripped. To preserve the
   markdown that begins with '#' below, be sure to preserve the leading
   whitespace on those lines.
-->

 #### Problem
Looks like duplicated calls to lock the ThreadStack creeped in to the EFR32 Device Layer.
<!-- ----------------------------------------------------------------
  In the Problem section please describe what motivates the proposed changes.

  Please do your best to couch the motivation as a problem you're
   trying to address.  This makes reviewers' jobs easier: they
   can verify that the code actually targets the problem and
   pick out code that maybe should be in another PR because it
   targets another problem.

  "Do" examples:
      "CHIP does not support IP-rendezvous"
      "SystemTimer::Cancel() causes a crash when the aContext is null"
      "OpCert generation can overflow the output buffer"

  "Don't" examples:
      "updating codeowners"
      ""
      "add BLE support"
-->

 #### Summary of Changes
Removed duplicated code.
<!-- ----------------------------------------------------------------
  In the Summary of Changes section please describe, as completely as possible,
   what changes you've made.  A bulleted list of items is great here, and if
   your PR is a draft, you can use checkboxes as you make progress through your
   planned steps.  The goal of this section is again to aid reviewer's work.  A
   reviewer can tick down the list looking at how your changes affect the code,
   that your list covers what's changed, and that your changes address the
   problem (and not another problem).
-->

 Fixes #6948

<!-- ----------------------------------------------------------------
  In the Fixes section, replace the text between and including the <>
   with an issue number.

  "Do" examples:
      "fixes #2927"
      "fixes #2927, fixes #2928" (for multiple issues)
      "fixes #2927, fixes other_user/other_repo#2928"

  "Don't" examples:
      "fixes #<2927>"
      "fixes <#2927>

  See https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords
-->
