### PR TITLE
Implement BlePlatformDelegateImpl::CloseConnection on Mac and iOS platforms

### DIFF
--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -98,7 +98,15 @@ namespace DeviceLayer {
             return found;
         }
 
-        bool BlePlatformDelegateImpl::CloseConnection(BLE_CONNECTION_OBJECT connObj) { return true; }
+        bool BlePlatformDelegateImpl::CloseConnection(BLE_CONNECTION_OBJECT connObj)
+        {
+            CBPeripheral * peripheral = (CBPeripheral *) connObj;
+            // CoreBluetooth API requires a CBCentralManager to close a connection which is a property of the peripheral.
+            CBCentralManager * manager = (CBCentralManager *) [peripheral valueForKey:@"manager"];
+            [manager cancelPeripheralConnection:peripheral];
+
+            return true;
+        }
 
         uint16_t BlePlatformDelegateImpl::GetMTU(BLE_CONNECTION_OBJECT connObj) const { return 0; }
 

--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -103,7 +103,8 @@ namespace DeviceLayer {
             CBPeripheral * peripheral = (CBPeripheral *) connObj;
             // CoreBluetooth API requires a CBCentralManager to close a connection which is a property of the peripheral.
             CBCentralManager * manager = (CBCentralManager *) [peripheral valueForKey:@"manager"];
-            [manager cancelPeripheralConnection:peripheral];
+            if (manager != nil)
+                [manager cancelPeripheralConnection:peripheral];
 
             return true;
         }


### PR DESCRIPTION
Details in issue #6959 but repeated here for convenience.

Closing BLE connection using chip-device-ctrl on Mac and iOS platform is unimplemented.

STR:
1 - open a BLE connection e.g. connect -ble 3840 12345678 12344321
2 - close the BLE connection i.e. close-ble

Result:
close-ble hangs or times out and the connection is never closed. You can also see it with the Bluetooth icon in the menu bar, it shows connected forever until you (force) quit chip-device-ctrl

Explanation:
BlePlatformDelegateImpl::CloseConnection is unimplemented, all it does is { return true; }

With the fixed code you see following in chip-device-ctrl:

chip-device-ctrl > close-ble
[1621419714544] [0x725b2c] CHIP: [IN] Clearing BLE pending packets.
[1621419714544] [0x725b2c] CHIP: [BLE] Auto-closing end point's BLE connection.
chip-device-ctrl > quit

With the old code you don't get the prompt back, you need to force quit unless you wait long enough, and the connection stays open, see above.
