### PR TITLE
Add CHIP stack module.

### DIFF
--- a/config/esp32/args.gni
+++ b/config/esp32/args.gni
@@ -17,7 +17,7 @@
 
 chip_device_platform = "esp32"
 
-chip_project_config_include = ""
+chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_system_project_config_include = ""
 chip_ble_project_config_include = ""
 

--- a/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
@@ -27,8 +27,6 @@
 #ifndef CHIP_PROJECT_CONFIG_H
 #define CHIP_PROJECT_CONFIG_H
 
-// Enable support functions for parsing command-line arguments
-#define CHIP_CONFIG_ENABLE_ARG_PARSER 1
-#define CHIP_CONFIG_ESP32_QEMU 1
+// Override ESP32 CHIP Config here
 
 #endif // CHIP_PROJECT_CONFIG_H

--- a/examples/pigweed-app/esp32/main/include/CHIPProjectConfig.h
+++ b/examples/pigweed-app/esp32/main/include/CHIPProjectConfig.h
@@ -27,8 +27,6 @@
 #ifndef CHIP_PROJECT_CONFIG_H
 #define CHIP_PROJECT_CONFIG_H
 
-// Enable support functions for parsing command-line arguments
-#define CHIP_CONFIG_ENABLE_ARG_PARSER 1
-#define CHIP_CONFIG_ESP32_QEMU 1
+// Override ESP32 CHIP Config here
 
 #endif // CHIP_PROJECT_CONFIG_H

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -239,12 +239,12 @@ void StartPinging(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Inet::IPAddress gDestAddr;
+    Inet::IPAddress destAddr;
     Transport::PeerAddress peerAddress;
     Transport::AdminPairingInfo * adminInfo = nullptr;
     uint32_t maxEchoCount                   = 0;
 
-    if (!IPAddress::FromString(destination, gDestAddr))
+    if (!IPAddress::FromString(destination, destAddr))
     {
         streamer_printf(stream, "Invalid Echo Server IP address: %s\n", destination);
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -258,12 +258,12 @@ void StartPinging(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gPingArguments.IsUsingTCP())
     {
-        peerAddress = Transport::PeerAddress::TCP(gDestAddr, gPingArguments.GetEchoPort());
+        peerAddress = Transport::PeerAddress::TCP(destAddr, gPingArguments.GetEchoPort());
     }
     else
 #endif
     {
-        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gPingArguments.GetEchoPort(), INET_NULL_INTERFACEID);
+        peerAddress = Transport::PeerAddress::UDP(destAddr, gPingArguments.GetEchoPort(), INET_NULL_INTERFACEID);
     }
 
     // Start the CHIP connection to the CHIP echo responder.
@@ -309,10 +309,7 @@ void StartPinging(streamer_t * stream, char * destination)
     gStack.GetTransportManager().Disconnect(peerAddress);
 #endif
 
-    gStack.GetTransportManager().Close();
-
     gEchoClient.Shutdown();
-
     gStack.Shutdown();
 
 exit:

--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -250,7 +250,7 @@ void StartPinging(streamer_t * stream, char * destination)
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    gStack.Init();
+    gStack.Init(StackParameters());
 
     adminInfo = gStack.GetAdmins().AssignAdminId(gAdminId, kTestControllerNodeId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -226,11 +226,11 @@ void ProcessCommand(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Inet::IPAddress gDestAddr;
+    Inet::IPAddress destAddr;
     Transport::PeerAddress peerAddress;
     Transport::AdminPairingInfo * adminInfo = nullptr;
 
-    if (!chip::Inet::IPAddress::FromString(destination, gDestAddr))
+    if (!chip::Inet::IPAddress::FromString(destination, destAddr))
     {
         streamer_printf(stream, "Invalid CHIP Server IP address: %s\n", destination);
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -242,12 +242,12 @@ void ProcessCommand(streamer_t * stream, char * destination)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gSendArguments.IsUsingTCP())
     {
-        peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
+        peerAddress = Transport::PeerAddress::TCP(destAddr, gSendArguments.GetPort());
     }
     else
 #endif
     {
-        peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
+        peerAddress = Transport::PeerAddress::UDP(destAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
     }
 
     // Start the CHIP connection to the CHIP server.
@@ -264,7 +264,6 @@ void ProcessCommand(streamer_t * stream, char * destination)
     gStack.GetTransportManager().Disconnect(peerAddress);
 #endif
 
-    gStack.GetTransportManager().Close();
     gStack.Shutdown();
 
 exit:

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -142,7 +142,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     }
 
     // Create a new exchange context.
-    gExchangeCtx = gExchangeManager.NewContext({ kTestDeviceNodeId, 0, gAdminId }, &gMockAppDelegate);
+    gExchangeCtx = gStack.GetExchangeManager().NewContext({ kTestDeviceNodeId, 0, gAdminId }, &gMockAppDelegate);
     VerifyOrExit(gExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     size = gSendArguments.GetPayloadSize();
@@ -205,8 +205,8 @@ CHIP_ERROR EstablishSecureSession(streamer_t * stream, Transport::PeerAddress & 
     peerAddr = Optional<Transport::PeerAddress>::Value(peerAddress);
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret, SecureSession::SessionRole::kInitiator,
-                                     gAdminId);
+    err = gStack.GetSecureSessionManager().NewPairing(peerAddr, kTestDeviceNodeId, testSecurePairingSecret,
+                                                      SecureSession::SessionRole::kInitiator, gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -226,7 +226,7 @@ void ProcessCommand(streamer_t * stream, char * destination)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    Transport::AdminPairingTable admins;
+    Inet::IPAddress gDestAddr;
     Transport::PeerAddress peerAddress;
     Transport::AdminPairingInfo * adminInfo = nullptr;
 
@@ -236,45 +236,19 @@ void ProcessCommand(streamer_t * stream, char * destination)
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    adminInfo = admins.AssignAdminId(gAdminId, kTestControllerNodeId);
+    adminInfo = gStack.GetAdmins().AssignAdminId(gAdminId, kTestControllerNodeId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    err = gTCPManager.Init(Transport::TcpListenParameters(&DeviceLayer::InetLayer)
-                               .SetAddressType(gDestAddr.Type())
-                               .SetListenPort(gSendArguments.GetPort() + 1));
-    VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init TCP manager error: %s\n", ErrorStr(err)));
-#endif
-
-    err = gUDPManager.Init(Transport::UdpListenParameters(&DeviceLayer::InetLayer)
-                               .SetAddressType(gDestAddr.Type())
-                               .SetListenPort(gSendArguments.GetPort() + 1));
-    VerifyOrExit(err == CHIP_NO_ERROR, streamer_printf(stream, "Failed to init UDP manager error: %s\n", ErrorStr(err)));
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     if (gSendArguments.IsUsingTCP())
     {
         peerAddress = Transport::PeerAddress::TCP(gDestAddr, gSendArguments.GetPort());
-
-        err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gTCPManager, &admins, &gMessageCounterManager);
-        SuccessOrExit(err);
     }
     else
 #endif
     {
         peerAddress = Transport::PeerAddress::UDP(gDestAddr, gSendArguments.GetPort(), INET_NULL_INTERFACEID);
-
-        err =
-            gSessionManager.Init(kTestControllerNodeId, &DeviceLayer::SystemLayer, &gUDPManager, &admins, &gMessageCounterManager);
-        SuccessOrExit(err);
     }
-
-    err = gExchangeManager.Init(&gSessionManager);
-    SuccessOrExit(err);
-
-    err = gMessageCounterManager.Init(&gExchangeManager);
-    SuccessOrExit(err);
 
     // Start the CHIP connection to the CHIP server.
     err = EstablishSecureSession(stream, peerAddress);
@@ -287,13 +261,11 @@ void ProcessCommand(streamer_t * stream, char * destination)
     sleep(2);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    gTCPManager.Disconnect(peerAddress);
-    gTCPManager.Close();
+    gStack.GetTransportManager().Disconnect(peerAddress);
 #endif
-    gUDPManager.Close();
 
-    gExchangeManager.Shutdown();
-    gSessionManager.Shutdown();
+    gStack.GetTransportManager().Close();
+    gStack.Shutdown();
 
 exit:
     if ((err != CHIP_NO_ERROR))

--- a/examples/shell/shell_common/globals.cpp
+++ b/examples/shell/shell_common/globals.cpp
@@ -17,14 +17,11 @@
 
 #include <Globals.h>
 
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
-chip::Messaging::ExchangeManager gExchangeManager;
-chip::SecureSessionMgr gSessionManager;
-chip::Inet::IPAddress gDestAddr;
-
-chip::Transport::AdminId gAdminId = 0;
+#include <protocols/secure_channel/PASESession.h>
+#include <stack/Stack.h>
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
+chip::Stack<TransportConfigurationWithTcp> gStack(chip::kTestControllerNodeId);
+#else
+chip::Stack<> gStack(chip::kTestControllerNodeId);
 #endif
-chip::TransportMgr<chip::Transport::UDP> gUDPManager;

--- a/examples/shell/shell_common/include/Globals.h
+++ b/examples/shell/shell_common/include/Globals.h
@@ -39,23 +39,35 @@ public:
 #endif
         chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>, chip::Transport::UDP>;
 
-    CHIP_ERROR Init(chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
+    CHIP_ERROR Init(const chip::StackParameters & parameters, chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
     {
         return mTransportManager.Init(
 #if INET_CONFIG_ENABLE_IPV4
-            chip::Transport::TcpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4).SetListenPort(mPort),
-            chip::Transport::UdpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4).SetListenPort(mPort),
+            chip::Transport::TcpListenParameters(&inetLayer)
+                .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                .SetListenPort(parameters.GetListenPort()),
+            chip::Transport::UdpListenParameters(&inetLayer)
+                .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                .SetListenPort(parameters.GetListenPort()),
 #endif
-            chip::Transport::TcpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6).SetListenPort(mPort),
-            chip::Transport::UdpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv6).SetListenPort(mPort));
+            chip::Transport::TcpListenParameters(&inetLayer)
+                .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                .SetListenPort(parameters.GetListenPort()),
+            chip::Transport::UdpListenParameters(&inetLayer)
+                .SetAddressType(chip::Inet::kIPAddressType_IPv6)
+                .SetListenPort(parameters.GetListenPort()));
+    }
+
+    CHIP_ERROR Shutdown()
+    {
+        mTransportManager.Close();
+        return CHIP_NO_ERROR;
     }
 
     chip::TransportMgrBase & Get() { return mTransportManager; }
-    void SetListenPort(uint16_t port) { mPort = port; }
 
 private:
     transport mTransportManager;
-    uint16_t mPort = CHIP_PORT;
 };
 
 extern chip::Stack<TransportConfigurationWithTcp> gStack;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -101,13 +101,12 @@ class ServerStorageDelegate : public PersistentStorageDelegate
 class ServerStorageConfig : public StorageConfiguration
 {
 public:
-    CHIP_ERROR Init()
+    CHIP_ERROR Init(const StackParameters & parameters)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
 
 #if CHIP_DEVICE_LAYER_TARGET_DARWIN
         err = PersistedStorage::KeyValueStoreMgrImpl().Init("chip.store");
-        SuccessOrExit(err);
 #elif CHIP_DEVICE_LAYER_TARGET_LINUX
         PersistedStorage::KeyValueStoreMgrImpl().Init("/tmp/chip_server_kvs");
 #endif
@@ -137,29 +136,34 @@ public:
 #endif
                                          >;
 
-    CHIP_ERROR Init(chip::Inet::InetLayer & inetLayer, Ble::BleLayer * bleLayer)
+    CHIP_ERROR Init(const StackParameters & parameters, chip::Inet::InetLayer & inetLayer, Ble::BleLayer * bleLayer)
     {
-        return mTransportManager.Init(UdpListenParameters(&inetLayer).SetAddressType(kIPAddressType_IPv6)
+        return mTransportManager.Init(
+            UdpListenParameters(&inetLayer).SetAddressType(kIPAddressType_IPv6).SetListenPort(parameters.GetListenPort())
 #if INET_CONFIG_ENABLE_IPV4
-                                          ,
-                                      UdpListenParameters(&inetLayer).SetAddressType(kIPAddressType_IPv4)
+                ,
+            UdpListenParameters(&inetLayer).SetAddressType(kIPAddressType_IPv4).SetListenPort(parameters.GetListenPort())
 #endif
 #if CONFIG_NETWORK_LAYER_BLE
-                                          ,
-                                      BleListenParameters(bleLayer)
+                ,
+            BleListenParameters(bleLayer)
 #endif
         );
     }
 
+    CHIP_ERROR Shutdown()
+    {
+        mTransportManager.Close();
+        return CHIP_NO_ERROR;
+    }
+
     chip::TransportMgrBase & Get() { return mTransportManager; }
-    void SetListenPort(uint16_t port) { mPort = port; }
 
 private:
     transport mTransportManager;
-    uint16_t mPort = CHIP_PORT;
 };
 
-static chip::Stack<ServerStorageConfig> gStack(chip::kTestDeviceNodeId);
+static chip::Stack<ServerStorageConfig, ServerTransportConfig> gStack(chip::kTestDeviceNodeId);
 
 PersistentStorageDelegate & GetGlobalStorage()
 {
@@ -541,7 +545,7 @@ void InitServer(AppDelegate * delegate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = gStack.Init();
+    err = gStack.Init(StackParameters());
     SuccessOrExit(err);
 
     InitDataModelHandler(&gStack.GetExchangeManager());

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -28,17 +28,6 @@
 
 constexpr size_t kMaxBlePendingPackets = 1;
 
-using DemoTransportMgr = chip::TransportMgr<chip::Transport::UDP
-#if INET_CONFIG_ENABLE_IPV4
-                                            ,
-                                            chip::Transport::UDP
-#endif
-#if CONFIG_NETWORK_LAYER_BLE
-                                            ,
-                                            chip::Transport::BLE<kMaxBlePendingPackets>
-#endif
-                                            >;
-
 /**
  * Initialize DataModelHandler and start CHIP datamodel server, the server
  * assumes the platform's networking has been setup already.

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -240,7 +240,7 @@ void TestCommandInteraction::TestCommandSenderWithWrongState(nlTestSuite * apSui
     commandSender.Shutdown();
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                            = commandSender.Init(&gExchangeManager, nullptr);
+    err                            = commandSender.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     err = commandSender.SendCommandRequest(kTestDeviceNodeId, gAdminId);
@@ -261,9 +261,9 @@ void TestCommandInteraction::TestCommandHandlerWithWrongState(nlTestSuite * apSu
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
     commandHandler.Shutdown();
 
-    err = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err = commandHandler.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gStack.GetExchangeManager().NewContext({ 0, 0, 0 }, nullptr);
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
     err = commandHandler.SendCommandResponse();
@@ -399,7 +399,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedNotExistComman
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err                                       = commandHandler.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     // Use some invalid endpoint / cluster / command.
     GenerateReceivedCommand(apSuite, apContext, commandDatabuf, false /*aNeedCommandData*/, 0xDE /* endpoint */,
@@ -418,7 +418,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err                                       = commandHandler.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     chip::isCommandDispatched = false;
     GenerateReceivedCommand(apSuite, apContext, commandDatabuf, false /*aNeedCommandData*/);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -342,6 +342,7 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     err = invokeCommandParser.CheckSchemaValidity();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 #endif
+    commandHandler.Shutdown();
 }
 
 void TestCommandInteraction::TestCommandHandlerWithSendSimpleCommandData(nlTestSuite * apSuite, void * apContext)
@@ -413,11 +414,6 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
 
 namespace {
 
-void InitializeChip(nlTestSuite * apSuite)
-{
-    NL_TEST_ASSERT(apSuite, chip::gStack.Init() == CHIP_NO_ERROR);
-}
-
 // clang-format off
 const nlTest sTests[] =
 {
@@ -450,11 +446,12 @@ int TestCommandInteraction()
     };
     // clang-format on
 
-    InitializeChip(&theSuite);
-
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Init(chip::StackParameters()) == CHIP_NO_ERROR);
     nlTestRunner(&theSuite, nullptr);
+    int result = nlTestRunnerStats(&theSuite);
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Shutdown() == CHIP_NO_ERROR);
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestCommandInteraction)

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -47,7 +47,25 @@
 #include <nlunit-test.h>
 
 namespace chip {
-static Stack<> gStack(kTestControllerNodeId);
+
+class NoopTransportConfig : TransportConfiguration
+{
+public:
+    using transport = TransportMgr<>;
+
+    CHIP_ERROR Init(const StackParameters & parameters, Inet::InetLayer & inetLayer, Ble::BleLayer * bleLayer)
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    TransportMgrBase & Get() { return mTransportManager; }
+
+private:
+    transport mTransportManager;
+};
+
+static Stack<NoopTransportConfig> gStack(kTestControllerNodeId);
 static Transport::AdminId gAdminId = 0;
 static bool isCommandDispatched    = false;
 

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -35,6 +35,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
+#include <stack/Stack.h>
 #include <support/ErrorStr.h>
 #include <support/UnitTestRegistration.h>
 #include <support/logging/CHIPLogging.h>
@@ -46,11 +47,7 @@
 #include <nlunit-test.h>
 
 namespace chip {
-static System::Layer gSystemLayer;
-static SecureSessionMgr gSessionManager;
-static Messaging::ExchangeManager gExchangeManager;
-static TransportMgr<Transport::UDP> gTransportManager;
-static secure_channel::MessageCounterManager gMessageCounterManager;
+static Stack<> gStack(kTestControllerNodeId);
 static Transport::AdminId gAdminId = 0;
 static bool isCommandDispatched    = false;
 
@@ -263,7 +260,7 @@ void TestCommandInteraction::TestCommandSenderWithSendCommand(nlTestSuite * apSu
     app::CommandSender commandSender;
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                            = commandSender.Init(&gExchangeManager, nullptr);
+    err                            = commandSender.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     AddCommandDataElement(apSuite, apContext, &commandSender, false, false);
@@ -286,10 +283,10 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
                                                        (chip::app::CommandPathFlags::kEndpointIdValid) };
     app::CommandHandler commandHandler;
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err                                       = commandHandler.Init(&chip::gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gStack.GetExchangeManager().NewContext({ 0, 0, 0 }, nullptr);
 
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
@@ -309,7 +306,7 @@ void TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg(nlTestSuite
     app::CommandSender commandSender;
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                            = commandSender.Init(&gExchangeManager, nullptr);
+    err                            = commandSender.Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     GenerateReceivedCommand(apSuite, apContext, buf, true /*aNeedCommandData*/);
@@ -323,10 +320,10 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
-    err = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err = commandHandler.Init(&chip::gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    commandHandler.mpExchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    commandHandler.mpExchangeCtx = gStack.GetExchangeManager().NewContext({ 0, 0, 0 }, nullptr);
     TestExchangeDelegate delegate;
     commandHandler.mpExchangeCtx->SetDelegate(&delegate);
 
@@ -370,7 +367,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg(nlTestSuit
     CHIP_ERROR err = CHIP_NO_ERROR;
     app::CommandHandler commandHandler;
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    err                                       = commandHandler.Init(&chip::gExchangeManager, nullptr);
+    err                                       = commandHandler.Init(&chip::gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     GenerateReceivedCommand(apSuite, apContext, commandDatabuf, true /*aNeedCommandData*/);
     err = commandHandler.ProcessCommandMessage(std::move(commandDatabuf), Command::CommandRoleId::HandlerId);
@@ -418,30 +415,7 @@ namespace {
 
 void InitializeChip(nlTestSuite * apSuite)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
-
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
-
-    err = chip::Platform::MemoryInit();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    chip::gSystemLayer.Init(nullptr);
-
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
-                                     &chip::gMessageCounterManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = chip::gExchangeManager.Init(&chip::gSessionManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = chip::gMessageCounterManager.Init(&chip::gExchangeManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&chip::gExchangeManager, nullptr);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, chip::gStack.Init() == CHIP_NO_ERROR);
 }
 
 // clang-format off

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -62,11 +62,6 @@ static uint8_t gInfoEventBuffer[128];
 static uint8_t gCritEventBuffer[128];
 static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 
-void InitializeChip(nlTestSuite * apSuite)
-{
-    NL_TEST_ASSERT(apSuite, gStack.Init() == CHIP_NO_ERROR);
-}
-
 void InitializeEventLogging()
 {
     chip::app::LogStorageResources logStorageResources[] = {
@@ -275,11 +270,13 @@ int TestEventLogging()
     };
     // clang-format on
 
-    InitializeChip(&theSuite);
+    NL_TEST_ASSERT(&theSuite, gStack.Init(chip::StackParameters()) == CHIP_NO_ERROR);
     InitializeEventLogging();
     nlTestRunner(&theSuite, nullptr);
+    int result = nlTestRunnerStats(&theSuite);
+    NL_TEST_ASSERT(&theSuite, gStack.Shutdown() == CHIP_NO_ERROR);
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestEventLogging)

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -49,7 +49,24 @@
 
 namespace {
 
-static chip::Stack<> gStack(chip::kTestDeviceNodeId);
+class NoopTransportConfig : chip::TransportConfiguration
+{
+public:
+    using transport = chip::TransportMgr<>;
+
+    CHIP_ERROR Init(const chip::StackParameters & parameters, chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    chip::TransportMgrBase & Get() { return mTransportManager; }
+
+private:
+    transport mTransportManager;
+};
+
+static chip::Stack<NoopTransportConfig> gStack(chip::kTestDeviceNodeId);
 
 static const chip::NodeId kTestDeviceNodeId     = 0x18B4300000000001ULL;
 static const chip::ClusterId kLivenessClusterId = 0x00000022;

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -37,6 +37,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
+#include <stack/Stack.h>
 #include <support/ErrorStr.h>
 #include <support/UnitTestRegistration.h>
 #include <system/SystemPacketBuffer.h>
@@ -48,46 +49,22 @@
 
 namespace {
 
+static chip::Stack<> gStack(chip::kTestDeviceNodeId);
+
 static const chip::NodeId kTestDeviceNodeId     = 0x18B4300000000001ULL;
 static const chip::ClusterId kLivenessClusterId = 0x00000022;
 static const uint32_t kLivenessChangeEvent      = 1;
 static const chip::EndpointId kTestEndpointId   = 2;
 static const uint64_t kLivenessDeviceStatus     = chip::TLV::ContextTag(1);
-static const chip::Transport::AdminId gAdminId  = 0;
-static chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-static chip::System::Layer gSystemLayer;
 
 static uint8_t gDebugEventBuffer[128];
 static uint8_t gInfoEventBuffer[128];
 static uint8_t gCritEventBuffer[128];
 static chip::app::CircularEventBuffer gCircularEventBuffer[3];
 
-chip::SecureSessionMgr gSessionManager;
-chip::Messaging::ExchangeManager gExchangeManager;
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
-
 void InitializeChip(nlTestSuite * apSuite)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, kTestDeviceNodeId);
-
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
-
-    err = chip::Platform::MemoryInit();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    gSystemLayer.Init(nullptr);
-
-    err = gSessionManager.Init(chip::kTestDeviceNodeId, &gSystemLayer, &gTransportManager, &admins, &gMessageCounterManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = gExchangeManager.Init(&gSessionManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = gMessageCounterManager.Init(&gExchangeManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, gStack.Init() == CHIP_NO_ERROR);
 }
 
 void InitializeEventLogging()
@@ -98,8 +75,9 @@ void InitializeEventLogging()
         { &gCritEventBuffer[0], sizeof(gCritEventBuffer), nullptr, 0, nullptr, chip::app::PriorityLevel::Critical },
     };
 
-    chip::app::EventManagement::CreateEventManagement(
-        &gExchangeManager, sizeof(logStorageResources) / sizeof(logStorageResources[0]), gCircularEventBuffer, logStorageResources);
+    chip::app::EventManagement::CreateEventManagement(&gStack.GetExchangeManager(),
+                                                      sizeof(logStorageResources) / sizeof(logStorageResources[0]),
+                                                      gCircularEventBuffer, logStorageResources);
 }
 
 void SimpleDumpWriter(const char * aFormat, ...)

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -43,7 +43,24 @@
 
 #include <nlunit-test.h>
 
-static chip::Stack<> gStack(chip::kTestDeviceNodeId);
+class NoopTransportConfig : chip::TransportConfiguration
+{
+public:
+    using transport = chip::TransportMgr<>;
+
+    CHIP_ERROR Init(const chip::StackParameters & parameters, chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    chip::TransportMgrBase & Get() { return mTransportManager; }
+
+private:
+    transport mTransportManager;
+};
+
+static chip::Stack<NoopTransportConfig> gStack(chip::kTestDeviceNodeId);
 
 namespace chip {
 namespace app {

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -99,10 +99,6 @@ void TestInteractionModelEngine::TestClusterInfoPushRelease(nlTestSuite * apSuit
 } // namespace chip
 
 namespace {
-void InitializeChip(nlTestSuite * apSuite)
-{
-    NL_TEST_ASSERT(apSuite, gStack.Init() == CHIP_NO_ERROR);
-}
 
 // clang-format off
 const nlTest sTests[] =
@@ -125,11 +121,12 @@ int TestInteractionModelEngine()
     };
     // clang-format on
 
-    InitializeChip(&theSuite);
-
+    NL_TEST_ASSERT(&theSuite, gStack.Init(chip::StackParameters()) == CHIP_NO_ERROR);
     nlTestRunner(&theSuite, nullptr);
+    int result = nlTestRunnerStats(&theSuite);
+    NL_TEST_ASSERT(&theSuite, gStack.Shutdown() == CHIP_NO_ERROR);
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestInteractionModelEngine)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -142,11 +142,6 @@ void TestReadInteraction::TestReadHandler(nlTestSuite * apSuite, void * apContex
 
 namespace {
 
-void InitializeChip(nlTestSuite * apSuite)
-{
-    NL_TEST_ASSERT(apSuite, chip::gStack.Init() == CHIP_NO_ERROR);
-}
-
 /**
  *   Test Suite. It lists all the test functions.
  */
@@ -174,11 +169,12 @@ int TestReadInteraction()
     };
     // clang-format on
 
-    InitializeChip(&theSuite);
-
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Init(chip::StackParameters()) == CHIP_NO_ERROR);
     nlTestRunner(&theSuite, nullptr);
+    int result = nlTestRunnerStats(&theSuite);
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Shutdown() == CHIP_NO_ERROR);
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestReadInteraction)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -44,7 +44,25 @@
 #include <nlunit-test.h>
 
 namespace chip {
-static Stack<> gStack(chip::kTestDeviceNodeId);
+
+class NoopTransportConfig : TransportConfiguration
+{
+public:
+    using transport = TransportMgr<>;
+
+    CHIP_ERROR Init(const StackParameters & parameters, Inet::InetLayer & inetLayer, Ble::BleLayer * bleLayer)
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    TransportMgrBase & Get() { return mTransportManager; }
+
+private:
+    transport mTransportManager;
+};
+
+static Stack<NoopTransportConfig> gStack(chip::kTestDeviceNodeId);
 const Transport::AdminId gAdminId = 0;
 
 namespace app {

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -137,10 +137,6 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
 } // namespace chip
 
 namespace {
-void InitializeChip(nlTestSuite * apSuite)
-{
-    NL_TEST_ASSERT(apSuite, chip::gStack.Init() == CHIP_NO_ERROR);
-}
 
 // clang-format off
 const nlTest sTests[] =
@@ -163,11 +159,12 @@ int TestReportingEngine()
     };
     // clang-format on
 
-    InitializeChip(&theSuite);
-
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Init(chip::StackParameters()) == CHIP_NO_ERROR);
     nlTestRunner(&theSuite, nullptr);
+    int result = nlTestRunnerStats(&theSuite);
+    NL_TEST_ASSERT(&theSuite, chip::gStack.Shutdown() == CHIP_NO_ERROR);
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestReportingEngine)

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -34,6 +34,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
+#include <stack/Stack.h>
 #include <support/ErrorStr.h>
 #include <support/UnitTestRegistration.h>
 #include <system/SystemPacketBuffer.h>
@@ -44,18 +45,13 @@
 #include <nlunit-test.h>
 
 namespace chip {
-static System::Layer gSystemLayer;
-static SecureSessionMgr gSessionManager;
-static Messaging::ExchangeManager gExchangeManager;
-static TransportMgr<Transport::UDP> gTransportManager;
-static secure_channel::MessageCounterManager gMessageCounterManager;
-static const Transport::AdminId gAdminId = 0;
-constexpr ClusterId kTestClusterId       = 6;
-constexpr EndpointId kTestEndpointId     = 1;
-constexpr chip::FieldId kTestFieldId1    = 1;
-constexpr chip::FieldId kTestFieldId2    = 2;
-constexpr uint8_t kTestFieldValue1       = 1;
-constexpr uint8_t kTestFieldValue2       = 2;
+static Stack<> gStack(chip::kTestDeviceNodeId);
+constexpr ClusterId kTestClusterId    = 6;
+constexpr EndpointId kTestEndpointId  = 1;
+constexpr chip::FieldId kTestFieldId1 = 1;
+constexpr chip::FieldId kTestFieldId2 = 2;
+constexpr uint8_t kTestFieldValue1    = 1;
+constexpr uint8_t kTestFieldValue2    = 2;
 
 namespace app {
 CHIP_ERROR ReadSingleClusterData(AttributePathParams & aAttributePathParams, TLV::TLVWriter & aWriter)
@@ -107,9 +103,9 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     AttributePathList::Builder attributePathListBuilder;
     AttributePath::Builder attributePathBuilder;
 
-    err = InteractionModelEngine::GetInstance()->Init(&gExchangeManager, nullptr);
+    err = InteractionModelEngine::GetInstance()->Init(&gStack.GetExchangeManager(), nullptr);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    Messaging::ExchangeContext * exchangeCtx = gExchangeManager.NewContext({ 0, 0, 0 }, nullptr);
+    Messaging::ExchangeContext * exchangeCtx = gStack.GetExchangeManager().NewContext({ 0, 0, 0 }, nullptr);
     TestExchangeDelegate delegate;
     exchangeCtx->SetDelegate(&delegate);
 
@@ -143,27 +139,7 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
 namespace {
 void InitializeChip(nlTestSuite * apSuite)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(chip::gAdminId, chip::kTestDeviceNodeId);
-
-    NL_TEST_ASSERT(apSuite, adminInfo != nullptr);
-
-    err = chip::Platform::MemoryInit();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    chip::gSystemLayer.Init(nullptr);
-
-    err = chip::gSessionManager.Init(chip::kTestDeviceNodeId, &chip::gSystemLayer, &chip::gTransportManager, &admins,
-                                     &chip::gMessageCounterManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = chip::gExchangeManager.Init(&chip::gSessionManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    err = chip::gMessageCounterManager.Init(&chip::gExchangeManager);
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, chip::gStack.Init() == CHIP_NO_ERROR);
 }
 
 // clang-format off

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -45,6 +45,7 @@
 #include <nlunit-test.h>
 
 namespace chip {
+
 static Stack<> gStack(chip::kTestDeviceNodeId);
 constexpr ClusterId kTestClusterId    = 6;
 constexpr EndpointId kTestEndpointId  = 1;

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -362,7 +362,7 @@ int main(int argc, char * argv[])
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    GetChipStack().Init();
+    GetChipStack().Init(chip::StackParameters());
 
     adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -42,6 +42,8 @@
 #include <transport/SecureSessionMgr.h>
 #include <transport/raw/UDP.h>
 
+const chip::NodeId gLocalDeviceId = chip::kTestDeviceNodeId;
+
 namespace chip {
 namespace app {
 
@@ -130,10 +132,7 @@ exit:
 } // namespace chip
 
 namespace {
-chip::TransportMgr<chip::Transport::UDP> gTransportManager;
-chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
 LivenessEventGenerator gLivenessGenerator;
 
 uint8_t gDebugEventBuffer[2048];
@@ -160,39 +159,25 @@ int main(int argc, char * argv[])
     chip::app::InteractionModelDelegate mockDelegate;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
     const chip::Transport::AdminId gAdminId = 0;
-    chip::Transport::AdminPairingTable admins;
-    chip::Transport::AdminPairingInfo * adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
+    chip::Transport::AdminPairingInfo * adminInfo;
 
+    GetChipStack().Init();
+
+    adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    InitializeChip();
-
-    err = gTransportManager.Init(
-        chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&GetChipStack().GetExchangeManager(), &mockDelegate);
     SuccessOrExit(err);
 
-    err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTransportManager, &admins,
-                               &gMessageCounterManager);
-    SuccessOrExit(err);
+    InitializeEventLogging(&GetChipStack().GetExchangeManager());
 
-    err = gExchangeManager.Init(&gSessionManager);
-    SuccessOrExit(err);
-
-    err = gMessageCounterManager.Init(&gExchangeManager);
-    SuccessOrExit(err);
-
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&gExchangeManager, &mockDelegate);
-    SuccessOrExit(err);
-
-    InitializeEventLogging(&gExchangeManager);
-
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
-                                     gAdminId);
+    err = GetChipStack().GetSecureSessionManager().NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
+                                                              chip::SecureSession::SessionRole::kResponder, gAdminId);
     SuccessOrExit(err);
 
     printf("Listening for IM requests...\n");
 
-    MockEventGenerator::GetInstance()->Init(&gExchangeManager, &gLivenessGenerator, 1000, true);
+    MockEventGenerator::GetInstance()->Init(&GetChipStack().GetExchangeManager(), &gLivenessGenerator, 1000, true);
 
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
 
@@ -207,7 +192,7 @@ exit:
 
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
 
-    ShutdownChip();
+    GetChipStack().Shutdown();
 
     return EXIT_SUCCESS;
 }

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -161,7 +161,7 @@ int main(int argc, char * argv[])
     const chip::Transport::AdminId gAdminId = 0;
     chip::Transport::AdminPairingInfo * adminInfo;
 
-    GetChipStack().Init();
+    GetChipStack().Init(chip::StackParameters());
 
     adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/app/tests/integration/common.cpp
+++ b/src/app/tests/integration/common.cpp
@@ -25,40 +25,15 @@
 #include <errno.h>
 
 #include <app/tests/integration/common.h>
+
 #include <core/CHIPCore.h>
 #include <core/CHIPTLVDebug.hpp>
-#include <platform/CHIPDeviceLayer.h>
 #include <support/ErrorStr.h>
 
-// The ExchangeManager global object.
-chip::Messaging::ExchangeManager gExchangeManager;
-
-void InitializeChip(void)
+chip::Stack<> & GetChipStack()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    printf("Init CHIP Stack\r\n");
-
-    // Initialize System memory and resources
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
-
-    // Initialize the CHIP stack.
-    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        printf("Failed to init CHIP Stack with err: %s\r\n", chip::ErrorStr(err));
-        exit(EXIT_FAILURE);
-    }
-}
-
-void ShutdownChip(void)
-{
-    gExchangeManager.Shutdown();
-    chip::DeviceLayer::PlatformMgr().Shutdown();
+    static chip::Stack<> gStack(gLocalDeviceId);
+    return gStack;
 }
 
 void TLVPrettyPrinter(const char * aFormat, ...)

--- a/src/app/tests/integration/common.h
+++ b/src/app/tests/integration/common.h
@@ -25,12 +25,10 @@
 #pragma once
 
 #include <app/util/basic-types.h>
-#include <messaging/ExchangeMgr.h>
+#include <stack/Stack.h>
 
 #define MAX_MESSAGE_SOURCE_STR_LENGTH (100)
 #define NETWORK_SLEEP_TIME_MSECS (100 * 1000)
-
-extern chip::Messaging::ExchangeManager gExchangeManager;
 
 constexpr chip::ClusterId kTestClusterId     = 6;
 constexpr chip::CommandId kTestCommandId     = 40;
@@ -41,6 +39,7 @@ constexpr chip::FieldId kTestFieldId2        = 2;
 constexpr uint8_t kTestFieldValue1           = 1;
 constexpr uint8_t kTestFieldValue2           = 2;
 constexpr chip::EventId kLivenessChangeEvent = 1;
-void InitializeChip(void);
-void ShutdownChip(void);
 void TLVPrettyPrinter(const char * aFormat, ...);
+
+extern const chip::NodeId gLocalDeviceId;
+chip::Stack<> & GetChipStack();

--- a/src/include/platform/internal/GenericPlatformManagerImpl.cpp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.cpp
@@ -94,6 +94,8 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     SuccessOrExit(err);
 #endif
 
+#if !defined(CHIP_CONFIG_ESP32_QEMU)
+    // TODO(#7076): esp_wifi_init is pretty unstable on esp32_qemu
     // Initialize the Connectivity Manager object.
     err = ConnectivityMgr().Init();
     if (err != CHIP_NO_ERROR)
@@ -101,6 +103,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
         ChipLogError(DeviceLayer, "Connectivity Manager initialization failed: %s", ErrorStr(err));
     }
     SuccessOrExit(err);
+#endif
 
     // Initialize the NFC Manager.
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -87,19 +87,6 @@
 #endif // CHIP_CONFIG_ERROR_TYPE
 
 /**
- *  @def CHIP_CONFIG_CHIP_IS_SINGLETON
- *
- *  @brief
- *    This defines whether chip is singleton. If chip is singleton, all
- *    pointers to chip components like SecureSessionMgr, ExchangeManager, etc
- *    can be omitted, which saves memory on small platforms. For some situation
- *    where there can be multiple chip instances, define this to 0.
- */
-#ifndef CHIP_CONFIG_CHIP_IS_SINGLETON
-#define CHIP_CONFIG_CHIP_IS_SINGLETON 1
-#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
-
-/**
  *  @def CHIP_CONFIG_NO_ERROR
  *
  *  @brief

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -87,6 +87,19 @@
 #endif // CHIP_CONFIG_ERROR_TYPE
 
 /**
+ *  @def CHIP_CONFIG_CHIP_IS_SINGLETON
+ *
+ *  @brief
+ *    This defines whether chip is singleton. If chip is singleton, all
+ *    pointers to chip components like SecureSessionMgr, ExchangeManager, etc
+ *    can be omitted, which saves memory on small platforms. For some situation
+ *    where there can be multiple chip instances, define this to 0.
+ */
+#ifndef CHIP_CONFIG_CHIP_IS_SINGLETON
+#define CHIP_CONFIG_CHIP_IS_SINGLETON 1
+#endif // CHIP_CONFIG_CHIP_IS_SINGLETON
+
+/**
  *  @def CHIP_CONFIG_NO_ERROR
  *
  *  @brief

--- a/src/messaging/tests/echo/common.cpp
+++ b/src/messaging/tests/echo/common.cpp
@@ -25,39 +25,12 @@
 #include <errno.h>
 
 #include "common.h"
+
 #include <core/CHIPCore.h>
-#include <platform/CHIPDeviceLayer.h>
-#include <protocols/secure_channel/MessageCounterManager.h>
-#include <support/ErrorStr.h>
+#include <stack/Stack.h>
 
-// The ExchangeManager global object.
-chip::Messaging::ExchangeManager gExchangeManager;
-chip::secure_channel::MessageCounterManager gMessageCounterManager;
-
-void InitializeChip(void)
+chip::Stack<TransportConfigurationWithTcp> & GetChipStack()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    printf("Init CHIP Stack\r\n");
-
-    // Initialize System memory and resources
-    err = chip::Platform::MemoryInit();
-    SuccessOrExit(err);
-
-    // Initialize the CHIP stack.
-    err = chip::DeviceLayer::PlatformMgr().InitChipStack();
-    SuccessOrExit(err);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        printf("Failed to init CHIP Stack with err: %s\r\n", chip::ErrorStr(err));
-        exit(EXIT_FAILURE);
-    }
-}
-
-void ShutdownChip(void)
-{
-    gExchangeManager.Shutdown();
-    chip::DeviceLayer::PlatformMgr().Shutdown();
+    static chip::Stack<TransportConfigurationWithTcp> gStack(gLocalDeviceId);
+    return gStack;
 }

--- a/src/messaging/tests/echo/common.h
+++ b/src/messaging/tests/echo/common.h
@@ -36,19 +36,26 @@ public:
     using transport =
         chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>, chip::Transport::UDP>;
 
-    CHIP_ERROR Init(chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
+    CHIP_ERROR Init(const chip::StackParameters & parameters, chip::Inet::InetLayer & inetLayer, chip::Ble::BleLayer * bleLayer)
     {
-        return mTransportManager.Init(
-            chip::Transport::TcpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4).SetListenPort(mPort),
-            chip::Transport::UdpListenParameters(&inetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4).SetListenPort(mPort));
+        return mTransportManager.Init(chip::Transport::TcpListenParameters(&inetLayer)
+                                          .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                                          .SetListenPort(parameters.GetListenPort()),
+                                      chip::Transport::UdpListenParameters(&inetLayer)
+                                          .SetAddressType(chip::Inet::kIPAddressType_IPv4)
+                                          .SetListenPort(parameters.GetListenPort()));
+    }
+
+    CHIP_ERROR Shutdown()
+    {
+        mTransportManager.Close();
+        return CHIP_NO_ERROR;
     }
 
     chip::TransportMgrBase & Get() { return mTransportManager; }
-    void SetListenPort(uint16_t port) { mPort = port; }
 
 private:
     transport mTransportManager;
-    uint16_t mPort = CHIP_PORT;
 };
 
 extern const chip::NodeId gLocalDeviceId;

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -225,8 +225,7 @@ int main(int argc, char * argv[])
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    GetChipStack().GetTransportConfig().SetListenPort(ECHO_CLIENT_PORT);
-    GetChipStack().Init();
+    GetChipStack().Init(chip::StackParameters().SetListenPort(ECHO_CLIENT_PORT));
 
     adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -45,6 +45,8 @@
 
 #define ECHO_CLIENT_PORT (CHIP_PORT + 1)
 
+const chip::NodeId gLocalDeviceId = chip::kTestControllerNodeId;
+
 namespace {
 
 // Max value for the number of EchoRequests sent.
@@ -58,9 +60,6 @@ constexpr chip::Transport::AdminId gAdminId = 0;
 // The EchoClient object.
 chip::Protocols::Echo::EchoClient gEchoClient;
 
-chip::TransportMgr<chip::Transport::UDP> gUDPManager;
-chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecureSessionMgr gSessionManager;
 chip::Inet::IPAddress gDestAddr;
 
 // The last time a CHIP Echo was attempted to be sent.
@@ -137,8 +136,8 @@ CHIP_ERROR EstablishSecureSession()
     }
 
     // Attempt to connect to the peer.
-    err = gSessionManager.NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
-                                     chip::SecureSession::SessionRole::kInitiator, gAdminId);
+    err = GetChipStack().GetSecureSessionManager().NewPairing(peerAddr, chip::kTestDeviceNodeId, testSecurePairingSecret,
+                                                              chip::SecureSession::SessionRole::kInitiator, gAdminId);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -201,7 +200,6 @@ int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    chip::Transport::AdminPairingTable admins;
     chip::Transport::AdminPairingInfo * adminInfo = nullptr;
 
     if (argc <= 1)
@@ -227,48 +225,20 @@ int main(int argc, char * argv[])
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    InitializeChip();
+    GetChipStack().GetTransportConfig().SetListenPort(ECHO_CLIENT_PORT);
+    GetChipStack().Init();
 
-    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
-
-    adminInfo = admins.AssignAdminId(gAdminId, chip::kTestControllerNodeId);
+    adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    if (gUseTCP)
-    {
-        err = gTCPManager.Init(chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer)
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv4)
-                                   .SetListenPort(ECHO_CLIENT_PORT));
-        SuccessOrExit(err);
-
-        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &admins,
-                                   &gMessageCounterManager);
-        SuccessOrExit(err);
-    }
-    else
-    {
-        err = gUDPManager.Init(chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer)
-                                   .SetAddressType(chip::Inet::kIPAddressType_IPv4)
-                                   .SetListenPort(ECHO_CLIENT_PORT));
-        SuccessOrExit(err);
-
-        err = gSessionManager.Init(chip::kTestControllerNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &admins,
-                                   &gMessageCounterManager);
-        SuccessOrExit(err);
-    }
-
-    err = gExchangeManager.Init(&gSessionManager);
-    SuccessOrExit(err);
-
-    err = gMessageCounterManager.Init(&gExchangeManager);
-    SuccessOrExit(err);
+    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
 
     // Start the CHIP connection to the CHIP echo responder.
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
     // TODO: temprary create a SecureSessionHandle from node id to unblock end-to-end test. Complete solution is tracked in PR:4451
-    err = gEchoClient.Init(&gExchangeManager, { chip::kTestDeviceNodeId, 0, gAdminId });
+    err = gEchoClient.Init(&GetChipStack().GetExchangeManager(), { chip::kTestDeviceNodeId, 0, gAdminId });
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.
@@ -278,7 +248,7 @@ int main(int argc, char * argv[])
 
     gEchoClient.Shutdown();
 
-    ShutdownChip();
+    GetChipStack().Shutdown();
 
 exit:
     if ((err != CHIP_NO_ERROR) || (gEchoRespCount != kMaxEchoCount))

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -76,7 +76,7 @@ int main(int argc, char * argv[])
         disableEcho = true;
     }
 
-    GetChipStack().Init();
+    GetChipStack().Init(chip::StackParameters());
 
     adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -39,13 +39,12 @@
 #include <transport/raw/TCP.h>
 #include <transport/raw/UDP.h>
 
+const chip::NodeId gLocalDeviceId = chip::kTestDeviceNodeId;
+
 namespace {
 
 // The EchoServer object.
 chip::Protocols::Echo::EchoServer gEchoServer;
-chip::TransportMgr<chip::Transport::UDP> gUDPManager;
-chip::TransportMgr<chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>> gTCPManager;
-chip::SecureSessionMgr gSessionManager;
 chip::SecurePairingUsingTestSecret gTestPairing;
 
 // Callback handler when a CHIP EchoRequest is received.
@@ -60,10 +59,8 @@ int main(int argc, char * argv[])
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Optional<chip::Transport::PeerAddress> peer(chip::Transport::Type::kUndefined);
-    bool useTCP      = false;
     bool disableEcho = false;
 
-    chip::Transport::AdminPairingTable admins;
     chip::Transport::AdminPairingInfo * adminInfo = nullptr;
 
     const chip::Transport::AdminId gAdminId = 0;
@@ -74,56 +71,24 @@ int main(int argc, char * argv[])
         ExitNow(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
-    if ((argc == 2) && (strcmp(argv[1], "--tcp") == 0))
-    {
-        useTCP = true;
-    }
-
     if ((argc == 2) && (strcmp(argv[1], "--disable") == 0))
     {
         disableEcho = true;
     }
 
-    InitializeChip();
+    GetChipStack().Init();
 
-    adminInfo = admins.AssignAdminId(gAdminId, chip::kTestDeviceNodeId);
+    adminInfo = GetChipStack().GetAdmins().AssignAdminId(gAdminId, gLocalDeviceId);
     VerifyOrExit(adminInfo != nullptr, err = CHIP_ERROR_NO_MEMORY);
-
-    if (useTCP)
-    {
-        err = gTCPManager.Init(
-            chip::Transport::TcpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
-        SuccessOrExit(err);
-
-        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gTCPManager, &admins,
-                                   &gMessageCounterManager);
-        SuccessOrExit(err);
-    }
-    else
-    {
-        err = gUDPManager.Init(
-            chip::Transport::UdpListenParameters(&chip::DeviceLayer::InetLayer).SetAddressType(chip::Inet::kIPAddressType_IPv4));
-        SuccessOrExit(err);
-
-        err = gSessionManager.Init(chip::kTestDeviceNodeId, &chip::DeviceLayer::SystemLayer, &gUDPManager, &admins,
-                                   &gMessageCounterManager);
-        SuccessOrExit(err);
-    }
-
-    err = gExchangeManager.Init(&gSessionManager);
-    SuccessOrExit(err);
-
-    err = gMessageCounterManager.Init(&gExchangeManager);
-    SuccessOrExit(err);
 
     if (!disableEcho)
     {
-        err = gEchoServer.Init(&gExchangeManager);
+        err = gEchoServer.Init(&GetChipStack().GetExchangeManager());
         SuccessOrExit(err);
     }
 
-    err = gSessionManager.NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing, chip::SecureSession::SessionRole::kResponder,
-                                     gAdminId);
+    err = GetChipStack().GetSecureSessionManager().NewPairing(peer, chip::kTestControllerNodeId, &gTestPairing,
+                                                              chip::SecureSession::SessionRole::kResponder, gAdminId);
     SuccessOrExit(err);
 
     if (!disableEcho)
@@ -148,7 +113,7 @@ exit:
         gEchoServer.Shutdown();
     }
 
-    ShutdownChip();
+    GetChipStack().Shutdown();
 
     return EXIT_SUCCESS;
 }

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -55,10 +55,16 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
-    CHIP_ERROR err;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     wifi_init_config_t cfg;
     uint8_t ap_mac[6];
     wifi_mode_t mode;
+
+    if (mInitialized)
+    {
+        return CHIP_NO_ERROR;
+    }
+    mInitialized = true;
 
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();
@@ -104,6 +110,11 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
 exit:
     return err;
+}
+
+CHIP_ERROR PlatformManagerImpl::_Shutdown(void)
+{
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR PlatformManagerImpl::InitLwIPCoreLock(void)

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -56,9 +56,11 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
+#if !defined(CHIP_CONFIG_ESP32_QEMU)
     wifi_init_config_t cfg;
     uint8_t ap_mac[6];
     wifi_mode_t mode;
+#endif
 
     if (mInitialized)
     {
@@ -85,6 +87,8 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
     SuccessOrExit(err);
 
+#if !defined(CHIP_CONFIG_ESP32_QEMU)
+    // TODO(#7076): esp_wifi_init is pretty unstable on esp32_qemu
     // Initialize the ESP WiFi layer.
     cfg = WIFI_INIT_CONFIG_DEFAULT();
     err = esp_wifi_init(&cfg);
@@ -99,6 +103,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
         err = esp_wifi_set_mac(ESP_IF_WIFI_AP, ap_mac);
         SuccessOrExit(err);
     }
+#endif
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -55,6 +55,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    CHIP_ERROR _Shutdown(void);
 
     // ===== Members for internal use by the following friends.
 
@@ -62,6 +63,7 @@ private:
     friend PlatformManagerImpl & PlatformMgrImpl(void);
 
     static PlatformManagerImpl sInstance;
+    bool mInitialized = false;
 };
 
 /**

--- a/src/stack/BUILD.gn
+++ b/src/stack/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/common_flags.gni")
+
+static_library("stack") {
+  sources = [
+    "Stack.h",
+    "Traits.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/mdns",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
+    "${chip_root}/src/platform",
+    "${chip_root}/src/setup_payload",
+    "${chip_root}/src/transport",
+  ]
+}

--- a/src/stack/Stack.h
+++ b/src/stack/Stack.h
@@ -221,10 +221,10 @@ public:
     // TODO(#6931): CHIP initialization should be posted to chip thread, in order to avoid racing problems
     CHIP_ERROR Init(const StackParameters & parameters)
     {
-        ReturnErrorOnFailure(chip::Platform::MemoryInit());
+        ReturnErrorOnFailure(Platform::MemoryInit());
 #if CONFIG_DEVICE_LAYER
         // Initialize the CHIP stack.
-        ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgr().InitChipStack());
+        ReturnErrorOnFailure(DeviceLayer::PlatformMgr().InitChipStack());
 #endif
         ReturnErrorOnFailure(mSystemLayer.Init(parameters));
         ReturnErrorOnFailure(mInetLayer.Init(parameters, GetSystemLayer()));

--- a/src/stack/Stack.h
+++ b/src/stack/Stack.h
@@ -1,0 +1,264 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <stack/Stack.h>
+#include <stack/Traits.h>
+
+#include <messaging/ExchangeMgr.h>
+#include <protocols/secure_channel/MessageCounterManager.h>
+#include <transport/SecureSessionMgr.h>
+#include <transport/TransportMgr.h>
+#include <transport/raw/UDP.h>
+
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/PlatformManager.h>
+#endif
+
+namespace chip {
+
+/* ========================== SystemLayer Configuration ========================== */
+struct SystemLayerConfiguration
+{
+};
+template <typename T>
+struct IsSystemLayerConfiguration : std::is_base_of<SystemLayerConfiguration, T>
+{
+};
+
+#if CONFIG_DEVICE_LAYER
+class DefaultSystemLayer : SystemLayerConfiguration
+{
+public:
+    CHIP_ERROR Init() { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    System::Layer & Get() { return DeviceLayer::SystemLayer; }
+};
+#else
+class DefaultSystemLayer : SystemLayerConfiguration
+{
+public:
+    CHIP_ERROR Init() { return mSystemLayer.Init(nullptr); }
+
+    CHIP_ERROR Shutdown() { return mSystemLayer.Shutdown(); }
+
+    System::Layer & Get() { return mSystemLayer; }
+
+private:
+    System::Layer mSystemLayer;
+};
+#endif // CONFIG_DEVICE_LAYER
+
+/* ========================== InetLayer Configuration ========================== */
+struct InetLayerConfiguration
+{
+};
+template <typename T>
+struct IsInetLayerConfiguration : std::is_base_of<InetLayerConfiguration, T>
+{
+};
+
+#if CONFIG_DEVICE_LAYER
+class DefaultInetLayer : InetLayerConfiguration
+{
+public:
+    CHIP_ERROR Init(System::Layer & aSystemLayer) { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    Inet::InetLayer & Get() { return DeviceLayer::InetLayer; }
+};
+#else
+class DefaultInetLayer : InetLayerConfiguration
+{
+public:
+    CHIP_ERROR Init(System::Layer & aSystemLayer) { return mInetLayer.Init(aSystemLayer, nullptr); }
+
+    CHIP_ERROR Shutdown() { return mInetLayer.Shutdown(); }
+
+    Inet::InetLayer & Get() { return mInetLayer; }
+
+private:
+    Inet::InetLayer mInetLayer;
+};
+#endif // CONFIG_DEVICE_LAYER
+
+/* ========================== Storage Configuration ========================== */
+struct StorageConfiguration
+{
+};
+template <typename T>
+struct IsStorageConfiguration : std::is_base_of<StorageConfiguration, T>
+{
+};
+
+class DefaultStorage : StorageConfiguration
+{
+public:
+    CHIP_ERROR Init() { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+
+    PersistentStorageDelegate * Get() { return nullptr; }
+};
+
+/* ========================== BleLayer Configuration ========================== */
+struct BleLayerConfiguration
+{
+};
+template <typename T>
+struct IsBleLayerConfiguration : std::is_base_of<BleLayerConfiguration, T>
+{
+};
+
+class DefaultBleLayer : BleLayerConfiguration
+{
+public:
+    template <typename T>
+    CHIP_ERROR Init(T * stack)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    Ble::BleLayer * Get() { return nullptr; }
+};
+
+/* ========================== Transport Configuration ========================== */
+struct TransportConfiguration
+{
+};
+template <typename T>
+struct IsTransportConfiguration : std::is_base_of<TransportConfiguration, T>
+{
+};
+
+class DefaultTransport : TransportConfiguration
+{
+public:
+    using transport = TransportMgr<
+#if INET_CONFIG_ENABLE_IPV4
+        Transport::UDP, /* IPv4 */
+#endif
+        Transport::UDP>;
+
+    CHIP_ERROR Init(Inet::InetLayer & inetLayer, Ble::BleLayer * bleLayer)
+    {
+        return mTransportManager.Init(
+#if INET_CONFIG_ENABLE_IPV4
+            Transport::UdpListenParameters(&inetLayer).SetAddressType(Inet::kIPAddressType_IPv4).SetListenPort(mPort),
+#endif
+            Transport::UdpListenParameters(&inetLayer).SetAddressType(Inet::kIPAddressType_IPv6).SetListenPort(mPort));
+    }
+
+    TransportMgrBase & Get() { return mTransportManager; }
+    void SetListenPort(uint16_t port) { mPort = port; }
+
+private:
+    transport mTransportManager;
+    uint16_t mPort = CHIP_PORT;
+};
+
+/* ========================== Stack ========================== */
+template <typename... Configurations>
+class Stack
+{
+private:
+    using SystemLayerConfig =
+        typename first_if_any_or_default<IsSystemLayerConfiguration, DefaultSystemLayer, Configurations...>::type;
+    using InetLayerConfig = typename first_if_any_or_default<IsInetLayerConfiguration, DefaultInetLayer, Configurations...>::type;
+    using StorageConfig   = typename first_if_any_or_default<IsStorageConfiguration, DefaultStorage, Configurations...>::type;
+    using BleLayerConfig  = typename first_if_any_or_default<IsBleLayerConfiguration, DefaultBleLayer, Configurations...>::type;
+    using TransportConfig = typename first_if_any_or_default<IsTransportConfiguration, DefaultTransport, Configurations...>::type;
+
+public:
+    Stack(NodeId localDeviceId) : mLocalDeviceId(localDeviceId) {}
+    virtual ~Stack() {}
+
+    CHIP_ERROR Init()
+    {
+        ReturnErrorOnFailure(chip::Platform::MemoryInit());
+#if CONFIG_DEVICE_LAYER
+        // Initialize the CHIP stack.
+        ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgr().InitChipStack());
+#endif
+        ReturnErrorOnFailure(mSystemLayer.Init());
+        ReturnErrorOnFailure(mInetLayer.Init(GetSystemLayer()));
+        ReturnErrorOnFailure(mStorage.Init());
+        ReturnErrorOnFailure(mBleLayer.Init(this));
+        ReturnErrorOnFailure(mTransport.Init(GetInetLayer(), GetBleLayer()));
+        auto * storage = mStorage.Get();
+        if (storage != nullptr)
+        {
+            ReturnErrorOnFailure(mAdmins.Init(storage));
+        }
+        ReturnErrorOnFailure(
+            mSessionManager.Init(mLocalDeviceId, &GetSystemLayer(), &GetTransportManager(), &mAdmins, &mMessageCounterManager));
+        ReturnErrorOnFailure(mExchangeManager.Init(&mSessionManager));
+        ReturnErrorOnFailure(mMessageCounterManager.Init(&mExchangeManager));
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Shutdown()
+    {
+        mMessageCounterManager.Shutdown();
+        mExchangeManager.Shutdown();
+        mSessionManager.Shutdown();
+
+        Ble::BleLayer * ble = GetBleLayer();
+        if (ble != nullptr)
+            ble->Shutdown();
+        mInetLayer.Shutdown();
+        mSystemLayer.Shutdown();
+#if CONFIG_DEVICE_LAYER
+        ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
+#endif // CONFIG_DEVICE_LAYER
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ResetTransport() { return mTransport.Init(mInetLayer.Get()); }
+
+    TransportConfig & GetTransportConfig() { return mTransport; }
+
+    NodeId GetLocalNodeId() { return mLocalDeviceId; }
+    System::Layer & GetSystemLayer() { return mSystemLayer.Get(); }
+    Inet::InetLayer & GetInetLayer() { return mInetLayer.Get(); }
+    BleLayerConfig & GetBleLayerConfig() { return mBleLayer; }
+    Ble::BleLayer * GetBleLayer() { return mBleLayer.Get(); }
+    PersistentStorageDelegate * GetStorage() { return mStorage.Get(); }
+    TransportMgrBase & GetTransportManager() { return mTransport.Get(); }
+    SecureSessionMgr & GetSecureSessionManager() { return mSessionManager; }
+    Transport::AdminPairingTable & GetAdmins() { return mAdmins; }
+    Messaging::ExchangeManager & GetExchangeManager() { return mExchangeManager; }
+
+private:
+    NodeId mLocalDeviceId;
+
+    SystemLayerConfig mSystemLayer;
+    InetLayerConfig mInetLayer;
+    StorageConfig mStorage;
+    BleLayerConfig mBleLayer;
+
+    Transport::AdminPairingTable mAdmins;
+
+    TransportConfig mTransport;
+    SecureSessionMgr mSessionManager;
+    Messaging::ExchangeManager mExchangeManager;
+    secure_channel::MessageCounterManager mMessageCounterManager;
+};
+
+} // namespace chip

--- a/src/stack/Traits.h
+++ b/src/stack/Traits.h
@@ -27,8 +27,7 @@ struct first_if_any_or_default;
 template <template <typename> class Cond, typename Default>
 struct first_if_any_or_default<Cond, Default>
 {
-    using type                  = Default;
-    static constexpr bool found = false;
+    using type = Default;
 };
 
 template <template <typename> class Cond, typename Default, typename T, typename... Ts>
@@ -38,18 +37,7 @@ private:
     using next = first_if_any_or_default<Cond, Default, Ts...>;
 
 public:
-    using type                  = typename std::conditional<Cond<T>::value, T, typename next::type>::type;
-    static constexpr bool found = Cond<T>::value || next::found;
-};
-
-template <class, template <class, class...> class>
-struct is_instance : public std::false_type
-{
-};
-
-template <class... Ts, template <class, class...> class U>
-struct is_instance<U<Ts...>, U> : public std::true_type
-{
+    using type = typename std::conditional<Cond<T>::value, T, typename next::type>::type;
 };
 
 } // namespace chip

--- a/src/stack/Traits.h
+++ b/src/stack/Traits.h
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace chip {
+
+template <template <typename> class Cond, typename Default, typename... Ts>
+struct first_if_any_or_default;
+
+template <template <typename> class Cond, typename Default>
+struct first_if_any_or_default<Cond, Default>
+{
+    using type                  = Default;
+    static constexpr bool found = false;
+};
+
+template <template <typename> class Cond, typename Default, typename T, typename... Ts>
+struct first_if_any_or_default<Cond, Default, T, Ts...>
+{
+private:
+    using next = first_if_any_or_default<Cond, Default, Ts...>;
+
+public:
+    using type                  = typename std::conditional<Cond<T>::value, T, typename next::type>::type;
+    static constexpr bool found = Cond<T>::value || next::found;
+};
+
+template <class, template <class, class...> class>
+struct is_instance : public std::false_type
+{
+};
+
+template <class... Ts, template <class, class...> class U>
+struct is_instance<U<Ts...>, U> : public std::true_type
+{
+};
+
+} // namespace chip

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -44,6 +44,10 @@
 #include <lwip/tcpip.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
+#if CONFIG_DEVICE_LAYER
+#include <platform/CHIPDeviceLayer.h>
+#endif
+
 #include <nlunit-test.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
@@ -1962,10 +1966,16 @@ int TestSystemPacketBuffer(void)
     };
     // clang-format on
 
-    // Run test suit againt one context.
+#if CONFIG_DEVICE_LAYER
+    NL_TEST_ASSERT(&theSuite, chip::DeviceLayer::PlatformMgr().InitChipStack() == CHIP_NO_ERROR);
+#endif // CONFIG_DEVICE_LAYER
     nlTestRunner(&theSuite, &sContext);
+    int result = nlTestRunnerStats(&theSuite);
+#if CONFIG_DEVICE_LAYER
+    NL_TEST_ASSERT(&theSuite, chip::DeviceLayer::PlatformMgr().Shutdown() == CHIP_NO_ERROR);
+#endif // CONFIG_DEVICE_LAYER
 
-    return (nlTestRunnerStats(&theSuite));
+    return result;
 }
 
 CHIP_REGISTER_TEST_SUITE(TestSystemPacketBuffer)

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -38,13 +38,6 @@ using namespace ::chip::DeviceLayer;
 
 const char * TAG = "CHIP-tests";
 
-static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
-{
-    esp_fill_random(output, len);
-    *olen = len;
-    return 0;
-}
-
 static void tester_task(void * pvParameters)
 {
     ESP_LOGI(TAG, "Starting CHIP tests!");
@@ -78,52 +71,6 @@ extern "C" void app_main()
     if (err != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "nvs_flash_init() failed: %s", ErrorStr(err));
-        exit(err);
-    }
-
-    // Initialize the LwIP core lock.  This must be done before the ESP
-    // tcpip_adapter layer is initialized.
-    err = PlatformMgrImpl().InitLwIPCoreLock();
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "PlatformMgr().InitLocks() failed: %s", ErrorStr(err));
-        exit(err);
-    }
-
-    err = esp_netif_init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_netif_init() failed: %s", ErrorStr(err));
-        exit(err);
-    }
-
-    // Arrange for the ESP event loop to deliver events into the CHIP Device layer.
-    err = esp_event_loop_create_default();
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_event_loop_create_default() failed: %s", ErrorStr(err));
-        exit(err);
-    }
-    esp_netif_create_default_wifi_ap();
-    esp_netif_create_default_wifi_sta();
-
-    err = esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_event_handler_register() failed for WIFI_EVENT: %s", ErrorStr(err));
-        exit(err);
-    }
-    err = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "esp_event_handler_register() failed for IP_EVENT: %s", ErrorStr(err));
-        exit(err);
-    }
-
-    err = Crypto::add_entropy_source(app_entropy_source, NULL, 16);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "add_entropy_source() failed: %s", ErrorStr(err));
         exit(err);
     }
 


### PR DESCRIPTION
#### Problem
CHIP stack initialization and shutdown are spread around. There are lots of duplicated code in all test cases and applications.

#### Change overview
This PR add a centralized class to initialize and shutdown all chip stack singletons.

#### Testing
This PR is a refactor, unit tests are used for verify.

I have manually tested echo requester/responder and im requester/responder. All verified are working.