### PR TITLE
[lighting-app] Fix lighting-app after changing endpoint ID

### DIFF
--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -526,7 +526,7 @@ void AppTask::UpdateClusterState(void)
     uint8_t newValue = LightMgr().IsLightOn();
 
     // write the new on/off value
-    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    EmberAfStatus status = emberAfWriteAttribute(0, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {

--- a/examples/lighting-app/k32w/main/AppTask.cpp
+++ b/examples/lighting-app/k32w/main/AppTask.cpp
@@ -616,7 +616,7 @@ void AppTask::UpdateClusterState(void)
     uint8_t newValue = !LightingMgr().IsTurnedOff();
 
     // write the new on/off value
-    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    EmberAfStatus status = emberAfWriteAttribute(0, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {

--- a/examples/lighting-app/lighting-common/gen/af-gen-event.h
+++ b/examples/lighting-app/lighting-common/gen/af-gen-event.h
@@ -53,7 +53,7 @@
     void emberAfLevelControlClusterServerTickCallbackWrapperFunction1(void)                                                        \
     {                                                                                                                              \
         clusterTickWrapper(&emberAfLevelControlClusterServerTickCallbackControl1, emberAfLevelControlClusterServerTickCallback,    \
-                           1);                                                                                                     \
+                           0);                                                                                                     \
     }
 
 // EmberEventData structs used to populate the EmberEventData table
@@ -67,6 +67,6 @@
 
 // EmberAfEventContext structs used to populate the EmberAfEventContext table
 #define EMBER_AF_GENERATED_EVENT_CONTEXT                                                                                           \
-    { 0x1, 0x8, false, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP, &emberAfLevelControlClusterServerTickCallbackControl1 },
+    { 0x0, 0x8, false, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP, &emberAfLevelControlClusterServerTickCallbackControl1 },
 
 #endif // __AF_GEN_EVENT__

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -541,7 +541,7 @@ void AppTask::UpdateClusterState()
     uint8_t onoff = LightingMgr().IsTurnedOn();
 
     // write the new on/off value
-    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &onoff,
+    EmberAfStatus status = emberAfWriteAttribute(0, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &onoff,
                                                  ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -550,7 +550,7 @@ void AppTask::UpdateClusterState()
 
     uint8_t level = LightingMgr().GetLevel();
 
-    status = emberAfWriteAttribute(1, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
+    status = emberAfWriteAttribute(0, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER, &level,
                                    ZCL_DATA8_ATTRIBUTE_TYPE);
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -47,7 +47,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
     else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
     {
-        if (attributeId != ZCL_MOVE_TO_LEVEL_COMMAND_ID)
+        if (attributeId != ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
         {
             ChipLogProgress(Zcl, "Unknown attribute ID: %d", attributeId);
             return;

--- a/examples/lighting-app/qpg6100/src/AppTask.cpp
+++ b/examples/lighting-app/qpg6100/src/AppTask.cpp
@@ -434,7 +434,7 @@ void AppTask::UpdateClusterState(void)
 {
     uint8_t newValue = !LightingMgr().IsTurnedOn();
     // write the new on/off value
-    EmberAfStatus status = emberAfWriteAttribute(1, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    EmberAfStatus status = emberAfWriteAttribute(0, ZCL_ON_OFF_CLUSTER_ID, ZCL_ON_OFF_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                                  (uint8_t *) &newValue, ZCL_BOOLEAN_ATTRIBUTE_TYPE);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
@@ -444,7 +444,7 @@ void AppTask::UpdateClusterState(void)
     ChipLogProgress(NotSpecified, "UpdateClusterState");
     newValue = LightingMgr().GetLevel();
     // TODO understand well enough to implement the level cluster ZCL_CURRENT_LEVEL_ATTRIBUTE_ID
-    status = emberAfWriteAttribute(1, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
+    status = emberAfWriteAttribute(0, ZCL_LEVEL_CONTROL_CLUSTER_ID, ZCL_CURRENT_LEVEL_ATTRIBUTE_ID, CLUSTER_MASK_SERVER,
                                    (uint8_t *) &newValue, ZCL_DATA8_ATTRIBUTE_TYPE);
 
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg6100/src/ZclCallbacks.cpp
@@ -48,7 +48,7 @@ void emberAfPostAttributeChangeCallback(EndpointId endpoint, ClusterId clusterId
     }
     else if (clusterId == ZCL_LEVEL_CONTROL_CLUSTER_ID)
     {
-        if (attributeId != ZCL_MOVE_TO_LEVEL_COMMAND_ID)
+        if (attributeId != ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
         {
             ChipLogProgress(Zcl, "Unknown attribute ID: %d", attributeId);
             return;


### PR DESCRIPTION
 #### Problem
A few changes were missed in #6487 breaking some of the
lighting-app features:
* initialization of clusters no longer works
* events no longer work as af-gen-event.h is still not
  auto-generated so endpoint ID must be manually changed;
  as a result, setting the lighting brightness stopped
  working correctly.

 #### Summary of Changes
Change endpoint ID from 1 to 0 in lighting-app files which are not auto-generated.

I've tested the change manually using Python CHIP Controller and nRF Connect lighting-app by performing the full commissioning over BLE and sending `zcl OnOff Toggle` and `zcl LevelControl MoveToLevel` commands.