### PR TITLE
Have `scripts/tools/memory` use pyelftools by default.

### DIFF
--- a/scripts/tools/memory/memdf/collect.py
+++ b/scripts/tools/memory/memdf/collect.py
@@ -65,7 +65,7 @@ CONFIG: ConfigDescription = {
         'help': 'Method of input processing',
         'metavar': 'METHOD',
         'choices': ['elftools', 'readelf', 'bloaty', 'csv', 'tsv', 'su'],
-        'default': 'readelf',
+        'default': 'elftools',
         'argparse': {
             'alias': ['-f'],
         },


### PR DESCRIPTION
#### Problem

Scripts under scripts/tools/memory can collect information from images
in different ways. The default has been to use `readelf` because it's
fastest. However, `readelf` is not available by default on Mac OS.

#### Summary of Changes

Use `elftools` as the default collection method. (The previous default
method can be used by giving a `--collect-method readelf` option.)

#### Testing

Ran each scripts in `scripts/tools/memory/*.py` in an environment with
no working `readelf`.
