### PR TITLE
Remove some of generated binaries as artifacts.

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -77,8 +77,6 @@ jobs:
                   path: |
                       out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out
                       out/lock_app_debug/BRD4161A/chip-efr32-lock-example.out.map
-                      out/lighting_app_debug/BRD4161A/chip-efr32-lighting-example.out
-                      out/lighting_app_debug/BRD4161A/chip-efr32-lighting-example.out.map
                       out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out
                       out/lighting_app_debug_rpc/BRD4161A/chip-efr32-lighting-example.out.map
             - name: Remove third_party binaries for CodeQL Analysis

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -66,8 +66,6 @@ jobs:
                   path: |
                       out/lock_app_debug/chip-k32w061-lock-example.out
                       out/lock_app_debug/chip-k32w061-lock-example.out.map
-                      out/lighting_app_debug/chip-k32w061-light-example
-                      out/lighting_app_debug/chip-k32w061-light-example.map
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
 #            - name: Perform CodeQL Analysis

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -82,14 +82,6 @@ jobs:
                   path: |
                       out/all_clusters_debug/all-clusters-server
                       out/all_clusters_debug/all-clusters-server.map
-                      out/bridge_debug/bridge-app-server
-                      out/bridge_debug/bridge-app-server.map
-                      out/chip_tool_debug/chip-tool
-                      out/chip_tool_debug/chip-tool.map
-                      out/lighting_app_debug_rpc/chip-lighting-app
-                      out/lighting_app_debug_rpc/chip-lighting-app.map
-                      out/shell_debug/chip-shell
-                      out/shell_debug/chip-shell.map
             - name: Remove third_party binaries for CodeQL Analysis
               run: find out -type d -name "third_party" -exec rm -rf {} +
             - name: Remove dbus binaries for CodeQL Analysis

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -72,8 +72,6 @@ jobs:
                   mkdir -p /tmp/output_binaries/$BUILD_TYPE-build
                   cp examples/lock-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
                       /tmp/output_binaries/$BUILD_TYPE-build/chip-lock.elf
-                  cp examples/lighting-app/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
-                      /tmp/output_binaries/$BUILD_TYPE-build/chip-lighting.elf
                   cp examples/shell/nrfconnect/build/nrf52840dk_nrf52840/zephyr/zephyr.elf \
                       /tmp/output_binaries/$BUILD_TYPE-build/chip-shell.elf
             - name: Binary artifact suffix

--- a/.github/workflows/examples-qpg6100.yaml
+++ b/.github/workflows/examples-qpg6100.yaml
@@ -63,8 +63,6 @@ jobs:
                       ${{ env.BUILD_TYPE }}-example-build-${{
                       steps.outsuffix.outputs.value }}
                   path: |
-                      out/lock_app_debug/chip-qpg6100-lock-example.out
-                      out/lock_app_debug/chip-qpg6100-lock-example.out.map
                       out/lighting_app_debug/chip-qpg6100-lighting-example.out
                       out/lighting_app_debug/chip-qpg6100-lighting-example.out.map
             - name: Remove third_party binaries for CodeQL Analysis


### PR DESCRIPTION
#### Problem
Github enforces a artifact storage quotas, we only require artifacts for
some size deltas and there is little incremental benefit to adding more
applications for similar platforms.

Tried to only keep one example application as an artifact.

#### Summary of Changes
Remove some of the artifact uploads.

#### Testing:

github workflow, not tested however expect github execution to have information about what was uploaded and detect success/failure.