### PR TITLE
SecureSessionMgr::SecureMessageDispatch should not assume GetDestinationNodeId has value

### DIFF
--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -394,7 +394,16 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
                 "Secure transport received message, but destination node ID (%llu) doesn't match our node ID (%llu), discarding",
                 packetHeader.GetDestinationNodeId().Value(), admin->GetNodeId()));
     }
-    ChipLogError(Inet, "Secure transport received message destined to node ID (%llu)", packetHeader.GetDestinationNodeId().Value());
+
+    if (packetHeader.GetDestinationNodeId().HasValue())
+    {
+        ChipLogError(Inet, "Secure transport received message destined to node ID (%llu)", packetHeader.GetDestinationNodeId().Value());
+    }
+    else
+    {
+        ChipLogError(Inet, "Secure transport received message without node ID with key ID (%d)", packetHeader.GetEncryptionKeyID());
+    }
+
     mPeerConnections.MarkConnectionActive(state);
 
     // Decode the message

--- a/src/transport/SecureSessionMgr.cpp
+++ b/src/transport/SecureSessionMgr.cpp
@@ -397,7 +397,8 @@ void SecureSessionMgr::SecureMessageDispatch(const PacketHeader & packetHeader, 
 
     if (packetHeader.GetDestinationNodeId().HasValue())
     {
-        ChipLogError(Inet, "Secure transport received message destined to node ID (%llu)", packetHeader.GetDestinationNodeId().Value());
+        ChipLogError(Inet, "Secure transport received message destined to node ID (%llu)",
+                     packetHeader.GetDestinationNodeId().Value());
     }
     else
     {

--- a/src/transport/tests/TestSecureSessionMgr.cpp
+++ b/src/transport/tests/TestSecureSessionMgr.cpp
@@ -434,6 +434,21 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     /* -------------------------------------------------------------------------------------------*/
     state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
+    // Change Source Node ID
+    EncryptedPacketBufferHandle noDstNodeIdMsg = msgBuf.CloneData();
+    NL_TEST_ASSERT(inSuite, noDstNodeIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);
+
+    packetHeader.ClearDestinationNodeId();
+    NL_TEST_ASSERT(inSuite, noDstNodeIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
+
+    err = secureSessionMgr.SendEncryptedMessage(localToRemoteSession, std::move(noDstNodeIdMsg), nullptr);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
+
+    /* -------------------------------------------------------------------------------------------*/
+    state->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
+
     // Change Message ID
     EncryptedPacketBufferHandle badMessageIdMsg = msgBuf.CloneData();
     NL_TEST_ASSERT(inSuite, badMessageIdMsg.ExtractPacketHeader(packetHeader) == CHIP_NO_ERROR);


### PR DESCRIPTION
 #### Problem
Receiving a packet without destination node id in packet header will cause a crash

 #### How did you test this
Add a test-case which will fail without this change.

This is a small change, using given test-case is sufficient.