### PR TITLE
Use MemoryCalloc instead of MemoryAlloc to reduce non-determinism.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -659,7 +659,7 @@ CHIP_ERROR DeviceController::InitializePairedDeviceList()
     if (!mPairedDevicesInitialized)
     {
         constexpr uint16_t max_size = sizeof(uint64_t) * kNumMaxPairedDevices;
-        buffer                      = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(max_size));
+        buffer                      = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(max_size, 1));
         uint16_t size               = max_size;
 
         VerifyOrExit(buffer != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
This is a belt-and-suspenders protection against someone doing
something wrong with the memory.  At least it will be
deterministically 0.

Fixes https://github.com/project-chip/connectedhomeip/issues/6889