### PR TITLE
[qpg6100] Move extern alloc to ThreadStackManagerImpl

### DIFF
--- a/src/platform/qpg6100/Logging.cpp
+++ b/src/platform/qpg6100/Logging.cpp
@@ -123,20 +123,4 @@ extern "C" void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const ch
     chip::DeviceLayer::OnLogOutput();
 }
 
-// TODO: have qpg6100 openthread platform implementation defines the APIs.
-// It is not perfect to have the openthread platform calloc/free
-// APIs defined here. If a dedicated source file (e.g. Memory.cpp)
-// that includes only the two functions is used, the target file
-// Memory.o will be thrown away whening linking the libary because
-// there is no one referring the symbols (We are not linking
-// the 'platform' library against openthread).
-extern "C" void * otPlatCAlloc(size_t aNum, size_t aSize)
-{
-    return CHIPPlatformMemoryCalloc(aNum, aSize);
-}
-
-extern "C" void otPlatFree(void * aPtr)
-{
-    CHIPPlatformMemoryFree(aPtr);
-}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/qpg6100/ThreadStackManagerImpl.cpp
+++ b/src/platform/qpg6100/ThreadStackManagerImpl.cpp
@@ -101,3 +101,13 @@ extern "C" void otSysEventSignalPending(void)
     BaseType_t yieldRequired = ThreadStackMgrImpl().SignalThreadActivityPendingFromISR();
     portYIELD_FROM_ISR(yieldRequired);
 }
+
+extern "C" void * otPlatCAlloc(size_t aNum, size_t aSize)
+{
+    return CHIPPlatformMemoryCalloc(aNum, aSize);
+}
+
+extern "C" void otPlatFree(void * aPtr)
+{
+    CHIPPlatformMemoryFree(aPtr);
+}


### PR DESCRIPTION
#### Problem
Allocating extern functions defined in Logging.cpp for qpg6100 

#### Change overview
Move allocating functions defines to ThreadStackManagerImpl 

#### Testing
    • Build tested for qpg6100 (only affected platform)
