### PR TITLE
ESP32: Fix all-clusters-app with the addition of occupancy-sensor-server

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -49,6 +49,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/bindings"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/reporting"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/door-lock-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/occupancy-sensor-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ias-zone-server"
                       #${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ias-zone-client
                       PRIV_REQUIRES chip QRCode tft spidriver bt screen-framework)


### PR DESCRIPTION

 #### Problem
ESP32 all-clusters-app is failing with the latest head using CMake

 #### Summary of Changes
Added an entry for occupancy-sensor-server in esp32 all-clusters-app CMakeLists.txt

 #### Testing
Successful compilation of the example using CMake (idf.py)