### PR TITLE
Enable arc for chip-device-ctrl

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -63,6 +63,7 @@ shared_library("ChipDeviceCtrl") {
         "chip/ble/darwin/AdapterListing.mm",
         "chip/ble/darwin/Scanning.mm",
       ]
+      cflags = [ "-fobjc-arc" ]
     } else {
       assert(false, "No BLE implementation available for the current OS.")
     }

--- a/src/controller/python/chip/ble/darwin/AdapterListing.mm
+++ b/src/controller/python/chip/ble/darwin/AdapterListing.mm
@@ -9,7 +9,7 @@
 @property (strong, nonatomic) CBCentralManager * centralManager;
 @property (nonatomic) bool advanced;
 @property (nonatomic) bool hasStatus;
-@property (assign, nonatomic) dispatch_semaphore_t statusSemaphore;
+@property (strong, nonatomic) dispatch_semaphore_t statusSemaphore;
 
 - (id)init;
 - (bool)isPoweredOn;
@@ -84,9 +84,12 @@
 
 @end
 
-extern "C" void * pychip_ble_adapter_list_new() { return static_cast<void *>([[FakeBleAdapterInformation alloc] init]); }
+extern "C" void * pychip_ble_adapter_list_new() { return (__bridge_retained void *) [[FakeBleAdapterInformation alloc] init]; }
 
-extern "C" void pychip_ble_adapter_list_delete(FakeBleAdapterInformation * adapterIterator) { [adapterIterator release]; }
+extern "C" void pychip_ble_adapter_list_delete(FakeBleAdapterInformation * adapterIterator)
+{
+    CFRelease((CFTypeRef) adapterIterator);
+}
 
 extern "C" bool pychip_ble_adapter_list_next(FakeBleAdapterInformation * adapterIterator)
 {
@@ -115,5 +118,5 @@ extern "C" bool pychip_ble_adapter_list_is_powered(FakeBleAdapterInformation * a
 
 extern "C" void * pychip_ble_adapter_list_get_raw_adapter(FakeBleAdapterInformation * adapterIterator)
 {
-    return static_cast<void *>(adapterIterator);
+    return (__bridge void *) adapterIterator;
 }

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -135,5 +135,5 @@ extern "C" void * pychip_ble_start_scanning(
                                                                   completeCallback:completeCallback
                                                                          timeoutMs:timeout];
 
-    return static_cast<void *>(scanner);
+    return (__bridge_retained void *) (scanner);
 }

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -335,6 +335,8 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         ]
       }
     } else if (chip_device_platform == "darwin") {
+      cflags += [ "-fobjc-arc" ]
+
       sources += [
         "Darwin/BLEManagerImpl.cpp",
         "Darwin/BLEManagerImpl.h",

--- a/src/platform/Darwin/BleApplicationDelegateImpl.mm
+++ b/src/platform/Darwin/BleApplicationDelegateImpl.mm
@@ -20,6 +20,10 @@
  *          Provides an implementation of BleApplicationDelegate for Darwin platforms.
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #include <ble/BleConfig.h>
 #include <platform/Darwin/BleApplicationDelegate.h>
 

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -21,6 +21,10 @@
  *          Provides an implementation of BleConnectionDelegate for Darwin platforms.
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #include <ble/BleConfig.h>
 #include <ble/BleError.h>
 #include <ble/BleLayer.h>
@@ -70,7 +74,7 @@ namespace DeviceLayer {
             ble.appState = appState;
             ble.onConnectionComplete = OnConnectionComplete;
             ble.onConnectionError = OnConnectionError;
-            [ble.centralManager initWithDelegate:ble queue:ble.workQueue];
+            ble.centralManager = [ble.centralManager initWithDelegate:ble queue:ble.workQueue];
         }
 
         BLE_ERROR BleConnectionDelegateImpl::CancelConnection()
@@ -356,7 +360,6 @@ namespace DeviceLayer {
     }
 
     _peripheral = peripheral;
-    [_peripheral retain];
     [_centralManager connectPeripheral:peripheral options:nil];
 }
 

--- a/src/platform/Darwin/BlePlatformDelegateImpl.mm
+++ b/src/platform/Darwin/BlePlatformDelegateImpl.mm
@@ -21,6 +21,10 @@
  *          Provides an implementation of BlePlatformDelegate for Darwin platforms.
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #include <ble/BleConfig.h>
 #include <ble/BleError.h>
 #include <ble/BleLayer.h>
@@ -43,7 +47,7 @@ namespace DeviceLayer {
             bool found = false;
             CBUUID * serviceId = nil;
             CBUUID * characteristicId = nil;
-            CBPeripheral * peripheral = (CBPeripheral *) connObj;
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
 
             if (NULL != svcId) {
                 serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
@@ -74,7 +78,7 @@ namespace DeviceLayer {
             bool found = false;
             CBUUID * serviceId = nil;
             CBUUID * characteristicId = nil;
-            CBPeripheral * peripheral = (CBPeripheral *) connObj;
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
 
             if (NULL != svcId) {
                 serviceId = [UUIDHelper GetShortestServiceUUID:svcId];
@@ -100,7 +104,8 @@ namespace DeviceLayer {
 
         bool BlePlatformDelegateImpl::CloseConnection(BLE_CONNECTION_OBJECT connObj)
         {
-            CBPeripheral * peripheral = (CBPeripheral *) connObj;
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
+
             // CoreBluetooth API requires a CBCentralManager to close a connection which is a property of the peripheral.
             CBCentralManager * manager = (CBCentralManager *) [peripheral valueForKey:@"manager"];
             if (manager != nil)
@@ -124,7 +129,7 @@ namespace DeviceLayer {
             CBUUID * serviceId = nil;
             CBUUID * characteristicId = nil;
             NSData * data = nil;
-            CBPeripheral * peripheral = (CBPeripheral *) connObj;
+            CBPeripheral * peripheral = (__bridge CBPeripheral *) connObj;
 
             if (NULL != svcId) {
                 serviceId = [UUIDHelper GetShortestServiceUUID:svcId];

--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -21,6 +21,10 @@
  *          Platform-specific key value storage implementation for Darwin
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #include <platform/KeyValueStoreManager.h>
 
 #include <algorithm>

--- a/src/platform/Darwin/UUIDHelperImpl.mm
+++ b/src/platform/Darwin/UUIDHelperImpl.mm
@@ -16,6 +16,10 @@
  *    limitations under the License.
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #import "UUIDHelper.h"
 
 @implementation UUIDHelper


### PR DESCRIPTION
#### Problem

`ARC` is not enabled for `src/platform/Darwin` which results into leaks.

#### Change overview
 * Enable arc with `-fobjc-arc` in `src/platform/BUILD.gn` when `chip_device_layer` is set to `darwin`.
 * Enable arc with `-fobjc-arc` in `src/platform/python/BUILD.gn` since it contains custom Objc++ files.
 * Update `src/platform/Darwin/*.mm` files that needs it.
 * Update `src/platform/python/chip/darwin/*.mm` files.

#### Testing
This is not especially easy to write tests for ARC. So I did manual testing involving pairing over BLE in order to validate the underlying BLE stack using `chip-tool` on Mac and `iOS ChipTool`.