### PR TITLE
[android/CHIPTool] Resurrect Thread commissioning

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -84,8 +84,12 @@ class CHIPToolActivity :
     }
   }
 
-  override fun onPairingComplete() {
-    showFragment(OnOffClientFragment.newInstance(), false)
+  override fun onCommissioningComplete(code: Int) {
+    if (code == 0) {
+      showFragment(OnOffClientFragment.newInstance(), false)
+    } else {
+      showFragment(SelectActionFragment.newInstance(), false)
+    }
   }
 
   override fun handleScanQrCodeClicked() {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
@@ -23,6 +23,10 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
+  override fun onNetworkCommissioningComplete(code: Int) {
+    // No op
+  }
+
   override fun onNotifyChipConnectionClosed() {
     // No op
   }

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -120,21 +120,36 @@ class DeviceProvisioningFragment : Fragment() {
     }
 
     override fun onStatusUpdate(status: Int) {
-      Log.i(TAG, "Pairing status update: $status");
-
-      if (status == STATUS_NETWORK_PROVISIONING_SUCCESS) {
-        showMessage(R.string.rendezvous_over_ble_provisioning_success_text)
-        FragmentUtil.getHost(this@DeviceProvisioningFragment, Callback::class.java)
-            ?.onPairingComplete()
-      }
+      Log.d(TAG, "Pairing status update: $status");
     }
 
     override fun onPairingComplete(code: Int) {
       Log.d(TAG, "onPairingComplete: $code")
+
+      if (code == 0) {
+        childFragmentManager.beginTransaction()
+            .add(R.id.fragment_container, EnterNetworkFragment.newInstance(networkType))
+            .commit()
+      } else {
+        showMessage(R.string.rendezvous_over_ble_pairing_failure_text)
+      }
     }
 
     override fun onPairingDeleted(code: Int) {
       Log.d(TAG, "onPairingDeleted: $code")
+    }
+
+    override fun onNetworkCommissioningComplete(code: Int) {
+      Log.d(TAG, "onNetworkCommissioningComplete: $code")
+
+      if (code == 0) {
+        showMessage(R.string.rendezvous_over_ble_commissioning_success_text)
+      } else {
+        showMessage(R.string.rendezvous_over_ble_commissioning_failure_text)
+      }
+
+      FragmentUtil.getHost(this@DeviceProvisioningFragment, Callback::class.java)
+          ?.onCommissioningComplete(code)
     }
 
     override fun onCloseBleComplete() {
@@ -148,8 +163,8 @@ class DeviceProvisioningFragment : Fragment() {
 
   /** Callback from [DeviceProvisioningFragment] notifying any registered listeners. */
   interface Callback {
-    /** Notifies that pairing has been completed. */
-    fun onPairingComplete()
+    /** Notifies that commissioning has been completed. */
+    fun onCommissioningComplete(code: Int)
   }
 
   companion object {

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -24,14 +24,18 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import chip.devicecontroller.ChipDeviceControllerException
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
+import com.google.chip.chiptool.util.DeviceIdUtil
+import com.google.chip.chiptool.util.FragmentUtil
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.channelEd
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.masterKeyEd
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.panIdEd
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.xpanIdEd
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.*
 import kotlinx.android.synthetic.main.enter_wifi_network_fragment.view.*
+import kotlinx.android.synthetic.main.on_off_client_fragment.*
 
 /**
  * Fragment to collect Wi-Fi network information from user and send it to device being provisioned.
@@ -114,7 +118,18 @@ class EnterNetworkFragment : Fragment() {
       return
     }
 
-    // Do something with the credentials
+    try {
+      ChipClient.getDeviceController().enableThreadNetwork(
+          DeviceIdUtil.getLastDeviceId(requireContext()),
+          channelStr.toString().toInt(),
+          panIdStr.toString().toInt(16),
+          xpanIdStr.hexToByteArray(),
+          masterKeyStr.hexToByteArray())
+    } catch (e: ChipDeviceControllerException) {
+      Toast.makeText(requireContext(), R.string.rendezvous_over_ble_commissioning_failure_text, Toast.LENGTH_SHORT).show()
+      FragmentUtil.getHost(this, DeviceProvisioningFragment.Callback::class.java)
+          ?.onCommissioningComplete(e.errorCode)
+    }
   }
 
   private fun String.hexToByteArray(): ByteArray {

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -43,7 +43,9 @@
     <string name="rendezvous_over_ble_scanning_failed_text">Device not found</string>
     <string name="rendezvous_over_ble_connecting_text">Connecting to %1$s</string>
     <string name="rendezvous_over_ble_pairing_text">Pairing</string>
-    <string name="rendezvous_over_ble_provisioning_success_text">Network provisioning completed</string>
+    <string name="rendezvous_over_ble_pairing_failure_text">Pairing failed</string>
+    <string name="rendezvous_over_ble_commissioning_success_text">Network commissioning completed</string>
+    <string name="rendezvous_over_ble_commissioning_failure_text">Network commissioning failed</string>
 
     <string name="commissioner_openthread_commissioning">Open Thread Commissioning</string>
     <string name="commissioner_name">Commissioner</string>

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -847,13 +847,13 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kBle ||
         params.GetPeerAddress().GetTransportType() == Transport::Type::kUndefined)
     {
-#if CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
+#if CONFIG_NETWORK_LAYER_BLE
         if (!params.HasBleLayer())
         {
             params.SetPeerAddress(Transport::PeerAddress::BLE());
         }
         peerAddress = Transport::PeerAddress::BLE();
-#endif // CONFIG_DEVICE_LAYER && CONFIG_NETWORK_LAYER_BLE
+#endif // CONFIG_NETWORK_LAYER_BLE
     }
     else if (params.GetPeerAddress().GetTransportType() == Transport::Type::kTcp ||
              params.GetPeerAddress().GetTransportType() == Transport::Type::kUdp)

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -85,6 +85,11 @@ void AndroidDeviceControllerWrapper::SetJavaObjectRef(JavaVM * vm, jobject obj)
     mJavaObjectRef = GetJavaEnv()->NewGlobalRef(obj);
 }
 
+void AndroidDeviceControllerWrapper::CallJavaMethod(const char * methodName, jint argument)
+{
+    CallVoidInt(GetJavaEnv(), mJavaObjectRef, methodName, argument);
+}
+
 JNIEnv * AndroidDeviceControllerWrapper::GetJavaEnv()
 {
     if (mJavaVM == nullptr)
@@ -170,17 +175,17 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(Jav
 
 void AndroidDeviceControllerWrapper::OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status)
 {
-    CallVoidInt(GetJavaEnv(), mJavaObjectRef, "onStatusUpdate", static_cast<jint>(status));
+    CallJavaMethod("onStatusUpdate", static_cast<jint>(status));
 }
 
 void AndroidDeviceControllerWrapper::OnPairingComplete(CHIP_ERROR error)
 {
-    CallVoidInt(GetJavaEnv(), mJavaObjectRef, "onPairingComplete", static_cast<jint>(error));
+    CallJavaMethod("onPairingComplete", static_cast<jint>(error));
 }
 
 void AndroidDeviceControllerWrapper::OnPairingDeleted(CHIP_ERROR error)
 {
-    CallVoidInt(GetJavaEnv(), mJavaObjectRef, "onPairingDeleted", static_cast<jint>(error));
+    CallJavaMethod("onPairingDeleted", static_cast<jint>(error));
 }
 
 void AndroidDeviceControllerWrapper::OnMessage(chip::System::PacketBufferHandle && msg) {}

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -41,6 +41,10 @@ public:
     chip::Controller::DeviceCommissioner * Controller() { return mController.get(); }
     chip::Controller::ExampleOperationalCredentialsIssuer & OpCredsIssuer() { return mOpCredsIssuer; }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
+    jobject JavaObjectRef() { return mJavaObjectRef; }
+    jlong ToJNIHandle();
+
+    void CallJavaMethod(const char * methodName, jint argument);
 
     // DevicePairingDelegate implementation
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
@@ -55,14 +59,6 @@ public:
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
-
-    jlong ToJNIHandle()
-    {
-        static_assert(sizeof(jlong) >= sizeof(void *), "Need to store a pointer in a java handle");
-        return reinterpret_cast<jlong>(this);
-    }
-
-    jobject JavaObjectRef() { return mJavaObjectRef; }
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {
@@ -88,3 +84,9 @@ private:
 
     AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller) : mController(std::move(controller)) {}
 };
+
+inline jlong AndroidDeviceControllerWrapper::ToJNIHandle()
+{
+    static_assert(sizeof(jlong) >= sizeof(void *), "Need to store a pointer in a java handle");
+    return reinterpret_cast<jlong>(this);
+}

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -46,6 +46,9 @@
 #include <support/ThreadOperationalDataset.h>
 #include <support/logging/CHIPLogging.h>
 
+#include <gen/CHIPClientCallbacks.h>
+#include <gen/CHIPClusters.h>
+
 // Choose an approximation of PTHREAD_NULL if pthread.h doesn't define one.
 #ifndef PTHREAD_NULL
 #define PTHREAD_NULL 0
@@ -54,6 +57,7 @@
 using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Controller;
+using namespace chip::Thread;
 
 #define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
     extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_ChipDeviceController_##METHOD_NAME
@@ -79,6 +83,10 @@ static CHIP_ERROR N2J_ByteArray(JNIEnv * env, const uint8_t * inArray, uint32_t 
 static CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx);
 
 namespace {
+
+constexpr EndpointId kNodeEndpoint = 0;
+constexpr uint64_t kBreadcrumb     = 0;
+constexpr uint32_t kZclTimeoutMs   = 10000;
 
 JavaVM * sJVM;
 System::Layer sSystemLayer;
@@ -469,6 +477,120 @@ JNI_METHOD(void, sendCommand)(JNIEnv * env, jobject self, jlong handle, jlong de
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed to send CHIP command.");
+        ThrowError(env, err);
+    }
+}
+
+namespace {
+
+void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
+void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText);
+void OnNetworkCommissioningFailed(void * context, uint8_t errorCode);
+
+// Context used for processing "AddThreadNetwork" and "EnableNetwork" commands.
+struct NetworkCommissioningCtx
+{
+    static constexpr size_t kMaxNetworkIDLen = 32;
+
+    NetworkCommissioningCtx(JNIEnv * env, jlong handle, uint64_t deviceID, ByteSpan networkID) :
+        mEnv(env), mHandle(handle), mDeviceID(deviceID)
+    {
+        VerifyOrReturn(networkID.size() <= sizeof(mNetworkID), ThrowError(env, CHIP_ERROR_BUFFER_TOO_SMALL));
+        memcpy(mNetworkID, networkID.data(), networkID.size());
+        mNetworkIDLen = networkID.size();
+    }
+
+    JNIEnv * mEnv;
+    jlong mHandle;
+    uint64_t mDeviceID;
+    uint8_t mNetworkID[kMaxNetworkIDLen];
+    size_t mNetworkIDLen;
+    Callback::Callback<NetworkCommissioningClusterAddThreadNetworkResponseCallback> mOnAddNetwork{ OnAddNetworkResponse, this };
+    Callback::Callback<NetworkCommissioningClusterEnableNetworkResponseCallback> mOnEnableNetwork{ OnEnableNetworkResponse, this };
+    Callback::Callback<DefaultFailureCallback> mOnCommissioningFailed{ OnNetworkCommissioningFailed, this };
+};
+
+void FinishCommissioning(NetworkCommissioningCtx * ctx, CHIP_ERROR err)
+{
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(ctx->mHandle);
+    wrapper->CallJavaMethod("onNetworkCommissioningComplete", static_cast<jint>(err));
+    delete ctx;
+}
+
+void OnAddNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+{
+    NetworkCommissioningCtx * ctx            = static_cast<NetworkCommissioningCtx *>(context);
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(ctx->mHandle);
+    CHIP_ERROR err                           = CHIP_NO_ERROR;
+    Device * chipDevice                      = nullptr;
+    NetworkCommissioningCluster cluster;
+
+    SuccessOrExit(err = wrapper->Controller()->GetDevice(ctx->mDeviceID, &chipDevice));
+
+    cluster.Associate(chipDevice, kNodeEndpoint);
+    err = cluster.EnableNetwork(ctx->mOnEnableNetwork.Cancel(), ctx->mOnCommissioningFailed.Cancel(),
+                                ByteSpan(ctx->mNetworkID, ctx->mNetworkIDLen), kBreadcrumb, kZclTimeoutMs);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        FinishCommissioning(ctx, err);
+    }
+}
+
+void OnEnableNetworkResponse(void * context, uint8_t errorCode, uint8_t * debugText)
+{
+    NetworkCommissioningCtx * ctx = static_cast<NetworkCommissioningCtx *>(context);
+    FinishCommissioning(ctx, CHIP_NO_ERROR);
+}
+
+void OnNetworkCommissioningFailed(void * context, uint8_t errorCode)
+{
+    NetworkCommissioningCtx * ctx = static_cast<NetworkCommissioningCtx *>(context);
+    FinishCommissioning(ctx, CHIP_ERROR_INTERNAL);
+}
+
+} // namespace
+
+JNI_METHOD(void, enableThreadNetwork)
+(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jint channel, jint panId, jbyteArray extPanId, jbyteArray masterKey)
+{
+    CHIP_ERROR err             = CHIP_NO_ERROR;
+    Device * chipDevice        = nullptr;
+    OperationalDataset dataset = {};
+
+    JniByteArray extPanIdAccessor(env, extPanId);
+    JniByteArray masterKeyAccessor(env, masterKey);
+    uint8_t extPanIdBytes[kSizeExtendedPanId];
+    uint8_t masterKeyBytes[kSizeMasterKey];
+
+    VerifyOrExit(CanCastTo<uint16_t>(channel), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(CanCastTo<uint16_t>(panId), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(extPanIdAccessor.size() == kSizeExtendedPanId, err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(masterKeyAccessor.size() == kSizeMasterKey, err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    GetCHIPDevice(env, handle, deviceId, &chipDevice);
+    memcpy(extPanIdBytes, extPanIdAccessor.data(), kSizeExtendedPanId);
+    memcpy(masterKeyBytes, masterKeyAccessor.data(), kSizeMasterKey);
+    dataset.SetChannel(channel);
+    dataset.SetPanId(panId);
+    dataset.SetExtendedPanId(extPanIdBytes);
+    dataset.SetMasterKey(masterKeyBytes);
+
+    {
+        auto ctx = std::make_unique<NetworkCommissioningCtx>(env, handle, deviceId, ByteSpan(extPanIdBytes, kSizeExtendedPanId));
+        ScopedPthreadLock lock(&sStackLock);
+        NetworkCommissioningCluster cluster;
+        cluster.Associate(chipDevice, kNodeEndpoint);
+        SuccessOrExit(err = cluster.AddThreadNetwork(ctx->mOnAddNetwork.Cancel(), ctx->mOnCommissioningFailed.Cancel(),
+                                                     dataset.AsByteSpan(), kBreadcrumb, kZclTimeoutMs));
+        ctx.release();
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to enable Thread network");
         ThrowError(env, err);
     }
 }
@@ -1013,6 +1135,7 @@ CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx)
     jstring errStrObj   = NULL;
     jmethodID constructor;
 
+    env->ExceptionClear();
     constructor = env->GetMethodID(sChipDeviceControllerExceptionCls, "<init>", "(ILjava/lang/String;)V");
     VerifyOrExit(constructor != NULL, err = CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
@@ -1033,7 +1156,6 @@ CHIP_ERROR N2J_Error(JNIEnv * env, CHIP_ERROR inErr, jthrowable & outEx)
     }
     errStrObj = (errStr != NULL) ? env->NewStringUTF(errStr) : NULL;
 
-    env->ExceptionClear();
     outEx = (jthrowable) env->NewObject(sChipDeviceControllerExceptionCls, constructor, (jint) inErr, errStrObj);
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -108,6 +108,12 @@ public class ChipDeviceController {
     }
   }
 
+  public void onNetworkCommissioningComplete(int errorCode) {
+    if (completionListener != null) {
+      completionListener.onNetworkCommissioningComplete(errorCode);
+    }
+  }
+
   public void onNotifyChipConnectionClosed(int connId) {
     // Clear connection state.
     AndroidChipStack.getInstance().removeConnection(connId);
@@ -164,6 +170,11 @@ public class ChipDeviceController {
     sendCommand(deviceControllerPtr, deviceId, command, value);
   }
 
+  public void enableThreadNetwork(
+      long deviceId, int channel, int panId, byte[] extPanId, byte[] masterKey) {
+    enableThreadNetwork(deviceControllerPtr, deviceId, channel, panId, extPanId, masterKey);
+  }
+
   public boolean openPairingWindow(long deviceId, int duration) {
     return openPairingWindow(deviceControllerPtr, deviceId, duration);
   }
@@ -191,6 +202,9 @@ public class ChipDeviceController {
 
   private native void sendCommand(
       long deviceControllerPtr, long deviceId, ChipCommandType command, int value);
+
+  private native void enableThreadNetwork(
+      long deviceControllerPtr, long deviceId, int channel, int panId, byte[] extPanId, byte[] masterKey);
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 
@@ -227,6 +241,9 @@ public class ChipDeviceController {
 
     /** Notifies the deletion of pairing session. */
     void onPairingDeleted(int errorCode);
+
+    /** Notifies the completion of network commissioning */
+    void onNetworkCommissioningComplete(int errorCode);
 
     /** Notifies that the Chip connection has been closed. */
     void onNotifyChipConnectionClosed();

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -204,7 +204,12 @@ public class ChipDeviceController {
       long deviceControllerPtr, long deviceId, ChipCommandType command, int value);
 
   private native void enableThreadNetwork(
-      long deviceControllerPtr, long deviceId, int channel, int panId, byte[] extPanId, byte[] masterKey);
+      long deviceControllerPtr,
+      long deviceId,
+      int channel,
+      int panId,
+      byte[] extPanId,
+      byte[] masterKey);
 
   private native boolean openPairingWindow(long deviceControllerPtr, long deviceId, int duration);
 


### PR DESCRIPTION
 #### Problem
Device commissioning now longer works after switching to the cluster-based approach.

 #### Summary of Changes
Implement the new commissioning flow of Thread devices using Network Commissioning cluster:
* after establishing a secure session show a dialog for   entering Thread credentials
* when a user taps the "Save network" button send   AddThreadNetwork and EnableNetwork commands.
* when a response to the latter command arrives switch to the device control screen, otherwise show an error.

Wi-Fi commissioning is still to be added and so is DNS-SD to obtain the device address.

 #### Testing
The change has been test manually using:
 * Android CHIPTool on an Android 8.1
 * nRF Connect lighting-app on nRF5340DK with #6955 patch included

Scenarios:
 * Successful commissioning - verified that the device joined a Thread network and CHIPTool reported success
 * Failed commissioning - verified by turning off the lighting device in various commissioning stages that CHIPTool reported failure and switched back to the main screen.
